### PR TITLE
Better docs for XH.message() + variants w/typedef

### DIFF
--- a/core/XH.js
+++ b/core/XH.js
@@ -298,25 +298,11 @@ class XHClass {
     //------------------------------
     /**
      * Show a modal message dialog.
+     * @param {MessageConfig} config
      *
-     * @param {Object} config - message options.
-     * @param {string} config.message - message text to be displayed.
-     * @param {string} [config.title] - title of message box.
-     * @param {Element} [config.icon] - icon to be displayed.
-     * @param {MessageInput} [config.input] - config for input to be displayed (as a prompt).
-     * @param {string} [config.confirmProps] - props for primary confirm button.
-     *      Must provide either text or icon for button to be displayed, or use a preconfigured
-     *      helper such as `XH.alert()` or `XH.confirm()` for default buttons.
-     * @param {string} [config.cancelProps] - props for secondary cancel button.
-     *      Must provide either text or icon for button to be displayed, or use a preconfigured
-     *      helper such as `XH.alert()` or `XH.confirm()` for default buttons.
-     * @param {function} [config.onConfirm] - Callback to execute when confirm is clicked.
-     * @param {function} [config.onCancel] - Callback to execute when cancel is clicked.
-     *
-     *
-     * Note that this method will auto focus the confirm button by default.  To focus the
-     * cancel button instead (e.g. for confirming risky operations), applications should specify a
-     * cancelProps argument of the following form:  cancelProps: {..., autoFocus: true}.
+     * Note that this method will auto focus the confirm button by default. To focus the cancel
+     * button instead (e.g. for confirming risky operations), applications should specify a
+     * `cancelProps` argument of the following form `cancelProps: {..., autoFocus: true}`.
      *
      * @returns {Promise} - resolves to true if user confirms, false if user cancels.
      *      If an input is provided, the Promise will resolve to the input value if user confirms.
@@ -327,8 +313,7 @@ class XHClass {
 
     /**
      * Show a modal 'alert' dialog with message and default 'OK' button.
-     *
-     * @param {Object} config - see XH.message() for available options.
+     * @param {MessageConfig} config
      * @returns {Promise} - resolves to true when user acknowledges alert.
      */
     alert(config) {
@@ -337,8 +322,7 @@ class XHClass {
 
     /**
      * Show a modal 'confirm' dialog with message and default 'OK'/'Cancel' buttons.
-     *
-     * @param {Object} config - see XH.message() for available options.
+     * @param {MessageConfig} config
      * @returns {Promise} - resolves to true if user confirms, false if user cancels.
      */
     confirm(config) {
@@ -354,7 +338,7 @@ class XHClass {
      *   3. onKeyDown handler to confirm on <enter> (same as clicking 'OK') (desktop only)
      * Applications may also provide a custom HoistInput, in which all props must be set.
      *
-     * @param {Object} config - see XH.message() for available options.
+     * @param {MessageConfig} config
      * @returns {Promise} - resolves to value of input if user confirms, false if user cancels.
      */
     prompt(config) {
@@ -365,10 +349,10 @@ class XHClass {
      * Show a non-modal "toast" notification that appears and then automatically dismisses.
      *
      * @param {Object} config - options for toast instance.
-     * @param {string} config.message - the message to show in the toast.
+     * @param {ReactNode} config.message - the message to show in the toast.
      * @param {Element} [config.icon] - icon to be displayed
      * @param {number} [config.timeout] - time in milliseconds to display the toast.
-     * @param {string} [config.intent] - The Blueprint intent (desktop only)
+     * @param {string} [config.intent] - the Blueprint intent (desktop only)
      * @param {Object} [config.position] - Position in viewport to display toast. See Blueprint
      *     Position enum (desktop only).
      * @param {Component} [config.containerRef] - Component that should contain (locate) the Toast.
@@ -666,3 +650,20 @@ class XHClass {
     }
 }
 export const XH = window.XH = new XHClass();
+
+
+/**
+ * @typedef {Object} MessageConfig - configuration object for a modal alert, confirm, or prompt.
+ * @property {ReactNode} message - message to be displayed - a string or any valid React node.
+ * @property {string} [title] - title of message box.
+ * @property {Element} [icon] - icon to be displayed.
+ * @property {MessageInput} [input] - config for input to be displayed (as a prompt).
+ * @property {string} [confirmProps] - props for primary confirm button.
+ *      Must provide either text or icon for button to be displayed, or use a preconfigured
+ *      helper such as `XH.alert()` or `XH.confirm()` for default buttons.
+ * @property {string} [cancelProps] - props for secondary cancel button.
+ *      Must provide either text or icon for button to be displayed, or use a preconfigured
+ *      helper such as `XH.alert()` or `XH.confirm()` for default buttons.
+ * @property {function} [onConfirm] - Callback to execute when confirm is clicked.
+ * @property {function} [onCancel] - Callback to execute when cancel is clicked.
+ */


### PR DESCRIPTION
+ Specify that `message` config itself can be any `ReactNode`
+ Note - will update dev-utils to import @types/react as a transitive dev dependency - that should cause IDEs to properly recognize `ReactNode` as a type if they don't already.
+ Fixes #1405

Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or open as a draft PR / add `wip` label).
- [ ] Added CHANGELOG entry (or N/A)
- [ ] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [ ] Reviewed and tested on Mobile (or N/A)
- [ ] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

