### PR TITLE
Elided header tooltip + bonus bugfix!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🎁 New Features
 
+* Elided Grid column headers now show the full `headerName` value in a browser "title" tooltip on hover.
 * Added new a `AppSpec.showBrowserContextMenu` config to control whether the browser's default
   context menu will be shown if no app-specific context menu (e.g. from a grid) would be triggered.
   * ⚠ Note this new config defaults to `false`, meaning the browser context menu will *not* be
@@ -28,7 +29,7 @@
     can key off of these classes directly if required.
 
 ### 🐞 Bug Fixes
-
+* Fixed tooltipElement so that it can work if a headerTooltip is also specified on the same column.
 * Fixed issue where newly loaded records in `Store` were not being frozen as promised by the API.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v35.2.1...develop)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🎁 New Features
 
-* Elided Grid column headers now show the full `headerName` value in a browser "title" tooltip on hover.
+* By default, elided Grid column headers now show the full `headerName` value in a tooltip
 * Added new a `AppSpec.showBrowserContextMenu` config to control whether the browser's default
   context menu will be shown if no app-specific context menu (e.g. from a grid) would be triggered.
   * ⚠ Note this new config defaults to `false`, meaning the browser context menu will *not* be
@@ -32,7 +32,8 @@
     can key off of these classes directly if required.
 
 ### 🐞 Bug Fixes
-* Fixed tooltipElement so that it can work if a headerTooltip is also specified on the same column.
+* Fixed `Column.tooltipElement` so that it can work if a `headerTooltip` is also specified on the same column.
+* Fixed issue where certain values (e.g. `%`) would break in `Column.tooltipElement`.
 * Fixed issue where newly loaded records in `Store` were not being frozen as promised by the API.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v35.2.1...develop)

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -394,7 +394,7 @@ export class Column {
                     }
 
                     const record = api.getDisplayedRowAtIndex(rowIndex).data,
-                        value = record.get(colDef.colId);
+                        value = record.data[colDef.field];
                     return me.tooltipElement(value, {record, column: me, gridModel, agParams});
                 }
             };

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -19,6 +19,7 @@ import {
     isString,
     startCase
 } from 'lodash';
+import {div} from '@xh/hoist/cmp/layout';
 import {Component} from 'react';
 import {ExportFormat} from './ExportFormat';
 import {GridSorter} from '../impl/GridSorter';
