### PR TITLE
Json input context model fix (Fixes #1456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v29.0.0-SNAPSHOT - under development
 
+### 🐞 Bug Fixes
+
+* Fixed issue where JsonInput was not receiving its `model` from context ([#1456](https://github.com/xh/hoist-react/issues/1456))
+
 ### 📚 Libraries
 
 * @blueprintjs/core `3.19 -> 3.20`

--- a/cmp/input/HoistInput.js
+++ b/cmp/input/HoistInput.js
@@ -88,8 +88,8 @@ export class HoistInput extends Component {
     @observable hasFocus = false;
     @observable internalValue = null;
 
-    constructor(props) {
-        super(props);
+    constructor(props, context) {
+        super(props, context);
 
         throwIf(props.onKeyPress, "HoistInputs no longer support a 'onKeyPress' property.  Use 'onKeyDown' instead.");
         throwIf(props.field, "HoistInput no longer supports a 'field' property.  Use 'bind' instead.");

--- a/desktop/cmp/input/JsonInput.js
+++ b/desktop/cmp/input/JsonInput.js
@@ -66,8 +66,8 @@ export class JsonInput extends HoistInput {
         return withDefault(this.props.showActionButtons, true);
     }
 
-    constructor(props) {
-        super(props);
+    constructor(props, context) {
+        super(props, context);
         this.addReaction({
             track: () => XH.darkTheme,
             run: () => {

--- a/desktop/cmp/input/RadioInput.js
+++ b/desktop/cmp/input/RadioInput.js
@@ -45,8 +45,8 @@ export class RadioInput extends HoistInput {
     @observable.ref internalOptions = [];
     @action setInternalOptions(options) {this.internalOptions = options}
 
-    constructor(props) {
-        super(props);
+    constructor(props, context) {
+        super(props, context);
         this.addReaction({
             track: () => this.props.options,
             run: (opts) => {
@@ -96,7 +96,7 @@ export class RadioInput extends HoistInput {
             return ret;
         });
     }
-    
+
     onChange = (e) => {
         this.noteValueChange(e.target.value);
     }

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -159,8 +159,8 @@ export class Select extends HoistInput {
         return !this.inputValue || !this._inputChangedSinceSelect || this._defaultLocalFilterFn(opt, inputVal);
     };
 
-    constructor(props) {
-        super(props);
+    constructor(props, context) {
+        super(props, context);
 
         const queryBuffer = withDefault(props.queryBuffer, 300);
         if (queryBuffer) this.doQueryAsync = debouncePromise(this.doQueryAsync, queryBuffer);

--- a/mobile/cmp/input/Select.js
+++ b/mobile/cmp/input/Select.js
@@ -85,8 +85,8 @@ export class Select extends HoistInput {
     @observable.ref internalOptions = [];
     @action setInternalOptions(options) {this.internalOptions = options}
 
-    constructor(props) {
-        super(props);
+    constructor(props, context) {
+        super(props, context);
         this.addReaction({
             track: () => this.props.options,
             run: (opts) => {


### PR DESCRIPTION
Small change to pass the `context` through to `super` in the constructors for our HoistInput components which have constructors. 

See https://github.com/facebook/react/issues/13944

The issue was only occurring for JsonInput, since the other components were not referencing their `model` in the constructor, but seemed safest to add everywhere.

In general any HoistComponent which has `supportModelFromContext = true` and has a constructor should be doing this. Not sure how/if we should communicate that in the changelog?


Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or open as a draft PR / add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [x] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [N/A] Updated doc comments / prop-types (or N/A)
- [N/A] Reviewed and tested on Mobile (or N/A)
- [N/A] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

