### PR TITLE
Delay focus on exceptionDialog dismiss Button. (#2096)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐞 Bug Fixes
 * Fixed issue in `LocalDate.previousWeekday()` which did not correctly handle Sunday dates.
+* `exceptionDialog` no longer closes immediately when event that triggered exception is still bubbling up.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.2.0...develop)
 

--- a/appcontainer/ExceptionDialogModel.js
+++ b/appcontainer/ExceptionDialogModel.js
@@ -4,8 +4,10 @@
  *
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
+import {createRef} from 'react';
 import {HoistModel, XH} from '@xh/hoist/core';
 import {action, observable} from '@xh/hoist/mobx';
+import {wait} from '@xh/hoist/promise';
 
 /**
  * Manages the default display of exceptions.
@@ -17,6 +19,8 @@ import {action, observable} from '@xh/hoist/mobx';
  */
 @HoistModel
 export class ExceptionDialogModel {
+
+    dismissButtonRef = createRef();
 
     @observable.ref displayData;
     @observable detailsIsOpen = false;
@@ -41,6 +45,7 @@ export class ExceptionDialogModel {
     show(exception, options) {
         if (this.displayData?.options.requireReload)  return;
         this.displayData = {exception, options};
+        wait(500).then(() => this.dismissButtonRef.focus());
     }
 
     @action

--- a/appcontainer/ExceptionDialogModel.js
+++ b/appcontainer/ExceptionDialogModel.js
@@ -45,7 +45,9 @@ export class ExceptionDialogModel {
     show(exception, options) {
         if (this.displayData?.options.requireReload)  return;
         this.displayData = {exception, options};
-        wait(500).then(() => this.dismissButtonRef.focus());
+        wait(500).then(() => {
+            if (this.dismissButtonRef.focus) this.dismissButtonRef.focus();
+        });
     }
 
     @action

--- a/desktop/appcontainer/ExceptionDialog.js
+++ b/desktop/appcontainer/ExceptionDialog.js
@@ -4,6 +4,8 @@
  *
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
+import {FocusStyleManager} from '@blueprintjs/core';
+
 import {ExceptionDialogModel} from '@xh/hoist/appcontainer/ExceptionDialogModel';
 import {filler, fragment} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses, XH} from '@xh/hoist/core';
@@ -27,7 +29,12 @@ export const exceptionDialog = hoistCmp.factory({
     render({model}) {
         const {exception, options} = model;
 
-        if (!exception) return null;
+        if (!exception) {
+            FocusStyleManager.onlyShowFocusOnTabs();
+            return null;
+        }
+
+        FocusStyleManager.alwaysShowFocus();
 
         const onClose = !options.requireReload ? () => model.close() : null;
 
@@ -84,12 +91,12 @@ export const dismissButton = hoistCmp.factory(
             button({
                 icon: loginRequired ? Icon.login() : Icon.refresh(),
                 text: loginRequired ? 'Login' : 'Reload App',
-                autoFocus: true,
+                elementRef: (el) => model.dismissButtonRef = el,
                 onClick: () => XH.reloadApp()
             }) :
             button({
                 text: 'Close',
-                autoFocus: true,
+                elementRef: (el) => model.dismissButtonRef = el,
                 onClick: () => model.close()
             });
     }


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry: added.
- [x] Reviewed for breaking changes.  No breaking changes.
- [x] Updated doc comments / prop-types: not required.
- [x] Reviewed and tested on Mobile: The bug does not exist on Mobile, because the exceptionDialog close button is not focused on Mobile.  This fix is null safe for Mobile.
- [x] Created Toolbox branch: [This branch](https://github.com/xh/toolbox/tree/exceptionDialogFocusDelay) reproduces the bug in the [desktop OHLC chart](http://localhost:3000/app/charts) and in this [mobile grid](http://localhost:3000/mobile/grids) demonstrates that the bug does not exist in mobile.


> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

