### PR TITLE
Fix for #2048 - contextMenu function only run on first call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ below regarding related updates to `GridModel.columns` config processing.
 
 ### 🐞 Bug Fixes
 
+* Fixed `UseContextMenu` hook so that if given a function for its 2nd arg `contextMenu`, that function
+  is run every time onContextMenu is called, not just the first time.
 * Fixed `Column.tooltipElement` so that it can work if a `headerTooltip` is also specified on the
   same column.
 * Fixed issue where certain values (e.g. `%`) would break in `Column.tooltipElement`.

--- a/core/HoistComponentClass.js
+++ b/core/HoistComponentClass.js
@@ -73,7 +73,7 @@ export function HoistComponent(C) {
                     // 1) Return any model instance that has already been processed / set on the Component.
                     if (!isUndefined(_model)) return _model;
 
-                    // 2) Otherwise we will source, validate, and memoize as appropriated
+                    // 2) Otherwise we will source, validate, and memoize as appropriate.
                     const {modelClass} = C,
                         propsModel = props.model;
                     let ret = null;

--- a/desktop/hooks/UseContextMenu.js
+++ b/desktop/hooks/UseContextMenu.js
@@ -32,7 +32,7 @@ export function useContextMenu(child, contextMenu) {
         e.preventDefault();
 
         // 1) Pre-process to an element (potentially via item list) or null
-        if (isFunction(contextMenu)) {
+        if (isFunction(contextMenuOutput)) {
             contextMenuOutput = contextMenu(e);
         }
         if (isArray(contextMenuOutput)) {

--- a/desktop/hooks/UseContextMenu.js
+++ b/desktop/hooks/UseContextMenu.js
@@ -25,6 +25,7 @@ export function useContextMenu(child, contextMenu) {
     if (!child || isUndefined(contextMenu)) return child;
 
     const onContextMenu = (e) => {
+        let contextMenuOutput = contextMenu;
 
         // 0) Skip if already consumed, otherwise consume (Adapted from Blueprint 'ContextMenuTarget')
         if (e.defaultPrevented) return;
@@ -32,19 +33,19 @@ export function useContextMenu(child, contextMenu) {
 
         // 1) Pre-process to an element (potentially via item list) or null
         if (isFunction(contextMenu)) {
-            contextMenu = contextMenu(e);
+            contextMenuOutput = contextMenu(e);
         }
-        if (isArray(contextMenu)) {
-            contextMenu = !isEmpty(contextMenu) ? contextMenuEl({menuItems: contextMenu}) : null;
+        if (isArray(contextMenuOutput)) {
+            contextMenuOutput = !isEmpty(contextMenuOutput) ? contextMenuEl({menuItems: contextMenuOutput}) : null;
         }
-        if (contextMenu && !isValidElement(contextMenu)) {
+        if (contextMenuOutput && !isValidElement(contextMenuOutput)) {
             console.error("Incorrect specification of 'contextMenu' arg in useContextMenu()");
-            contextMenu = null;
+            contextMenuOutput = null;
         }
 
         // 2) Render via blueprint!
-        if (contextMenu) {
-            ContextMenu.show(contextMenu, {left: e.clientX, top: e.clientY}, null, XH.darkTheme);
+        if (contextMenuOutput) {
+            ContextMenu.show(contextMenuOutput, {left: e.clientX, top: e.clientY}, null, XH.darkTheme);
         }
     };
 


### PR DESCRIPTION
in the UseContextMenu hook, if contextMenu is a function, the function will now be run every time onContextMenu is called.

Prior to this change, the contextMenu arg was overwritten by its own output, and so only run the first time.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes: not a breaking change.
- [x] Updated doc comments / prop-types: not required.
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

