### PR TITLE
Use `preventDefault()` in panel dragger event listeners to prevent overscroll on tablets

### DIFF
--- a/desktop/cmp/panel/impl/dragger/Dragger.js
+++ b/desktop/cmp/panel/impl/dragger/Dragger.js
@@ -20,18 +20,9 @@ export const dragger = hoistCmp.factory({
             dragModel = useLocalModel(() => new DraggerModel(panelModel));
 
         return div({
+            ref: dragModel.ref,
             className: `xh-resizable-dragger ${panelModel.side}`,
-            draggable: true,
-
-            // Mouse events
-            onDrag: dragModel.onDrag,
-            onDragStart: dragModel.onDragStart,
-            onDragEnd: dragModel.onDragEnd,
-
-            // Touch events
-            onTouchMove: dragModel.onDrag,
-            onTouchStart: dragModel.onDragStart,
-            onTouchEnd: dragModel.onDragEnd
+            draggable: true
         });
     }
 });


### PR DESCRIPTION
Note that in order to preventDefault, events listeners must be added to the element directly using a ref (React events are `passive: true`)

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

