### PR TITLE
Improve Bindability of Select with Objects

### DIFF
--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -19,7 +19,7 @@ import {action, observable} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 import {throwIf, withDefault} from '@xh/hoist/utils/js';
 import debouncePromise from 'debounce-promise';
-import {castArray, isEmpty, isNil, isPlainObject, keyBy, merge} from 'lodash';
+import {castArray, isEmpty, isNil, isPlainObject, keyBy, merge, isEqual} from 'lodash';
 import PT from 'prop-types';
 import React from 'react';
 import {createFilter} from 'react-select';
@@ -372,7 +372,7 @@ export class Select extends HoistInput {
                 const ret = this.findOption(value, false, option.options);
                 if (ret) return ret;
             } else {
-                if (option.value === value) return option;
+                if (isEqual(option.value, value)) return option;
             }
         }
 


### PR DESCRIPTION
I can't understand why we didn't have this in the first place.  If you ever want to usefully use object values in a select with binding, or even just controlling them with an external value, you really need it.  Its also consistent with the isEqual that we use in the superclass (HoistInput)  for value comparison.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

