### PR TITLE
Stricter desktop DateInput handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,25 @@
 # Changelog
 
+## v29.0.0-SNAPSHOT - under development
+
+### 🎁 New Features
+
+* `DateInput` supports a new `strictInputParsing` prop to enforce strict parsing of keyed-in entries
+  by the underlying moment library. The default value is false, maintained the existing behavior
+  where [moment will do its best](https://momentjs.com/guides/#/parsing/) to parse an entered date
+  string that doesn't exactly match the specified format
+* Any `DateInput` values entered that exceed any specified max/minDate will now be reset to null,
+  instead of being set to the boundary date (which was surprising and potentially much less obvious
+  to a user that their input had been adjusted automatically).
+
+[Commit Log](https://github.com/xh/hoist-react/compare/v28.0.0...develop)
+
 ## v28.0.0 - 2019-10-07
 
 ----
 
-⚠ Special note - at release time, the `terser` library has released a broken patch update. (Terser is
-a transitive dependency used to minify code for production builds.) Apps are advised to fix the
+⚠ Special note - at release time, the `terser` library has released a broken patch update. (Terser
+is a transitive dependency used to minify code for production builds.) Apps are advised to fix the
 version of terser used for compilation by specifying the following in their `package.json` file:
 
 ```

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -78,10 +78,22 @@ export class DateInput extends HoistInput {
          */
         rightElement: PT.element,
 
-        /** Maximum (inclusive) valid date. */
+        /**
+         * Maximum (inclusive) valid date. Controls which dates can be selected via the calendar
+         * picker. Will reset any out-of-bounds manually entered input to `null`.
+         *
+         * Note this is distinct in these ways from FormModel based validation, which will leave an
+         * invalid date entry in place but flag as invalid via FormField. For cases where it is
+         * possible to use FormField, that is often a better choice.
+         */
         maxDate: PT.oneOfType([PT.instanceOf(Date), PT.instanceOf(LocalDate)]),
 
-        /** Minimum (inclusive) valid date. */
+        /**
+         * Minimum (inclusive) valid date. Controls which dates can be selected via the calendar
+         * picker. Will reset any out-of-bounds manually entered input to `null`.
+         *
+         * See note re. validation on maxDate, above.
+         */
         minDate: PT.oneOfType([PT.instanceOf(Date), PT.instanceOf(LocalDate)]),
 
         /** Text to display when control is empty. */
@@ -101,6 +113,14 @@ export class DateInput extends HoistInput {
 
         /** True to show the picker upon focusing the input. */
         showPickerOnFocus: PT.bool,
+
+        /**
+         * True to parse any dates entered via the text input with moment's "strict" mode enabled.
+         * This ensures that the input entry matches the format specified by `formatString` exactly.
+         * If it does not, the input will be considered invalid and the value set to `null`.
+         * @see https://momentjs.com/guides/#/parsing/strict-mode/
+         */
+        strictInputParsing: PT.bool,
 
         /** Alignment of entry text within control, default 'left'. */
         textAlign: PT.oneOf(['left', 'right']),
@@ -143,8 +163,9 @@ export class DateInput extends HoistInput {
         return isLocalDate(initialMonth) ? initialMonth.date : initialMonth;
     }
 
-    get valueType() {return withDefault(this.props.valueType, 'date')}
-    get timePrecision() {return this.valueType === 'localDate' ? null : this.props.timePrecision}
+    get valueType()             {return withDefault(this.props.valueType, 'date')}
+    get strictInputParsing()    {return withDefault(this.props.strictInputParsing, false)}
+    get timePrecision()         {return this.valueType === 'localDate' ? null : this.props.timePrecision}
 
     render() {
         const props = this.getNonLayoutProps();
@@ -329,10 +350,15 @@ export class DateInput extends HoistInput {
 
     onDateChange = (date) => {
         if (date) {
+            // Dates outside of min/max constraints are reset to null.
             const {minDate, maxDate} = this;
-            if (minDate && date < minDate) date = minDate;
-            if (maxDate && date > maxDate) date = maxDate;
-            date = this.applyPrecision(date);
+            if (minDate && date < minDate) date = null;
+            if (maxDate && date > maxDate) date = null;
+            if (date) {
+                date = this.applyPrecision(date);
+            } else {
+                console.debug('DateInput value exceeded max/minDate bounds on change - reset to null.');
+            }
         }
         this.noteValueChange(date);
     };
@@ -369,9 +395,8 @@ export class DateInput extends HoistInput {
     }
 
     parseDate(dateString) {
-        // Handle 'invalid date'  as null.
-        const ret = moment(dateString, this.getFormat()).toDate();
-        return isNaN(ret) ? null : ret;
+        const parsedMoment = moment(dateString, this.getFormat(), this.strictInputParsing);
+        return parsedMoment.isValid() ? parsedMoment.toDate() : null;
     }
 
     consumeEvent(e) {


### PR DESCRIPTION
+ New `strictInputParsing` prop (default false) to enforce strict parsing of text input by moment
+ Inputted values exceeding max/min date reset to null, instead of being coerced to the boundary date.
+ Expanded doc strings on min/max constraints.
+ Fixes #1396 

Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or open as a draft PR / add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [x] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [NA] Reviewed and tested on Mobile (or N/A)
- [x] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

