### PR TITLE
Support XH messages/toasts pre-auth

### DIFF
--- a/desktop/appcontainer/AppContainer.js
+++ b/desktop/appcontainer/AppContainer.js
@@ -63,7 +63,11 @@ export const AppContainer = hoistCmp({
                 item: viewForState(),
                 onError: (e) => XH.handleException(e, {requireReload: true})
             }),
-            exceptionDialog()
+            // Modal component helpers rendered here at top-level to support display of messages
+            // and exceptions at any point during the app lifecycle.
+            exceptionDialog(),
+            messageSource(),
+            toastSource()
         );
     }
 });
@@ -107,11 +111,9 @@ const appContainerView = hoistCmp.factory({
                 versionBar()
             ),
             mask({model: model.appLoadModel, spinner: true}),
-            messageSource(),
-            toastSource(),
-            optionsDialog(),
+            aboutDialog(),
             feedbackDialog(),
-            aboutDialog()
+            optionsDialog()
         );
 
         if (!appSpec.showBrowserContextMenu) {

--- a/mobile/appcontainer/AppContainer.js
+++ b/mobile/appcontainer/AppContainer.js
@@ -60,7 +60,11 @@ export const AppContainer = hoistCmp({
                 item: viewForState(),
                 onError: (e) => XH.handleException(e, {requireReload: true})
             }),
-            exceptionDialog()
+            // Modal component helpers rendered here at top-level to support display of messages
+            // and exceptions at any point during the app lifecycle.
+            exceptionDialog(),
+            messageSource(),
+            toastSource()
         );
     }
 });
@@ -105,11 +109,9 @@ const appContainerView = hoistCmp.factory({
                 versionBar()
             ),
             mask({model: model.appLoadModel, spinner: true}),
-            messageSource(),
-            toastSource(),
+            aboutDialog(),
             feedbackDialog(),
-            optionsDialog(),
-            aboutDialog()
+            optionsDialog()
         );
     }
 });


### PR DESCRIPTION
+ Render modal component helpers at top-level of DOM to support use of XH messages and toasts prior to authorization complete (specifically, support use from within `preAuthInitAsync()`).

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

