### PR TITLE
Tree grid alignment fixes (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,23 @@
 # Changelog
 
-## v33.2.0 - 2020-05-06
+## v34.0.0-SNAPSHOT - under development
 
 ### 🎁 New Features
-* We have turned off the use of virtual columns in `GridModel` by default.  See new property
-`useVirtualColumns`, which may be set to `true` to re-enable this behavior.
+
+* Virtual column rendering has been disabled by default, as it offered a minimal performance benefit
+  for most grids while compromising autosizing. See new `GridModel.useVirtualColumns` config, which
+  can be set to `true` to re-enable this behavior if required.
 
 ### 🐞 Bug Fixes
+
 * Fixed several issues with new grid auto-sizing feature.
-* Fixed an issue with alignment in tree grids.
+* Fixed issues with and generally improved expand/collapse column alignment in tree grids.
+  * 💥 Note that this improvement introduced a minor breaking change for apps that have customized
+    tree indentation via the removed `--grid-tree-indent-px` CSS var. Use `--grid-tree-indent`
+    instead. Note the new var is specified in em units to scale well across grid sizing modes.
+
+[Commit Log](https://github.com/xh/hoist-react/compare/v33.1.0...develop)
+
 
 ## v33.1.0 - 2020-05-05
 

--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -83,19 +83,13 @@
 
     // Set a constant width, since the two icons are different sizes.
     // This caused rows to jump around when expansion was toggled.
-    .ag-group-expanded {
-      margin: 0 var(--xh-pad-half-px) 0 0;
-
-      svg {
-        width: var(--xh-pad-px);
-      }
-    }
-
+    .ag-group-expanded,
     .ag-group-contracted {
-      margin: 0 var(--xh-pad-half-px) 0 0;
+      margin: 0;
+      width: var(--xh-grid-tree-indent);
 
       svg {
-        width: var(--xh-pad-px);
+        width: var(--xh-grid-tree-icon-px) !important;
       }
     }
   }
@@ -170,6 +164,11 @@
       height: 50%;
       margin-top: unset;
       top: unset;
+    }
+
+    // Adjust left padding for tree columns.
+    &.xh-tree-column {
+      padding-left: calc(var(--xh-grid-tree-indent) - var(--xh-grid-tree-icon-px));
     }
   }
 
@@ -355,21 +354,6 @@
   // Vertically center tree grid affordances
   .ag-row .ag-cell-wrapper.ag-row-group {
     align-items: center;
-  }
-
-  // Reduce right margin to an appropriate value for the smaller sizing modes.
-  &--compact .ag-row {
-    .ag-group-expanded,
-    .ag-group-contracted {
-      margin: 0 2px 0 0;
-    }
-  }
-
-  &--tiny .ag-row {
-    .ag-group-expanded,
-    .ag-group-contracted {
-      margin: 0 1px 0 0;
-    }
   }
 }
 

--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -98,48 +98,48 @@
   // Generate indentations for tree grids with hierarchical data.
   .ag-ltr {
     .ag-row-group-indent-0 {
-      padding-left: calc(0 * var(--xh-grid-tree-indent-px));
+      padding-left: calc(0 * var(--xh-grid-tree-indent));
     }
 
     .ag-row-group-indent-1 {
-      padding-left: calc(1 * var(--xh-grid-tree-indent-px));
+      padding-left: calc(1 * var(--xh-grid-tree-indent));
     }
 
     .ag-row-group-indent-2 {
-      padding-left: calc(2 * var(--xh-grid-tree-indent-px));
+      padding-left: calc(2 * var(--xh-grid-tree-indent));
     }
 
     .ag-row-group-indent-3 {
-      padding-left: calc(3 * var(--xh-grid-tree-indent-px));
+      padding-left: calc(3 * var(--xh-grid-tree-indent));
     }
 
     .ag-row-group-indent-4 {
-      padding-left: calc(4 * var(--xh-grid-tree-indent-px));
+      padding-left: calc(4 * var(--xh-grid-tree-indent));
     }
 
     .ag-row-group-indent-5 {
-      padding-left: calc(5 * var(--xh-grid-tree-indent-px));
+      padding-left: calc(5 * var(--xh-grid-tree-indent));
     }
 
     .ag-row-group-indent-6 {
-      padding-left: calc(6 * var(--xh-grid-tree-indent-px));
+      padding-left: calc(6 * var(--xh-grid-tree-indent));
     }
 
     .ag-row-group-indent-7 {
-      padding-left: calc(7 * var(--xh-grid-tree-indent-px));
+      padding-left: calc(7 * var(--xh-grid-tree-indent));
     }
 
     .ag-row-group-indent-8 {
-      padding-left: calc(8 * var(--xh-grid-tree-indent-px));
+      padding-left: calc(8 * var(--xh-grid-tree-indent));
     }
 
     .ag-row-group-indent-9 {
-      padding-left: calc(9 * var(--xh-grid-tree-indent-px));
+      padding-left: calc(9 * var(--xh-grid-tree-indent));
     }
   }
 
   .ag-ltr .ag-row-group-leaf-indent {
-    margin-left: var(--xh-pad-double-px);
+    margin-left: var(--xh-grid-tree-indent);
   }
 
   .ag-group-contracted + .ag-group-value:not(:empty) {
@@ -210,7 +210,7 @@
 
   // This property is not actually used in rendering, but is provided here
   // for later interpretation by GridAutosizeService.getIndentation()
-  left: var(--xh-grid-tree-indent-px);
+  left: var(--xh-grid-tree-indent);
 
   &--active {
     display: inline-block;

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -398,6 +398,9 @@ export class Column {
                         this.cellClass
                 );
             }
+            if (this.isTreeColumn) {
+                r.push('xh-tree-column');
+            }
             if (align === 'center' || align === 'right') {
                 r.push('xh-align-' + align);
             }

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -113,7 +113,8 @@ body {
   --xh-grid-pinned-column-border-color: var(--grid-pinned-column-border-color, #{mc('grey', '300')});
   --xh-grid-summary-row-border-color: var(--grid-summary-row-border-color, var(--xh-grid-border-color));
   --xh-grid-text-color: var(--grid-text-color, var(--xh-text-color));
-  --xh-grid-tree-indent-px: var(--grid-tree-indent-px, var(--xh-pad-double-px));
+  --xh-grid-tree-indent: var(--grid-tree-indent, 1.2em);
+  --xh-grid-tree-icon-px: var(--grid-tree-icon-px, 10px);
 
   // Large Grid
   --xh-grid-large-cell-lr-pad: var(--grid-large-cell-lr-pad, 12);
@@ -400,7 +401,6 @@ body.xh-mobile {
   --xh-grid-line-height: var(--grid-line-height, 30);
   --xh-grid-compact-font-size: var(--grid-compact-font-size, 13);
   --xh-grid-compact-line-height: var(--grid-compact-line-height, 26);
-  --xh-grid-tree-indent-px: var(--grid-tree-indent-px, var(--xh-pad-half-px));
 
   // Fonts
   --xh-font-size: var(--font-size, 15);


### PR DESCRIPTION
Gets to the root of #1878 by taking control of tree column left padding:

+ Use 'em' based `--xh-grid-tree-indent` var to account for different sizing modes
+ Use same `--xh-grid-tree-indent` var for both group indents and leaf indents
+ Use fixed width icon

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

