### PR TITLE
Handle status 205 correctly in fetchJson

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "fast-deep-equal": "~2.0.1",
     "filesize": "~4.2.1",
     "highcharts": "~7.2.0",
+    "http-status-codes": "~1.3.2",
     "lodash": "~4.17.15",
     "lodash-inflection": "~1.5.0",
     "mobx": "~5.14.0",

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -164,7 +164,13 @@ export class FetchService {
                 ...opts.headers
             }
         });
-        return ret.status === 204 ? null : ret.json();
+        switch (ret.status) {
+            case 204:
+            case 205:
+                return null;
+            default:
+                return ret.json();
+        }
     }
 
     /**

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -10,6 +10,7 @@ import {throwIf, warnIf} from '@xh/hoist/utils/js';
 import {stringify} from 'qs';
 import {isFunction, isPlainObject, isNil, isDate, omitBy} from 'lodash';
 import {isLocalDate} from '@xh/hoist/utils/datetime';
+import {NO_CONTENT, RESET_CONTENT} from 'http-status-codes';
 
 /**
  * Service to send an HTTP request to a URL.
@@ -165,8 +166,8 @@ export class FetchService {
             }
         });
         switch (ret.status) {
-            case 204:
-            case 205:
+            case NO_CONTENT:
+            case RESET_CONTENT:
                 return null;
             default:
                 return ret.json();
@@ -258,5 +259,3 @@ export class FetchService {
         return value;
     }
 }
-
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -4741,6 +4741,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+http-status-codes@~1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-1.3.2.tgz#181dfa4455ef454e5e4d827718fca3936680d10d"
+  integrity sha512-nDUtj0ltIt08tGi2VWSpSzNNFye0v3YSe9lX3lIqLTuVvvRiYCvs4QQBSHo0eomFYw1wlUuofurUAlTm+vHnXg==
+
 https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [X] Up to date with `develop` branch as of last change.
- [X] Ready for review (or open as a draft PR / add `wip` label).
- [ ] Added CHANGELOG entry (or N/A)
- [X] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [N/A] Updated doc comments / prop-types (or N/A)
- [ ] Reviewed and tested on Mobile (or N/A)
- [N/A] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

As per https://httpstatuses.com/205   205 should also return null when using fetchJson.