### PR TITLE
selectOnFocus fix: Use while loop to traverse down to comp with inputRef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐞 Bug Fixes
 
-* `Select` fixed `selectOnFocus` when `enabledWindowed` is true.
+* `Select` fixed `selectOnFocus` when `enabledWindowed:true` or when `queryFn` and `enableCreate:true` are used together.
 * `FilterChooser` auto-suggest values sourced from the *unfiltered* records on `sourceStore`.
 * `RestForm` editors source their default label from the corresponding `Field.displayName` property.
   Previously an undocumented `label` config could be provided with each editor object - this has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐞 Bug Fixes
 
-* `Select` fixed `selectOnFocus` when `enabledWindowed:true` or when `queryFn` and `enableCreate:true` are used together.
+*  Fixed several cases where `selectOnFocus` prop on `Select` was not working.
 * `FilterChooser` auto-suggest values sourced from the *unfiltered* records on `sourceStore`.
 * `RestForm` editors source their default label from the corresponding `Field.displayName` property.
   Previously an undocumented `label` config could be provided with each editor object - this has

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -334,7 +334,7 @@ export class Select extends HoistInput {
                 const rsRef = this.reactSelectRef.current;
                 if (!rsRef) return;
 
-                // Use of creatable and async variants will create another level of nesting we must
+                // Use of windowedMode, creatable and async variants will create levels of nesting we must
                 // traverse to get to the underlying Select comp and its inputRef.
                 let selectComp = rsRef.select;
                 while (selectComp && !selectComp.inputRef) {selectComp = selectComp.select}

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -336,9 +336,9 @@ export class Select extends HoistInput {
 
                 // Use of creatable and async variants will create another level of nesting we must
                 // traverse to get to the underlying Select comp and its inputRef.
-                const refComp = rsRef.select,
-                    selectComp = refComp.inputRef ? refComp : refComp.select,
-                    inputElem = selectComp.inputRef;
+                let selectComp = rsRef.select;
+                while (selectComp && !selectComp.inputRef) {selectComp = selectComp.select}
+                const inputElem = selectComp?.inputRef;
 
                 if (this.hasFocus && inputElem && document.activeElement === inputElem) {
                     inputElem.select();


### PR DESCRIPTION
This fixes the case when a queryFn is used and allowCreate is true.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry.
- [x] Reviewed for breaking changes: no breaking changes.
- [x] Updated doc comments / prop-types: not required
- [x] Reviewed and tested on Mobile:  not required.
- [x] Created Toolbox branch / PR: not required.  

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

