### PR TITLE
Column/ColumnGroup fixes/enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * `Column` and `ColumnGroup` now accept a function for `headerName`. The header will be
   automatically re-rendered when any observable properties referenced by the `headerName` function
   are modified.
+* `ColumnGroup` now accepts an `align` config for setting the header text alignment
 
 ### 🐞 Bug Fixes
 
@@ -21,6 +22,14 @@
   ag-Grid group cell renderer auto-applied to tree columns (#1397).
 * Use of a custom `Column.comparator` function will no longer break agGrid-provided column header
   filter menus (#1400).
+  
+### ⚙️ Technical
+
+* Grid column group headers now use a custom React component instead of the default ag-Grid column
+  header, resulting in a different DOM structure and CSS classes. Existing CSS overrides of the 
+  ag-Grid column group headers may need to be updated to work with the new structure/classes.
+  
+  
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v28.0.0...develop)
 

--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -21,6 +21,7 @@
     }
 
     span {
+      flex: 1;
       overflow: hidden;
       text-overflow: ellipsis;
     }
@@ -58,12 +59,16 @@
     }
   }
 
-  .xh-column-header-align-right .xh-grid-header {
-    text-align: right;
+  .xh-column-header-align-right {
+    .xh-grid-header, .xh-grid-group-header {
+      text-align: right;
+    }
   }
 
-  .xh-column-header-align-center .xh-grid-header {
-    text-align: center;
+  .xh-column-header-align-center {
+    .xh-grid-header, .xh-grid-group-header {
+      text-align: center;
+    }
   }
 
   //------------------------

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -15,7 +15,6 @@ import {ExportFormat} from './ExportFormat';
 /**
  * Cross-platform definition and API for a standardized Grid column.
  * Provided to GridModels as plain configuration objects.
- * @alias HoistColumn
  */
 export class Column {
 

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -29,8 +29,8 @@ export class Column {
      *      Defaults to field name - one of these two properties must be specified.
      * @param {(Column~headerNameFn|string)} [c.headerName] - display text for grid header.
      * @param {string} [c.headerTooltip] - tooltip text for grid header.
-     * @param {(Column~headerClassFn|string|string[])} [c.headerClass] - additional css classes to add
-     *      to the column header. Supports both string values or function to generate strings.
+     * @param {(Column~headerClassFn|string|string[])} [c.headerClass] - CSS classes to add to the
+     *      header. Supports both string values or a function to generate strings.
      * @param {(Column~cellClassFn|string|string[])} [c.cellClass] - additional css classes to add
      *      to each cell in the column. Supports both string values or function to generate strings.
      * @param {boolean} [c.isTreeColumn] - true if this column should show the tree affordances for a

--- a/cmp/grid/columns/ColumnGroup.js
+++ b/cmp/grid/columns/ColumnGroup.js
@@ -20,7 +20,8 @@ export class ColumnGroup {
      * @param {Object[]} c.children - Column or ColumnGroup configurations for children of this group.
      * @param {string} [c.groupId] - unique identifier for the ColumnGroup within its grid.
      * @param {Column~headerNameFn|string} [c.headerName] - display text for column group header.
-     * @param {(string|string[])} [c.headerClass] - additional css classes to add to the column group header.
+     * @param {(Column~headerClassFn|string|string[])} [c.headerClass] - CSS classes to add to the
+     *      header. Supports both string values or a function to generate strings.
      * @param {string} [c.align] - horizontal alignment of cell contents.
      * @param {Object} [c.agOptions] - "escape hatch" object to pass directly to Ag-Grid for
      *      desktop implementations. Note these options may be used / overwritten by the framework
@@ -46,7 +47,7 @@ export class ColumnGroup {
         this.groupId = withDefault(groupId, headerName);
 
         this.headerName = withDefault(headerName, startCase(this.groupId));
-        this.headerClass = castArray(headerClass);
+        this.headerClass = headerClass;
         this.align = align;
 
         this.children = children.map(c => gridModel.buildColumn(c));

--- a/cmp/grid/columns/ColumnGroup.js
+++ b/cmp/grid/columns/ColumnGroup.js
@@ -7,6 +7,7 @@
 
 import {withDefault, throwIf} from '@xh/hoist/utils/js';
 import {startCase, isEmpty, castArray, clone, isFunction, isString} from 'lodash';
+import {getAgHeaderClassFn} from './Column';
 
 /**
  * Cross-platform definition and API for a standardized Grid column group.
@@ -16,10 +17,11 @@ import {startCase, isEmpty, castArray, clone, isFunction, isString} from 'lodash
 export class ColumnGroup {
     /**
      * @param {Object} c - ColumnGroup configuration.
+     * @param {Object[]} c.children - Column or ColumnGroup configurations for children of this group.
      * @param {string} [c.groupId] - unique identifier for the ColumnGroup within its grid.
      * @param {Column~headerNameFn|string} [c.headerName] - display text for column group header.
      * @param {(string|string[])} [c.headerClass] - additional css classes to add to the column group header.
-     * @param {Object[]} c.children - Column or ColumnGroup configurations for children of this group.
+     * @param {string} [c.align] - horizontal alignment of cell contents.
      * @param {Object} [c.agOptions] - "escape hatch" object to pass directly to Ag-Grid for
      *      desktop implementations. Note these options may be used / overwritten by the framework
      *      itself, and are not all guaranteed to be compatible with its usages of Ag-Grid.
@@ -32,6 +34,7 @@ export class ColumnGroup {
         groupId,
         headerName,
         headerClass,
+        align,
         agOptions,
         ...rest
     }, gridModel) {
@@ -44,6 +47,7 @@ export class ColumnGroup {
 
         this.headerName = withDefault(headerName, startCase(this.groupId));
         this.headerClass = castArray(headerClass);
+        this.align = align;
 
         this.children = children.map(c => gridModel.buildColumn(c));
 
@@ -56,7 +60,7 @@ export class ColumnGroup {
         return {
             groupId: this.groupId,
             headerValueGetter: (agParams) => isFunction(headerName) ? headerName({columnGroup: this, gridModel, agParams}) : headerName,
-            headerClass: this.headerClass,
+            headerClass: getAgHeaderClassFn(this),
             headerGroupComponentParams: {gridModel, xhColumnGroup: this},
             children: this.children.map(it => it.getAgSpec()),
             marryChildren: true, // enforce 'sealed' column groups

--- a/cmp/grid/columns/ColumnGroup.js
+++ b/cmp/grid/columns/ColumnGroup.js
@@ -5,19 +5,18 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 
-import {withDefault, throwIf} from '@xh/hoist/utils/js';
-import {startCase, isEmpty, castArray, clone, isFunction, isString} from 'lodash';
+import {throwIf, withDefault} from '@xh/hoist/utils/js';
+import {clone, isEmpty, isFunction, isString, startCase} from 'lodash';
 import {getAgHeaderClassFn} from './Column';
 
 /**
  * Cross-platform definition and API for a standardized Grid column group.
  * Provided to GridModels as plain configuration objects.
- * @alias HoistColumnGroup
  */
 export class ColumnGroup {
     /**
      * @param {Object} c - ColumnGroup configuration.
-     * @param {Object[]} c.children - Column or ColumnGroup configurations for children of this group.
+     * @param {Object[]} c.children - Column or ColumnGroup configs for children of this group.
      * @param {string} [c.groupId] - unique identifier for the ColumnGroup within its grid.
      * @param {Column~headerNameFn|string} [c.headerName] - display text for column group header.
      * @param {(Column~headerClassFn|string|string[])} [c.headerClass] - CSS classes to add to the

--- a/svc/GridExportService.js
+++ b/svc/GridExportService.js
@@ -15,7 +15,7 @@ import {castArray, isArray, isFunction, isNil, isString, uniq} from 'lodash';
 
 /**
  * Exports Grid data to either Excel or CSV via Hoist's server-side export capabilities.
- * @see HoistColumn API for options to control exported values and formats.
+ * @see Column API for options to control exported values and formats.
  */
 @HoistService
 export class GridExportService {


### PR DESCRIPTION
+ Fix issue where chooserName would be a stringified function if headerName was a function (and no chooserName specified)

+ Add support for align on ColumnGroup

+ Add changelog note about new dom/css structure for column group headers

Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or open as a draft PR / add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [x] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [N/A] Reviewed and tested on Mobile (or N/A)
- [N/A] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

--------

Added support for `align` on ColumnGroup

Also noticed an issue with the new function `headerName` which would show the function as a string in the column chooser, tweaked the chooser name defaulting logic to handle it
