### PR TITLE
Icons now have fa-fw className applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### 🐞 Bug Fixes
 
 * Fixed an issue where zeroes entered by the user in PinPad would be displayed as blanks.
+* Fixed `fontAwesomeIcon` elem factory component to include the default 'fa-fw' className.
+Previously, it was overridden by any `className` passed in via optional params.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v29.1.0...develop)
 

--- a/icon/Icon.js
+++ b/icon/Icon.js
@@ -949,9 +949,9 @@ export const fileIcon = function(extension) {
 //-----------------------------
 // Implementation
 //-----------------------------
-const fa = function(props = {}, name) {
-    const prefix = withDefault(props.prefix, 'far'),
-        iconClassNames = classNames('fa-fw', props.className);  // apply fa-fw for consistent icon widths in buttons, etc
+const fa = function({prefix, className, ...rest} = {}, name) {
+    prefix = withDefault(prefix, 'far');
+    className = classNames('fa-fw', className);  // apply fa-fw for consistent icon widths in buttons, etc
 
-    return fontAwesomeIcon({icon: [prefix, name], className: iconClassNames, ...props});
+    return fontAwesomeIcon({icon: [prefix, name], className, ...rest});
 };


### PR DESCRIPTION
Anselm fixed bug in fontAwesomeIcon elem factory function to include 'fa-fw' as default className. Previously was overridden by additional classNames passed into props.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

