### PR TITLE
Add support for multiple Grid sizing modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ to review any possible breaking changes to direct/custom use of ag-Grid APIs and
 ### 🎁 New Features
 
 * `AppOption` configs now accept an `omit` property for conditionally excluding options.
+* The `compact` config on `GridModel` has been deprecated in favor of the more powerful `sizingMode`
+  which supports the values 'large', 'standard', 'compact', or 'tiny'
+  * Each of these sizing modes has their own css variables for applications to override as needed
+  * Header and row heights are configurable for each via the `HEADER_HEIGHTS` or `ROW_HEIGHTS`
+    properties of the `AgGrid` component
 
 ### 🐞 Bug Fixes
 

--- a/cmp/ag-grid/AgGrid.js
+++ b/cmp/ag-grid/AgGrid.js
@@ -110,8 +110,11 @@ class LocalModel {
         // Only update header height if was not explicitly provided to the component
         if (isNil(agGridProps.headerHeight)) {
             this.addReaction({
-                track: () => this.model.headerHeight,
-                run: (height) => this.model.agApi.setHeaderHeight(height)
+                track: () => this.model.sizingMode,
+                run: (sizingMode) => {
+                    const headerHeights = XH.isMobile ? AgGrid.HEADER_HEIGHTS_MOBILE : AgGrid.HEADER_HEIGHTS;
+                    this.model.agApi.setHeaderHeight(headerHeights[sizingMode]);
+                }
             });
         }
     }

