### PR TITLE
Fix switch value for Sunday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v37.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+* Fixed issue in `LocalDate.previousWeekday()` which did not correctly handle Sunday dates.
+
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.2.0...develop)
 
 ## v36.2.0 - 2020-09-25

--- a/utils/datetime/LocalDate.js
+++ b/utils/datetime/LocalDate.js
@@ -263,7 +263,7 @@ export class LocalDate {
     previousWeekday() {
         switch (this._moment.day()) {
             case 1:     return this.subtract(3);
-            case 7:     return this.subtract(2);
+            case 0:     return this.subtract(2);
             default:    return this.subtract(1);
         }
     }


### PR DESCRIPTION
This PR fixes bug reported in https://github.com/xh/hoist-react/issues/2098.
- Moment day getter returns 0 for Sunday (not 7).

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [N/A] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

