### PR TITLE
App options enhancement/fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v30.0.0-SNAPSHOT - Unreleased
 
+### 🎁 New Features
+* AppOption configs now accept an `omit` property for excluding options
+
 ### 🐞 Bug Fixes
 
 * Improved up/down keyboard navigation for non-selectable rows.  These rows are now skipped.

--- a/appcontainer/OptionsDialogModel.js
+++ b/appcontainer/OptionsDialogModel.js
@@ -39,7 +39,7 @@ export class OptionsDialogModel {
     // Setting options
     //-------------------
     setOptions(options) {
-        this.options = options.map(o => new AppOption(o));
+        this.options = options.filter(o => !o.omit).map(o => new AppOption(o));
         const fields = this.options.map(o => assign({name: o.name}, o.fieldModel));
         this.formModel = new FormModel({fields});
     }

--- a/core/HoistAppModel.js
+++ b/core/HoistAppModel.js
@@ -52,11 +52,13 @@ export function HoistAppModel(C) {
             },
 
             /**
-             * Provide a list of app-wide options to be displayed in the app's Options Dialog,
-             * accessible from the default AppBar menu when this method returns non-empty.
-             *
-             * @returns {Object[]} - AppOption configs
+             * Provide a list of app-wide options to be displayed in the App's built-in Options
+             * dialog, accessible from the default AppBar menu when this method returns non-empty.
              * @see AppOption
+             *
+             * @returns {Object[]} - AppOption configs. An additional `omit` property is supported
+             *      here that, if true, will skip construction of that particular option and drop
+             *      it out of the Options dialog.
              */
             getAppOptions() {
                 return [];

--- a/desktop/cmp/button/RestoreDefaultsButton.js
+++ b/desktop/cmp/button/RestoreDefaultsButton.js
@@ -21,8 +21,8 @@ export const [RestoreDefaultsButton, restoreDefaultsButton] = hoistCmp.withFacto
     model: false,
 
     render({
-        warningMessage = 'Are you sure you want to restore defaults?',
-        warningTitle = 'All app customizations, including grid customizations, will be restored to their default settings and the app will be reloaded.',
+        warningTitle = 'Are you sure you want to restore defaults?',
+        warningMessage = 'All app customizations, including grid customizations, will be restored to their default settings and the app will be reloaded.',
         ...buttonProps
     }) {
 


### PR DESCRIPTION
Noticed a couple things while setting up app options for a client app:
* We did not have support for an `omit` prop, which is cleaner than using if statements to build the options based on user roles
* The title and message were swapped for the RestoreDefauiltsButton confirm dialog

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [N/A] Reviewed and tested on Mobile, or determined not required.
- [N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

