### PR TITLE
Don't swallow exceptions thrown by async Select option processing

### DIFF
--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -436,7 +436,8 @@ export class Select extends HoistInput {
 
                 // But only return the matching options back to the combo.
                 return matchOpts;
-            });
+            })
+            .catch(e => console.error(e));
     };
 
     loadingMessageFn = (params) => {

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -437,7 +437,10 @@ export class Select extends HoistInput {
                 // But only return the matching options back to the combo.
                 return matchOpts;
             })
-            .catch(e => console.error(e));
+            .catch(e => {
+                console.error(e);
+                throw e;
+            });
     };
 
     loadingMessageFn = (params) => {


### PR DESCRIPTION
Small change to make sure we log any exceptions in the Select `queryFn` or while processing the options - was at a loss as to why my select wasn't working, turned out I needed to add the `valueField` and `labelField` props, but the exception we throw was being swallowed by higher level code.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [N/A] Added CHANGELOG entry, or determined not required.
- [N/A] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [N/A] Updated doc comments / prop-types, or determined not required.
- [N/A] Reviewed and tested on Mobile, or determined not required.
- [N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

