### PR TITLE
Set --panel-bg in Hoist-React Admin app.

### DIFF
--- a/admin/App.scss
+++ b/admin/App.scss
@@ -5,6 +5,10 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 
+body {
+  --panel-bg: var(--xh-bg);
+}
+
 .xh-admin-app-frame {
   .bp3-tabs.bp3-vertical > .bp3-tab-list {
     min-width: 130px;


### PR DESCRIPTION
Fixes a styling issue in the Admin app that Lee noticed on the IdleDialog.
If an App does not specify a --panel-bg color, an App's Panel background will fall back to 'transparent'

See 
https://github.com/xh/hoist-react/blob/develop/desktop/cmp/panel/Panel.scss#L3 
and
https://github.com/xh/hoist-react/blob/develop/styles/vars.scss#L229

