### PR TITLE
Monitor status tab is masked when monitors are undefined or disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## v37.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+#### Other
+
+* The Admin console's Monitor Status tab is masked when monitors are either undefined or disabled.
 
 ## v36.0.0-rc1 - 2020-08-31
 
@@ -66,7 +71,6 @@ below regarding related updates to `GridModel.columns` config processing.
   objects that can benefit from such caching.
 * `CodeInput` and `JsonInput` get new `enableSearch` and `showToolbar` props. Enabling search
   provides an simple inline find feature for searching the input's contents.
-* The Admin console's Monitor Status tab is masked when monitors are either undefined or disabled.
 
 ### 💥 Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ below regarding related updates to `GridModel.columns` config processing.
   objects that can benefit from such caching.
 * `CodeInput` and `JsonInput` get new `enableSearch` and `showToolbar` props. Enabling search
   provides an simple inline find feature for searching the input's contents.
+* The Admin console's Monitor Status tab is masked when monitors are either undefined or disabled.
 
 ### 💥 Breaking Changes
 

--- a/admin/tabs/monitor/MonitorResultsDisplay.js
+++ b/admin/tabs/monitor/MonitorResultsDisplay.js
@@ -7,13 +7,16 @@
 import {hbox} from '@xh/hoist/cmp/layout';
 import {hoistCmp} from '@xh/hoist/core';
 import {tile} from './Tile';
+import {isEmpty} from 'lodash';
 
 export const monitorResultsDisplay = hoistCmp.factory(
-    ({model}) => hbox({
-        className: 'xh-monitor-status-display',
-        items: model.results.map((check, idx) => tile({
-            key: `tile-${idx}`,
-            check
-        }))
-    })
+    ({model}) => {
+        const {results} = model;
+        return hbox({
+            className: 'xh-monitor-status-display',
+            items: isEmpty(results) ?
+                'No monitors configured for this application.' :
+                model.results.map((check, idx) => tile({key: `tile-${idx}`, check}))
+        });
+    }
 );

--- a/admin/tabs/monitor/MonitorResultsModel.js
+++ b/admin/tabs/monitor/MonitorResultsModel.js
@@ -5,7 +5,6 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 import {HoistModel, LoadSupport, managed, XH} from '@xh/hoist/core';
-import {mask} from '@xh/hoist/desktop/cmp/mask';
 import {action, computed, observable} from '@xh/hoist/mobx';
 import {Timer} from '@xh/hoist/utils/async';
 import {SECONDS} from '@xh/hoist/utils/datetime';
@@ -36,19 +35,9 @@ export class MonitorResultsModel {
         return this.results.filter(monitor => monitor.status === 'FAIL').length;
     }
 
