### PR TITLE
Make charts keep zoom state across data refresh

### DIFF
--- a/desktop/cmp/chart/Chart.js
+++ b/desktop/cmp/chart/Chart.js
@@ -39,16 +39,16 @@ export const [Chart, chart] = hoistCmp.withFactory({
         impl.model = model;
 
         if (impl.xMin === undefined) {
-            impl.xMin = props.defaultXMin;
+            impl.xMin = defaultXMin;
         }
         if (impl.xMax === undefined) {
-            impl.xMax = props.defaultXMax;
+            impl.xMax = defaultXMax;
         }
         if (props.xMin !== undefined) {
-            impl.xMin = props.xMin;
+            impl.xMin = xMin;
         }
         if (props.xMax !== undefined) {
-            impl.xMax = props.xMax;
+            impl.xMax = xMax;
         }
 
         // Default flex = 1 (flex: 1 1 0) if no dimensions / flex specified, i.e. do not consult child for dimensions;

--- a/desktop/cmp/chart/Chart.js
+++ b/desktop/cmp/chart/Chart.js
@@ -32,7 +32,7 @@ export const [Chart, chart] = hoistCmp.withFactory({
     model: uses(ChartModel),
     className: 'xh-chart',
 
-    render({model, className, xMin, xMax, defaultXMin, defaultXMax, aspectRatio, ...props}) {
+    render({model, className, defaultXMin, defaultXMax, aspectRatio, ...props}) {
 
         const impl = useLocalModel(LocalModel);
         impl.setAspectRatio(aspectRatio);
@@ -43,12 +43,6 @@ export const [Chart, chart] = hoistCmp.withFactory({
         }
         if (impl.xMax === undefined) {
             impl.xMax = defaultXMax;
-        }
-        if (props.xMin !== undefined) {
-            impl.xMin = xMin;
-        }
-        if (props.xMax !== undefined) {
-            impl.xMax = xMax;
         }
 
         // Default flex = 1 (flex: 1 1 0) if no dimensions / flex specified, i.e. do not consult child for dimensions;

--- a/desktop/cmp/chart/Chart.js
+++ b/desktop/cmp/chart/Chart.js
@@ -32,11 +32,24 @@ export const [Chart, chart] = hoistCmp.withFactory({
     model: uses(ChartModel),
     className: 'xh-chart',
 
-    render({model, className, aspectRatio, ...props}) {
+    render({model, className, xMin, xMax, defaultXMin, defaultXMax, aspectRatio, ...props}) {
 
         const impl = useLocalModel(LocalModel);
         impl.setAspectRatio(aspectRatio);
         impl.model = model;
+
+        if (impl.xMin === undefined) {
+            impl.xMin = props.defaultXMin;
+        }
+        if (impl.xMax === undefined) {
+            impl.xMax = props.defaultXMax;
+        }
+        if (props.xMin !== undefined) {
+            impl.xMin = props.xMin;
+        }
+        if (props.xMax !== undefined) {
+            impl.xMax = props.xMax;
+        }
 
         // Default flex = 1 (flex: 1 1 0) if no dimensions / flex specified, i.e. do not consult child for dimensions;
         const layoutProps = getLayoutProps(props);
@@ -81,8 +94,8 @@ class LocalModel {
     chartRef = createObservableRef();
     chart = null;
     model;
-    min = null;
-    max = null;
+    xMin;
+    xMax;
 
     renderHighChart() {
         this.destroyHighChart();
@@ -203,8 +216,8 @@ class LocalModel {
                     month: '%b-%y',
                     year: '%Y'
                 },
-                min: this.min,
-                max: this.max,
+                min: this.xMin,
+                max: this.xMax,
                 events: {
                     setExtremes: this.onSetExtremes
                 }
@@ -231,7 +244,7 @@ class LocalModel {
     // Handlers
     //---------------------------
     onSetExtremes = (event) => {
-        this.min = event.min;
-        this.max = event.max;
+        this.xMin = event.min;
+        this.xMax = event.max;
     }
 }


### PR DESCRIPTION
The chart will now record the minimum and maximum x-axis values in memory and restore them when the data is refreshed.

It is possible to specify default zoom levels to use when the page loads (the defaultXMin and defaultXMax parameters) or to override the remembered zoom levels at a data refresh (the xMin and xMax parameters).

The core functionality of this seems to work well, but I'm not totally happy with the interface.

Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [ ] Up to date with `develop` branch as of last change.
- [ ] Ready for review (or open as a draft PR / add `wip` label).
- [ ] Added CHANGELOG entry (or N/A)
- [ ] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [ ] Updated doc comments / prop-types (or N/A)
- [ ] Reviewed and tested on Mobile (or N/A)
- [ ] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

