### PR TITLE
Document Mask support elements for message

### DIFF
--- a/desktop/cmp/mask/Mask.js
+++ b/desktop/cmp/mask/Mask.js
@@ -56,7 +56,7 @@ Mask.propTypes = {
     isDisplayed: PT.bool,
 
     /** Optional text to be displayed. */
-    message: PT.string,
+    message: PT.oneOfType([PT.string, PT.element]),
 
     /** True to display a spinning image.  Default false. */
     spinner: PT.bool,


### PR DESCRIPTION
We have a client app that uses an element for a mask message. PropTypes logs an error without this change.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

