### PR TITLE
Fix overflow for dash container titles

### DIFF
--- a/desktop/cmp/dash/DashContainerModel.js
+++ b/desktop/cmp/dash/DashContainerModel.js
@@ -353,8 +353,10 @@ export class DashContainerModel {
         $inputEl.blur(() => this.hideTitleForm($el));
         $formEl.submit(() => {
             const title = $inputEl.val();
-            $titleEl.text(title);
-            viewModel.setTitle(title);
+            if (title.length) {
+                $titleEl.text(title);
+                viewModel.setTitle(title);
+            }
 
             this.hideTitleForm($el);
             return false;

--- a/kit/golden-layout/styles.scss
+++ b/kit/golden-layout/styles.scss
@@ -11,6 +11,7 @@
   background: var(--xh-bg-alt);
 
   .lm_header {
+    display: flex;
     background: rgba(0, 0, 0, 0.06);
 
     .xh-dash-container-add-button {
@@ -23,11 +24,23 @@
       }
     }
 
+    .lm_tabs {
+      flex: 1;
+      position: relative;
+      overflow: hidden;
+      margin-bottom: -1px; // Allows vertical overflow of 1px, without scrollbars
+    }
+
+    .lm_controls {
+      position: relative;
+    }
+
     .lm_tab {
       display: flex;
       align-items: center;
       margin: 2px 0 0 2px;
       padding: 4px 8px;
+      max-width: calc(100% - 25px);
       font-family: var(--xh-font-family);
       font-size: var(--xh-font-size-px);
       line-height: 1;
@@ -51,6 +64,10 @@
         margin-left: var(--xh-pad-half-px);
         position: static;
         background-image: inline-svg('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="#999" d="M207.6 256l107.72-107.72c6.23-6.23 6.23-16.34 0-22.58l-25.03-25.03c-6.23-6.23-16.34-6.23-22.58 0L160 208.4 52.28 100.68c-6.23-6.23-16.34-6.23-22.58 0L4.68 125.7c-6.23 6.23-6.23 16.34 0 22.58L112.4 256 4.68 363.72c-6.23 6.23-6.23 16.34 0 22.58l25.03 25.03c6.23 6.23 16.34 6.23 22.58 0L160 303.6l107.72 107.72c6.23 6.23 16.34 6.23 22.58 0l25.03-25.03c6.23-6.23 6.23-16.34 0-22.58L207.6 256z"/></svg>');
+      }
+
+      .lm_title {
+        white-space: nowrap;
       }
 
       .title-form {

--- a/kit/golden-layout/styles.scss
+++ b/kit/golden-layout/styles.scss
@@ -7,6 +7,8 @@
 
 @import '../../styles/helpers';
 
+$add-btn-offset: 25px;
+
 .lm_goldenlayout {
   background: var(--xh-bg-alt);
 
@@ -40,7 +42,7 @@
       align-items: center;
       margin: 2px 0 0 2px;
       padding: 4px 8px;
-      max-width: calc(100% - 25px);
+      max-width: calc(100% - #{$add-btn-offset});
       font-family: var(--xh-font-family);
       font-size: var(--xh-font-size-px);
       line-height: 1;
@@ -64,6 +66,8 @@
         margin-left: var(--xh-pad-half-px);
         position: static;
         background-image: inline-svg('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="#999" d="M207.6 256l107.72-107.72c6.23-6.23 6.23-16.34 0-22.58l-25.03-25.03c-6.23-6.23-16.34-6.23-22.58 0L160 208.4 52.28 100.68c-6.23-6.23-16.34-6.23-22.58 0L4.68 125.7c-6.23 6.23-6.23 16.34 0 22.58L112.4 256 4.68 363.72c-6.23 6.23-6.23 16.34 0 22.58l25.03 25.03c6.23 6.23 16.34 6.23 22.58 0L160 303.6l107.72 107.72c6.23 6.23 16.34 6.23 22.58 0l25.03-25.03c6.23-6.23 6.23-16.34 0-22.58L207.6 256z"/></svg>');
+        width: 11px;
+        min-width: 11px;
       }
 
       .lm_title {
@@ -71,7 +75,7 @@
       }
 
       .title-form {
-        max-width: calc(100% - 25px);
+        max-width: calc(100% - #{$add-btn-offset});
         display: none;
 
         input {

--- a/kit/golden-layout/styles.scss
+++ b/kit/golden-layout/styles.scss
@@ -71,13 +71,17 @@
       }
 
       .title-form {
+        max-width: calc(100% - 25px);
         display: none;
 
         input {
           padding: 2px 0 1px;
           width: 140px;
+          max-width: 100%;
           font-family: var(--xh-font-family);
           font-size: var(--xh-font-size-px);
+          color: var(--xh-text-color);
+          background: none;
           border: 1px solid var(--xh-intent-primary);
           border-width: 0 0 1px;
         }


### PR DESCRIPTION
This was trickier than anticipated to get working without totally breaking GoldenLayout!

Note: GoldenLayout automatically drops out tabs when the container shrinks. To get the undesirable overflow behaviour that prompted this ticket, you need just one tab whose title is wider than its container.

Before:
<img width="529" alt="Screenshot 2020-01-24 at 15 34 02" src="https://user-images.githubusercontent.com/3017757/73081141-fdbdbc80-3ebe-11ea-8da3-f4e411956570.png">

After:
<img width="589" alt="Screenshot 2020-01-24 at 15 32 56" src="https://user-images.githubusercontent.com/3017757/73081054-d4049580-3ebe-11ea-8f2d-2da9efe1ca56.png">

Also includes styling tweaks to the title input to better suit dark mode

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

