### PR TITLE
Prop to choose or turn off navigator animations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   data package and support observable "Views". See documentation on `Cube` for more information.
 * `RecordAction.actionFn` parameters now include a `buttonEl` property containing the button element
   when used in an action column.
+* Mobile Navigator component now takes an `animation` prop which can be set to one of: 'slide', 'lift', 'fade', 'none'.
+  The default `animation` setting is `slide`.  These values are passed to the underlying OnsenUi onsenNavigator component.
+  ([#1641](https://github.com/xh/hoist-react/pull/1641))
 
 ### 🐞 Bug Fixes
 

--- a/mobile/cmp/navigator/Navigator.js
+++ b/mobile/cmp/navigator/Navigator.js
@@ -21,10 +21,11 @@ export const [Navigator, navigator] = hoistCmp.withFactory({
     model: uses(NavigatorModel),
     className: 'xh-navigator',
 
-    render({model, className}) {
+    render({model, className, animation = 'slide'}) {
         return onsenNavigator({
             className,
             initialRoute: {init: true},
+            animation,
             animationOptions: {duration: 0.2, delay: 0, timing: 'ease-in'},
             renderPage: (pageModel, navigator) => model.renderPage(pageModel, navigator),
             onPostPush: () => model.onPageChange(),
@@ -35,5 +36,8 @@ export const [Navigator, navigator] = hoistCmp.withFactory({
 
 Navigator.propTypes = {
     /** Primary component model instance. */
-    model: PT.oneOfType([PT.instanceOf(NavigatorModel), PT.object])
+    model: PT.oneOfType([PT.instanceOf(NavigatorModel), PT.object]),
+    
+    /** Set animation style or turn off, default 'slide' */
+    animation: PT.oneOf(['slide', 'lift', 'fade', 'none'])
 };


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

Client requests to be able to turn off page transition animations on mobile app.
This change just lifts the onsen animation options up to our navigator component, which seems useful.
One could go farther and give our component more options, but this change so far is all that has been requested.