### PR TITLE
Support empty DashContainer state

### DIFF
--- a/desktop/cmp/dash/DashContainerModel.js
+++ b/desktop/cmp/dash/DashContainerModel.js
@@ -196,6 +196,12 @@ export class DashContainerModel {
         const {goldenLayout} = this;
         if (!goldenLayout.isInitialised) return;
 
+        // If the layout becomes completely empty, ensure we have our minimal empty layout
+        if (!goldenLayout.root.contentItems.length) {
+            this.loadStateAsync([]);
+            return;
+        }
+
         this.state = convertGLToState(goldenLayout, this);
 
         // Update tab headers on state change to reflect title/icon changes.

--- a/desktop/cmp/dash/impl/DashContainerUtils.js
+++ b/desktop/cmp/dash/impl/DashContainerUtils.js
@@ -72,7 +72,9 @@ export function convertStateToGL(state = [], dashContainerModel) {
             height: containerRef.current.offsetHeight
         };
 
-    return convertStateToGLInner(state, viewSpecs, containerSize).filter(it => !isNil(it));
+    // Replace any completely empty state with an empty stack, to allow users to add views
+    const ret = convertStateToGLInner(state, viewSpecs, containerSize).filter(it => !isNil(it));
+    return !ret.length ? [{type: 'stack'}] : ret;
 }
 
 function convertStateToGLInner(items = [], viewSpecs = [], containerSize, containerItem) {

--- a/kit/golden-layout/styles.scss
+++ b/kit/golden-layout/styles.scss
@@ -15,6 +15,7 @@ $add-btn-offset: 25px;
   .lm_header {
     display: flex;
     background: rgba(0, 0, 0, 0.06);
+    min-height: 25px;
 
     .xh-dash-container-add-button {
       padding: 5px;


### PR DESCRIPTION
If you remove all views from a DashContainer, you end up with a completely empty view. This means that users are then unable to rebuild their dash, since the add button is in the stack header.

This change ensures that an empty DashContainer always has an empty stack.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

