### PR TITLE
Allow buttons in mobile ButtonGroupInput to be individually disabled

### DIFF
--- a/mobile/cmp/input/ButtonGroupInput.js
+++ b/mobile/cmp/input/ButtonGroupInput.js
@@ -11,6 +11,7 @@ import {Button, buttonGroup} from '@xh/hoist/mobile/cmp/button';
 import {throwIf, withDefault} from '@xh/hoist/utils/js';
 import {HoistInput} from '@xh/hoist/cmp/input';
 import {castArray} from 'lodash';
+import PT from 'prop-types';
 
 import './ButtonGroupInput.scss';
 
@@ -26,25 +27,39 @@ import './ButtonGroupInput.scss';
 export class ButtonGroupInput extends HoistInput {
 
     static propTypes = {
-        ...HoistInput.propTypes
+        ...HoistInput.propTypes,
+
+        /** True to allow buttons to be unselected (aka inactivated). Defaults to false. */
+        enableClear: PT.bool
     };
 
     baseClassName = 'xh-button-group-input';
 
     render() {
-        const {children, disabled, ...rest} = this.getNonLayoutProps(),
-            buttons = castArray(children).map(button => {
-                const {value} = button.props;
+        const {children, disabled, enableClear, ...rest} = this.getNonLayoutProps();
 
-                throwIf(button.type !== Button, 'ButtonGroupInput child must be a Button.');
-                throwIf(!value, 'ButtonGroupInput child must declare a value');
+        const buttons = castArray(children).map(button => {
+            if (!button) return null;
 
-                return React.cloneElement(button, {
-                    active: this.renderValue == value,
-                    disabled: withDefault(disabled, false),
-                    onClick: () => this.noteValueChange(value)
-                });
+            const {value} = button.props,
+                btnDisabled = disabled || button.props.disabled;
+
+            throwIf(button.type !== Button, 'ButtonGroupInput child must be a Button.');
+            throwIf(value == null, 'ButtonGroupInput child must declare a non-null value');
+
+            const active = (this.renderValue === value);
+            return React.cloneElement(button, {
+                active,
+                disabled: withDefault(btnDisabled, false),
+                onClick: () => {
+                    if (enableClear) {
+                        this.noteValueChange(active ? null : value);
+                    } else {
+                        this.noteValueChange(value);
+                    }
+                }
             });
+        });
 
         return buttonGroup({
             items: buttons,


### PR DESCRIPTION
Fixes #1486

Also add `enableClear` prop to mobile ButtonGroupInput, and generally brings it inline with the desktop version.

Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [X] Up to date with `develop` branch as of last change.
- [X] Ready for review (or open as a draft PR / add `wip` label).
- [X] Added CHANGELOG entry (or N/A)
- [X] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [X] Updated doc comments / prop-types (or N/A)
- [X] Reviewed and tested on Mobile (or N/A)
- [N/A] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

