### PR TITLE
Allow (app-wide) override of ag-Grid row heights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 # Changelog
 
-## v30.0.0-SNAPSHOT - Unreleased 
+## v30.0.0-SNAPSHOT - Unreleased
 
+### ⚙️ Technical
+
+* The default row heights for Hoist `AgGrid` and `Grid` components are now defined within static
+  `ROW_HEIGHTS` and `ROW_HEIGHTS_MOBILE` properties of the `AgGrid` component and can be modified
+  directly by applications that wish to customize the default row heights globally on init.
+  * 💥 Note that these were previously exported as similar constants from AgGrid.js. This would be
+    a breaking change for any apps that imported the old objects directly (considered unlikely).
+
+[Commit Log](https://github.com/xh/hoist-react/compare/v29.0.0...develop)
 
 ## v29.0.0 - 2020-01-24
 
@@ -176,7 +185,7 @@ Note the following more specific changes to these related classes:
 * react-dropzone `10.1 -> 10.2`
 * react-windowed-select `added @ 2.0.1`
 
-[Commit Log](https://github.com/xh/hoist-react/compare/v28.2.0...develop)
+[Commit Log](https://github.com/xh/hoist-react/compare/v28.2.0...v29.0.0)
 
 ## v28.2.0 - 2019-11-08
 

--- a/cmp/ag-grid/AgGrid.js
+++ b/cmp/ag-grid/AgGrid.js
@@ -33,9 +33,6 @@ import './AgGrid.scss';
  * underlying component not yet supported by the Hoist layer - most notably pivoting - where the
  * managed option would conflict with or complicate access to those features.
  */
-export const AG_ROW_HEIGHTS = {mobile: 34, desktop: 28};
-export const AG_COMPACT_ROW_HEIGHTS = {mobile: 30, desktop: 24};
-
 export const [AgGrid, agGrid] = hoistCmp.withFactory({
     displayName: 'AgGrid',
     className: 'xh-ag-grid',
@@ -82,6 +79,14 @@ export const [AgGrid, agGrid] = hoistCmp.withFactory({
     }
 });
 
+/**
+ * Row heights (in pixels) enumerated here and available for global override if required
+ * by stomping on these values directly. To override for individual grids, supply a custom
+ * `getRowHeight` function as a direct prop to this component, or via `Grid.agOptions`.
+ */
+AgGrid.ROW_HEIGHTS = {standard: 28, compact: 24};
+AgGrid.ROW_HEIGHTS_MOBILE = {standard: 34, compact: 30};
+
 @HoistModel
 class LocalModel {
 
@@ -118,7 +123,7 @@ class LocalModel {
     }
 
     getRowHeight = () => {
-        const heights = this.model.compact ? AG_COMPACT_ROW_HEIGHTS : AG_ROW_HEIGHTS;
-        return XH.isMobile ? heights.mobile : heights.desktop;
+        const heights = XH.isMobile ? AgGrid.ROW_HEIGHTS_MOBILE : AgGrid.ROW_HEIGHTS;
+        return this.model.compact ? heights.compact : heights.standard;
     };
 }

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -4,7 +4,7 @@
  *
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
-import {AG_COMPACT_ROW_HEIGHTS, AG_ROW_HEIGHTS, agGrid} from '@xh/hoist/cmp/ag-grid';
+import {agGrid, AgGrid} from '@xh/hoist/cmp/ag-grid';
 import {fragment, frame} from '@xh/hoist/cmp/layout';
 import {hoistCmp, HoistModel, useLocalModel, uses, XH} from '@xh/hoist/core';
 import {colChooser as desktopColChooser, StoreContextMenu} from '@xh/hoist/dynamics/desktop';
@@ -153,10 +153,11 @@ class LocalModel {
     // The minimum required row height specified by the columns (if any) */
     @computed
     get rowHeight() {
-        const agHeights = this.model.compact ? AG_COMPACT_ROW_HEIGHTS : AG_ROW_HEIGHTS,
-            modelHeight = XH.isMobile ? agHeights.mobile : agHeights.desktop,
-            columnHeight = Math.max(...map(this.model.columns, 'rowHeight').filter(isFinite));
-        return isFinite(columnHeight) ? Math.max(modelHeight, columnHeight) : modelHeight;
+        const platformHeights = XH.isMobile ? AgGrid.ROW_HEIGHTS_MOBILE : AgGrid.ROW_HEIGHTS,
+            gridDefaultHeight = this.model.compact ? platformHeights.compact : platformHeights.standard,
+            maxColHeight = Math.max(...map(this.model.columns, 'rowHeight').filter(isFinite));
+
+        return isFinite(maxColHeight) ? Math.max(gridDefaultHeight, maxColHeight) : gridDefaultHeight;
     }
 
     // Observable stamp incremented every time the ag-Grid receives a new set of data.


### PR DESCRIPTION
+ Define ag-grid row height defaults in static objects off of the `AgGrid` component, making it easier for apps to override globally if required.
+ Fixes #1465

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

