### PR TITLE
Tighten/Clean-up handling of 'content' param in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ Note the following more specific changes to these related classes:
   impersonate other users. Note that this defaults to `false`. Apps will need to set this config to
   continue using impersonation. (Note that an update to hoist-core 6.4+ is required for this config
   to be enforced on the server.)
-
+  
 ### 💥 Breaking Changes
 
 * The `GridModel.contextMenuFn` parameter has been replaced with a `contextMenu` parameter. The new
@@ -109,6 +109,10 @@ Note the following more specific changes to these related classes:
 * `TabRenderMode` and `TabRefreshMode` have been renamed to `RenderMode` and `RefreshMode` and moved
   to the `core` package. These enumerations are now used in the APIs for `Panel`, `TabContainer`,
   and `DashContainer`.
+* `DockViewModel` now requires a function, or a HoistComponent as its `content` param.  It has always 
+  been documented this way, but a bug in the original implementation had it accepting an actual 
+  element rather than a function.  As now implemented, the form of the `content` param is 
+  consistent across `TabModel`, `DockViewModel`, and `DashViewSpec`.   
 
 ### 🐞 Bug Fixes
 

--- a/cmp/dock/DockViewModel.js
+++ b/cmp/dock/DockViewModel.js
@@ -36,8 +36,8 @@ export class DockViewModel {
      *      container when constructing these models - no need to specify manually.
      * @param {string} [c.title] - Title text added to the header.
      * @param {Icon} [c.icon] - An icon placed at the left-side of the header.
-     * @param {Object} c.content - content to be rendered by this DockedView. Component class or a
-     *      custom element factory of the form returned by elemFactory.
+     * @param {(Object|function)} c.content - content to be rendered by this DockedView.
+     *      HoistComponent or a function returning a react element.
      * @param {boolean} [c.docked] - true (default) to initialise in dock, false to use Dialog.
      *      Respects allowDialog.
      * @param {boolean} [c.collapsed] - true to initialise collapsed, false (default) for expanded.

--- a/desktop/cmp/dash/DashViewSpec.js
+++ b/desktop/cmp/dash/DashViewSpec.js
@@ -26,8 +26,8 @@ export class DashViewSpec {
 
     /**
      * @param {string} id - unique identifier of the DashViewSpec
-     * @param {Object} content - content to be rendered by the DashTab. Component class or a
-     *      custom element factory of the form returned by elemFactory.
+    * @param {(Object|function)} c.content - content to be rendered by this DashView.
+     *      HoistComponent or a function returning a react element.
      * @param {string} title - Title text added to the tab header.
      * @param {Icon} [icon] - An icon placed at the left-side of the tab header.
      * @param {boolean} [unique] - true to prevent multiple instances of this view. Default false.

--- a/desktop/cmp/dash/impl/DashView.js
+++ b/desktop/cmp/dash/impl/DashView.js
@@ -4,8 +4,9 @@
  *
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
-import React, {useRef} from 'react';
-import {elem, hoistCmp, uses, ModelPublishMode, RenderMode} from '@xh/hoist/core';
+import {useRef} from 'react';
+import {elementFromContent} from '@xh/hoist/utils/react';
+import {hoistCmp, uses, ModelPublishMode, RenderMode} from '@xh/hoist/core';
 import {modelLookupContextProvider} from '@xh/hoist/core/impl';
 import {refreshContextView} from '@xh/hoist/core/refresh';
 import {frame} from '@xh/hoist/cmp/layout';
@@ -46,17 +47,13 @@ export const dashView = hoistCmp.factory({
             return null;
         }
 
-        const {content} = viewSpec;
-        let contentElem = content.isHoistComponent ? elem(content) : content();
-        contentElem = React.cloneElement(contentElem, {flex: 1, viewModel: model});
-
         return modelLookupContextProvider({
             value: model.containerModel.modelLookupContext,
             item: frame({
                 className,
                 item: refreshContextView({
                     model: refreshContextModel,
-                    item: contentElem
+                    item: elementFromContent(viewSpec.content, {flex: 1, viewModel: model})
                 })
             })
         });

--- a/desktop/cmp/dock/impl/DockView.js
+++ b/desktop/cmp/dock/impl/DockView.js
@@ -4,9 +4,9 @@
  *
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
-import {isValidElement} from 'react';
-import {elem, hoistCmp, uses} from '@xh/hoist/core';
+import {hoistCmp, uses} from '@xh/hoist/core';
 import {div, hbox, vbox, span, filler} from '@xh/hoist/cmp/layout';
+import {elementFromContent} from '@xh/hoist/utils/react';
 import {dialog} from '@xh/hoist/kit/blueprint';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
@@ -28,11 +28,14 @@ export const dockView = hoistCmp.factory({
     render({model, className, compactHeaders}) {
         const {collapsed, docked} = model;
 
+        const header = headerCmp({compactHeaders}),
+            body = div({className: 'xh-dock-view__body', item: elementFromContent(model.content)});
+
         // 1) Render docked
         if (collapsed || docked) {
             return vbox({
                 className: classNames(className, collapsed ? 'xh-dock-view--collapsed' : null),
-                items: [header({compactHeaders}), body()]
+                items: [header, body]
             });
         }
 
@@ -42,13 +45,13 @@ export const dockView = hoistCmp.factory({
             isOpen: true,
             onClose: () => model.onClose(),
             canOutsideClickClose: false,
-            items: [header({compactHeaders}), body()]
+            items: [header, body]
         });
     }
 });
 
 
-const header = hoistCmp.factory(
+const headerCmp = hoistCmp.factory(
     ({model, compactHeaders}) => {
         const {icon, title, collapsed, docked, allowClose, allowDialog} = model;
 
@@ -84,18 +87,5 @@ const header = hoistCmp.factory(
                 })
             ]
         });
-    }
-);
-
-const body = hoistCmp.factory(
-    ({model}) => {
-        let {content} = model,
-            contentEl = content.isHoistComponent ? elem(content) : content;
-        if (!isValidElement(contentEl)) {
-            console.error("Please specify a React element, or a Component for the 'content' of a DockedView");
-            contentEl = null;
-        }
-
-        return div({className: 'xh-dock-view__body', item: contentEl});
     }
 );

--- a/desktop/cmp/tab/impl/Tab.js
+++ b/desktop/cmp/tab/impl/Tab.js
@@ -5,10 +5,11 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 import {useRef} from 'react';
-import {elem, hoistCmp, uses, ModelPublishMode, RenderMode} from '@xh/hoist/core';
+import {hoistCmp, uses, ModelPublishMode, RenderMode} from '@xh/hoist/core';
 import {refreshContextView} from '@xh/hoist/core/refresh';
 import {frame} from '@xh/hoist/cmp/layout';
 import {TabModel} from '@xh/hoist/cmp/tab';
+import {elementFromContent} from '@xh/hoist/utils/react';
 
 /**
  * Wrapper for contents to be shown within a TabContainer. This Component is used by TabContainer's
@@ -41,14 +42,12 @@ export const tab = hoistCmp.factory({
             return null;
         }
 
-        const contentElem = content.isHoistComponent ? elem(content, {flex: 1}) : content();
-
         return frame({
             display: isActive ? 'flex' : 'none',
             className,
             item: refreshContextView({
                 model: refreshContextModel,
-                item: contentElem
+                item: elementFromContent(content, {flex: 1})
             })
         });
     }

--- a/mobile/cmp/tab/impl/Tab.js
+++ b/mobile/cmp/tab/impl/Tab.js
@@ -4,8 +4,9 @@
  *
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
+import {elementFromContent} from '@xh/hoist/utils/react';
 import {useRef} from 'react';
-import {elem, hoistCmp, ModelPublishMode, RenderMode, uses} from '@xh/hoist/core';
+import {hoistCmp, ModelPublishMode, RenderMode, uses} from '@xh/hoist/core';
 import {refreshContextView} from '@xh/hoist/core/refresh';
 import {page as onsenPage} from '@xh/hoist/kit/onsen';
 
@@ -40,11 +41,10 @@ export const tab = hoistCmp.factory({
             // Note: We must render an empty placeholder Onsen page to work with Onsen's tabbar.
             return onsenPage();
         }
-        const contentElem = content.isHoistComponent ? elem(content) : content();
 
         return refreshContextView({
             model: refreshContextModel,
-            item: contentElem
+            item: elementFromContent(content)
         });
     }
 });

--- a/utils/react/ReactUtils.js
+++ b/utils/react/ReactUtils.js
@@ -8,21 +8,24 @@
 import {isValidElement, createElement, cloneElement} from 'react';
 import {throwIf} from '../js';
 
+/**
+ * Return the display name for either a class-based or functional Component.
+ * @param obj
+ * @return {string}
+ */
 export function getReactElementName(obj) {
-    return obj.type.name || obj.type.displayName;  // Support for class-based and functional cmps, respectively
+    return obj.type.name || obj.type.displayName;
 }
 
 /**
- * Create a react element from either a HoistComponent, or a function returning an element.
+ * Create a React element from either a HoistComponent or a function returning an element.
  *
- * Used by the TabContainer, DashContainer, and DockView APIs to process the application
- * 'content' parameters provided to them for their tabs and views.
+ * Used by the TabContainer, DashContainer, and DockView APIs to process the 'content' configs
+ * provided to them for their tabs and views.
  *
- * @param {(Object|function)} content - HoistComponent or function returning a React element.  If a
- *      function, it may be an 'elemFactory' (as created by elemFactory()), or simply any
- *      function that returns a valid react element.  In any case, the function will be called
- *      with no arguments.
- *
+ * @param {(Object|function)} content - HoistComponent or function returning a React element. If a
+ *      function, it may be an 'elemFactory' (as created by elemFactory()), or any function that
+ *      returns a React element. In either case, the function will be called with no arguments.
  * @param {Object} [addProps] -- optional additional props to apply to the element.
  *      These will override any existing props placed on the element, and should be used with care.
  */
@@ -35,7 +38,7 @@ export function elementFromContent(content, addProps) {
 
     const ret = content();
     throwIf(!isValidElement(ret),
-        'Must specify either a HoistComponent or a function that returns a valid React Element.'
+        'Must specify either a HoistComponent or a function that returns a React Element.'
     );
     return addProps ? cloneElement(ret, addProps) : ret;
 }

--- a/utils/react/ReactUtils.js
+++ b/utils/react/ReactUtils.js
@@ -5,6 +5,37 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 
+import {isValidElement, createElement, cloneElement} from 'react';
+import {throwIf} from '../js';
+
 export function getReactElementName(obj) {
     return obj.type.name || obj.type.displayName;  // Support for class-based and functional cmps, respectively
+}
+
+/**
+ * Create a react element from either a HoistComponent, or a function returning an element.
+ *
+ * Used by the TabContainer, DashContainer, and DockView APIs to process the application
+ * 'content' parameters provided to them for their tabs and views.
+ *
+ * @param {(Object|function)} content - HoistComponent or function returning a React element.  If a
+ *      function, it may be an 'elemFactory' (as created by elemFactory()), or simply any
+ *      function that returns a valid react element.  In any case, the function will be called
+ *      with no arguments.
+ *
+ * @param {Object} [addProps] -- optional additional props to apply to the element.
+ *      These will override any existing props placed on the element, and should be used with care.
+ */
+export function elementFromContent(content, addProps) {
+
+    // Note: Would be more general to look for a *react* component.
+    if (content.isHoistComponent) {
+        return createElement(content, addProps);
+    }
+
+    const ret = content();
+    throwIf(!isValidElement(ret),
+        'Must specify either a HoistComponent or a function that returns a valid React Element.'
+    );
+    return addProps ? cloneElement(ret, addProps) : ret;
 }


### PR DESCRIPTION
+ Make content arg consistent across tab/dock/dash containers
+ Apply additional props consistently regardless of how content specified
+ DRY for all implementations

Fixes: https://github.com/xh/hoist-react/issues/1537
Toolbox PR:  https://github.com/xh/toolbox/pull/325

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

