### PR TITLE
More thorough test of DOM node visibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🐞 Bug Fixes
 
-* Improved test of is Dom node visible.
+* Improved test of is DOM node visible.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.4.0...develop)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v37.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Improved test of is Dom node visible.
+
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.4.0...develop)
 
 ## v36.4.0 - 2020-10-09

--- a/cmp/chart/Chart.js
+++ b/cmp/chart/Chart.js
@@ -16,7 +16,7 @@ import {
     useOnResize,
     useOnVisibleChange
 } from '@xh/hoist/utils/react';
-import {isElVisible} from '@xh/hoist/utils/js/';
+import {isNodeVisible} from '@xh/hoist/utils/js/';
 import {assign, castArray, clone, isEqual, merge, omit} from 'lodash';
 import PT from 'prop-types';
 import {ChartModel} from './ChartModel';
@@ -155,7 +155,7 @@ class LocalModel {
 
             // Skip creating HighCharts instance if hidden - we will
             // instead create when it becomes visible
-            if (!isElVisible(parentEl)) return;
+            if (!isNodeVisible(parentEl)) return;
 
             const dims = this.getChartDims(parentDims);
             assign(config.chart, dims);

--- a/cmp/chart/Chart.js
+++ b/cmp/chart/Chart.js
@@ -16,6 +16,7 @@ import {
     useOnResize,
     useOnVisibleChange
 } from '@xh/hoist/utils/react';
+import {isElVisible} from '@xh/hoist/utils/js/';
 import {assign, castArray, clone, isEqual, merge, omit} from 'lodash';
 import PT from 'prop-types';
 import {ChartModel} from './ChartModel';
@@ -154,7 +155,7 @@ class LocalModel {
 
             // Skip creating HighCharts instance if hidden - we will
             // instead create when it becomes visible
-            if (parentDims.width === 0 || parentDims.height === 0) return;
+            if (!isElVisible(parentEl)) return;
 
             const dims = this.getChartDims(parentDims);
             assign(config.chart, dims);

--- a/utils/js/DomUtils.js
+++ b/utils/js/DomUtils.js
@@ -42,7 +42,7 @@ export function observeResize(fn, node, {debounce}) {
     let wrappedFn = (e) => {
         const {contentRect, target} = e[0],
             {width, height} = contentRect,
-            isVisible = isElVisible(target),
+            isVisible = isNodeVisible(target),
             hasChanged = width !== prevWidth || height !== prevHeight;
 
         if (isVisible && hasChanged) {
@@ -74,7 +74,7 @@ export function observeResize(fn, node, {debounce}) {
 export function observeVisibleChange(fn, node) {
     let prevVisible = null;
     const ret = new ResizeObserver(e => {
-        const visible = isElVisible(e[0].target),
+        const visible = isNodeVisible(e[0].target),
             hasChanged = visible !== prevVisible;
 
         if (hasChanged) {
@@ -86,6 +86,12 @@ export function observeVisibleChange(fn, node) {
     return ret;
 }
 
-export function isElVisible(el) {
-    return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+/**
+ * Check if a DOM Node is visible.
+ *
+ * @param {Object} node - The DOM node to check
+ *
+ */
+export function isNodeVisible(node) {
+    return !!(node.offsetWidth || node.offsetHeight || node.getClientRects().length);
 }

--- a/utils/js/DomUtils.js
+++ b/utils/js/DomUtils.js
@@ -40,9 +40,9 @@ export function isDisplayed(elem) {
 export function observeResize(fn, node, {debounce}) {
     let prevWidth = null, prevHeight = null;
     let wrappedFn = (e) => {
-        const {contentRect} = e[0],
+        const {contentRect, target} = e[0],
             {width, height} = contentRect,
-            isVisible = width !== 0 && height !== 0,
+            isVisible = isElVisible(target),
             hasChanged = width !== prevWidth || height !== prevHeight;
 
         if (isVisible && hasChanged) {
@@ -74,8 +74,7 @@ export function observeResize(fn, node, {debounce}) {
 export function observeVisibleChange(fn, node) {
     let prevVisible = null;
     const ret = new ResizeObserver(e => {
-        const {width, height} = e[0].contentRect,
-            visible = width !== 0 && height !== 0,
+        const visible = isElVisible(e[0].target),
             hasChanged = visible !== prevVisible;
 
         if (hasChanged) {
@@ -85,4 +84,8 @@ export function observeVisibleChange(fn, node) {
     });
     ret.observe(node);
     return ret;
+}
+
+export function isElVisible(el) {
+    return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
 }


### PR DESCRIPTION
This proposes to resolve issue: https://github.com/xh/hoist-react/issues/2118

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes: no breaking changes
- [x] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile: Ack! There are no Chart demos on mobile Toolbox!.
- [x] Created Toolbox branch: 
https://github.com/xh/toolbox/tree/isElVisible  This new branch reproduces the test that Tom described here: https://github.com/xh/hoist-react/issues/1703 back in Feb 2020 and confirms that the change proposed in this PR still solves the original problem:  prevents the chart from rendering if it is not visible.  You can test it when running this branch by loading this URL: http://localhost:3000/app/charts/line
This branch also demonstrates this bug if you run it against hoist-react's `develop` branch: load http://localhost:3000/app/charts/ohlc. to see 4 charts that do NOT render.
Switch hoist-react to the new bugfix branch `isElVisible` to see the charts render.

The OHLC page has been recoded to put the panel that contains the 4 charts in a div that has no height, and is not a flexbox.
So, the div does not expand vertically, and the panel inside it does not, so the current visible test fails the height === 0 test.






> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

