### PR TITLE
DashContainer sizing improvements

### DIFF
--- a/desktop/cmp/dash/DashContainer.js
+++ b/desktop/cmp/dash/DashContainer.js
@@ -30,7 +30,7 @@ export const [DashContainer, dashContainer] = hoistCmp.withFactory({
         const modelLookupContext = useContext(ModelLookupContext);
         useOnMount(() => model.setModelLookupContext(modelLookupContext));
 
-        // Get container ref for GoldenLayouts resize handling
+        // Get container ref for GoldenLayout resize handling
         const ref = useOnResize(() => model.onResize(), 100, model.containerRef);
 
         return frame(

--- a/desktop/cmp/dash/DashContainerModel.js
+++ b/desktop/cmp/dash/DashContainerModel.js
@@ -31,9 +31,9 @@ import {convertGLToState, convertStateToGL, getTabModelId} from './impl/DashCont
  * Note that loading state will destroy and reinitialize all components. Therefore,
  * it is recommended you do so sparingly.
  *
- * We differ from GoldenLayouts by offering a new type `view`. These should be configured as
+ * We differ from GoldenLayout by offering a new type `view`. These should be configured as
  * id references to the provided DashViewSpec, e.g. {type: `view`, id: ViewSpec.id}. These should
- * be used instead of the `component` and `react-component` types provided by GoldenLayouts.
+ * be used instead of the `component` and `react-component` types provided by GoldenLayout.
  *
  * e.g.
  *
@@ -125,7 +125,7 @@ export class DashContainerModel {
         ensureUniqueBy(viewSpecs, 'id');
         this.viewSpecs = viewSpecs.map(cfg => new DashViewSpec(cfg));
 
-        // Initialize GoldenLayouts with initial state once ref is ready
+        // Initialize GoldenLayout with initial state once ref is ready
         this.addReaction({
             when: () => this.containerRef.current,
             run: () => this.loadStateAsync(initialState)
@@ -150,7 +150,7 @@ export class DashContainerModel {
         return start(() => {
             this.destroyGoldenLayout();
 
-            // Recreate GoldenLayouts with state
+            // Create new GoldenLayout instance with state
             const goldenLayout = new GoldenLayout({
                 content: convertStateToGL(state, this.viewSpecs),
                 settings: {
@@ -211,7 +211,7 @@ export class DashContainerModel {
         throwIf(viewSpec.unique && instances.length, `Trying to add multiple instance of a DashViewSpec flagged "unique". id=${id}`);
 
         if (!container) container = goldenLayout.root.contentItems[0];
-        container.addChild(viewSpec.goldenLayoutsConfig);
+        container.addChild(viewSpec.goldenLayoutConfig);
     }
 
     //------------------------

--- a/desktop/cmp/dash/DashContainerModel.js
+++ b/desktop/cmp/dash/DashContainerModel.js
@@ -12,7 +12,7 @@ import {PendingTaskModel} from '@xh/hoist/utils/async';
 import {createObservableRef} from '@xh/hoist/utils/react';
 import {ensureUniqueBy, throwIf, debounced, withDefault} from '@xh/hoist/utils/js';
 import {start} from '@xh/hoist/promise';
-import {isEmpty} from 'lodash';
+import {isEmpty, cloneDeep} from 'lodash';
 
 import {DashViewSpec} from './DashViewSpec';
 import {dashTab} from './impl/DashTab';
@@ -42,6 +42,7 @@ import {convertGLToState, convertStateToGL, getTabModelId} from './impl/DashCont
  *     contents: [
  *         {
  *             type: 'stack',
+ *             width: '200px',
  *             contents: [
  *                 {type: 'view', id: 'viewId'},
  *                 {type: 'view', id: 'viewId'}
@@ -50,6 +51,7 @@ import {convertGLToState, convertStateToGL, getTabModelId} from './impl/DashCont
  *         {
  *             type: 'column',
  *             contents: [
+ *                 {type: 'view', id: 'viewId', height: 40},
  *                 {type: 'view', id: 'viewId'}
  *             ]
  *         }
@@ -152,7 +154,7 @@ export class DashContainerModel {
 
             // Create new GoldenLayout instance with state
             const goldenLayout = new GoldenLayout({
-                content: convertStateToGL(state, this.viewSpecs),
+                content: convertStateToGL(cloneDeep(state), this),
                 settings: {
                     // Remove icons by default
                     showPopoutIcon: false,

--- a/desktop/cmp/dash/DashViewSpec.js
+++ b/desktop/cmp/dash/DashViewSpec.js
@@ -24,7 +24,7 @@ export class DashViewSpec {
     renderMode;
     refreshMode;
 
-    get goldenLayoutsConfig() {
+    get goldenLayoutConfig() {
         const {id, title, allowClose} = this;
         return {
             component: id,

--- a/desktop/cmp/dash/impl/DashContainerUtils.js
+++ b/desktop/cmp/dash/impl/DashContainerUtils.js
@@ -4,8 +4,16 @@
  *
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
-import {isEmpty, isFinite, isArray, isPlainObject} from 'lodash';
 import {throwIf} from '@xh/hoist/utils/js';
+import {isEmpty, isFinite, isArray, isPlainObject, isNil, isString} from 'lodash';
+
+/**
+ * Lookup the DashTabModel id of a rendered view
+ */
+export function getTabModelId(view) {
+    if (!view || !view.isInitialised || !view.isComponent) return;
+    return view.instance?._reactComponent?.props?.id;
+}
 
 /**
  * Convert the output from Golden Layouts into our serializable state
@@ -51,9 +59,24 @@ function convertGLToStateInner(configItems = [], contentItems = [], viewState) {
 /**
  * Convert our serializable state into GoldenLayout config
  */
-export function convertStateToGL(state = [], viewSpecs = []) {
-    return state.map(item => {
-        const {type} = item;
+export function convertStateToGL(state = [], dashContainerModel) {
+    const {viewSpecs, containerRef} = dashContainerModel,
+        containerSize = {
+            width: containerRef.current.offsetWidth,
+            height: containerRef.current.offsetHeight
+        };
+
+    return convertStateToGLInner(state, viewSpecs, containerSize);
+}
+
+function convertStateToGLInner(items = [], viewSpecs = [], containerSize, containerItem) {
+    // If placed in a row or column, size its content according to its container
+    const dimension = getContainerDimension(containerItem?.type);
+    if (dimension) items = sizeItemsToContainer(items, containerSize, dimension);
+
+    // Convert each item into a GoldenLayout config
+    return items.map(item => {
+        const {type, width, height} = item;
 
         throwIf(type === 'component' || type === 'react-component',
             'Trying to use "component" or "react-component" types. Use type="view" instead.'
@@ -67,25 +90,67 @@ export function convertStateToGL(state = [], viewSpecs = []) {
                 return {type: 'row'};
             }
 
-            const ret = viewSpec.goldenLayoutConfig,
-                {state, width, height} = item;
+            const ret = viewSpec.goldenLayoutConfig;
 
-            if (isPlainObject(state)) ret.state = state;
+            if (isPlainObject(item.state)) ret.state = item.state;
             if (isFinite(width)) ret.width = width;
             if (isFinite(height)) ret.height = height;
 
             return ret;
         } else {
-            const content = convertStateToGL(item.content, viewSpecs);
+            const itemSize = {...containerSize};
+
+            if (dimension) {
+                itemSize[dimension] = relativeSizeToPixels(item[dimension], containerSize[dimension]);
+            }
+
+            const content = convertStateToGLInner(item.content, viewSpecs, itemSize, item);
             return {...item, content};
         }
     });
 }
 
-/**
- * Lookup the DashTabModel id of a rendered view
- */
-export function getTabModelId(view) {
-    if (!view || !view.isInitialised || !view.isComponent) return;
-    return view.instance?._reactComponent?.props?.id;
+function sizeItemsToContainer(items, containerSize, dimension) {
+    const unsizedItems = [];
+    let totalSize = 0;
+    items.forEach(item => {
+        // If this item is unsized, keep track of it for later
+        if (isNil(item[dimension])) {
+            unsizedItems.push(item);
+            return;
+        }
+
+        //  GoldenLayout deals exclusively with relative sizes. If the size
+        //  is defined in pixels, we must convert it to a relative size.
+        //  We can use the containerSize to do so.
+        if (isString(item[dimension]) && item[dimension].endsWith('px')) {
+            const intSize = parseInt(item[dimension]);
+            item[dimension] = pixelsToRelativeSize(intSize, containerSize[dimension]);
+        }
+
+        totalSize += item[dimension];
+    });
+
+    // Insert an explicit size on any unsized items, by equally dividing the remaining size
+    const remainingSize = 100 - totalSize;
+    unsizedItems.forEach(item => {
+        item[dimension] = (remainingSize / unsizedItems.length);
+    });
+
+    return items;
+}
+
+function getContainerDimension(type) {
+    if (type === 'row') return 'width';
+    if (type === 'column') return 'height';
+    return null;
+}
+
+function pixelsToRelativeSize(pixelSize, containerSize) {
+    const borderSize = 3;
+    return ((pixelSize + borderSize) / containerSize) * 100;
+}
+
+function relativeSizeToPixels(relSize, containerSize) {
+    return (containerSize / 100) * relSize;
 }

--- a/desktop/cmp/dash/impl/DashContainerUtils.js
+++ b/desktop/cmp/dash/impl/DashContainerUtils.js
@@ -4,7 +4,7 @@
  *
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
-import {isEmpty, isFinite, isArray} from 'lodash';
+import {isEmpty, isFinite, isArray, isPlainObject} from 'lodash';
 import {throwIf} from '@xh/hoist/utils/js';
 
 /**
@@ -49,7 +49,7 @@ function convertGLToStateInner(configItems = [], contentItems = [], viewState) {
 }
 
 /**
- * Convert our serializable state into GoldenLayouts config
+ * Convert our serializable state into GoldenLayout config
  */
 export function convertStateToGL(state = [], viewSpecs = []) {
     return state.map(item => {
@@ -61,13 +61,18 @@ export function convertStateToGL(state = [], viewSpecs = []) {
 
         if (type === 'view') {
             const viewSpec = viewSpecs.find(v => v.id === item.id);
+
             if (!viewSpec) {
                 console.warn(`Attempting to load unrecognised view "${item.id}" from state`);
                 return {type: 'row'};
             }
 
-            const ret = viewSpec.goldenLayoutsConfig;
-            if (item.state) ret.state = item.state;
+            const ret = viewSpec.goldenLayoutConfig,
+                {state, width, height} = item;
+
+            if (isPlainObject(state)) ret.state = state;
+            if (isFinite(width)) ret.width = width;
+            if (isFinite(height)) ret.height = height;
 
             return ret;
         } else {

--- a/desktop/cmp/dash/impl/DashTabModel.js
+++ b/desktop/cmp/dash/impl/DashTabModel.js
@@ -48,7 +48,7 @@ export class DashTabModel {
     }
 
     /**
-     * @param {string} id - Typically created by GoldenLayouts.
+     * @param {string} id - Typically created by GoldenLayout.
      * @param {DashViewSpec} viewSpec - DashViewSpec used to create this DashTab.
      * @param {DashContainerModel} containerModel - parent DashContainerModel. Provided by the
      *      container when constructing these models - no need to specify manually.

--- a/kit/golden-layout/styles.scss
+++ b/kit/golden-layout/styles.scss
@@ -42,7 +42,7 @@
       }
 
       svg {
-        margin-right: var(--xh-pad-half-px);
+        margin-right: 6px;
         font-size: 12px;
         color: var(--xh-text-color);
       }


### PR DESCRIPTION
Tweaks to how DashContainer interprets sizes specified in state:

+ You can specify sizes on views directly, without having to wrap it in a sized stack. This is default GoldenLayout behaviour that was lost in our implementation.
+ You can specify sizes in pixels. We use the dimensions of containers to convert this into a relative size at the moment the state is applied.

Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or open as a draft PR / add `wip` label).
- [N/A] Added CHANGELOG entry (or N/A)
- [x] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [N/A] Reviewed and tested on Mobile (or N/A)
- [N/A] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