-    get monitorMask() {
-        const {results, loadModel} = this,
-            monitorCount = results.length,
-            monitorsDisabled = results.every(monitor => !monitor.active);
-
-        if (!monitorCount || monitorsDisabled) {
-            return mask({
-                message: !monitorCount ? 'No monitors defined' : 'Monitors disabled',
-                isDisplayed: true
-            });
-        }
-
-        return loadModel.isPending ? 'onLoad' : null;
+    @computed
+    get active() {
+        return this.results.filter(monitor => monitor.active).length;
     }
 
     constructor() {

--- a/admin/tabs/monitor/MonitorResultsModel.js
+++ b/admin/tabs/monitor/MonitorResultsModel.js
@@ -36,8 +36,8 @@ export class MonitorResultsModel {
     }
 
     @computed
-    get active() {
-        return this.results.filter(monitor => monitor.active).length;
+    get inactive() {
+        return this.results.filter(monitor => monitor.status === 'INACTIVE').length;
     }
 
     constructor() {

--- a/admin/tabs/monitor/MonitorResultsModel.js
+++ b/admin/tabs/monitor/MonitorResultsModel.js
@@ -5,6 +5,7 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 import {HoistModel, LoadSupport, managed, XH} from '@xh/hoist/core';
+import {mask} from '@xh/hoist/desktop/cmp/mask';
 import {action, computed, observable} from '@xh/hoist/mobx';
 import {Timer} from '@xh/hoist/utils/async';
 import {SECONDS} from '@xh/hoist/utils/datetime';
@@ -33,6 +34,22 @@ export class MonitorResultsModel {
     @computed
     get failed() {
         return this.results.filter(monitor => monitor.status === 'FAIL').length;
+    }
+
+    get monitorMask() {
+        const {results, loadModel} = this,
+            monitorCount = results.length,
+            monitorsDisabled = results.every(monitor => monitor.status === 'INACTIVE');
+        // TODO - add another status to MonitorResult to distinguish between inactive and disabled
+
+        if (!monitorCount || monitorsDisabled) {
+            return mask({
+                message: !monitorCount ? 'No monitors defined' : 'Monitors disabled',
+                isDisplayed: true
+            });
+        }
+
+        return loadModel.isPending ? 'onLoad' : null;
     }
 
     constructor() {

--- a/admin/tabs/monitor/MonitorResultsModel.js
+++ b/admin/tabs/monitor/MonitorResultsModel.js
@@ -39,8 +39,7 @@ export class MonitorResultsModel {
     get monitorMask() {
         const {results, loadModel} = this,
             monitorCount = results.length,
-            monitorsDisabled = results.every(monitor => monitor.status === 'INACTIVE');
-        // TODO - add another status to MonitorResult to distinguish between inactive and disabled
+            monitorsDisabled = results.every(monitor => !monitor.active);
 
         if (!monitorCount || monitorsDisabled) {
             return mask({

--- a/admin/tabs/monitor/MonitorResultsPanel.js
+++ b/admin/tabs/monitor/MonitorResultsPanel.js
@@ -5,12 +5,10 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 import {creates, hoistCmp} from '@xh/hoist/core';
-import {mask} from '@xh/hoist/desktop/cmp/mask';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {monitorResultsDisplay} from './MonitorResultsDisplay';
 import {MonitorResultsModel} from './MonitorResultsModel';
 import {monitorResultsToolbar} from './MonitorResultsToolbar';
-import {isEmpty} from 'lodash';
 import './MonitorResultsPanel.scss';
 
 export const monitorResultsPanel = hoistCmp.factory({
@@ -19,22 +17,10 @@ export const monitorResultsPanel = hoistCmp.factory({
     render({model}) {
         return panel({
             ref: model.viewRef,
-            mask: renderMask(model),
+            mask: 'onLoad',
             className: 'xh-monitor-results-panel',
             tbar: monitorResultsToolbar(),
             item: monitorResultsDisplay()
         });
     }
 });
-
-
-function renderMask({results}) {
-    if (isEmpty(results)) {
-        return mask({
-            message: 'No monitors active',
-            isDisplayed: true
-        });
-    }
-
-    return 'onLoad';
-}

--- a/admin/tabs/monitor/MonitorResultsPanel.js
+++ b/admin/tabs/monitor/MonitorResultsPanel.js
@@ -17,7 +17,7 @@ export const monitorResultsPanel = hoistCmp.factory({
     render({model}) {
         return panel({
             ref: model.viewRef,
-            mask: 'onLoad',
+            mask: model.monitorMask,
             className: 'xh-monitor-results-panel',
             tbar: monitorResultsToolbar(),
             item: monitorResultsDisplay()

--- a/admin/tabs/monitor/MonitorResultsPanel.js
+++ b/admin/tabs/monitor/MonitorResultsPanel.js
@@ -5,6 +5,7 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 import {creates, hoistCmp} from '@xh/hoist/core';
+import {mask} from '@xh/hoist/desktop/cmp/mask';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {monitorResultsDisplay} from './MonitorResultsDisplay';
 import {MonitorResultsModel} from './MonitorResultsModel';
@@ -17,10 +18,25 @@ export const monitorResultsPanel = hoistCmp.factory({
     render({model}) {
         return panel({
             ref: model.viewRef,
-            mask: model.monitorMask,
+            mask: renderMask(model),
             className: 'xh-monitor-results-panel',
             tbar: monitorResultsToolbar(),
             item: monitorResultsDisplay()
         });
     }
 });
+
+
+function renderMask(model) {
+    const {results} = model,
+        monitorCount = results.length;
+
+    if (!monitorCount) {
+        return mask({
+            message: 'No monitors active',
+            isDisplayed: true
+        });
+    }
+
+    return 'onLoad';
+}

--- a/admin/tabs/monitor/MonitorResultsPanel.js
+++ b/admin/tabs/monitor/MonitorResultsPanel.js
@@ -9,8 +9,9 @@ import {mask} from '@xh/hoist/desktop/cmp/mask';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {monitorResultsDisplay} from './MonitorResultsDisplay';
 import {MonitorResultsModel} from './MonitorResultsModel';
-import './MonitorResultsPanel.scss';
 import {monitorResultsToolbar} from './MonitorResultsToolbar';
+import {isEmpty} from 'lodash';
+import './MonitorResultsPanel.scss';
 
 export const monitorResultsPanel = hoistCmp.factory({
     model: creates(MonitorResultsModel),
@@ -27,11 +28,8 @@ export const monitorResultsPanel = hoistCmp.factory({
 });
 
 
-function renderMask(model) {
-    const {results} = model,
-        monitorCount = results.length;
-
-    if (!monitorCount) {
+function renderMask({results}) {
+    if (isEmpty(results)) {
         return mask({
             message: 'No monitors active',
             isDisplayed: true

--- a/admin/tabs/monitor/MonitorResultsToolbar.js
+++ b/admin/tabs/monitor/MonitorResultsToolbar.js
@@ -10,16 +10,22 @@ import {hoistCmp} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
+import {pluralize} from '@xh/hoist/utils/js';
 
 export const monitorResultsToolbar = hoistCmp.factory(
     ({model}) => {
-        const {passed, warned, failed} = model;
+        const {passed, warned, failed, active} = model;
 
         return toolbar(
             button({
                 icon: Icon.refresh(),
                 text: 'Run all now',
                 onClick: () => model.forceRunAllMonitors()
+            }),
+            hbox({
+                items: [
+                    label(`${active} Active ${pluralize('monitor', active)}`)
+                ]
             }),
             hbox({
                 className: !failed ? 'hidden' : '',

--- a/admin/tabs/monitor/MonitorResultsToolbar.js
+++ b/admin/tabs/monitor/MonitorResultsToolbar.js
@@ -10,22 +10,18 @@ import {hoistCmp} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
-import {pluralize} from '@xh/hoist/utils/js';
+import {isEmpty} from 'lodash';
 
 export const monitorResultsToolbar = hoistCmp.factory(
     ({model}) => {
-        const {passed, warned, failed, active} = model;
+        const {passed, warned, failed, inactive, results} = model;
 
         return toolbar(
             button({
                 icon: Icon.refresh(),
                 text: 'Run all now',
+                disabled: isEmpty(results),
                 onClick: () => model.forceRunAllMonitors()
-            }),
-            hbox({
-                items: [
-                    label(`${active} Active ${pluralize('monitor', active)}`)
-                ]
             }),
             hbox({
                 className: !failed ? 'hidden' : '',
@@ -48,8 +44,15 @@ export const monitorResultsToolbar = hoistCmp.factory(
                     label(`${passed} passed`)
                 ]
             }),
+            hbox({
+                className: !inactive ? 'hidden' : '',
+                items: [
+                    Icon.disabled({prefix: 'fas', className: 'xh-gray'}),
+                    label(`${inactive} inactive`)
+                ]
+            }),
             filler(),
-            relativeTimestamp({bind: 'lastRun', options: {emptyResult: 'No results available!'}})
+            relativeTimestamp({bind: 'lastRun'})
         );
     }
 );


### PR DESCRIPTION
This PR and [Hoist-Core PR](https://github.com/xh/hoist-core/pull/163) addresses Issue #2050 to provide a mask+message for the monitor status tab when monitors are either undefined or disabled.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [N/A] Updated doc comments / prop-types, or determined not required.
- [N/A] Reviewed and tested on Mobile, or determined not required.
- [N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

