### PR TITLE
Fix scrollbar in toolbar multi-select when using custom fonts.

### DIFF
--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -123,6 +123,10 @@
     &__value-container--is-multi {
       height: 28px;
       overflow-y: auto !important;
+
+      & > div {
+        margin: 0 2px;
+      }
     }
   }
 }

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -55,6 +55,7 @@
 
     &__value-container input {
       opacity: 1 !important;
+      // Avoid unexpected scrollbar within input when using a custom font-face.
       line-height: 15px;
     }
 

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -55,6 +55,7 @@
 
     &__value-container input {
       opacity: 1 !important;
+      line-height: 15px;
     }
 
     &__indicator {
@@ -123,10 +124,6 @@
     &__value-container--is-multi {
       height: 28px;
       overflow-y: auto !important;
-
-      & > div {
-        margin: 0 2px;
-      }
     }
   }
 }


### PR DESCRIPTION
Fixes #1676

Note that this fix just buys us a few extra pixels of wriggle room before it starts scrolling. If the dev opts to use font-sizes that are larger than the toolbar height, the scrollbars will reappear.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

