### PR TITLE
Context Menu fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### 🐞 Bug Fixes
 * Fix to Average Aggregators when used with hierarchical data.
 
+* Fixes to Context Menu handling on `Panel` to allow better handling of `[]` and `null`.
+
 [Commit Log](https://github.com/xh/hoist-react/compare/v33.3.0...develop)
 
 

--- a/desktop/hooks/UseContextMenu.js
+++ b/desktop/hooks/UseContextMenu.js
@@ -7,7 +7,7 @@
 import {XH} from '@xh/hoist/core';
 import {contextMenu as contextMenuEl} from '@xh/hoist/desktop/cmp/contextmenu/ContextMenu';
 import {ContextMenu} from '@xh/hoist/kit/blueprint';
-import {isArray, isFunction, isUndefined} from 'lodash';
+import {isArray, isFunction, isUndefined, isEmpty} from 'lodash';
 import {cloneElement, isValidElement} from 'react';
 
 /**
@@ -26,22 +26,23 @@ export function useContextMenu(child, contextMenu) {
 
     const onContextMenu = (e) => {
 
-        // Skip if already consumed, otherwise consume (Adapted from Blueprint 'ContextMenuTarget')
+        // 0) Skip if already consumed, otherwise consume (Adapted from Blueprint 'ContextMenuTarget')
         if (e.defaultPrevented) return;
         e.preventDefault();
 
+        // 1) Pre-process to an element (potentially via item list) or null
         if (isFunction(contextMenu)) {
             contextMenu = contextMenu(e);
         }
         if (isArray(contextMenu)) {
-            contextMenu = contextMenuEl({menuItems: contextMenu});
+            contextMenu = !isEmpty(contextMenu) ? contextMenuEl({menuItems: contextMenu}) : null;
         }
-
         if (contextMenu && !isValidElement(contextMenu)) {
             console.error("Incorrect specification of 'contextMenu' arg in useContextMenu()");
             contextMenu = null;
         }
 
+        // 2) Render via blueprint!
         if (contextMenu) {
             ContextMenu.show(contextMenu, {left: e.clientX, top: e.clientY}, null, XH.darkTheme);
         }

--- a/desktop/hooks/UseContextMenu.js
+++ b/desktop/hooks/UseContextMenu.js
@@ -37,7 +37,7 @@ export function useContextMenu(child, contextMenu) {
             contextMenu = contextMenuEl({menuItems: contextMenu});
         }
 
-        if (!isValidElement(contextMenu)) {
+        if (contextMenu && !isValidElement(contextMenu)) {
             console.error("Incorrect specification of 'contextMenu' arg in useContextMenu()");
             contextMenu = null;
         }

--- a/desktop/hooks/UseContextMenu.js
+++ b/desktop/hooks/UseContextMenu.js
@@ -7,7 +7,7 @@
 import {XH} from '@xh/hoist/core';
 import {contextMenu as contextMenuEl} from '@xh/hoist/desktop/cmp/contextmenu/ContextMenu';
 import {ContextMenu} from '@xh/hoist/kit/blueprint';
-import {isArray, isFunction} from 'lodash';
+import {isArray, isFunction, isUndefined} from 'lodash';
 import {cloneElement, isValidElement} from 'react';
 
 /**
@@ -17,13 +17,19 @@ import {cloneElement, isValidElement} from 'react';
  *      that takes react context menu event as a prop (e.g. boxes, panel, div, etc).
  * @param {(Array|function|element)} [contextMenu] -  Array of ContextMenuItems, configs to create them,
  *      Elements, or '-' (divider).  Or a function that receives the triggering event and returns such an array.
+ *      If null, or the number of items is empty, no menu will be rendered, and the event will be consumed.
  *      A ContextMenu element may also be provided.
  */
 export function useContextMenu(child, contextMenu) {
 
-    if (!child || !contextMenu) return child;
+    if (!child || isUndefined(contextMenu)) return child;
 
     const onContextMenu = (e) => {
+
+        // Skip if already consumed, otherwise consume (Adapted from Blueprint 'ContextMenuTarget')
+        if (e.defaultPrevented) return;
+        e.preventDefault();
+
         if (isFunction(contextMenu)) {
             contextMenu = contextMenu(e);
         }
@@ -33,13 +39,12 @@ export function useContextMenu(child, contextMenu) {
 
         if (!isValidElement(contextMenu)) {
             console.error("Incorrect specification of 'contextMenu' arg in useContextMenu()");
-            return;
+            contextMenu = null;
         }
 
-        // Adapted from Blueprint 'ContextMenuTarget'
-        if (e.defaultPrevented) return;
-        e.preventDefault();
-        ContextMenu.show(contextMenu, {left: e.clientX, top: e.clientY}, null, XH.darkTheme);
+        if (contextMenu) {
+            ContextMenu.show(contextMenu, {left: e.clientX, top: e.clientY}, null, XH.darkTheme);
+        }
     };
 
     return cloneElement(child, {onContextMenu});


### PR DESCRIPTION
+ contextMenu property of null should consume event quietly
+ minor efficiency fix for consumed context menu events.
+ poorly formed contextMenus should also consume quietly

Please see also the following commit on develop -- this handles the [] case:
https://github.com/xh/hoist-react/commit/cc4dbb62f8f15f7eaf7efdf810cdb8377343099c

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

