### PR TITLE
Add ManualProvider class to Persistence API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v37.0.0-SNAPSHOT - unreleased
 
 ### 🎁 New Features
-* Provides new `ManualProvider` for applications that want to use the Persistence API, but
+* Provides new `CustomProvider` for applications that want to use the Persistence API, but
 need to provide their own storage implementation.
 ### 🐞 Bug Fixes
 * Fixed a regression introduced in v36.1.0 in `FilterChooser`. Now supports `disabled` prop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v37.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+* Provides new `ManualProvider` for applications that want to use the Persistence API, but
+need to provide their own storage implementations.
+
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.1.0...develop)
 
 

--- a/core/index.js
+++ b/core/index.js
@@ -41,6 +41,6 @@ export * from './persist/PersistenceProvider';
 export * from './persist/LocalStorageProvider';
 export * from './persist/DashViewProvider';
 export * from './persist/PrefProvider';
-
+export * from './persist/ManualProvider';
 
 export * from './XH';

--- a/core/index.js
+++ b/core/index.js
@@ -41,6 +41,6 @@ export * from './persist/PersistenceProvider';
 export * from './persist/LocalStorageProvider';
 export * from './persist/DashViewProvider';
 export * from './persist/PrefProvider';
-export * from './persist/ManualProvider';
+export * from './persist/CustomProvider';
 
 export * from './XH';

