### PR TITLE
Correct setting of cors property on fetch.

### DIFF
--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -96,7 +96,6 @@ export class FetchService {
 
         // 3) Prepare merged options
         const fetchOpts = Object.assign({
-            cors: true,
             credentials: 'include',
             redirect: 'follow'
         }, {


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [X] Up to date with `develop` branch as of last change.
- [X] Ready for review (or open as a draft PR / add `wip` label).
- [N/A] Added CHANGELOG entry (or N/A)
- [X] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [N/A] Updated doc comments / prop-types (or N/A)
- [ ] Reviewed and tested on Mobile (or N/A)
- [X] Created Toolbox branch / PR (https://github.com/xh/toolbox/tree/fetch307  - see Fetch API under Admin/Tests)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

When reviewing our fetchservice code as part of looking into #307, I noticed that the CORS setting did not match what the documentation specified:
https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Syntax

I think we "imported" this incorrect setting from extjs:
https://docs.sencha.com/extjs/6.2.1/modern/Ext.data.Connection.html#cfg-cors

Well wait, how did this ever work then?
From looking at other docs about fetch:
https://developers.google.com/web/updates/2015/03/introduction-to-fetch#why_is_no-cors_supported_in_service_workers_but_not_the_window
https://fetch.spec.whatwg.org/
https://github.com/github/fetch

it seems that there is no special options property needed for fetch to make CORS requests to a server that responds with the correct headers, and that does not require a credentials cookie.
If a server requires credentials, then the option `credentials: 'include'` is needed, which our code was providing.

The option `mode: 'cors'` only serves to tighten up the range of possible request types that fetch can make to: those requests that are same origin or, if not same-origin, are to servers that return the appropriate CORS headers.
See middle of https://developers.google.com/web/updates/2015/03/introduction-to-fetch#why_is_no-cors_supported_in_service_workers_but_not_the_window for the best (IMO) explanation of this)