### PR TITLE
Grid tooltip issues

### DIFF
--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -193,6 +193,17 @@
 
 .xh-grid-tooltip {
   position: absolute;
+
+  &:empty {
+    display: none;
+  }
+
+  // Default minimal styling. This is not applied when using a custom tooltipElement.
+  &--default {
+    padding: var(--xh-pad-half-px);
+    background: var(--xh-bg);
+    border: var(--xh-border-solid);
+  }
 }
 
 //-----------


### PR DESCRIPTION
Column.tooltipValueGetter must *always* returns a value - if it returns a nil value, the tooltip won't be shown, even if there is a value later. See issue https://github.com/xh/hoist-react/issues/2058 for more details. To work around this, a placeholder is returned instead of a nil value.

Column always uses tooltipComponentFramework. This allows us to handle the placeholder values set by tooltipValueGetter.

+ Provide minimal default styling for tooltip component.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

