### PR TITLE
Initialize TreeMap data immediately on model construction (Fixes #1471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ specification currently supported.
 
 * Fixed autoFocus on NumberInput.
 * Fixed issue where JsonInput was not receiving its `model` from context ([#1456](https://github.com/xh/hoist-react/issues/1456))
+* Fixed issue where TreeMap would not be initialized if the TreeMapModel was created after the GridModel
+  data was loaded ([#1471](https://github.com/xh/hoist-react/issues/1471))
 
 ### 📚 Libraries
 

--- a/desktop/cmp/treemap/TreeMapModel.js
+++ b/desktop/cmp/treemap/TreeMapModel.js
@@ -152,7 +152,8 @@ export class TreeMapModel {
                 this.heatField,
                 this.maxDepth
             ],
-            run: ([rawData]) => this.data = this.processData(rawData)
+            run: ([rawData]) => this.data = this.processData(rawData),
+            fireImmediately: true
         });
     }
 


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or open as a draft PR / add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [x] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [N/A] Updated doc comments / prop-types (or N/A)
- [N/A] Reviewed and tested on Mobile (or N/A)
- [N/A] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

--------------------

Fix for #1471 

Small change to fire the data reaction immediately in TreeMapModel to handle the case where it was created after the GridModel/Store was initially loaded. This is effectively a no-op if the data processing in TreeMapModel is run before the Grid/Store has any data, as the tree map data will just end up being set to an empty array, which is also the default value.