--- a/core/mixins/PersistSupport.js
+++ b/core/mixins/PersistSupport.js
@@ -140,15 +140,20 @@ function createDescriptor(target, property, descriptor, options) {
  *      persisted and the concrete `PersistenceProvider` instance created to do so.
  *
  * @property {string} [type] - Type of PersistenceProvider to be used. May be one of
- *      'pref'|'localStorage'|'dashView'. If not provided (most common), Hoist will auto-detect
- *      the type based on other keys provided. For example a 'prefKey' argument implies a type of
- *      'pref', while a 'localStorageKey' implies a type of 'localStorage' - see below.
+ *      'pref'|'localStorage'|'dashView'|'custom'. If not provided (most common), Hoist
+ *      will auto-detect the type based on other keys provided. For example a 'prefKey'
+ *      argument implies a type of 'pref', while a 'localStorageKey' implies a type
+ *      of 'localStorage' - see below.
  * @property {string} [prefKey] - name of Hoist preference for pref-based storage. Supplying a
  *      value for this property will create a {@see PrefProvider}.
  * @property {string} [localStorageKey] - unique string key for LocalStorage based state storage.
  *      Supplying a value for this property will create a {@see LocalStorageProvider}.
  * @property {DashViewModel} [dashViewModel] - model instance for Dashboard-based state storage.
  *      Supplying a value for this property will create a {@see DashViewProvider}.
+ * @property {function} [setData] - function for setting custom state storage.
+ *      Supplying a value for this property will create a {@see CustomProvider}.
+ * @property {function} [getData] - function for getting custom state storage.
+ *      Supplying a value for this property will create a {@see CustomProvider}.
  * @property {string} [path] - path or key in provider data where state should be stored.
  *      If not provided, the provider will use the name of the class property being persisted or
  *      another auto-selected name suitable to the particular target (e.g. 'gridModel')

--- a/core/persist/CustomProvider.js
+++ b/core/persist/CustomProvider.js
@@ -15,7 +15,7 @@ import {throwIf} from '@xh/hoist/utils/js';
  * This provider allows applications to use the Persistence API to populate and read state from
  * components without actually writing to any pre-defined storage.
  */
-export class ManualProvider extends PersistenceProvider {
+export class CustomProvider extends PersistenceProvider {
 
     getData;
     setData;
@@ -25,7 +25,7 @@ export class ManualProvider extends PersistenceProvider {
      * @param {function} setData - function to be used to write blob of data representing state.
      */
     constructor({getData, setData, ...rest}) {
-        throwIf(!getData || !setData, `ManualProvider requires a 'getData' and a 'setData' function.`);
+        throwIf(!getData || !setData, `CustomProvider requires a 'getData' and a 'setData' function.`);
         super(rest);
         this.getData = getData;
         this.setData = setData;

--- a/core/persist/ManualProvider.js
+++ b/core/persist/ManualProvider.js
@@ -1,0 +1,47 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2020 Extremely Heavy Industries Inc.
+ */
+
+import {PersistenceProvider} from '@xh/hoist/core';
+import {throwIf} from '@xh/hoist/utils/js';
+
+/**
+ * A Minimal Persistence provider for use in applications that wish
+ * to provide the actual persistence.
+ *
+ * This provider allows applications to use the Persistence API to
+ * populate, and read state from components, without actually writing
+ * to any pre-defined storage.
+ */
+export class ManualProvider extends PersistenceProvider {
+
+    getData;
+    setData;
+
+    /** @param {function} getData - function returning blob of data to be used for reading state.*/
+    /** @param {function} setData - function to be used to write blob of data representing state.*/
+    constructor({getData, setData, ...rest}) {
+        throwIf(!getData || !setData, `ManualProvider requires a 'getData' and a 'setData' function.`);
+        super(rest);
+        this.getData = getData;
+        this.setData = setData;
+    }
+
+    //----------------
+    // Implementation
+    //----------------
+    readRaw() {
+        return this.getData();
+    }
+
+    writeRaw(data) {
+        this.setData(data);
+    }
+
+    clearRaw() {
+        this.setData(null);
+    }
+}

--- a/core/persist/ManualProvider.js
+++ b/core/persist/ManualProvider.js
@@ -9,20 +9,21 @@ import {PersistenceProvider} from '@xh/hoist/core';
 import {throwIf} from '@xh/hoist/utils/js';
 
 /**
- * A Minimal Persistence provider for use in applications that wish
- * to provide the actual persistence.
+ * A minimal Persistence provider for use by apps that wish to implement the actual persistence
+ * of the backing data via custom handlers.
  *
- * This provider allows applications to use the Persistence API to
- * populate, and read state from components, without actually writing
- * to any pre-defined storage.
+ * This provider allows applications to use the Persistence API to populate and read state from
+ * components without actually writing to any pre-defined storage.
  */
 export class ManualProvider extends PersistenceProvider {
 
     getData;
     setData;
 
-    /** @param {function} getData - function returning blob of data to be used for reading state.*/
-    /** @param {function} setData - function to be used to write blob of data representing state.*/
+    /**
+     * @param {function} getData - function returning blob of data to be used for reading state.
+     * @param {function} setData - function to be used to write blob of data representing state.
+     */
     constructor({getData, setData, ...rest}) {
         throwIf(!getData || !setData, `ManualProvider requires a 'getData' and a 'setData' function.`);
         super(rest);

--- a/core/persist/PersistenceProvider.js
+++ b/core/persist/PersistenceProvider.js
@@ -69,10 +69,10 @@ export class PersistenceProvider {
     /**
      * @private
      *
-     * Called by implementations only.  See create.
+     * Called by implementations only. See create.
      *
      * @param {string} path - dot delimited path
-     * @param {number|object} debounce
+     * @param {(number|object)} debounce - debounce interval in ms, or a lodash debounce config.
      */
     constructor({path, debounce = 250}) {
         throwIf(isUndefined(path), 'Path not specified in PersistenceProvider.');

--- a/core/persist/PersistenceProvider.js
+++ b/core/persist/PersistenceProvider.js
@@ -6,7 +6,7 @@
  */
 
 import {XH} from '@xh/hoist/core';
-import {LocalStorageProvider, PrefProvider, DashViewProvider} from '../';
+import {LocalStorageProvider, PrefProvider, DashViewProvider, ManualProvider} from '../';
 import {
     isUndefined,
     cloneDeep,
@@ -28,6 +28,8 @@ import {throwIf} from '@xh/hoist/utils/js';
  * @see PrefProvider - stores state in a predefined Hoist application Preference.
  * @see LocalStorageProvider - stores state in browser local storage under a configured key.
  * @see DashViewProvider - stores state with other Dashboard-specific state via a `DashViewModel`.
+ * @see ManualProvider - provides API for application and components to provide their own
+ *      storage mechanism.
  */
 export class PersistenceProvider {
 
@@ -47,6 +49,7 @@ export class PersistenceProvider {
             if (rest.prefKey) type = 'pref';
             if (rest.localStorageKey) type = 'localStorage';
             if (rest.dashViewModel) type = 'dashView';
+            if (rest.getData || rest.setData) type = 'manual';
         }
 
         switch (type) {
@@ -56,6 +59,8 @@ export class PersistenceProvider {
                 return new LocalStorageProvider(rest);
             case `dashView`:
                 return new DashViewProvider(rest);
+            case 'manual':
+                return new ManualProvider(rest);
             default:
                 throw XH.exception(`Unknown Persistence Provider for type: ${type}`);
         }

--- a/core/persist/PersistenceProvider.js
+++ b/core/persist/PersistenceProvider.js
@@ -6,7 +6,7 @@
  */
 
 import {XH} from '@xh/hoist/core';
-import {LocalStorageProvider, PrefProvider, DashViewProvider, ManualProvider} from '../';
+import {LocalStorageProvider, PrefProvider, DashViewProvider, CustomProvider} from '../';
 import {
     isUndefined,
     cloneDeep,
@@ -28,7 +28,7 @@ import {throwIf} from '@xh/hoist/utils/js';
  * @see PrefProvider - stores state in a predefined Hoist application Preference.
  * @see LocalStorageProvider - stores state in browser local storage under a configured key.
  * @see DashViewProvider - stores state with other Dashboard-specific state via a `DashViewModel`.
- * @see ManualProvider - provides API for application and components to provide their own
+ * @see CustomProvider - provides API for application and components to provide their own
  *      storage mechanism.
  */
 export class PersistenceProvider {
@@ -49,7 +49,7 @@ export class PersistenceProvider {
             if (rest.prefKey) type = 'pref';
             if (rest.localStorageKey) type = 'localStorage';
             if (rest.dashViewModel) type = 'dashView';
-            if (rest.getData || rest.setData) type = 'manual';
+            if (rest.getData || rest.setData) type = 'custom';
         }
 
         switch (type) {
@@ -59,8 +59,8 @@ export class PersistenceProvider {
                 return new LocalStorageProvider(rest);
             case `dashView`:
                 return new DashViewProvider(rest);
-            case 'manual':
-                return new ManualProvider(rest);
+            case 'custom':
+                return new CustomProvider(rest);
             default:
                 throw XH.exception(`Unknown Persistence Provider for type: ${type}`);
         }


### PR DESCRIPTION
This turned out to be a bit of a nothing burger. :-)

Think we could call it ManualProvider or CustomProvider. 

We had thought about 'InMemoryProvider', but I think at this point this has gone in another direction -- it really requires the developer to write a bit of code and provide the implementation.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

