### PR TITLE
Always wrap grid cell contents to support flexbox alignment and overflow

### DIFF
--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -180,10 +180,11 @@
     display: flex;
     align-items: center;
 
-    & > span {
+    & > * {
       flex: 1;
       overflow: hidden;
       text-overflow: ellipsis;
+      min-width: 0;
     }
   }
 

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -475,6 +475,8 @@ export class Column {
 
                 refresh() {return false}
             });
+        } else {
+            setRenderer((agParams) => agParams.value);
         }
 
         const sortCfg = find(gridModel.sortBy, {colId: ret.colId});


### PR DESCRIPTION
Grid cells were not eliding properly if they didn't use renderers. This is because non-renderer cells outputted a string (text node) as the direct contents of the flex container.

> `text-overflow: ellipsis` won't work on flex container (`display: flex`). The main reason is that the text node becomes an anonymous flex child and needs `min-width: 0` to behave (or else it won't shrink beyond its content size), but as one can't target a text node with CSS, we need to wrap it, here done with a span.
>
> https://stackoverflow.com/questions/48545178/use-text-overflow-ellipsis-and-flexbox-align-items-center-in-combination

The proposed change here always adds a renderer to our columns, which ensures the contents are wrapped in a span if no renderer provided. Then we can reliably target the containers child for text-overflow.

Are we concerned about performance implications with this? It's interesting that the statement above claims the browser will treat the text node as an anonymous flex child, which to me implies there shouldn't be much impact in making the flex child explicit. We certainly have grids in client apps where *not* using a renderer is the anomaly.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

