### PR TITLE
Pass some layout props to panel's content container

### DIFF
--- a/desktop/appcontainer/LoginPanel.js
+++ b/desktop/appcontainer/LoginPanel.js
@@ -5,7 +5,7 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 import {LoginPanelModel} from '@xh/hoist/appcontainer/login/LoginPanelModel';
-import {div, filler, form, viewport, vspacer} from '@xh/hoist/cmp/layout';
+import {div, filler, form, viewport} from '@xh/hoist/cmp/layout';
 import {creates, hoistCmp, XH} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {textInput} from '@xh/hoist/desktop/cmp/input';
@@ -40,9 +40,9 @@ export const loginPanel = hoistCmp.factory({
                 icon: Icon.login(),
                 className: 'xh-login',
                 width: 300,
+                padding: 10,
                 mask: loadModel,
                 items: [
-                    vspacer(10),
                     form(
                         textInput({
                             bind: 'username',

--- a/desktop/appcontainer/LoginPanel.scss
+++ b/desktop/appcontainer/LoginPanel.scss
@@ -10,13 +10,12 @@
   border-radius: var(--xh-border-radius-px);
 
   .bp3-input-group {
-    margin: 0 var(--xh-pad-px) var(--xh-pad-px) var(--xh-pad-px);
+    margin-bottom: var(--xh-pad-px);
   }
 
   &__warning,
   &__message {
     text-align: center;
-    margin: 0 var(--xh-pad-px) var(--xh-pad-px) var(--xh-pad-px);
     padding: var(--xh-pad-px);
     border-radius: var(--xh-border-radius-px);
   }

--- a/desktop/cmp/panel/Panel.js
+++ b/desktop/cmp/panel/Panel.js
@@ -71,9 +71,12 @@ export const [Panel, panel] = hoistCmp.withFactory({
         } = nonLayoutProps;
 
         // 1) Pre-process layout
-        // Block unwanted use of padding props, which will separate the panel's header
-        // and bottom toolbar from its edges in a confusing way.
-        layoutProps = omitBy(layoutProps, (v, k) => k.startsWith('padding'));
+        // Extract content styling props, to pass them on to the content element of the panel,
+        // and remove them from the panel's wrapper element so that they
+        // do not have bad effects on the panel's header and bottom toolbar.
+        const contentStyleFilter = (k) => k.startsWith('padding')|| k.startsWith('overflow') || ['alignItems', 'alignContent', 'justifyContent'].includes(k),
+            contentStyleProps = omitBy(layoutProps, (v, k) => !contentStyleFilter(k));
+        layoutProps = omitBy(layoutProps, (v, k) => contentStyleFilter(k));
 
         // Give Panels a default flexing behavior if no dimensions / flex specified.
         if (layoutProps.width == null && layoutProps.height == null && layoutProps.flex == null) {
@@ -106,7 +109,7 @@ export const [Panel, panel] = hoistCmp.withFactory({
                 style: {display: collapsed ? 'none' : 'flex'},
                 items: [
                     parseToolbar(tbar),
-                    ...(castArray(children)),
+                    vframe({style: { ...contentStyleProps}, items: castArray(children)}),
                     parseToolbar(bbar)
                 ]
             });


### PR DESCRIPTION
Toolbox branch:  https://github.com/xh/toolbox/tree/paddingOnPanel
Toolbox PR: https://github.com/xh/toolbox/pull/415

This PR resolves issue #1971 .  I found that in addition to 'padding' it made sense to pass the following style keys to the content container:
'overflow', 'alignItems', 'alignContent', 'justifyContent'

If others don't share my enthusiasm for all of these, I could back down on 'alignItems', 'alignContent', 'justifyContent', but 'padding' and 'overflow' are great.

I was pleasantly surprised by how many cleanups were possible in Toolbox ([see PR](https://github.com/xh/toolbox/pull/415)) by using this change.

The one disadvantage to this is that the app's standard padding value --xh-pad-px is not available to the JS when using panel({padding: 10}).   This could resolved by creating a js version on the appModel or some other central location, but leaving that for discussion.

Also wondering if it is worth documenting on Panel.js what style props are accepted and placed where.   'width', 'height', 'flex', etc... have all been accepted and working but not documented clearly.  Now with some style props being applied differently, it might be worth putting in the docs which apply where.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

