### PR TITLE
Workaround for GoldenLayout's activeItemIndex out of bounds issue.

### DIFF
--- a/desktop/cmp/dash/impl/DashContainerUtils.js
+++ b/desktop/cmp/dash/impl/DashContainerUtils.js
@@ -116,7 +116,15 @@ function convertStateToGLInner(items = [], viewSpecs = [], containerSize, contai
 
             const content = convertStateToGLInner(item.content, viewSpecs, itemSize, item).filter(it => !isNil(it));
             if (!content.length) return null;
-            return {...item, content};
+
+            // Below is a workaround for issue https://github.com/golden-layout/golden-layout/issues/418
+            // GoldenLayouts can sometimes export its state with an out-of-bounds `activeItemIndex`.
+            // If we encounter this, we overwrite `activeItemIndex` to point to the last item.
+            const ret = {...item, content};
+            if (type === 'stack' && isFinite(ret.activeItemIndex) && ret.activeItemIndex >= content.length) {
+                ret.activeItemIndex = content.length - 1;
+            }
+            return ret;
         }
     });
 }


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

