### PR TITLE
Add selectFirst() and autoSelectFirst() methods to GridSelectionModel

### DIFF
--- a/data/BaseStore.js
+++ b/data/BaseStore.js
@@ -47,14 +47,6 @@ export class BaseStore {
     getById(id, filteredOnly) {}
 
     /**
-     * Get records sorted by property
-     *
-     * @param sorters[], One or more objects in the form {property: '', direction: 'asc' | 'desc'}
-     * @param filteredOnly, set to true to skip non-filtered records
-     */
-    getSorted(sorters, filteredOnly) {}
-
-    /**
      * Construct this object.
      *
      * @param fields, list of Fields or valid configuration for Fields.

--- a/data/LocalStore.js
+++ b/data/LocalStore.js
@@ -7,7 +7,6 @@
 
 import {start, LastPromiseModel} from 'hoist/promise';
 import {observable, action} from 'hoist/mobx';
-import {castArray, orderBy} from 'lodash';
 
 import {BaseStore} from './BaseStore';
 
@@ -82,18 +81,6 @@ export class LocalStore extends BaseStore {
         return (filteredOnly && rec && this._filter && !this.filter(rec)) ?
             null :
             rec;
-    }
-
-    getSorted(sorters, filteredOnly) {
-        const recs = filteredOnly ? this.records : this.allRecords,
-            props = [], orders = [];
-
-        castArray(sorters).forEach(it => {
-            props.push(it.property);
-            orders.push(it.direction.toLowerCase());
-        });
-
-        return orderBy(recs, props, orders);
     }
 
     //-----------------------------------

--- a/grid/GridSelectionModel.js
+++ b/grid/GridSelectionModel.js
@@ -6,7 +6,7 @@
  */
 
 import {autorun, action, observable, computed} from 'hoist/mobx';
-import {castArray, intersection, union} from 'lodash';
+import {castArray, intersection, union, orderBy} from 'lodash';
 
 /**
  * Model for managing the selection in a GridPanel.
@@ -59,21 +59,15 @@ export class GridSelectionModel {
     }
 
     /**
-     * Selects first row in grid, accounting for grid sorting
+     * Selects first row in grid
      */
     selectFirst() {
-        const {store, gridApi} = this.parent,
-            sorters = gridApi.getSortModel().map(it => { return {property: it.colId, direction: it.sort} }),
-            recs = sorters.length ? store.getSorted(sorters, true) : store.records;
-        if (recs.length) this.select(recs[0]);
-    }
+        const {store, sortBy} = this.parent,
+            colIds = sortBy.map(it => it.colId),
+            sorts = sortBy.map(it => it.sort),
+            recs = orderBy(store.records, colIds, sorts);
 
-    /**
-     * Select first record in grid if none are already selected.
-     * Useful for grids that should always have a selection
-     */
-    ensureRecordSelected() {
-        if (this.isEmpty) this.selectFirst();
+        if (recs.length) this.select(recs[0]);
     }
 
 }


### PR DESCRIPTION
One pattern I'm often coming across is the need to auto-select the first grid row after loading data into the grid. This makes that functionality available on the GridSelectionModel.