### PR TITLE
Correct bug in textInput and add selectOnFocus to dateInput

### DIFF
--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -108,6 +108,9 @@ export class DateInput extends HoistInput {
             'auto'
         ]),
 
+        /** True to select contents when control receives focus. */
+        selectOnFocus: PT.bool,
+
         /** True to show a bar with Today + Clear buttons at bottom of date picker popover. */
         showActionsBar: PT.bool,
 
@@ -224,6 +227,7 @@ export class DateInput extends HoistInput {
                         tabIndex: props.tabIndex,
                         placeholder: props.placeholder,
                         textAlign: props.textAlign,
+                        selectOnFocus: props.selectOnFocus,
                         inputRef: this.inputRef,
                         ...layoutProps
                     }),
@@ -404,5 +408,6 @@ export class DateInput extends HoistInput {
         e.stopPropagation();
     }
 }
+
 
 export const dateInput = elemFactory(DateInput);

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -147,9 +147,12 @@ export class TextInput extends HoistInput {
     }
 
     onFocus = (ev) => {
-        if (this.props.selectOnFocus) {
-            ev.target.select();
+        if (ev.target.nodeName === 'INPUT') {
+            if (this.props.selectOnFocus) {
+                ev.target.select();
+            }
         }
+        
         this.noteFocused();
     }
 }

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -147,10 +147,8 @@ export class TextInput extends HoistInput {
     }
 
     onFocus = (ev) => {
-        if (ev.target.nodeName === 'INPUT') {
-            if (this.props.selectOnFocus) {
-                ev.target.select();
-            }
+        if (this.props.selectOnFocus && ev.target.nodeName === 'INPUT' ) {
+            ev.target.select();
         }
         
         this.noteFocused();

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -147,10 +147,10 @@ export class TextInput extends HoistInput {
     }
 
     onFocus = (ev) => {
-        if (this.props.selectOnFocus && ev.target.nodeName === 'INPUT' ) {
+        if (this.props.selectOnFocus && ev.target.nodeName === 'INPUT') {
             ev.target.select();
         }
-        
+
         this.noteFocused();
     }
 }


### PR DESCRIPTION
TextInput can have a right element. If this right element is focused,
the event will bubble up to the parent TextInput. This would cause the
event handler defined in TextInput to try to call select on the rightElement,
which did not work. Now the TextInput will only try to select on focus if
the event targeted the input rather than the right element.

Adding selectOnFocus to the DateInput was trivial.
We just pass selectOnFocus to the child TextInput.

Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [ ] Up to date with `develop` branch as of last change.
- [ ] Ready for review (or open as a draft PR / add `wip` label).
- [ ] Added CHANGELOG entry (or N/A)
- [ ] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [ ] Reviewed and tested on Mobile (or N/A)
- [ ] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

