### PR TITLE
StoreFilterField supports dotSeparated col fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,24 @@
 
 ## v34.0.0-SNAPSHOT - unreleased
 
-[Commit Log](https://github.com/xh/hoist-react/compare/v33.0.0...develop)
+### 🎁 New Features
 
+* `StoreFieldField` supports dot-separated field names in a bound `GridModel`, meaning it will now
+  match on columns with fields such as `address.city`.
+
+[Commit Log](https://github.com/xh/hoist-react/compare/v33.0.0...develop)
 
 ## v33.0.0 - 2020-04-22
 
 ### 🎁 New Features
+
 * The object returned by the `data` property on `Record` now includes the record `id`. This will
   allow for convenient access of the id with the other field values on the record.
-
 * The `Timer` class has been enhanced and further standardized with its Hoist Core counterpart:
-    * Both the `interval` and `timeout` arguments may be specified as functions, or config keys
+  * Both the `interval` and `timeout` arguments may be specified as functions, or config keys
     allowing for dynamic lookup and reconfiguration.
-    * Added `intervalUnits` and `timeoutUnits` arguments.
-    * `delay` can now be specified as a boolean for greater convenience.
+  * Added `intervalUnits` and `timeoutUnits` arguments.
+  * `delay` can now be specified as a boolean for greater convenience.
 
 ### 💥 Breaking Changes
 
@@ -1467,9 +1471,10 @@ leverage the context for model support discussed above.
 * ag-Grid has been updated to v20.0.0. Most apps shouldn't require any changes - however, if you are
   using `agOptions` to set sorting, filtering or resizing properties, these may need to change:
 
-  For the `Grid`, `agOptions.enableColResize`, `agOptions.enableSorting` and `agOptions.enableFilter`
-  have been removed. You can replicate their effects by using `agOptions.defaultColDef`. For
-  `Columns`, `suppressFilter` has been removed, an should be replaced with `filter: false`.
+  For the `Grid`, `agOptions.enableColResize`, `agOptions.enableSorting` and
+  `agOptions.enableFilter` have been removed. You can replicate their effects by using
+  `agOptions.defaultColDef`. For `Columns`, `suppressFilter` has been removed, an should be replaced
+  with `filter: false`.
 
 * `HoistAppModel.requestRefresh` and `TabContainerModel.requestRefresh` have been removed.
   Applications should use the new Refresh architecture described above instead.
@@ -2282,9 +2287,9 @@ and ag-Grid upgrade, and more. 🚀
   * `Panel` and `Resizable` components have moved to their own packages in
     `@xh/hoist/desktop/cmp/panel` and `@xh/hoist/desktop/cmp/resizable`.
 * **Multiple changes and improvements made to tab-related APIs and components.**
-  * The `TabContainerModel` constructor API has changed, notably `children` -> `tabs`, `useRoutes` ->
-    `route` (to specify a starting route as a string) and `switcherPosition` has moved from a model
-    config to a prop on the `TabContainer` component.
+  * The `TabContainerModel` constructor API has changed, notably `children` -> `tabs`, `useRoutes`
+    -> `route` (to specify a starting route as a string) and `switcherPosition` has moved from a
+    model config to a prop on the `TabContainer` component.
   * `TabPane` and `TabPaneModel` have been renamed `Tab` and `TabModel`, respectively, with several
     related renames.
 * **Application entry-point classes decorated with `@HoistApp` must implement the new getter method

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -620,6 +620,14 @@ export class GridModel {
     }
 
     /**
+     * Return all currently-visible leaf-level columns.
+     * @returns {Column[]}
+     */
+    getVisibleLeafColumns() {
+        return this.getLeafColumns().filter(it => this.isColumnVisible(it.colId));
+    }
+
+    /**
      * Determine whether or not a given leaf-level column is currently visible.
      *
      * Call this method instead of inspecting the `hidden` property on the Column itself, as that

--- a/cmp/store/impl/StoreFilterFieldImplModel.js
+++ b/cmp/store/impl/StoreFilterFieldImplModel.js
@@ -169,6 +169,9 @@ export class StoreFilterFieldImplModel {
                 }
             });
 
+            // Run exclude once more to support explicitly excluding a dot-sep field added above.
+            if (excludeFields) ret = without(ret, ...excludeFields);
+
             ret = ret.filter(f => {
                 return (
                     (includeFields && includeFields.includes(f)) ||


### PR DESCRIPTION
+ Also, add `GridModel.getVisibleLeafColumns()` - have seen this done in a few places.
+ Remove special handling for record.id now that id is included in data object.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

