### PR TITLE
Fixes "Calling gridModel.clear() does not clear summary row content"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Changelog
 
+## v36.0.0-SNAPSHOT - under development
+
 ### 🎁 New Features
 
 * Added a `validEmail` constraint for forms.
 
 ### 🐞 Bug Fixes
 
-* Grid Summary Row is now cleared when grid is cleared
-* `chevron-right/left` svg icons added to `requiredBlueprintIcons.js`
-  to bring back calendar scroll icons on the DatePicker component.
+* A Grid's docked summary row is now properly cleared when its bound Store is cleared.
+* Additional SVG paths added to `requiredBlueprintIcons.js` to bring back calendar scroll icons on
+  the DatePicker component.
+
+[Commit Log](https://github.com/xh/hoist-react/compare/v35.2.0...develop)
 
 
 ## v35.2.0 - 2020-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 * Added a `validEmail` constraint for forms.
 
+### 🐞 Bug Fixes
+
+* Grid Summary Row is now cleared when grid is cleared
+* `chevron-right/left` svg icons added to `requiredBlueprintIcons.js`
+  to bring back calendar scroll icons on the DatePicker component.
+
+
 ## v35.2.0 - 2020-07-21
 
 ### 🎁 New Features

--- a/data/Store.js
+++ b/data/Store.js
@@ -136,9 +136,9 @@ export class Store {
         this._committed = this._current = this._committed.withNewRecords(records);
         this.rebuildFiltered();
 
-        if (rawSummaryData) {
-            this.summaryRecord = this.createRecord(rawSummaryData, null, true);
-        }
+        this.summaryRecord = rawSummaryData ?
+            this.createRecord(rawSummaryData, null, true) :
+            null;
 
         this.lastLoaded = this.lastUpdated = Date.now();
     }


### PR DESCRIPTION
This fixes this issue: https://github.com/xh/hoist-react/issues/2017

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes: no breaking changes
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: https://github.com/xh/toolbox/tree/clearGridSummaryRow
- [x] Created Toolbox PR: https://github.com/xh/toolbox/pull/420

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

