### PR TITLE
Select can now show a check mark by the selected items in multiMode & hideSelectedOptions: false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## v37.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+* `Select` now supports `hideSelectedOptions` and `closeMenuOnSelect` props.
+
 ### 🐞 Bug Fixes
 * Fixed issue in `LocalDate.previousWeekday()` which did not correctly handle Sunday dates.
 * Fixed regression in `Grid` column header rendering for non-string headerNames.
-* Select now shows a check mark by the selected options when `enableMulti:true` and `rsOptions.hideSelectedOptions:false`.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.2.0...develop)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🐞 Bug Fixes
 * Fixed issue in `LocalDate.previousWeekday()` which did not correctly handle Sunday dates.
+* Select now shows a check mark by the selected items when the select is in enableMulti mode and selected options are not hidden.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.2.0...develop)
 

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -517,14 +517,7 @@ export class Select extends HoistInput {
     };
 
     get suppressCheck() {
-        const {props} = this;
-        let dflt = false;
-
-        if (props.enableMulti) {
-            dflt = this.hideSelectedOptions;
-        }
-
-        return withDefault(props.hideSelectedOptionCheck, dflt);
+        return withDefault(this.props.hideSelectedOptionCheck, this.hideSelectedOptions);
     }
 
     // Match react-select defaulting.

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -509,7 +509,13 @@ export class Select extends HoistInput {
 
     get suppressCheck() {
         const {props} = this;
-        return withDefault(props.hideSelectedOptionCheck, props.enableMulti && !props.rsOptions?.hideSelectedOptions);
+        let dflt = false;
+
+        if (props.enableMulti) {
+            dflt = props.rsOptions?.hideSelectedOptions;
+        }
+
+        return withDefault(props.hideSelectedOptionCheck, dflt);
     }
 
     //------------------------

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -176,11 +176,15 @@ export class Select extends HoistInput {
     get creatableMode() {return !!this.props.enableCreate}
     get windowedMode() {return !!this.props.enableWindowed}
     get multiMode() {return !!this.props.enableMulti}
-    get filterMode() {return withDefault(this.props.enableFilter, true)}
+    get filterMode() {return this.props.enableFilter ?? true}
     get selectOnFocus() {
-        return withDefault(this.props.selectOnFocus,
-            !this.multiMode && (this.filterMode || this.creatableMode));
+        return this.props.selectOnFocus ??
+            (!this.multiMode && (this.filterMode || this.creatableMode));
     }
+    get suppressCheck() {return this.props.hideSelectedOptionCheck ?? this.hideSelectedOptions}
+    // Match react-select defaulting for hideSelectedOptions.
+    get hideSelectedOptions() {return this.props.hideSelectedOptions ?? this.multiMode ?? false}
+
 
     // Managed value for underlying text input under certain conditions
     // This is a workaround for rs-select issue described in hoist-react #880
@@ -515,15 +519,6 @@ export class Select extends HoistInput {
             }) :
             div({item: opt.label, style: {paddingLeft: 25}});
     };
-
-    get suppressCheck() {
-        return withDefault(this.props.hideSelectedOptionCheck, this.hideSelectedOptions);
-    }
-
-    // Match react-select defaulting.
-    get hideSelectedOptions() {
-        return withDefault(this.props.hideSelectedOptions, this.props.enableMulti);
-    }
 
     //------------------------
     // Other Implementation

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -493,7 +493,7 @@ export class Select extends HoistInput {
             return div(opt.label);
         }
 