--- a/cmp/ag-grid/AgGrid.js
+++ b/cmp/ag-grid/AgGrid.js
@@ -40,7 +40,7 @@ export const [AgGrid, agGrid] = hoistCmp.withFactory({
 
     render({model, key, className, onGridReady, onCellContextMenu, ...props}) {
         const [layoutProps, agGridProps] = splitLayoutProps(props),
-            {compact, showHover, rowBorders, stripeRows, cellBorders, showCellFocus} = model,
+            {sizingMode, showHover, rowBorders, stripeRows, cellBorders, showCellFocus} = model,
             {darkTheme, isMobile} = XH;
 
         const impl = useLocalModel(() => new LocalModel(model));
@@ -55,7 +55,7 @@ export const [AgGrid, agGrid] = hoistCmp.withFactory({
             className: classNames(
                 className,
                 darkTheme ? 'ag-theme-balham-dark' : 'ag-theme-balham',
-                compact ? 'xh-ag-grid--compact' : 'xh-ag-grid--standard',
+                `xh-ag-grid--${sizingMode}`,
                 rowBorders ? 'xh-ag-grid--row-borders' : 'xh-ag-grid--no-row-borders',
                 stripeRows ? 'xh-ag-grid--stripe-rows' : 'xh-ag-grid--no-stripe-rows',
                 cellBorders ? 'xh-ag-grid--cell-borders' : 'xh-ag-grid--no-cell-borders',
@@ -67,6 +67,7 @@ export const [AgGrid, agGrid] = hoistCmp.withFactory({
                 // Default some ag-grid props, but allow overriding.
                 getRowHeight: impl.getRowHeight,
                 navigateToNextCell: impl.navigateToNextCell,
+                headerHeight: impl.headerHeight,
 
                 // Pass others on directly.
                 ...agGridProps,
@@ -84,8 +85,14 @@ export const [AgGrid, agGrid] = hoistCmp.withFactory({
  * by stomping on these values directly. To override for individual grids, supply a custom
  * `getRowHeight` function as a direct prop to this component, or via `Grid.agOptions`.
  */
-AgGrid.ROW_HEIGHTS = {standard: 28, compact: 24};
-AgGrid.ROW_HEIGHTS_MOBILE = {standard: 34, compact: 30};
+AgGrid.ROW_HEIGHTS = {large: 32, standard: 28, compact: 24, tiny: 18};
+AgGrid.ROW_HEIGHTS_MOBILE = {large: 38, standard: 34, compact: 30, tiny: 26};
+
+/**
+ * Header heights (in pixels)
+ */
+AgGrid.HEADER_HEIGHTS = {large: 36, standard: 32, compact: 28, tiny: 22};
+AgGrid.HEADER_HEIGHTS_MOBILE = {large: 42, standard: 38, compact: 34, tiny: 30};
 
 @HoistModel
 class LocalModel {
@@ -124,6 +131,6 @@ class LocalModel {
 
     getRowHeight = () => {
         const heights = XH.isMobile ? AgGrid.ROW_HEIGHTS_MOBILE : AgGrid.ROW_HEIGHTS;
-        return this.model.compact ? heights.compact : heights.standard;
+        return heights[this.model.sizingMode];
     };
 }

--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -201,6 +201,32 @@
   }
 
   //------------------------
+  // Large Mode
+  //------------------------
+  &--large {
+    font-size: var(--xh-grid-large-font-size-px);
+
+    .ag-cell-value {
+      line-height: var(--xh-grid-large-line-height-px);
+    }
+
+    .ag-header {
+      font-size: var(--xh-grid-large-font-size-px);
+    }
+
+    .ag-cell {
+      padding-left: var(--xh-grid-large-cell-lr-pad-px);
+      padding-right: var(--xh-grid-large-cell-lr-pad-px);
+    }
+
+    .ag-header-cell,
+    .ag-header-group-cell {
+      padding-left: var(--xh-grid-large-header-lr-pad-px);
+      padding-right: var(--xh-grid-large-header-lr-pad-px);
+    }
+  }
+
+  //------------------------
   // Compact Mode
   //------------------------
   &--compact {
@@ -223,6 +249,32 @@
     .ag-header-group-cell {
       padding-left: var(--xh-grid-compact-header-lr-pad-px);
       padding-right: var(--xh-grid-compact-header-lr-pad-px);
+    }
+  }
+
+  //------------------------
+  // Tiny Mode
+  //------------------------
+  &--tiny {
+    font-size: var(--xh-grid-tiny-font-size-px);
+
+    .ag-cell-value {
+      line-height: var(--xh-grid-tiny-line-height-px);
+    }
+
+    .ag-header {
+      font-size: var(--xh-grid-tiny-font-size-px);
+    }
+
+    .ag-cell {
+      padding-left: var(--xh-grid-tiny-cell-lr-pad-px);
+      padding-right: var(--xh-grid-tiny-cell-lr-pad-px);
+    }
+
+    .ag-header-cell,
+    .ag-header-group-cell {
+      padding-left: var(--xh-grid-tiny-header-lr-pad-px);
+      padding-right: var(--xh-grid-tiny-header-lr-pad-px);
     }
   }
 

--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -153,6 +153,13 @@
   .ag-header-group-cell {
     padding-left: var(--xh-grid-cell-lr-pad-px);
     padding-right: var(--xh-grid-cell-lr-pad-px);
+
+    // Override ag-Grid defaults for the header separator to make it responsive to different header heights
+    &::after {
+      height: 50%;
+      margin-top: unset;
+      top: unset;
+    }
   }
 
   .ag-cell.ag-cell-last-left-pinned:not(.ag-cell-focus) {
@@ -201,7 +208,7 @@
   }
 
   //------------------------
-  // Large Mode
+  // Large Sizing Mode
   //------------------------
   &--large {
     font-size: var(--xh-grid-large-font-size-px);
@@ -227,7 +234,7 @@
   }
 
   //------------------------
-  // Compact Mode
+  // Compact Sizing Mode
   //------------------------
   &--compact {
     font-size: var(--xh-grid-compact-font-size-px);
@@ -253,7 +260,7 @@
   }
 
   //------------------------
-  // Tiny Mode
+  // Tiny Sizing Mode
   //------------------------
   &--tiny {
     font-size: var(--xh-grid-tiny-font-size-px);

--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -77,11 +77,9 @@ export class AgGridModel {
         this.addReaction({
             track: () => this.sizingMode,
             run: () => {
-                if (this.agApi) {
-                    this.agApi.resetRowHeights();
-                    this.agApi.setHeaderHeight(this.headerHeight);
-
-                    // TODO: Do we need to set all of the different type of headers here?
+                const api = this.agApi;
+                if (api) {
+                    api.resetRowHeights();
                 }
             }
         });

--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -63,7 +63,7 @@ export class AgGridModel {
         showCellFocus = false
     } = {}) {
         if (compact) {
-            console.warn('The \'compact\' has been deprecated in favor of the more powerful \'sizingMode\' config.');
+            console.warn('The \'compact\' config has been deprecated in favor of the more powerful \'sizingMode\' config.');
             sizingMode = 'compact';
         }
 

--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -5,11 +5,10 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 
-import {HoistModel, XH} from '@xh/hoist/core';
+import {HoistModel} from '@xh/hoist/core';
 import {action, bindable, observable} from '@xh/hoist/mobx';
 import {cloneDeep, has, isArray, isEmpty, isEqual, isNil, last, set, startCase} from 'lodash';
-import {throwIf} from '../../utils/js';
-import {AgGrid} from './index';
+import {throwIf, warnIf} from '@xh/hoist/utils/js';
 
 /**
  * Model for an AgGrid, provides reactive support for setting grid styling as well as access to the
@@ -55,17 +54,15 @@ export class AgGridModel {
      */
     constructor({
         sizingMode = 'standard',
-        compact = false,
         showHover = false,
         rowBorders = false,
         cellBorders = false,
         stripeRows = true,
-        showCellFocus = false
+        showCellFocus = false,
+        compact
     } = {}) {
-        if (compact) {
-            console.warn('The \'compact\' config has been deprecated in favor of the more powerful \'sizingMode\' config.');
-            sizingMode = 'compact';
-        }
+        warnIf(compact !== undefined, "The 'compact' config has been deprecated. Use 'sizingMode' instead");
+        if (compact) sizingMode = 'compact';
 
         this.sizingMode = sizingMode;
         this.showHover = showHover;
@@ -90,14 +87,6 @@ export class AgGridModel {
      */
     get isReady() {
         return !isNil(this.agApi);
-    }
-
-    /**
-     * @returns {number} - height of the grid headers for the current sizing mode in pixels
-     */
-    get headerHeight() {
-        const headerHeights = XH.isMobile ? AgGrid.HEADER_HEIGHTS_MOBILE : AgGrid.HEADER_HEIGHTS;
-        return headerHeights[this.sizingMode];
     }
 
     /**

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -196,7 +196,6 @@ class LocalModel {
                 menuTabs: ['filterMenuTab']
             },
             popupParent: document.querySelector('body'),
-            headerHeight: props.hideHeaders ? 0 : undefined,
             suppressAggFuncInHeader: true,
             icons: {
                 groupExpanded: convertIconToSvg(
@@ -234,8 +233,13 @@ class LocalModel {
             rememberGroupStateWhenNewData: true, // turning this on by default so group state is maintained when apps are not using deltaRowDataMode
             autoGroupColumnDef: {
                 suppressSizeToFit: true // Without this the auto group col will get shrunk when we size to fit
-            }
+            },
+            autoSizePadding: 3 // allow cells to get a little tighter when autosizing
         };
+
+        if (props.hideHeaders) {
+            ret.headerHeight = 0;
+        }
 
         // Platform specific defaults
         if (XH.isMobile) {

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -154,7 +154,7 @@ class LocalModel {
     @computed
     get rowHeight() {
         const platformHeights = XH.isMobile ? AgGrid.ROW_HEIGHTS_MOBILE : AgGrid.ROW_HEIGHTS,
-            gridDefaultHeight = this.model.compact ? platformHeights.compact : platformHeights.standard,
+            gridDefaultHeight = platformHeights[this.model.sizingMode],
             maxColHeight = Math.max(...map(this.model.columns, 'rowHeight').filter(isFinite));
 
         return isFinite(maxColHeight) ? Math.max(gridDefaultHeight, maxColHeight) : gridDefaultHeight;

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -168,12 +168,12 @@ export class GridModel {
         groupBy = null,
 
         sizingMode = 'standard',
-        compact = false,
         showHover = false,
         rowBorders = false,
         cellBorders = false,
         stripeRows = true,
         showCellFocus = false,
+        compact,
 
         enableColumnPinning = true,
         enableColChooser = false,

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -133,7 +133,7 @@ export class GridModel {
      * @param {(string|string[]|Object|Object[])} [c.sortBy] - colId(s) or sorter config(s) with
      *      colId and sort direction.
      * @param {(string|string[])} [c.groupBy] - Column ID(s) by which to do full-width row grouping.
-     * @param {boolean} [c.compact] - true to render with a smaller font size and tighter padding.
+     * @param {string} [c.sizingMode] - one of large, standard, compact, tiny
      * @param {boolean} [c.showHover] - true to highlight the currently hovered row.
      * @param {boolean} [c.rowBorders] - true to render row borders.
      * @param {boolean} [c.stripeRows] - true (default) to use alternating backgrounds for rows.
@@ -167,6 +167,7 @@ export class GridModel {
         sortBy = [],
         groupBy = null,
 
+        sizingMode = 'standard',
         compact = false,
         showHover = false,
         rowBorders = false,
@@ -214,6 +215,7 @@ export class GridModel {
         this.setSortBy(sortBy);
 
         this.agGridModel = new AgGridModel({
+            sizingMode,
             compact,
             showHover,
             rowBorders,
@@ -328,8 +330,8 @@ export class GridModel {
     get agApi() {return this.agGridModel.agApi}
     get agColumnApi() {return this.agGridModel.agColumnApi}
 
-    get compact() { return this.agGridModel.compact}
-    setCompact(compact) { this.agGridModel.setCompact(compact)}
+    get sizingMode() {return this.agGridModel.sizingMode}
+    setSizingMode(sizingMode) {this.agGridModel.setSizingMode(sizingMode)}
 
     get showHover() { return this.agGridModel.showHover }
     setShowHover(showHover) { this.agGridModel.setShowHover(showHover) }

--- a/desktop/cmp/grid/columns/Actions.scss
+++ b/desktop/cmp/grid/columns/Actions.scss
@@ -32,15 +32,46 @@ $action-col-pad-px: $action-col-pad * 1px;
   }
 }
 
-// Tighten up buttons in compact grids to avoid clipping/overflow.
-.xh-ag-grid--compact {
-  .xh-action-col-cell {
-    button.xh-record-action-button {
-      padding-top: 4px;
-      min-height: unset;
+// Tighten up buttons in for the various grid sizing modes to avoid clipping/overflow.
+.xh-ag-grid {
+  &--large {
+    .xh-action-col-cell {
+      button.xh-record-action-button {
+        min-height: 28px;
+        max-height: 28px;
+        padding-top: 4px;
 
-      svg.svg-inline--fa {
-        width: 0.9em;
+        svg.svg-inline--fa {
+          width: 1.2em;
+        }
+      }
+    }
+  }
+
+  &--compact {
+    .xh-action-col-cell {
+      button.xh-record-action-button {
+        min-height: 20px;
+        max-height: 20px;
+        padding-top: 4px;
+
+        svg.svg-inline--fa {
+          width: 0.9em;
+        }
+      }
+    }
+  }
+
+  &--tiny {
+    .xh-action-col-cell {
+      button.xh-record-action-button {
+        padding-top: 1px;
+        max-height: 14px;
+        min-height: 14px;
+
+        svg.svg-inline--fa {
+          width: 0.7em;
+        }
       }
     }
   }

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -112,6 +112,16 @@ body {
   --xh-grid-text-color: var(--grid-text-color, var(--xh-text-color));
   --xh-grid-tree-indent-px: var(--grid-tree-indent-px, var(--xh-pad-double-px));
 
+  // Large Grid
+  --xh-grid-large-cell-lr-pad: var(--grid-large-cell-lr-pad, 6);
+  --xh-grid-large-cell-lr-pad-px: calc(var(--xh-grid-large-cell-lr-pad) * 1px);
+  --xh-grid-large-header-lr-pad: var(--grid-large-header-lr-pad, 8);
+  --xh-grid-large-header-lr-pad-px: calc(var(--xh-grid-large-header-lr-pad) * 1px);
+  --xh-grid-large-font-size: var(--grid-large-font-size, 13);
+  --xh-grid-large-font-size-px: calc(var(--xh-grid-large-font-size) * 1px);
+  --xh-grid-large-line-height: var(--grid-large-line-height, 26);
+  --xh-grid-large-line-height-px: calc(var(--xh-grid-large-line-height) * 1px);
+
   // Compact Grid
   --xh-grid-compact-cell-lr-pad: var(--grid-compact-cell-lr-pad, 4);
   --xh-grid-compact-cell-lr-pad-px: calc(var(--xh-grid-compact-cell-lr-pad) * 1px);
@@ -121,6 +131,16 @@ body {
   --xh-grid-compact-font-size-px: calc(var(--xh-grid-compact-font-size) * 1px);
   --xh-grid-compact-line-height: var(--grid-compact-line-height, 22);
   --xh-grid-compact-line-height-px: calc(var(--xh-grid-compact-line-height) * 1px);
+
+  // Tiny Grid
+  --xh-grid-tiny-cell-lr-pad: var(--grid-tiny-cell-lr-pad, 2);
+  --xh-grid-tiny-cell-lr-pad-px: calc(var(--xh-grid-tiny-cell-lr-pad) * 1px);
+  --xh-grid-tiny-header-lr-pad: var(--grid-tiny-header-lr-pad, 4);
+  --xh-grid-tiny-header-lr-pad-px: calc(var(--xh-grid-tiny-header-lr-pad) * 1px);
+  --xh-grid-tiny-font-size: var(--grid-tiny-font-size, 11);
+  --xh-grid-tiny-font-size-px: calc(var(--xh-grid-tiny-font-size) * 1px);
+  --xh-grid-tiny-line-height: var(--grid-tiny-line-height, 18);
+  --xh-grid-tiny-line-height-px: calc(var(--xh-grid-tiny-line-height) * 1px);
 
   // Multifield renderer
   --xh-grid-multifield-top-font-size: var(--grid-multifield-top-font-size, 12);

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -113,13 +113,13 @@ body {
   --xh-grid-tree-indent-px: var(--grid-tree-indent-px, var(--xh-pad-double-px));
 
   // Large Grid
-  --xh-grid-large-cell-lr-pad: var(--grid-large-cell-lr-pad, 6);
+  --xh-grid-large-cell-lr-pad: var(--grid-large-cell-lr-pad, 12);
   --xh-grid-large-cell-lr-pad-px: calc(var(--xh-grid-large-cell-lr-pad) * 1px);
-  --xh-grid-large-header-lr-pad: var(--grid-large-header-lr-pad, 8);
+  --xh-grid-large-header-lr-pad: var(--grid-large-header-lr-pad, 12);
   --xh-grid-large-header-lr-pad-px: calc(var(--xh-grid-large-header-lr-pad) * 1px);
-  --xh-grid-large-font-size: var(--grid-large-font-size, 13);
+  --xh-grid-large-font-size: var(--grid-large-font-size, 14);
   --xh-grid-large-font-size-px: calc(var(--xh-grid-large-font-size) * 1px);
-  --xh-grid-large-line-height: var(--grid-large-line-height, 26);
+  --xh-grid-large-line-height: var(--grid-large-line-height, 30);
   --xh-grid-large-line-height-px: calc(var(--xh-grid-large-line-height) * 1px);
 
   // Compact Grid


### PR DESCRIPTION
Fixes #1609 
Fixes #1433 

Adds support for a new `sizingMode` config on `GridModel` (really `AgGridModel`) which can be set to 'large', 'standard', 'compact', or 'tiny'. I did this is a non-breaking way to preserve support for the `compact` config which is likely used heavily. It is a very easy breaking change to handle with a mass rename, but need this merged ASAP so not sure we want to include a breaking change in a minor release ...

The 'standard' and 'compact' modes should look the same as before this change, aside from slightly shorter headers for compact mode.

This change also exposes the ability for apps to customize the grid header height for each of these modes via new `AgGrid.HEADER_HEIGHTS` property.

This is also setup in such a way that an app could provide any value they want to `sizingMode` and add a property to `AgGrid.ROW_HEIGHTS` and `AgGrid.HEADER_HEIGHTS` for that value, and also implement their own `xh-ag-grid--my-custom-sizing-mode` css overrides. Wasn't sure how/if that should be documented in the changelog.

Toolbox PR: https://github.com/xh/toolbox/pull/341

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

