### PR TITLE
Support for Column.displayName + defaulting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,21 @@ Store's ability to infer its Fields from Grid Column definitions.
 
 We are looking to gradually invert this relationship, so that core information about an app's
 business objects and their properties is configured once at the `data/Field` level and then made
-available to related APIs and components such as grids, filters, and forms. These deeper
-integrations remain a work in progress.
+available to related APIs and components such as grids, filters, and forms. See note in New Features
+below regarding related updates to `GridModel.columns` config processing.
+
+#### Grid
+
+* Added new `GridModel.setColumnVisible()` method, along with `showColumn()` and `hideColumn()`
+  convenience methods. Can replace calls to `applyColumnStateChanges()` when all you need to do is
+  show or hide a single column.
+* Elided Grid column headers now show the full `headerName` value in a tooltip.
+* Grid column definitions now accept a new `displayName` config as the recommended entry point for
+  defining a friendly user-facing label for a Column.
+  * If the GridModel's Store has configured a `displayName` for the linked data field, the column
+    will default to use that (if not otherwise specified).
+  * If specified or sourced from a Field, `displayName` will be used as the default value for the
+    pre-existing `headerName` and `chooserName` configs.
 
 #### Other
 
@@ -39,10 +52,6 @@ integrations remain a work in progress.
   menu will be shown if no app-specific context menu (e.g. from a grid) would be triggered.
   * ⚠ Note this new config defaults to `false`, meaning the browser context menu will *not* be
     available. Developers should set to true for apps that expect/depend on the built-in menu.
-* Added new `GridModel.setColumnVisible()` method, along with `showColumn()` and `hideColumn()`
-  convenience methods. Can replace calls to `applyColumnStateChanges()` when all you need to do is
-  show or hide a single column.
-* Elided Grid column headers now show the full `headerName` value in a tooltip.
 * `LocalDate` has gained new static factories `tomorrow()` and `yesterday()`.
 
 ### 💥 Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ below regarding related updates to `GridModel.columns` config processing.
     will default to use that (if not otherwise specified).
   * If specified or sourced from a Field, `displayName` will be used as the default value for the
     pre-existing `headerName` and `chooserName` configs.
+* Grid columns backed by a Store Field of type `number` or `int` will be right-aligned by default.
 
 #### Other
 

