### PR TITLE
Add FormModel.allFields getter

### DIFF
--- a/cmp/form/FormModel.js
+++ b/cmp/form/FormModel.js
@@ -5,14 +5,13 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 
-import {XH, HoistModel} from '@xh/hoist/core';
-import {bindable, computed, action, observable} from '@xh/hoist/mobx';
+import {HoistModel, XH} from '@xh/hoist/core';
+import {action, bindable, computed, observable} from '@xh/hoist/mobx';
 import {throwIf} from '@xh/hoist/utils/js';
-import {flatMap, forOwn, some, mapValues, map, values, pickBy} from 'lodash';
-
-import {ValidationState} from './validation/ValidationState';
+import {flatMap, forOwn, map, mapValues, pickBy, some, values} from 'lodash';
 import {FieldModel} from './field/FieldModel';
 import {SubformsFieldModel} from './field/SubformsFieldModel';
+import {ValidationState} from './validation/ValidationState';
 
 
 /**
@@ -43,6 +42,9 @@ export class FormModel {
 
     /** @member {Object} - container object for FieldModel instances, keyed by field name. */
     @observable.ref fields = {};
+
+    /** @return {FieldModel[]} - all FieldModel instances, as an array. */
+    get allFields() {return values(this.fields)}
 
     /** @member {FormModel} */
     parent = null;

--- a/cmp/form/FormModel.js
+++ b/cmp/form/FormModel.js
@@ -211,6 +211,6 @@ export class FormModel {
     }
 
     destroy() {
-        XH.safeDestroy(values(this.fields));
+        XH.safeDestroy(this.fieldList);
     }
 }

--- a/cmp/form/FormModel.js
+++ b/cmp/form/FormModel.js
@@ -44,7 +44,7 @@ export class FormModel {
     @observable.ref fields = {};
 
     /** @return {FieldModel[]} - all FieldModel instances, as an array. */
-    get allFields() {return values(this.fields)}
+    get fieldList() {return values(this.fields)}
 
     /** @member {FormModel} */
     parent = null;


### PR DESCRIPTION
+ Returns `FieldModel[]` - convenient and jsdoc typed way to get a reference to all owned FieldModels.
+ Useful on its own in a case I have, but might also help to clarify that `FormModel.fields` is an object (despite ctor taking them as an []), simply by providing a contrasting public getter.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

