### PR TITLE
StoreFilterField matches on `Record.id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   automatically hide.
 * Fixed an issue where multiple buttons in a `ButtonGroupInput` could be shown as active
   simultaneously. [#1592](https://github.com/xh/hoist-react/issues/1592)
+* `StoreFilterField` will again match on `Record.id` if bound to a Store or a GridModel with the
+  `id` column visible. [#1697](https://github.com/xh/hoist-react/issues/1697)
 
 ### ⚙️ Technical
 

--- a/cmp/store/impl/StoreFilterFieldImplModel.js
+++ b/cmp/store/impl/StoreFilterFieldImplModel.js
@@ -115,8 +115,8 @@ export class StoreFilterFieldImplModel {
         if (searchTerm && !isEmpty(activeFields)) {
             const regex = new RegExp(`(^|\\W)${searchTerm}`, 'i');
             fn = (rec) => activeFields.some(f => {
-                const fieldVal = rec.data[f];
-                return fieldVal && regex.test(fieldVal);
+                const fieldVal = (f == 'id') ? rec.id : rec.data[f];
+                return regex.test(fieldVal);
             });
         }
         this.filter = fn ? {...filterOptions, fn} : null;
@@ -142,7 +142,7 @@ export class StoreFilterFieldImplModel {
     getActiveFields() {
         let {gridModel, includeFields, excludeFields, store} = this;
 
-        let ret = store ? store.fields.map(f => f.name).concat(['id']) : [];
+        let ret = store ? ['id', ...store.fields.map(f => f.name)] : [];
         if (includeFields) ret = store ? intersection(ret, includeFields) : includeFields;
         if (excludeFields) ret = without(ret, ...excludeFields);
 


### PR DESCRIPTION
+ Remove falsey check on `fieldVal` before passing to regex - regex happily returns false when fed null/undefined (and would allow match on ID or other field val of 0).
+ Fixes #1697

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

