### PR TITLE
fixes #2068 :  Dragging grid column with element based header display…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,7 @@
 * Resetting Grid columns to their default state (e.g. via the Column Chooser) retains enhancements
   applied from matching Store fields.
 * Desktop `DateInput` now handles out-of-bounds dates without throwing exception during rendering.
-* A grid column header that has a function for headerName argument or element/object for resolved headerName
-  now falls back to column.chooserName for the value to display when dragging the column header
-  or in the column header tooltip.
+* Dragging a grid column with element based header no longer displays [object Object] in draggable.
 
 ### 📚 Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@
 * Resetting Grid columns to their default state (e.g. via the Column Chooser) retains enhancements
   applied from matching Store fields.
 * Desktop `DateInput` now handles out-of-bounds dates without throwing exception during rendering.
+* A grid column header that has a function for headerName argument or element/object for resolved headerName
+  now falls back to column.chooserName for the value to display when dragging the column header
+  or in the column header tooltip.
 
 ### 📚 Libraries
 

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -317,7 +317,9 @@ export class Column {
                 colId: this.colId,
                 headerValueGetter: (agParams) => {
                     return agParams.location === 'header' ?
-                        isFunction(headerName) ? headerName({column: this, gridModel, agParams}) : headerName :
+                        isFunction(headerName) ?
+                            this.chooserName :
+                            headerName :
                         this.chooserName;
                 },
                 headerClass: getAgHeaderClassFn(this),

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -8,7 +8,7 @@ import {div} from '@xh/hoist/cmp/layout';
 import {XH} from '@xh/hoist/core';
 import {genDisplayName} from '@xh/hoist/data';
 import {throwIf, warnIf, withDefault} from '@xh/hoist/utils/js';
-import {castArray, clone, find, get, isArray, isFinite, isFunction, isNil, isNumber, isEmpty} from 'lodash';
+import {castArray, clone, find, get, isArray, isFinite, isFunction, isNil, isNumber, isEmpty, isString} from 'lodash';
 import {Component} from 'react';
 import {GridSorter} from '../impl/GridSorter';
 import {ExportFormat} from './ExportFormat';
@@ -316,11 +316,9 @@ export class Column {
                 field,
                 colId: this.colId,
                 headerValueGetter: (agParams) => {
-                    return agParams.location === 'header' ?
-                        isFunction(headerName) ?
-                            this.chooserName :
-                            headerName :
-                        this.chooserName;
+                    return agParams.location === 'header' && isString(headerName) ?
+                        headerName :
+                        this.displayName;
                 },
                 headerClass: getAgHeaderClassFn(this),
                 headerTooltip: this.headerTooltip,

--- a/cmp/grid/impl/ColumnHeader.js
+++ b/cmp/grid/impl/ColumnHeader.js
@@ -12,7 +12,7 @@ import {useOnMount, createObservableRef} from '@xh/hoist/utils/react';
 import {debounced} from '@xh/hoist/utils/js';
 import {olderThan} from '@xh/hoist/utils/datetime';
 import classNames from 'classnames';
-import {filter, findIndex, isEmpty, isFunction, isFinite, isUndefined, isString, isObject} from 'lodash';
+import {filter, findIndex, isEmpty, isFunction, isFinite, isUndefined, isString} from 'lodash';
 import {GridSorter} from './GridSorter';
 import {Column} from '@xh/hoist/cmp/grid/columns/Column';
 
@@ -68,7 +68,7 @@ export const columnHeader = hoistCmp.factory({
         const {xhColumn, gridModel} = impl,
             {isDesktop} = XH;
 
-        const headerName = isFunction(xhColumn?.headerName) ?
+        const headerElem = isFunction(xhColumn?.headerName) ?
             xhColumn.headerName({column: xhColumn, gridModel}) :
             props.displayName;
 
@@ -77,7 +77,7 @@ export const columnHeader = hoistCmp.factory({
         if (isDesktop && isUndefined(xhColumn?.headerTooltip)) {
             onMouseEnter = ({target: el}) => {
                 if (el.offsetWidth < el.scrollWidth) {
-                    const title = isObject(headerName) ? xhColumn?.chooserName : headerName;
+                    const title = isString(headerElem) ? headerElem : props.displayName;
                     el.setAttribute('title', title);
                 } else {
                     el.removeAttribute('title');
@@ -95,7 +95,7 @@ export const columnHeader = hoistCmp.factory({
             onTouchEnd:     !isDesktop ? impl.onTouchEnd : null,
 
             items: [
-                span({onMouseEnter, item: headerName}),
+                span({onMouseEnter, item: headerElem}),
                 sortIcon(),
                 menuIcon()
             ]

--- a/cmp/grid/impl/ColumnHeader.js
+++ b/cmp/grid/impl/ColumnHeader.js
@@ -12,7 +12,7 @@ import {useOnMount, createObservableRef} from '@xh/hoist/utils/react';
 import {debounced} from '@xh/hoist/utils/js';
 import {olderThan} from '@xh/hoist/utils/datetime';
 import classNames from 'classnames';
-import {filter, findIndex, isEmpty, isFunction, isFinite, isUndefined, isString} from 'lodash';
+import {filter, findIndex, isEmpty, isFunction, isFinite, isUndefined, isString, isObject} from 'lodash';
 import {GridSorter} from './GridSorter';
 import {Column} from '@xh/hoist/cmp/grid/columns/Column';
 
@@ -77,7 +77,8 @@ export const columnHeader = hoistCmp.factory({
         if (isDesktop && isUndefined(xhColumn?.headerTooltip)) {
             onMouseEnter = ({target: el}) => {
                 if (el.offsetWidth < el.scrollWidth) {
-                    el.setAttribute('title', headerName);
+                    const title = isObject(headerName) ? xhColumn?.chooserName : headerName;
+                    el.setAttribute('title', title);
                 } else {
                     el.removeAttribute('title');
                 }


### PR DESCRIPTION
**Resolution:** 
A grid column header that has a function for headerName argument or element/object for resolved headerName
  now falls back to column.chooserName for the value to display when dragging the column header
  or in the column header tooltip.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry.
- [X] Reviewed for breaking changes: no breaking changes.
- [X] Updated doc comments: not required.
- [X] Reviewed and tested on Mobile: not required.
- [X] Created Toolbox branch: https://github.com/xh/toolbox/compare/gridHeaderNameOnDrag?expand=1

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

