### PR TITLE
CSS for checkboxes in Grid Tiny mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ will be cycled through when the user clicks on the header.
 
 ### 🐞 Bug Fixes
 
+* Checkboxes in grid rows in Tiny sizing mode have been styled to fit correctly within the row.
 * `GridStateModel` no longer saves/restores the width of non-resizable columns.
   [#1718](https://github.com/xh/hoist-react/issues/1718)
 

--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -288,11 +288,11 @@
       padding-left: var(--xh-grid-tiny-cell-lr-pad-px);
       padding-right: var(--xh-grid-tiny-cell-lr-pad-px);
 
-      .xh-check-box.bp3-control.bp3-inline {
+      .xh-check-box {
         padding-top: 1px;
 
         .bp3-control-indicator {
-          font-size: 12px;
+          font-size: calc(var(--xh-grid-tiny-font-size-px) + 2px);
         }
       }
     }

--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -284,6 +284,14 @@
     .ag-cell {
       padding-left: var(--xh-grid-tiny-cell-lr-pad-px);
       padding-right: var(--xh-grid-tiny-cell-lr-pad-px);
+
+      .xh-check-box.bp3-control.bp3-inline {
+        padding-top: 1px;
+
+        .bp3-control-indicator {
+          font-size: 12px;
+        }
+      }
     }
 
     .ag-header-cell,


### PR DESCRIPTION
This new CSS reduces the size of the checkboxes used here:
https://toolbox-dev.xh.io/app/grids/treeWithCheckBox
when in Tiny mode, so that they fit correctly within the Grid's row.

Before:
![image](https://user-images.githubusercontent.com/2573928/78059913-b5a49580-7358-11ea-924c-af86b88085ab.png)

After:
![image](https://user-images.githubusercontent.com/2573928/78059982-c8b76580-7358-11ea-9f7f-4cbdc9b10cae.png)

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

