### PR TITLE
Add Store.clearFilter()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,17 @@ transparency and ease-of-use, and to clarify and emphasize the suitability of Ho
 wide variety of enterprise software projects. For any questions regarding this change, please
 [contact us](https://xh.io/contact/).
 
+### 🎁 New Features
+
+* `Store` gets new `clearFilter()` and `recordIsFiltered()` helper functions.
+
 ### 💥 Breaking Changes
 
 * `PinPad` and `PinPadModel` have been moved to `@xh/hoist/cmp/pinpad`, and is now available for use
   with both standard and mobile toolkits.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v34.0.0...develop)
+
 
 ## v34.0.0 - 2020-05-26
 

--- a/data/StoreFilter.js
+++ b/data/StoreFilter.js
@@ -19,7 +19,7 @@ export class StoreFilter {
 
     /**
      * @param {Object} config
-     * @param {function} config.fn - function taking a record and returning a boolean.
+     * @param {StoreFilterFunction} config.fn - function taking a record and returning a boolean.
      * @param {boolean} [config.includeChildren] - true if all children of a passing record should
      *      also be considered passing (default false).
      */
@@ -29,4 +29,9 @@ export class StoreFilter {
     }
 }
 
-
+/**
+ * @callback StoreFilterFunction
+ * @param {Record} - record to evaluate
+ * @return {boolean} - true if the Record passes the filter and should be included in the Store's
+ *      filtered records collection.
+ */


### PR DESCRIPTION
+ Simple shortcut to `setFilter(null)`.
+ Automatically null Store's xhFilterText field if setting filter to null. While this store may be linked to StoreFilterFields that bind to an alternate source for their value, in default use cases (where SFFs stash their text state in Store) this should yield the least surprising results.
+ Move new `recordIsFiltered()` function closer to other filter-related APIs.
+ Add changelog noting both new methods.
+ Callback typedef for `StoreFilterFunction`.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

