### PR TITLE
Components used as a cellRendererFramework should have a refresh method*

### DIFF
--- a/cmp/leftRightChooser/impl/ItemRenderer.js
+++ b/cmp/leftRightChooser/impl/ItemRenderer.js
@@ -26,4 +26,8 @@ export class ItemRenderer extends Component {
             ]
         });
     }
+
+    refresh() {
+        return false;
+    }
 }


### PR DESCRIPTION
*Otherwise ag-grid will warn in the console

-In it's current implementation refresh is not called. The row is created and destroyed as it moves from grid to grid. Spoke to Lee about making this change anyway for consistency.