### PR TITLE
Fix TreeGrid Alignment issue across different sizing modes

### DIFF
--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -84,7 +84,8 @@
     // Set a constant width, since the two icons are different sizes.
     // This caused rows to jump around when expansion was toggled.
     .ag-group-expanded {
-      margin: 0 var(--xh-pad-half-px) 0 0;
+      margin: 0;
+      width: var(--xh-grid-tree-icon-px);
 
       svg {
         width: var(--xh-pad-px);
@@ -92,7 +93,8 @@
     }
 
     .ag-group-contracted {
-      margin: 0 var(--xh-pad-half-px) 0 0;
+      margin: 0;
+      width: var(--xh-grid-tree-icon-px);
 
       svg {
         width: var(--xh-pad-px);
@@ -357,18 +359,37 @@
     align-items: center;
   }
 
-  // Reduce right margin to an appropriate value for the smaller sizing modes.
+  // Adjust tree icon widths for different sizing modes.
+  &--large .ag-row {
+    .ag-group-expanded,
+    .ag-group-contracted {
+      width: var(--xh-grid-large-tree-icon-px);
+
+      svg {
+        width: var(--xh-pad-px);
+      }
+    }
+  }
+
   &--compact .ag-row {
     .ag-group-expanded,
     .ag-group-contracted {
-      margin: 0 2px 0 0;
+      width: var(--xh-grid-compact-tree-icon-px);
+
+      svg {
+        width: var(--xh-pad-px);
+      }
     }
   }
 
   &--tiny .ag-row {
     .ag-group-expanded,
     .ag-group-contracted {
-      margin: 0 1px 0 0;
+      width: var(--xh-grid-tiny-tree-icon-px);
+
+      svg {
+        width: var(--xh-pad-px);
+      }
     }
   }
 }

--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -94,7 +94,7 @@
 //------------------------
 // Trees and Grouping
 //------------------------
-.xh-grid--hierarchical:not(.xh-data-view) {
+.xh-grid--hierarchical:not(.xh-data-view) > .xh-ag-grid {
   // Generate indentations for tree grids with hierarchical data.
   .ag-ltr {
     .ag-row-group-indent-0 {
@@ -138,12 +138,24 @@
     }
   }
 
-  .ag-ltr .ag-row-group-leaf-indent {
-    margin-left: var(--xh-pad-double-px);
-  }
-
   .ag-group-contracted + .ag-group-value:not(:empty) {
     margin-left: 0;
+  }
+
+  .ag-ltr .ag-row-group-leaf-indent {
+    margin-left: var(--xh-grid-tree-icon-px);
+  }
+
+  &--large .ag-ltr .ag-row-group-leaf-indent {
+    margin-left: var(--xh-grid-large-tree-icon-px);
+  }
+
+  &--compact .ag-ltr .ag-row-group-leaf-indent {
+    margin-left: var(--xh-grid-compact-tree-icon-px);
+  }
+
+  &--tiny .ag-ltr .ag-row-group-leaf-indent {
+    margin-left: var(--xh-grid-tiny-tree-icon-px);
   }
 }
 

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -114,6 +114,7 @@ body {
   --xh-grid-summary-row-border-color: var(--grid-summary-row-border-color, var(--xh-grid-border-color));
   --xh-grid-text-color: var(--grid-text-color, var(--xh-text-color));
   --xh-grid-tree-indent-px: var(--grid-tree-indent-px, var(--xh-pad-double-px));
+  --xh-grid-tree-icon-px: var(--grid-tree-icon-px, 16px);
 
   // Large Grid
   --xh-grid-large-cell-lr-pad: var(--grid-large-cell-lr-pad, 12);
@@ -126,6 +127,7 @@ body {
   --xh-grid-large-header-lr-pad-px: calc(var(--xh-grid-large-header-lr-pad) * 1px);
   --xh-grid-large-line-height: var(--grid-large-line-height, 30);
   --xh-grid-large-line-height-px: calc(var(--xh-grid-large-line-height) * 1px);
+  --xh-grid-large-tree-icon-px: var(--grid-large-tree-icon-px, 20px);
 
   // Compact Grid
   --xh-grid-compact-cell-lr-pad: var(--grid-compact-cell-lr-pad, 4);
@@ -138,6 +140,7 @@ body {
   --xh-grid-compact-header-lr-pad-px: calc(var(--xh-grid-compact-header-lr-pad) * 1px);
   --xh-grid-compact-line-height: var(--grid-compact-line-height, 22);
   --xh-grid-compact-line-height-px: calc(var(--xh-grid-compact-line-height) * 1px);
+  --xh-grid-compact-tree-icon-px: var(--grid-compact-tree-icon-px, 14px);
 
   // Tiny Grid
   --xh-grid-tiny-cell-lr-pad: var(--grid-tiny-cell-lr-pad, 2);
@@ -150,6 +153,7 @@ body {
   --xh-grid-tiny-header-lr-pad-px: calc(var(--xh-grid-tiny-header-lr-pad) * 1px);
   --xh-grid-tiny-line-height: var(--grid-tiny-line-height, 18);
   --xh-grid-tiny-line-height-px: calc(var(--xh-grid-tiny-line-height) * 1px);
+  --xh-grid-tiny-tree-icon-px: var(--grid-tiny-tree-icon-px, 12px);
 
   // Multifield renderer
   --xh-grid-multifield-top-font-size: var(--grid-multifield-top-font-size, 12);


### PR DESCRIPTION
Use `--xh-grid-tree-icon-px` CSS vars to better control tree grid alignment across different sizing modes.

See https://github.com/xh/hoist-react/issues/1878

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

