### PR TITLE
Provide boolCheck renderer cmp a refresh method

### DIFF
--- a/columns/Core.js
+++ b/columns/Core.js
@@ -21,6 +21,7 @@ export const boolCheckCol = colFactory({
     cellRendererFramework: (
         class extends Component {
             render() {return this.props.value ? Icon.check({prefix: 'fas', cls: 'xh-green'}) : ''}
+            refresh() {return false}
         }
     )
 });


### PR DESCRIPTION
This stops ag-grid from warning: 

'frameworkComponentWrapper.js:34 ag-Grid: Framework component is missing the method refresh()'.  

Returning false from refresh as part of the cellRendererFramework is documented. I know we talked about this in Slack, not sure why it didn't get included before.