### PR TITLE
Make exportName use dynamic headerName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ specification currently supported.
 * Fixed issue where JsonInput was not receiving its `model` from context ([#1456](https://github.com/xh/hoist-react/issues/1456))
 * Fixed issue where TreeMap would not be initialized if the TreeMapModel was created after the GridModel
   data was loaded ([#1471](https://github.com/xh/hoist-react/issues/1471))
+* Fixed issue where export would break with dynamic header names  
 
 ### 📚 Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ specification currently supported.
 * Fixed issue where JsonInput was not receiving its `model` from context ([#1456](https://github.com/xh/hoist-react/issues/1456))
 * Fixed issue where TreeMap would not be initialized if the TreeMapModel was created after the GridModel
   data was loaded ([#1471](https://github.com/xh/hoist-react/issues/1471))
-* Fixed issue where export would break with dynamic header names  
+* Fixed issue where export would create malformed file with dynamic header names  
 
 ### 📚 Libraries
 

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -205,6 +205,7 @@ export class Column {
             me = this,
             ret = {
                 field,
+                colId: this.colId,
                 headerValueGetter: (agParams) => {
                     return agParams.location === 'header' ?
                         isFunction(headerName) ? headerName({column: this, gridModel, agParams}) : headerName :

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -182,7 +182,7 @@ export class Column {
         this.excludeFromChooser = withDefault(excludeFromChooser, false);
         this.hideable = withDefault(hideable, !this.isTreeColumn);
 
-        this.exportName = exportName || this.headerName || this.colId;
+        this.exportName = exportName || (isFunction(this.headerName) ? null : this.headerName) || this.colId;
         this.exportValue = exportValue;
         this.exportFormat = withDefault(exportFormat, ExportFormat.DEFAULT);
         this.exportWidth = exportWidth || null;

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -182,7 +182,11 @@ export class Column {
         this.excludeFromChooser = withDefault(excludeFromChooser, false);
         this.hideable = withDefault(hideable, !this.isTreeColumn);
 
-        this.exportName = exportName || (isFunction(this.headerName) ? null : this.headerName) || this.colId;
+        warnIf(
+            !exportName && headerName && !isString(headerName),
+            `Using dynamic header name for export on column with ID ${this.colId}.`
+        );
+        this.exportName = exportName || this.headerName || this.colId;
         this.exportValue = exportValue;
         this.exportFormat = withDefault(exportFormat, ExportFormat.DEFAULT);
         this.exportWidth = exportWidth || null;
@@ -201,7 +205,6 @@ export class Column {
             me = this,
             ret = {
                 field,
-                colId: this.colId,
                 headerValueGetter: (agParams) => {
                     return agParams.location === 'header' ?
                         isFunction(headerName) ? headerName({column: this, gridModel, agParams}) : headerName :

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -182,10 +182,6 @@ export class Column {
         this.excludeFromChooser = withDefault(excludeFromChooser, false);
         this.hideable = withDefault(hideable, !this.isTreeColumn);
 
-        warnIf(
-            !exportName && headerName && !isString(headerName),
-            `Using dynamic header name for export on column with ID ${this.colId}.`
-        );
         this.exportName = exportName || this.headerName || this.colId;
         this.exportValue = exportValue;
         this.exportFormat = withDefault(exportFormat, ExportFormat.DEFAULT);

--- a/svc/GridExportService.js
+++ b/svc/GridExportService.js
@@ -142,11 +142,9 @@ export class GridExportService {
 
     getHeaderRow(columns, type, gridModel) {
         const headers = columns.map(it => {
-            if (isString(it.exportName)) {
-                return it.exportName;
-            } else {
-                return it.exportName({column: it, gridModel});
-            }
+            isString(it.exportName) ?
+                it.exportName :
+                it.exportName({column: it, gridModel});
         });
         if (type === 'excelTable' && uniq(headers).length !== headers.length) {
             console.warn('Excel tables require unique headers on each column. Consider using the "exportName" property to ensure unique headers.');

--- a/svc/GridExportService.js
+++ b/svc/GridExportService.js
@@ -141,11 +141,11 @@ export class GridExportService {
     }
 
     getHeaderRow(columns, type, gridModel) {
-        const headers = columns.map(it => {
+        const headers = columns.map(it =>
             isString(it.exportName) ?
                 it.exportName :
-                it.exportName({column: it, gridModel});
-        });
+                it.exportName({column: it, gridModel})
+        );
         if (type === 'excelTable' && uniq(headers).length !== headers.length) {
             console.warn('Excel tables require unique headers on each column. Consider using the "exportName" property to ensure unique headers.');
         }

--- a/svc/GridExportService.js
+++ b/svc/GridExportService.js
@@ -55,7 +55,7 @@ export class GridExportService {
             return;
         }
 
-        rows.push(this.getHeaderRow(exportColumns, type));
+        rows.push(this.getHeaderRow(exportColumns, type, gridModel));
         rows.push(...this.getRecordRowsRecursive(gridModel, records, exportColumns, 0));
 
         // Show separate 'started' and 'complete' toasts for larger (i.e. slower) exports.
@@ -140,8 +140,14 @@ export class GridExportService {
         });
     }
 
-    getHeaderRow(columns, type) {
-        const headers = columns.map(it => it.exportName);
+    getHeaderRow(columns, type, gridModel) {
+        const headers = columns.map(it => {
+            if (isString(it.exportName)) {
+                return it.exportName;
+            } else {
+                return it.exportName({column: it, gridModel});
+            }
+        });
         if (type === 'excelTable' && uniq(headers).length !== headers.length) {
             console.warn('Excel tables require unique headers on each column. Consider using the "exportName" property to ensure unique headers.');
         }


### PR DESCRIPTION
The export system should now handle dynamic header names. The export system will save the headerName as it appears at export.

We issue a warning when creating a column with dynamic headers and no exportName specified, since exporting dynamic header names is probably a mistake most of the time.

Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or open as a draft PR / add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [x] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [x] Reviewed and tested on Mobile (or N/A)
- [x] Created Toolbox branch / PR (link provided here, or N/A)
https://github.com/xh/toolbox/pull/306

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

