### PR TITLE
Fix ag-grid popup zindex style.

### DIFF
--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -338,10 +338,13 @@
   .ag-set-filter-select-all {
     padding: var(--xh-pad-half-px) 0;
   }
+}
 
-  // Ensure ag-grid popups (context menus, tooltips, and column filter controls) with default z-index of 5
-  // appear over bp dialogs with z-index of 20.
-  &.ag-popup-child {
+// Ensure ag-grid popups (context menus, tooltips, and column filter controls) with default z-index of 5
+// appear over bp dialogs with z-index of 20.
+.ag-theme-balham.ag-popup,
+.ag-theme-balham-dark.ag-popup {
+  .ag-popup-child {
     z-index: 30;
   }
 }


### PR DESCRIPTION
Not sure when it changed, but the context menu is rendered in its own portal, breaking the z-index fix added here https://github.com/xh/hoist-react/pull/1840 (which expects it to also have the `xh-ag-grid` class)

<img width="418" alt="Screenshot 2020-06-04 at 18 06 48" src="https://user-images.githubusercontent.com/3017757/83789173-43b93700-a68e-11ea-993a-fff84432b600.png">


Fixes #1944.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