-        return this.externalValue === opt.value ?
+        return castArray(this.externalValue).includes(opt.value) ?
             hbox({
                 items: [
                     div({
@@ -509,7 +509,7 @@ export class Select extends HoistInput {
 
     get suppressCheck() {
         const {props} = this;
-        return withDefault(props.hideSelectedOptionCheck, props.enableMulti);
+        return withDefault(props.hideSelectedOptionCheck, props.enableMulti && !props.rsOptions.hideSelectedOptions);
     }
 
     //------------------------

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -56,6 +56,9 @@ export class Select extends HoistInput {
          */
         createMessageFn: PT.func,
 
+        /** True to close the menu after each selection.  Defaults to true. */
+        closeMenuOnSelect: PT.bool,
+
         /** True to show a "clear" button at the right of the control.  Defaults to false. */
         enableClear: PT.bool,
 
@@ -88,6 +91,9 @@ export class Select extends HoistInput {
 
         /** True to suppress the default check icon rendered for the currently selected option. */
         hideSelectedOptionCheck: PT.bool,
+
+        /** True to hide options in the drop down menu if they have been selected.  Defaults to false.*/
+        hideSelectedOptions: PT.bool,
 
         /** Field on provided options for sourcing each option's display text (default `label`). */
         labelField: PT.string,
@@ -220,6 +226,9 @@ export class Select extends HoistInput {
                 formatOptionLabel: this.formatOptionLabel,
                 isDisabled: props.disabled,
                 isMulti: props.enableMulti,
+                closeMenuOnSelect: props.closeMenuOnSelect,
+                hideSelectedOptions: props.hideSelectedOptions,
+
                 // Explicit false ensures consistent default for single and multi-value instances.
                 isClearable: withDefault(props.enableClear, false),
                 menuPlacement: withDefault(props.menuPlacement, 'auto'),
@@ -512,7 +521,7 @@ export class Select extends HoistInput {
         let dflt = false;
 
         if (props.enableMulti) {
-            dflt = props.rsOptions?.hideSelectedOptions;
+            dflt = props.hideSelectedOptions;
         }
 
         return withDefault(props.hideSelectedOptionCheck, dflt);

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -181,9 +181,8 @@ export class Select extends HoistInput {
         return this.props.selectOnFocus ??
             (!this.multiMode && (this.filterMode || this.creatableMode));
     }
-    get suppressCheck() {return this.props.hideSelectedOptionCheck ?? this.hideSelectedOptions}
-    // Match react-select defaulting for hideSelectedOptions.
-    get hideSelectedOptions() {return this.props.hideSelectedOptions ?? this.multiMode ?? false}
+    get hideSelectedOptions() {return this.props.hideSelectedOptions ?? this.multiMode}
+    get hideSelectedOptionCheck() {return this.props.hideSelectedOptionCheck || this.hideSelectedOptions}
 
 
     // Managed value for underlying text input under certain conditions
@@ -502,7 +501,7 @@ export class Select extends HoistInput {
     };
 
     optionRenderer = (opt) => {
-        if (this.suppressCheck) {
+        if (this.hideSelectedOptionCheck) {
             return div(opt.label);
         }
 

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -509,7 +509,7 @@ export class Select extends HoistInput {
 
     get suppressCheck() {
         const {props} = this;
-        return withDefault(props.hideSelectedOptionCheck, props.enableMulti && !props.rsOptions.hideSelectedOptions);
+        return withDefault(props.hideSelectedOptionCheck, props.enableMulti && !props.rsOptions?.hideSelectedOptions);
     }
 
     //------------------------

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -92,7 +92,7 @@ export class Select extends HoistInput {
         /** True to suppress the default check icon rendered for the currently selected option. */
         hideSelectedOptionCheck: PT.bool,
 
-        /** True to hide options in the drop down menu if they have been selected.  Defaults to false.*/
+        /** True to hide options in the drop down menu if they have been selected.  Defaults to same as enableMulti. */
         hideSelectedOptions: PT.bool,
 
         /** Field on provided options for sourcing each option's display text (default `label`). */
@@ -227,7 +227,7 @@ export class Select extends HoistInput {
                 isDisabled: props.disabled,
                 isMulti: props.enableMulti,
                 closeMenuOnSelect: props.closeMenuOnSelect,
-                hideSelectedOptions: props.hideSelectedOptions,
+                hideSelectedOptions: this.hideSelectedOptions,
 
                 // Explicit false ensures consistent default for single and multi-value instances.
                 isClearable: withDefault(props.enableClear, false),
@@ -521,10 +521,15 @@ export class Select extends HoistInput {
         let dflt = false;
 
         if (props.enableMulti) {
-            dflt = props.hideSelectedOptions;
+            dflt = this.hideSelectedOptions;
         }
 
         return withDefault(props.hideSelectedOptionCheck, dflt);
+    }
+
+    // Match react-select defaulting.
+    get hideSelectedOptions() {
+        return withDefault(this.props.hideSelectedOptions, this.props.enableMulti);
     }
 
     //------------------------


### PR DESCRIPTION
This change allows the checkmark on selected options to be shown when the select has this config:
```
enableMulti: true,
rsOptions: {
   closeMenuOnSelect: false,
   hideSelectedOptions: false
}
```

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry..
- [x] Reviewed for breaking changes: no breaking changes.
- [x] Updated doc comments / prop-types: not required.
- [x]  Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch / PR.   Did not create new toolbox branch, but you can test this by running the develop toolbox branch and testing the last select on http://localhost:3000/admin/tests/select.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

