### PR TITLE
FieldFilter comparisons exclude null vals

### DIFF
--- a/data/filter/FieldFilter.js
+++ b/data/filter/FieldFilter.js
@@ -8,13 +8,16 @@
 import {XH} from '@xh/hoist/core';
 import {parseFieldValue} from '@xh/hoist/data';
 import {throwIf} from '@xh/hoist/utils/js';
-import {castArray, escapeRegExp, isArray, isString, isEqual} from 'lodash';
+import {castArray, escapeRegExp, isArray, isEqual, isNil, isString} from 'lodash';
 
 import {Filter} from './Filter';
 
 /**
  * Filters by comparing the value of a given field to one or more given candidate values using one
  * of several supported operators.
+ *
+ * Note that the comparison operators [<,<=,>,>=] always return false for null and undefined values,
+ * favoring the behavior of Excel over Javascript's implicit conversion of nullish values to 0.
  *
  * Immutable.
  */
@@ -91,13 +94,25 @@ export class FieldFilter extends Filter {
             case '!=':
                 return r => !value.includes(getVal(r));
             case '>':
-                return r => getVal(r) > value;
+                return r => {
+                    const v = getVal(r);
+                    return !isNil(v) && v > value;
+                };
             case '>=':
-                return r => getVal(r) >= value;
+                return r => {
+                    const v = getVal(r);
+                    return !isNil(v) && v >= value;
+                };
             case '<':
-                return r => getVal(r) < value;
+                return r => {
+                    const v = getVal(r);
+                    return !isNil(v) && v < value;
+                };
             case '<=':
-                return r => getVal(r) <= value;
+                return r => {
+                    const v = getVal(r);
+                    return !isNil(v) && v <= value;
+                };
             case 'like':
                 regExps = value.map(v => new RegExp(escapeRegExp(v), 'i'));
                 return r => regExps.some(re => re.test(getVal(r)));


### PR DESCRIPTION
+ Comparison operators [<,<=,>,>=] always return false for null and undefined values, favoring the behavior of Excel over Javascript's implicit conversion of nullish values to 0.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

