### PR TITLE
Placeholder text color

### DIFF
--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -241,6 +241,11 @@ textarea.bp3-input,
   color: var(--xh-input-text-color);
   background: var(--xh-input-bg);
   font-size: var(--xh-font-size);
+
+  &::placeholder {
+    color: var(--xh-input-placeholder-text-color);
+    opacity: 1;
+  }
 }
 
 // Expose CSS var for box-shadow tweaking

--- a/kit/onsen/styles.scss
+++ b/kit/onsen/styles.scss
@@ -6,6 +6,7 @@
   textarea {
     font-size: var(--xh-font-size);
     font-family: var(--xh-font-family);
+    font-weight: 400;
     color: var(--xh-text-color);
     border: none !important;
     outline: none !important;
@@ -13,6 +14,7 @@
 
     &::placeholder {
       color: var(--xh-input-placeholder-text-color);
+      opacity: 1;
     }
   }
 

--- a/styles/XH.scss
+++ b/styles/XH.scss
@@ -33,10 +33,6 @@ body.xh-app {
     height: 10px;
   }
 
-  ::-webkit-input-placeholder {
-    color: var(--xh-input-placeholder-text-color);
-  }
-
   ::-webkit-scrollbar-corner {
     background-color: var(--xh-scrollbar-bg);
   }


### PR DESCRIPTION
Use `--xh-input-placeholder-text-color` for input placeholders consistently across light / dark theme & desktop / mobile. Fixes #1516

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