--- a/cmp/dimensionchooser/DimensionChooserModel.js
+++ b/cmp/dimensionchooser/DimensionChooserModel.js
@@ -5,6 +5,7 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 import {HoistModel, managed, PersistenceProvider, XH} from '@xh/hoist/core';
+import {genDisplayName} from '@xh/hoist/data';
 import {action, bindable, observable} from '@xh/hoist/mobx';
 import {apiRemoved, throwIf} from '@xh/hoist/utils/js';
 import {
@@ -18,7 +19,6 @@ import {
     isString,
     keys,
     sortBy,
-    startCase,
     take,
     without
 } from 'lodash';
@@ -282,7 +282,7 @@ export class DimensionChooserModel {
         );
 
         return {
-            displayName: startCase(src.name),
+            displayName: genDisplayName(src.name),
             isLeafDimension: false,
             ...src
         };

--- a/cmp/filter/impl/FilterChooserFieldSpec.js
+++ b/cmp/filter/impl/FilterChooserFieldSpec.js
@@ -74,13 +74,28 @@ export class FilterChooserFieldSpec {
     get isRangeType() { return this.filterType === 'range'}
     get isValueType() { return this.filterType === 'value'}
 
+    get isDateBasedFieldType() {
+        const {fieldType} = this;
+        return fieldType == FieldType.DATE || fieldType == FieldType.LOCAL_DATE;
+    }
+
+    get isNumericFieldType() {
+        const {fieldType} = this;
+        return fieldType == FieldType.INT || fieldType == FieldType.NUMBER;
+    }
+
+    get isBoolFieldType() {return this.fieldType == FieldType.BOOL}
+
     /**
      * @return {string} - a rendered example / representative data value to aid usability.
-     *      TODO - default return of upper fieldType is a bit rough (e.g. "INT")
      */
     get example() {
-        const {exampleValue, fieldType} = this;
-        return exampleValue ? this.renderValue(exampleValue) : fieldType.toUpperCase();
+        const {exampleValue} = this;
+        if (exampleValue) return this.renderValue(exampleValue);
+        if (this.isBoolFieldType) return 'true';
+        if (this.isDateBasedFieldType) return 'YYYYMMDD';
+        if (this.isNumericFieldType) return this.renderValue(1234);
+        return 'value';
     }
 
     /**
@@ -131,7 +146,7 @@ export class FilterChooserFieldSpec {
         let ret;
         if (isFunction(this.valueRenderer)) {
             ret = this.valueRenderer(value, op);
-        } else if (this.fieldType === FieldType.DATE || this.fieldType === FieldType.LOCAL_DATE) {
+        } else if (this.isDateBasedFieldType) {
             ret = fmtDate(value);
         } else {
             ret = value?.toString();
@@ -160,7 +175,7 @@ export class FilterChooserFieldSpec {
     parseValues(values, storeRecords) {
         if (values) return values; // If explicit values provided by caller, return as-is
         if (this.suggestValues) {
-            return this.fieldType === FieldType.BOOL ? [true, false] : this.extractValuesFromRecords(storeRecords);
+            return this.isBoolFieldType ? [true, false] : this.extractValuesFromRecords(storeRecords);
         }
         return null;
     }
@@ -171,7 +186,7 @@ export class FilterChooserFieldSpec {
     }
 
     getDefaultOperators() {
-        if (this.fieldType === FieldType.BOOL) return ['='];
+        if (this.isBoolFieldType) return ['='];
         return this.isValueType ? ['=', '!=', 'like'] : ['>', '>=', '<', '<=', '=', '!='];
     }
 

--- a/cmp/form/field/BaseFieldModel.js
+++ b/cmp/form/field/BaseFieldModel.js
@@ -4,13 +4,14 @@
  *
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
+import {Rule, ValidationState} from '@xh/hoist/cmp/form';
 import {managed} from '@xh/hoist/core';
+import {genDisplayName} from '@xh/hoist/data';
 import {action, computed, observable, runInAction} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 import {PendingTaskModel} from '@xh/hoist/utils/async/PendingTaskModel';
-import {compact, flatten, isEmpty, isFunction, isNil, isUndefined, startCase} from 'lodash';
-import {Rule} from '../validation/Rule';
-import {ValidationState} from '../validation/ValidationState';
+import {withDefault} from '@xh/hoist/utils/js';
+import {compact, flatten, isEmpty, isFunction, isNil, isUndefined} from 'lodash';
 
 /**
  * Abstract Base class for FieldModels.
@@ -71,14 +72,14 @@ export class BaseFieldModel {
      */
     constructor({
         name,
-        displayName = startCase(name),
+        displayName,
         initialValue = null,
         disabled = false,
         readonly = false,
         rules = []
     }) {
         this.name = name;
-        this.displayName = displayName;
+        this.displayName = withDefault(displayName, genDisplayName(name));
         this.value = initialValue;
         this.initialValue = initialValue;
         this._disabled = disabled;

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -760,7 +760,7 @@ export class GridModel {
                 const ret = this.findColumn(col.children, colId);
                 if (ret) return ret;
             } else {
-                if (col.colId == colId) return col;
+                if (col.colId === colId) return col;
             }
         }
         return null;
@@ -934,7 +934,7 @@ export class GridModel {
         // 3) Create and set columns with (possibly) enhanced configs.
         this.setColumns(colConfigs);
 
-        // 4) Enhance/create config (if needed) and set Store.
+        // 4) Enhance store config and create (if needed), then set.
         if (isPlainObject(store)) {
             const storeConfig = this.enhanceStoreConfigFromColumns(store);
             this.store = this.markManaged(new Store(storeConfig));
@@ -984,7 +984,7 @@ export class GridModel {
         const numTypes = [FieldType.INT, FieldType.NUMBER];
         return colConfigs.map(col => {
             // Note this routine currently works with either Field instances or configs.
-            const field = storeFields.find(f => f.name == col.field);
+            const field = storeFields.find(f => f.name === col.field);
             if (!field) return col;
 
             return {

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -210,21 +210,24 @@ export class Column {
             this.fieldPath = splitFieldPath ? field.split('.') : field;
         }
 
-        this.colId = withDefault(colId, field);
+        this.colId = colId || field;
         throwIf(!this.colId, 'Must specify colId or field for a Column.');
 
         this.isTreeColumn = withDefault(isTreeColumn, false);
 
         // Note that parent GridModel might have already defaulted displayName from an associated
-        // `Store.field` when pre-processing Column configs - prior to calling this ctor.
-        this.displayName = withDefault(displayName, genDisplayName(this.colId));
+        // `Store.field` when pre-processing Column configs - prior to calling this ctor. If that
+        // hasn't happened, displayName will still always be defaulted to a fallback based on colId.
+        this.displayName = displayName || genDisplayName(this.colId);
 
+        // In contrast, headerName supports a null or '' value when no header label is desired.
         this.headerName = withDefault(headerName, this.displayName);
+
         this.headerTooltip = headerTooltip;
         this.headerClass = headerClass;
         this.cellClass = cellClass;
         this.align = align;
-        this.headerAlign = headerAlign ?? align;
+        this.headerAlign = headerAlign || align;
 
         this.hidden = withDefault(hidden, false);
         warnIf(rest.hide, `Column ${this.colId} configured with {hide: true} - use "hidden" instead.`);
@@ -267,7 +270,7 @@ export class Column {
             'Specifying both renderIsComplex and highlightOnChange is not supported. Cells will be force-refreshed on all changes and always flash.'
         );
 
-        this.chooserName = withDefault(chooserName, this.displayName);
+        this.chooserName = chooserName || this.displayName;
         this.chooserGroup = chooserGroup;
         this.chooserDescription = chooserDescription;
         this.excludeFromChooser = withDefault(excludeFromChooser, false);

--- a/cmp/grid/columns/ColumnGroup.js
+++ b/cmp/grid/columns/ColumnGroup.js
@@ -4,8 +4,9 @@
  *
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
-import {throwIf, withDefault, apiRemoved} from '@xh/hoist/utils/js';
-import {clone, isEmpty, isFunction, isString, startCase} from 'lodash';
+import {genDisplayName} from '@xh/hoist/data';
+import {apiRemoved, throwIf, withDefault} from '@xh/hoist/utils/js';
+import {clone, isEmpty, isFunction, isString} from 'lodash';
 import {getAgHeaderClassFn} from './Column';
 
 /**
@@ -48,7 +49,7 @@ export class ColumnGroup {
 
         this.groupId = withDefault(groupId, headerName);
 
-        this.headerName = withDefault(headerName, startCase(this.groupId));
+        this.headerName = withDefault(headerName, genDisplayName(this.groupId));
         this.headerClass = headerClass;
         this.headerAlign = headerAlign;
 

--- a/data/Field.js
+++ b/data/Field.js
@@ -7,6 +7,7 @@
 
 import {XH} from '@xh/hoist/core';
 import {isLocalDate, LocalDate} from '@xh/hoist/utils/datetime';
+import {withDefault} from '@xh/hoist/utils/js';
 import equal from 'fast-deep-equal';
 import {isDate, startCase} from 'lodash';
 
@@ -28,12 +29,12 @@ export class Field {
     constructor({
         name,
         type = FieldType.AUTO,
-        displayName = startCase(name),
+        displayName,
         defaultValue = null
     }) {
         this.name = name;
         this.type = type;
-        this.displayName = displayName;
+        this.displayName = withDefault(displayName, genDisplayName(name));
         this.defaultValue = defaultValue;
     }
 
@@ -95,10 +96,18 @@ export const FieldType = Object.freeze({
 });
 
 /**
+ * @param {string} fieldName - short name / code for a field.
+ * @return {string} - fieldName transformed into user-facing / longer name for display.
+ */
+export function genDisplayName(fieldName) {
+    return fieldName == 'id' ? 'ID' : startCase(fieldName);
+}
+
+/**
  * @typedef {Object} FieldConfig - ctor arguments for a Hoist data package Field.
  * @property {string} name - unique key representing this field.
  * @property {FieldType} [type] - default `FieldType.AUTO` indicates no conversion.
- * @property {string} [displayName] - user-friendly / longer name for display, defaults to `name`
- *      transformed via lodash `startCase` (e.g. fooBar -> Foo Bar).
+ * @property {string} [displayName] - user-facing / longer name for display, defaults to `name`
+ *      transformed via `genDisplayName()` (e.g. 'myField' -> 'My Field').
  * @property {*} [defaultValue] - value to be used for records with a null, or non-existent value.
  */

--- a/data/Field.js
+++ b/data/Field.js
@@ -100,7 +100,7 @@ export const FieldType = Object.freeze({
  * @return {string} - fieldName transformed into user-facing / longer name for display.
  */
 export function genDisplayName(fieldName) {
-    return fieldName == 'id' ? 'ID' : startCase(fieldName);
+    return fieldName === 'id' ? 'ID' : startCase(fieldName);
 }
 
 /**

--- a/data/cube/CubeField.js
+++ b/data/cube/CubeField.js
@@ -96,8 +96,8 @@ export class CubeField extends Field {
  * @typedef {Object} CubeFieldConfig - extends {@see FieldConfig} with cube-specific configs.
  * @property {string} name - unique key representing this field.
  * @property {FieldType} [type] - default `FieldType.AUTO` indicates no conversion.
- * @property {string} [displayName] - user-friendly / longer name for display, defaults to `name`
- *      transformed via lodash `startCase` (e.g. fooBar -> Foo Bar).
+ * @property {string} [displayName] - user-facing / longer name for display, defaults to `name`
+ *      transformed via `genDisplayName()` (e.g. 'myField' -> 'My Field').
  * @property {*} [defaultValue] - value to be used for records with a null, or non-existent value.
  * @property {boolean} [c.isDimension] - true to allow this field to be used for grouping.
  * @property {(Aggregator|string)} [c.aggregator] - instance of a Hoist Cube Aggregator (from the

--- a/desktop/cmp/filter/FilterChooser.js
+++ b/desktop/cmp/filter/FilterChooser.js
@@ -25,6 +25,7 @@ export const [FilterChooser, filterChooser] = hoistCmp.withFactory({
             className,
             bind: 'selectValue',
             ref: inputRef,
+            placeholder: 'Filter...',
             enableMulti: true,
             enableClear: true,
             hideDropdownIndicator: true,


### PR DESCRIPTION
+ New config `Column.displayName` as general-purpose entry-point for the user-facing name of a Column.
+ Sourced via GridModel pre-processing from the `displayName` property of a linked store `Field` or config, if available, allowing further DRYing up of field metadata.
+ Also default columns bound to numeric field types to right alignment if not otherwise specified.
+ Add utility `genDisplayName()` function and use consistently in place of multiple independent calls to `startCase`.
+ Doc tweaks and auto-formatting.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

