### PR TITLE
Make dropdown indicator in Select a bit less bulky.

### DIFF
--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -6,7 +6,7 @@
  */
 import {HoistInput} from '@xh/hoist/cmp/input';
 import {box, div, hbox, span} from '@xh/hoist/cmp/layout';
-import {elemFactory, HoistComponent, LayoutSupport, hoistCmp} from '@xh/hoist/core';
+import {elemFactory, HoistComponent, LayoutSupport} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {
     reactAsyncCreatableSelect,
@@ -19,7 +19,7 @@ import {action, observable} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 import {throwIf, withDefault} from '@xh/hoist/utils/js';
 import debouncePromise from 'debounce-promise';
-import {assign, castArray, isEmpty, isNil, isPlainObject, keyBy} from 'lodash';
+import {merge, castArray, isEmpty, isNil, isPlainObject, keyBy} from 'lodash';
 import PT from 'prop-types';
 import React from 'react';
 import {createFilter} from 'react-select';
@@ -224,10 +224,9 @@ export class Select extends HoistInput {
                 placeholder: withDefault(props.placeholder, 'Select...'),
                 tabIndex: props.tabIndex,
 
-                // Provide a custom dropdown indicator component, which allows us
-                // to reduce its size without shrinking the icon.
+                // Minimize (or hide) bulky dropdown
                 components: {
-                    DropdownIndicator: () => dropdownIndicator(),
+                    DropdownIndicator: this.getDropdownIndicatorFactory(),
                     IndicatorSeparator: () => null
                 },
 
@@ -265,16 +264,9 @@ export class Select extends HoistInput {
             rsProps.formatCreateLabel = this.createMessageFn;
         }
 
-        if (props.hideDropdownIndicator) {
-            rsProps.components = {
-                ...rsProps.components,
-                DropdownIndicator: () => null
-            };
-        }
-
         const factory = this.getSelectFactory();
 
-        assign(rsProps, props.rsOptions);
+        merge(rsProps, props.rsOptions);
         return box({
             item: factory(rsProps),
             className: this.getClassName(),
@@ -283,7 +275,7 @@ export class Select extends HoistInput {
                 // propagation only if react-select already likely to have used for menu management.
                 // note: menuIsOpen will be undefined on AsyncSelect due to a react-select bug.
                 const {menuIsOpen} = this.reactSelectRef.current ? this.reactSelectRef.current.state : {};
-                if (menuIsOpen && (e.key == 'Escape' || e.key == 'Enter')) {
+                if (menuIsOpen && (e.key === 'Escape' || e.key === 'Enter')) {
                     e.stopPropagation();
                 }
             },
@@ -319,11 +311,11 @@ export class Select extends HoistInput {
     @action
     onInputChange = (value, {action}) => {
         if (this.manageInputValue) {
-            if (action == 'input-change') {
+            if (action === 'input-change') {
                 this.inputValue = value;
                 this._inputChangedSinceSelect = true;
                 if (!value) this.noteValueChange(null);
-            } else if (action == 'input-blur') {
+            } else if (action === 'input-blur') {
                 this.inputValue = null;
                 this._inputChangedSinceSelect = false;
             }
@@ -345,10 +337,10 @@ export class Select extends HoistInput {
                 // Use of creatable and async variants will create another level of nesting we must
                 // traverse to get to the underlying Select comp and its inputRef.
                 const refComp = rsRef.select,
-                    selectComp = refComp.constructor.name == 'Select' ? refComp : refComp.select,
+                    selectComp = refComp.constructor.name === 'Select' ? refComp : refComp.select,
                     inputElem = selectComp.inputRef;
 
-                if (this.hasFocus && inputElem && document.activeElement == inputElem) {
+                if (this.hasFocus && inputElem && document.activeElement === inputElem) {
                     inputElem.select();
                 }
             });
@@ -480,7 +472,7 @@ export class Select extends HoistInput {
     formatOptionLabel = (opt, params) => {
         // Always display the standard label string in the value container (context == 'value').
         // If we need to expose customization here, we could consider a dedicated prop.
-        if (params.context != 'menu') {
+        if (params.context !== 'menu') {
             return opt.label;
         }
 
@@ -517,6 +509,12 @@ export class Select extends HoistInput {
     //------------------------
     // Other Implementation
     //------------------------
+    getDropdownIndicatorFactory() {
+        return this.props.hideDropdownIndicator ?
+            () => null :
+            () => Icon.chevronDown({className: 'xh-select__indicator'});
+    }
+
     getThemeConfig() {
         return (base) => {
             return {
@@ -557,7 +555,3 @@ export class Select extends HoistInput {
 
 }
 export const select = elemFactory(Select);
-
-const dropdownIndicator = hoistCmp.factory(
-    () => Icon.chevronDown({className: 'xh-select__indicator'})
-);

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -6,7 +6,7 @@
  */
 import {HoistInput} from '@xh/hoist/cmp/input';
 import {box, div, hbox, span} from '@xh/hoist/cmp/layout';
-import {elemFactory, HoistComponent, LayoutSupport} from '@xh/hoist/core';
+import {elemFactory, HoistComponent, LayoutSupport, hoistCmp} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {
     reactAsyncCreatableSelect,
@@ -220,6 +220,13 @@ export class Select extends HoistInput {
                 placeholder: withDefault(props.placeholder, 'Select...'),
                 tabIndex: props.tabIndex,
 
+                // Provide a custom dropdown indicator component, which allows us
+                // to reduce its size without shrinking the icon.
+                components: {
+                    DropdownIndicator: () => dropdownIndicator(),
+                    IndicatorSeparator: () => null
+                },
+
                 // A shared div is created lazily here as needed, appended to the body, and assigned
                 // a high z-index to ensure options menus render over dialogs or other modals.
                 menuPortalTarget: this.getOrCreatePortalDiv(),
@@ -257,8 +264,7 @@ export class Select extends HoistInput {
         if (props.hideDropdownIndicator) {
             rsProps.components = {
                 ...rsProps.components,
-                DropdownIndicator: () => null,
-                IndicatorSeparator: () => null
+                DropdownIndicator: () => null
             };
         }
 
@@ -547,3 +553,7 @@ export class Select extends HoistInput {
 
 }
 export const select = elemFactory(Select);
+
+const dropdownIndicator = hoistCmp.factory(
+    () => Icon.chevronDown({className: 'xh-select__indicator'})
+);

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -60,8 +60,19 @@
     }
 
     &__indicator {
-      padding: 0 var(--xh-pad-half-px);
-      color: var(--xh-border-color);
+      padding: 0 8px 0 0;
+      width: 20px;
+      color: #999;
+      stroke: #999;
+      stroke-width: 1em;
+    }
+
+    &__indicators:hover {
+      cursor: pointer;
+
+      svg {
+        color: var(--xh-text-color);
+      }
     }
 
     &__indicator-separator {


### PR DESCRIPTION
This change reduces the dropdown width from 31px > 20px. The idea was to make it look consistent with our other right-align input actions, like clear.

<img width="318" alt="Screenshot 2020-03-02 at 10 24 34" src="https://user-images.githubusercontent.com/3017757/75667766-13699300-5c70-11ea-946f-b5625784e8ba.png">

vs. current prod:

<img width="309" alt="Screenshot 2020-03-02 at 10 24 46" src="https://user-images.githubusercontent.com/3017757/75667784-18c6dd80-5c70-11ea-85da-6e760df66023.png">

Don't know if there's too much more we can actually do here. See issue: #1717

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

