### PR TITLE
Add GridModel.select() convenience method

### DIFF
--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -298,6 +298,14 @@ export class GridModel {
         }
     }
 
+    /**
+     * @param {(Object[]|Object)} records - single record/ID or array of records/IDs to select.
+     * @param {boolean} [clearSelection] - true to clear previous selection (rather than add to it).
+     */
+    select(records, clearSelection = true) {
+        this.selModel.select(records, clearSelection);
+    }
+
     /** Select the first row in the grid. */
     selectFirst() {
         const {agGridModel, selModel} = this;
@@ -334,35 +342,25 @@ export class GridModel {
         }
     }
 
-    /** Does the grid have any records to show? */
-    get empty() {
-        return this.store.empty;
-    }
-
     /** Are any records currently selected? */
-    get hasSelection() {
-        return !this.selModel.isEmpty;
-    }
+    get hasSelection() {return !this.selModel.isEmpty}
 
     /**
      * Shortcut to the currently selected records (observable).
      * @see StoreSelectionModel.records
      */
-    get selection() {
-        return this.selModel.records;
-    }
+    get selection() {return this.selModel.records}
 
     /**
-     * Shortcut to a single selected record (observable).
-     * Null if multiple records are selected.
+     * Shortcut to a single selected record (observable). Null if multiple records are selected.
      * @see StoreSelectionModel.singleRecord
      */
-    get selectedRecord() {
-        return this.selModel.singleRecord;
-    }
+    get selectedRecord() {return this.selModel.singleRecord}
+
+    /** Does the grid have any records to show? */
+    get empty() {return this.store.empty}
 
     get isReady() {return this.agGridModel.isReady}
-
     get agApi() {return this.agGridModel.agApi}
     get agColumnApi() {return this.agGridModel.agColumnApi}
 


### PR DESCRIPTION
+ I always look for this core method on GridModel.
+ Especially given that we support `selectFirst()` - which I know is grid-specific as grid determines sort - and a few other selection-related shortcuts.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

