### PR TITLE
Handle activating next best tab after tab removal

### DIFF
--- a/cmp/tab/TabContainerModel.js
+++ b/cmp/tab/TabContainerModel.js
@@ -179,9 +179,10 @@ export class TabContainerModel {
     removeTab(tab) {
         let {tabs} = this,
             toRemove = find(tabs, (t) => t === tab || t.id === tab),
-            toActivate = (!toRemove.isActive || this.nextTab) ? this.activeTab : this.prevTab;
+            toActivate = this.activeTab;
+
         if (toRemove === toActivate) {
-            toActivate = this.nextTab;
+            toActivate = this.nextTab ?? this.prevTab;
         }
         if (toRemove) {
             this.setTabs(without(tabs, toRemove));

--- a/cmp/tab/TabContainerModel.js
+++ b/cmp/tab/TabContainerModel.js
@@ -180,14 +180,14 @@ export class TabContainerModel {
         let {tabs} = this,
             toRemove = find(tabs, (t) => t === tab || t.id === tab),
             toActivate = (!toRemove.isActive || this.nextTab) ? this.activeTab : this.prevTab;
-
         if (toRemove === toActivate) {
             toActivate = this.nextTab;
         }
-
         if (toRemove) {
             this.setTabs(without(tabs, toRemove));
-            this.activateTab(toActivate);
+            if (toActivate) {
+                this.activateTab(toActivate);
+            }
         }
     }
 

--- a/cmp/tab/TabContainerModel.js
+++ b/cmp/tab/TabContainerModel.js
@@ -178,9 +178,16 @@ export class TabContainerModel {
     @action
     removeTab(tab) {
         let {tabs} = this,
-            toRemove = find(tabs, (t) => t === tab || t.id === tab);
+            toRemove = find(tabs, (t) => t === tab || t.id === tab),
+            toActivate = (!toRemove.isActive || this.nextTab) ? this.activeTab : this.prevTab;
+
+        if (toRemove === toActivate) {
+            toActivate = this.nextTab;
+        }
+
         if (toRemove) {
             this.setTabs(without(tabs, toRemove));
+            this.activateTab(toActivate);
         }
     }
 


### PR DESCRIPTION
Follow Chrome rules for tab removal:
1. Default to active tab
2. If active tab is removed, activate nextTab, or prevTab if !nextTab

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [N/R] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [N/R] Reviewed and tested on Mobile, or determined not required.
- [N/R] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

