### PR TITLE
Defend against accidental double-submit of login

### DIFF
--- a/desktop/appcontainer/LoginPanel.js
+++ b/desktop/appcontainer/LoginPanel.js
@@ -25,7 +25,7 @@ export const loginPanel = hoistCmp.factory({
 
     render({model}) {
         const {loginMessage} = XH.appSpec,
-            {loadModel, warning, isValid} = model;
+            {loadModel, warning, isValid, loginInProgress} = model;
 
         const onKeyDown = (ev) => {
             if (ev.key === 'Enter') model.submitAsync();
@@ -77,10 +77,10 @@ export const loginPanel = hoistCmp.factory({
                 bbar: [
                     filler(),
                     button({
-                        text: 'Login',
+                        text: loginInProgress ? 'Please wait...' : 'Login',
                         intent: 'primary',
                         icon: Icon.login(),
-                        disabled: !isValid,
+                        disabled: !isValid || loginInProgress,
                         onClick: () => model.submitAsync()
                     })
                 ]

--- a/mobile/appcontainer/LoginPanel.js
+++ b/mobile/appcontainer/LoginPanel.js
@@ -26,7 +26,7 @@ export const loginPanel = hoistCmp.factory({
 
     render({model}) {
         const {loginMessage} = XH.appSpec,
-            {isValid, loadModel, warning} = model;
+            {isValid, loadModel, warning, loginInProgress} = model;
 
         return panel({
             className: 'xh-login',
@@ -70,9 +70,9 @@ export const loginPanel = hoistCmp.factory({
                         }),
                         button({
                             icon: Icon.login(),
-                            text: 'Login',
+                            text: loginInProgress ? 'Please wait...' : 'Login',
                             modifier: 'cta',
-                            disabled: !isValid,
+                            disabled: !isValid || loginInProgress,
                             onClick: () => model.submitAsync()
                         })
                     ]


### PR DESCRIPTION
+ Debounce LoginPanelModel.submitAsync (I think this is the real fix) and also disable / modify login button text to indicate login in progress.
+ Await XH.completeInitAsync() to avoid taking down login panel mask before the app has re-rendered with its primary interface.
+ Should avoid the rare-but-persistent double init exception (manifests as an exception re. re-init of IdentityService).

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