@@ -377,15 +378,23 @@ export class Column {
         } else if (this.tooltipElement) {
             ret.tooltipValueGetter = ({value}) => value;
             ret.tooltipComponentFramework = class extends Component {
-                getReactContainerClasses() {return ['xh-grid-tooltip']}
+                getReactContainerClasses() {
+                    const agParams = this.props,
+                        {location} = agParams;
+                    return location === 'header' ?
+                        ['ag-tooltip'] :
+                        ['xh-grid-tooltip'];
+                }
                 render() {
                     const agParams = this.props,
-                        {rowIndex, api, colDef} = agParams,
-                        {headerTooltip} = colDef,
-                        overHeader = isNil(rowIndex),
-                        value = overHeader ? headerTooltip : agParams.value,
-                        record = overHeader ? null : api.getDisplayedRowAtIndex(rowIndex).data;
+                        {rowIndex, api, colDef, location} = agParams;
 
+                    if (location === 'header') {
+                        return div(colDef.headerTooltip);
+                    }
+
+                    const value = agParams.value,
+                        record = api.getDisplayedRowAtIndex(rowIndex).data;
                     // ag-Grid encodes the value, so we decode it before passing to the renderer
                     return me.tooltipElement(decodeURIComponent(value), {record, column: me, gridModel, agParams});
                 }

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -380,8 +380,11 @@ export class Column {
                 getReactContainerClasses() {return ['xh-grid-tooltip']}
                 render() {
                     const agParams = this.props,
-                        {value, rowIndex, api} = agParams,
-                        record = api.getDisplayedRowAtIndex(rowIndex).data;
+                        {rowIndex, api, colDef} = agParams,
+                        {headerTooltip} = colDef,
+                        value = isNil(rowIndex) ? headerTooltip : agParams.value;
+
+                    const record = api.getDisplayedRowAtIndex(rowIndex)?.data;
 
                     // ag-Grid encodes the value, so we decode it before passing to the renderer
                     return me.tooltipElement(decodeURIComponent(value), {record, column: me, gridModel, agParams});

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -384,9 +384,7 @@ export class Column {
                         {headerTooltip} = colDef,
                         overHeader = isNil(rowIndex),
                         value = overHeader ? headerTooltip : agParams.value,
-                        record = overHeader ? null : api.getDisplayedRowAtIndex(rowIndex).data
-
-                    const record = api.getDisplayedRowAtIndex(rowIndex)?.data;
+                        record = overHeader ? null : api.getDisplayedRowAtIndex(rowIndex).data;
 
                     // ag-Grid encodes the value, so we decode it before passing to the renderer
                     return me.tooltipElement(decodeURIComponent(value), {record, column: me, gridModel, agParams});

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -382,7 +382,9 @@ export class Column {
                     const agParams = this.props,
                         {rowIndex, api, colDef} = agParams,
                         {headerTooltip} = colDef,
-                        value = isNil(rowIndex) ? headerTooltip : agParams.value;
+                        overHeader = isNil(rowIndex),
+                        value = overHeader ? headerTooltip : agParams.value,
+                        record = overHeader ? null : api.getDisplayedRowAtIndex(rowIndex).data
 
                     const record = api.getDisplayedRowAtIndex(rowIndex)?.data;
 

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -393,10 +393,9 @@ export class Column {
                         return div(colDef.headerTooltip);
                     }
 
-                    const value = agParams.value,
-                        record = api.getDisplayedRowAtIndex(rowIndex).data;
-                    // ag-Grid encodes the value, so we decode it before passing to the renderer
-                    return me.tooltipElement(decodeURIComponent(value), {record, column: me, gridModel, agParams});
+                    const record = api.getDisplayedRowAtIndex(rowIndex).data,
+                        value = record.get(colDef.colId);
+                    return me.tooltipElement(value, {record, column: me, gridModel, agParams});
                 }
             };
         }

--- a/cmp/grid/impl/ColumnHeader.js
+++ b/cmp/grid/impl/ColumnHeader.js
@@ -12,7 +12,7 @@ import {useOnMount, createObservableRef} from '@xh/hoist/utils/react';
 import {debounced} from '@xh/hoist/utils/js';
 import {olderThan} from '@xh/hoist/utils/datetime';
 import classNames from 'classnames';
-import {filter, findIndex, isEmpty, isFunction, isFinite, isNil, isString, unescape} from 'lodash';
+import {filter, findIndex, isEmpty, isFunction, isFinite, isNil, isString} from 'lodash';
 import {GridSorter} from './GridSorter';
 import {Column} from '@xh/hoist/cmp/grid/columns/Column';
 
@@ -59,12 +59,11 @@ export const columnHeader = hoistCmp.factory({
             });
         };
 
-        const {isDesktop} = XH,
-            extraClasses = [
-                impl.isFiltered ? 'xh-grid-header-filtered' : null,
-                impl.activeGridSorter ? 'xh-grid-header-sorted' : null,
-                impl.hasNonPrimarySort ? 'xh-grid-header-multisort' : null
-            ];
+        const extraClasses = [
+            impl.isFiltered ? 'xh-grid-header-filtered' : null,
+            impl.activeGridSorter ? 'xh-grid-header-sorted' : null,
+            impl.hasNonPrimarySort ? 'xh-grid-header-multisort' : null
+        ];
 
         let headerName = props.displayName;
         if (impl.xhColumn && isFunction(impl.xhColumn.headerName)) {
@@ -75,15 +74,16 @@ export const columnHeader = hoistCmp.factory({
         const showTooltipWhenElided = isNil(impl.xhColumn.headerTooltip),
             doShowTooltipWhenElided = (evt) => {
                 const el = evt.target,
-                    isElided = el.offsetWidth < el.scrollWidth,
-                    title = unescape(el.innerHTML);
+                    isElided = el.offsetWidth < el.scrollWidth;
 
                 if (isElided) {
-                    el.setAttribute('title', title);
+                    el.setAttribute('title', headerName);
                 } else {
                     el.removeAttribute('title');
                 }
             };
+
+        const {isDesktop} = XH;
 
         return div({
             className: classNames(props.className, extraClasses),

--- a/cmp/grid/impl/ColumnHeader.js
+++ b/cmp/grid/impl/ColumnHeader.js
@@ -84,7 +84,6 @@ export const columnHeader = hoistCmp.factory({
             };
 
         const {isDesktop} = XH;
-
         return div({
             className: classNames(props.className, extraClasses),
 

--- a/cmp/grid/impl/ColumnHeader.js
+++ b/cmp/grid/impl/ColumnHeader.js
@@ -66,12 +66,12 @@ export const columnHeader = hoistCmp.factory({
         ];
 
         let headerName = props.displayName;
-        if (impl.xhColumn && isFunction(impl.xhColumn.headerName)) {
+        if (isFunction(impl.xhColumn?.headerName)) {
             const {xhColumn, gridModel} = impl;
             headerName = xhColumn.headerName({column: xhColumn, gridModel});
         }
 
-        const showTooltipWhenElided = isNil(impl.xhColumn.headerTooltip),
+        const showTooltipWhenElided = isNil(impl.xhColumn?.headerTooltip),
             doShowTooltipWhenElided = (evt) => {
                 const el = evt.target,
                     isElided = el.offsetWidth < el.scrollWidth;

--- a/cmp/grid/impl/ColumnHeader.js
+++ b/cmp/grid/impl/ColumnHeader.js
@@ -12,7 +12,7 @@ import {useOnMount, createObservableRef} from '@xh/hoist/utils/react';
 import {debounced} from '@xh/hoist/utils/js';
 import {olderThan} from '@xh/hoist/utils/datetime';
 import classNames from 'classnames';
-import {filter, findIndex, isEmpty, isFunction, isFinite, isNil, isString} from 'lodash';
+import {filter, findIndex, isEmpty, isFunction, isFinite, isNil, isString, unescape} from 'lodash';
 import {GridSorter} from './GridSorter';
 import {Column} from '@xh/hoist/cmp/grid/columns/Column';
 
@@ -72,13 +72,16 @@ export const columnHeader = hoistCmp.factory({
             headerName = xhColumn.headerName({column: xhColumn, gridModel});
         }
 
-        const showTooltipWhenElided = isNil(impl.xhColumn.agOptions.headerTooltip),
+        const showTooltipWhenElided = isNil(impl.xhColumn.headerTooltip),
             doShowTooltipWhenElided = (evt) => {
                 const el = evt.target,
-                    isElided = el.offsetWidth < el.scrollWidth;
+                    isElided = el.offsetWidth < el.scrollWidth,
+                    title = unescape(el.innerHTML);
 
                 if (isElided) {
-                    el.setAttribute('title', el.innerHTML);
+                    el.setAttribute('title', title);
+                } else {
+                    el.removeAttribute('title');
                 }
             };
 


### PR DESCRIPTION
This resolves: https://github.com/xh/hoist-react/issues/2027

This PR brings in a small code change to automatically show the full headerName value in a browser "title" attribute tooltip if the headerName is elided in a Grid column header.

If the column width is expanded enough so that the headerName is no longer elided, the title tip no longer shows.

This logic does not run if the developer has already specified a `headerTooltip` on the column.


This PR also fixes a minor bug: prior, if a developer had specified a tooltipElement and a headerTooltip on the same column, mousing over the column header triggered a JS error.
This PR fixes this by passing the headerTooltip as the value to the tooltipElement when mousing over header.
See agGrid docs https://www.ag-grid.com/javascript-grid-tooltip-component/#header-tooltip-with-custom-tooltip  where they detail that this is what they expect a tooltipElement/Component to do.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry.
- [x] Reviewed for breaking changes: no breaking changes.
- [x] Updated doc comments / prop-types: not required
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR: https://github.com/xh/toolbox/tree/elidedHeaderTooltip

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

