### PR TITLE
Fix for model lookup logic when not found on context

### DIFF
--- a/core/HoistComponentFunctional.js
+++ b/core/HoistComponentFunctional.js
@@ -206,7 +206,8 @@ function lookupModel(spec, props, modelLookup, displayName) {
 
     // 3) context
     if (modelLookup && spec.fromContext) {
-        return {model: modelLookup.lookupModel(selector), isOwned: false};
+        const contextModel = modelLookup.lookupModel(selector);
+        if (contextModel) return {model: contextModel, isOwned: false};
     }
 
     // 4) default create


### PR DESCRIPTION
Encountered this while trying to have a component use a model from context, or create one if not found. The model lookup logic would not create in the case where it was not found on context, it would return `undefined` for the model.

Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or open as a draft PR / add `wip` label).
- [N/A] Added CHANGELOG entry (or N/A)
- [N/A] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [N/A] Updated doc comments / prop-types (or N/A)
- [N/A] Reviewed and tested on Mobile (or N/A)
- [N/A] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

