### PR TITLE
Fix GoldenLayout touchmove events

### DIFF
--- a/kit/golden-layout/index.js
+++ b/kit/golden-layout/index.js
@@ -5,6 +5,7 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 import GoldenLayout from 'golden-layout';
+import jquery from 'jquery';
 import 'golden-layout/src/css/goldenlayout-base.css';
 import 'golden-layout/src/css/goldenlayout-light-theme.css';
 import {uniqueId} from 'lodash';
@@ -49,5 +50,77 @@ class ReactComponentHandlerPatched extends ReactComponentHandler {
 }
 GoldenLayout['__lm'].utils.ReactComponentHandler = ReactComponentHandlerPatched;
 
-export {GoldenLayout};
+// GoldenLayout (v1.5.9) has an issue with touch events, where dragging views on
+// a touch device requires 2 touches. This is because the original target of
+// the touchstart event is removed. See: https://www.w3.org/TR/touch-events/#the-touchmove-event
+//
+// Below we patch the DragListener to ensure that the original touch target remains
+// until the drag is completed.
+const DragListener = GoldenLayout['__lm'].utils.DragListener;
+class DragListenerPatched extends DragListener {
+    onMouseDown(oEvent) {
+        oEvent.preventDefault();
 
+        // PATCH BEGINS
+        if (oEvent.type === 'touchstart') {
+            this._touchTarget = oEvent.target;
+
+            const parent = this._touchTarget.parentNode,
+                idx = Array.from(parent.children).indexOf(this._touchTarget),
+                clone = this._touchTarget.cloneNode(true);
+
+            // Move target to body, and hide
+            document.body.appendChild(this._touchTarget);
+            this._touchTarget.style.display = 'none';
+
+            // Replace target with a clone
+            parent.insertBefore(clone, idx < parent.children.length - 1 ? parent.childNodes[idx + 1] : null);
+        }
+        // PATCH ENDS
+
+        if (oEvent.button == 0 || oEvent.type === 'touchstart') {
+            const coordinates = this._getCoordinates(oEvent);
+
+            this._nOriginalX = coordinates.x;
+            this._nOriginalY = coordinates.y;
+
+            this._oDocument.on('mousemove touchmove', this._fMove);
+            this._oDocument.one('mouseup touchend', this._fUp);
+
+            this._timeout = setTimeout(GoldenLayout['__lm'].utils.fnBind(this._startDrag, this), this._nDelay);
+        }
+    }
+
+    onMouseUp(oEvent) {
+        // PATCH BEGINS
+        if (this._touchTarget) {
+            document.body.removeChild(this._touchTarget);
+        }
+        // PATCH ENDS
+
+        if (this._timeout != null) {
+            clearTimeout(this._timeout);
+            this._eBody.removeClass('lm_dragging');
+            this._eElement.removeClass('lm_dragging');
+            this._oDocument.find('iframe').css('pointer-events', '');
+            this._oDocument.unbind('mousemove touchmove', this._fMove);
+            this._oDocument.unbind('mouseup touchend', this._fUp);
+
+            if (this._bDragging === true) {
+                this._bDragging = false;
+                this.emit('dragStop', oEvent, this._nOriginalX + this._nX);
+            }
+        }
+    }
+}
+GoldenLayout['__lm'].utils.DragListener = DragListenerPatched;
+
+// Overwrite jquery's 'touchmove' handler wiring, to ensure 'touchmove' handlers are non-passive.
+// This is required to suppress and error thrown by trying to preventDefault() a passive event.
+jquery.event.special.touchmove = {
+    setup: function(_, ns, handle) {
+        this.addEventListener('touchmove', handle, {passive: false});
+    }
+};
+
+export {GoldenLayout};

--- a/kit/golden-layout/index.js
+++ b/kit/golden-layout/index.js
@@ -116,7 +116,7 @@ class DragListenerPatched extends DragListener {
 GoldenLayout['__lm'].utils.DragListener = DragListenerPatched;
 
 // Overwrite jquery's 'touchmove' handler wiring, to ensure 'touchmove' handlers are non-passive.
-// This is required to suppress and error thrown by trying to preventDefault() a passive event.
+// This is required to suppress an error thrown by trying to preventDefault() a passive event.
 jquery.event.special.touchmove = {
     setup: function(_, ns, handle) {
         this.addEventListener('touchmove', handle, {passive: false});


### PR DESCRIPTION
Patch GoldenLayout's DragListener to improve support for touchmove events.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

