### PR TITLE
Handle undefined xhColumn reference in ColumnHeader (Fixes #1520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
   ([#1498](https://github.com/xh/hoist-react/issues/1498))
 * Changed RestGrid to only display export button if export is enabled
   ([#1490](https://github.com/xh/hoist-react/issues/1490))
+* Fixed errors when grouping rows in Grids with `groupUseEntireRow` turned off
+  ([#1520](https://github.com/xh/hoist-react/issues/1520))
 
 ### 📚 Libraries
 

--- a/cmp/grid/impl/ColumnHeader.js
+++ b/cmp/grid/impl/ColumnHeader.js
@@ -5,13 +5,13 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 
-import {hoistCmp, useLocalModel, HoistModel} from '@xh/hoist/core';
-import {Icon} from '@xh/hoist/icon';
-import {createObservableRef} from '@xh/hoist/utils/react';
 import {div, span} from '@xh/hoist/cmp/layout';
+import {hoistCmp, HoistModel, useLocalModel} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
 import {bindable, computed} from '@xh/hoist/mobx';
-import {clone, isFunction, remove} from 'lodash';
+import {createObservableRef} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
+import {clone, isFunction, remove} from 'lodash';
 
 /**
  * A custom ag-Grid header component.
@@ -64,7 +64,7 @@ export const ColumnHeader = hoistCmp({
         ];
 
         let headerName = props.displayName;
-        if (isFunction(impl.xhColumn.headerName)) {
+        if (impl.xhColumn && isFunction(impl.xhColumn.headerName)) {
             const {xhColumn, gridModel} = impl;
             headerName = xhColumn.headerName({column: xhColumn, gridModel});
         }
@@ -85,7 +85,6 @@ export const ColumnHeader = hoistCmp({
 
 @HoistModel
 class LocalModel {
-
     gridModel;
     xhColumn;
     agColumn;


### PR DESCRIPTION
Fix for #1520 

Decided to just fix this specific issue introduced with the recent dynamic header name support, there are other issues with auto-group column support in our ColumnHeader component which are non-trivial to address (see #1521)


Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or open as a draft PR / add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [x] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [N/A] Reviewed and tested on Mobile (or N/A)
- [N/A] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

