### PR TITLE
ManagedAutoRun for HoistComponents

### DIFF
--- a/admin/tabs/logging/viewer/LogViewerDisplay.js
+++ b/admin/tabs/logging/viewer/LogViewerDisplay.js
@@ -8,7 +8,6 @@
 import {Component} from 'react';
 import {elemFactory, hoistComponent} from 'hoist/core';
 import {Ref} from 'hoist/utils/Ref';
-import {observer, observable, setter , toJS, autorun} from 'hoist/mobx';
 import {frame, table, tbody, td, tr} from 'hoist/layout';
 import {clipboardMenuItem, contextMenu, ContextMenuModel} from  'hoist/cmp';
 
@@ -16,6 +15,11 @@ import {clipboardMenuItem, contextMenu, ContextMenuModel} from  'hoist/cmp';
 class LogViewerDisplay extends Component {
 
     lastRow = new Ref();
+
+    constructor(props) {
+        super(props)
+        this.addAutoRun(() => this.syncTail());
+    }
 
     render() {
         const {rows} = this.model;
@@ -28,7 +32,7 @@ class LogViewerDisplay extends Component {
     }
 
     getTableRows(rows) {
-        return toJS(rows).map((row, idx) => {
+        return rows.map((row, idx) => {
             return tr({
                 cls: 'logviewer-row noselect',
                 ref: idx === rows.length - 1 ? this.lastRow.ref : undefined,
@@ -60,19 +64,13 @@ class LogViewerDisplay extends Component {
         ]);
         return contextMenu({style: {width: '200px'}, model: menuModel});
     }
-
-    componentDidMount() {
-        this.disposeTailRunner = autorun(() => {
-            if (!this.model.tail) return;
-            const lastRowElem = this.lastRow.value;
-            if (lastRowElem) {
-                lastRowElem.scrollIntoView();
-            }
-        });
-    }
-
-    componenentWillUnmount() {
-        this.disposeTailRunner();
+    
+    syncTail() {
+        if (!this.model.tail) return;
+        const lastRowElem = this.lastRow.value;
+        if (lastRowElem) {
+            lastRowElem.scrollIntoView();
+        }
     }
 }
 

--- a/admin/tabs/logging/viewer/LogViewerModel.js
+++ b/admin/tabs/logging/viewer/LogViewerModel.js
@@ -23,7 +23,7 @@ export class LogViewerModel {
 
     // Overall State
     @observable file = null;
-    @setter @observable rows = [];
+    @setter @observable.ref rows = [];
 
     loadModel = new LastPromiseModel();
 

--- a/cmp/tab/TabPane.js
+++ b/cmp/tab/TabPane.js
@@ -8,7 +8,6 @@ import {Component} from 'react';
 import {elem, elemFactory, hoistComponent} from 'hoist/core';
 import {Ref} from 'hoist/utils/Ref';
 import {frame} from 'hoist/layout';
-import {autorun} from 'hoist/mobx';
 
 /**
  * Container for an Admin Tab
@@ -29,6 +28,11 @@ export class TabPane extends Component {
 
     child = new Ref();
     isLazyState = true
+
+    constructor(props) {
+        super(props);
+        this.addAutoRun(() => this.syncLoad());
+    }
 
     render() {
         const model = this.model,
@@ -61,15 +65,10 @@ export class TabPane extends Component {
         }
     }
 
-    componentDidMount() {
-        this.disposeRunner = autorun(() => {
-            const {model, child} = this;
-            if (model.needsLoad && child.value) this.loadChild();
-        });
+    syncLoad() {
+        const {model, child} = this;
+        if (model.needsLoad && child.value) this.loadChild();
     }
 
-    componentWillUnmount() {
-        this.disposeRunner();
-    }
 }
 export const tabPane = elemFactory(TabPane);


### PR DESCRIPTION
This provides a cleaner way to add one or more autorun() to a HoistComponent that will only be active when the component is mounted, and will later cleaned up. Could be renamed 'autorunWhenMounted()', but I wasn't sure we would need such specificity and I thought this was probably the 99% use case, so we could choose a cleaner name.

Please also see the mixin() code in @hoistComponent. Its based on some code found in @Observer.

