### PR TITLE
Button set to active:true renders with active styling. (fixes #2129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐞 Bug Fixes
 
 * Improve hover and active background-color for header tool buttons in light theme.
+* Button set to active:true renders with active styling.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.4.0...develop)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,25 @@
 
 ## v37.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Ensure that `Button`s with `active: true` set directly (outside of a `ButtonGroupInput`) get the
+  correct active/pressed styling.
+
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.5.0...develop)
 
 ## v36.5.0 - 2020-10-16
+
+### 🐞 Bug Fixes
+
+* Fix text and hover+active background colors for header tool buttons in light theme.
+
+### ⚙️ Technical
+
+* Install a default simple string renderer on all columns. This provides consistency in column
+  rendering, and fixes some additional issues with alignment and rendering of Grid columns
+  introduced by the change to flexbox-based styling in grid cells.
+* Support (optional) logout action in SSO applications.
 
 ### 📚 Libraries
 
@@ -13,17 +29,6 @@
 * @fortawesome/fontawesome-pro `5.14 -> 5.15`
 * moment `2.24 -> 2.29`
 * numbro `2.2 -> 2.3`
-
-### 🐞 Bug Fixes
-* Improve hover and active background-color for header tool buttons in light theme.
-* Button set to active:true renders with active styling.
-
-### ⚙️ Technical
-* Install a default simple string renderer on all columns.  This provides consistency
- in column rendering, and fixes some additional issues with alignment and rendering of
- Grid columns introduced by the change to flexbox-based styling in grid cells.
-
-* Support (optional) logout action in SSO applications.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.4.0...v36.5.0)
 

--- a/desktop/cmp/button/Button.js
+++ b/desktop/cmp/button/Button.js
@@ -24,7 +24,7 @@ export const [Button, button] = hoistCmp.withFactory({
 
     render(props) {
         const [layoutProps, {
-                autoFocus, className, disabled, icon, intent, minimal = true, onClick, outlined, style, text, title, ...rest
+                autoFocus, className, disabled, icon, intent, minimal = true, onClick, outlined, style, text, title, active, ...rest
             }] = splitLayoutProps(props),
             classes = [];
 
@@ -45,6 +45,7 @@ export const [Button, button] = hoistCmp.withFactory({
         if (minimal) classes.push('xh-button--minimal');
         if (outlined) classes.push('xh-button--outlined');
         if (!minimal && !outlined) classes.push('xh-button--standard');
+        if (active) classes.push('xh-button--active');
 
         return bpButton({
             autoFocus,

--- a/desktop/cmp/button/Button.js
+++ b/desktop/cmp/button/Button.js
@@ -68,6 +68,7 @@ export const [Button, button] = hoistCmp.withFactory({
 });
 
 Button.propTypes = {
+    active: PT.bool,
     autoFocus: PT.bool,
     className: PT.string,
     disabled: PT.bool,

--- a/desktop/cmp/button/Button.js
+++ b/desktop/cmp/button/Button.js
@@ -48,6 +48,7 @@ export const [Button, button] = hoistCmp.withFactory({
         if (active) classes.push('xh-button--active');
 
         return bpButton({
+            active,
             autoFocus,
             className: classNames(className, classes),
             disabled,

--- a/desktop/cmp/button/Button.scss
+++ b/desktop/cmp/button/Button.scss
@@ -104,6 +104,17 @@
           &:hover {background-color: var(--xh-button-bg-lighter)}
           &:active {background-color: var(--xh-button-bg-darkest)}
         }
+
+        &.xh-button--active {
+          background-color: var(--xh-button-active-bg);
+          box-shadow: var(--xh-button-active-box-shadow);
+          background-image: none; // mimic bp3 active state
+
+          // Make sure these states replicate the active state
+          // so as to make it look like there is no reaction
+          &:hover {background-color: var(--xh-button-active-bg)}
+          &:active {background-color: var(--xh-button-active-bg)}
+        }
       }
 
       &.xh-button--intent-primary {
@@ -153,6 +164,16 @@
         &.xh-button--enabled {
           &:hover {background-color: var(--xh-button-bg-darker)}
           &:active {background-color: var(--xh-button-bg-darkest)}
+        }
+
+        &.xh-button--active {
+          background-color: var(--xh-button-active-bg);
+          background-image: none; // mimic bp3 active state
+
+          // Make sure these states replicate the active state
+          // so as to make it look like there is no reaction
+          &:hover {background-color: var(--xh-button-active-bg)}
+          &:active {background-color: var(--xh-button-active-bg)}
         }
       }
 

--- a/desktop/cmp/button/Button.scss
+++ b/desktop/cmp/button/Button.scss
@@ -92,36 +92,30 @@
   .xh-button.bp3-button {
     // Shaded/filled-in (non-minimal) mode.
     &.xh-button--standard {
+      &.xh-button--active {
+        box-shadow: var(--xh-button-active-box-shadow);
+      }
+
       &.xh-button--intent-none {
         color: var(--xh-button-text-color);
         background-color: var(--xh-button-bg-lightest);
+
+        &.xh-button--active {background-color: var(--xh-button-active-bg)}
         // BG styles for :hover and :active limited to enabled buttons only - prevent misleading
-        // highlight on hover for a disabled button. Nest :active under same block to ensure
-        // combination of hover+active results in active style due to selector specificity.
-        // Note that buttonGroupInput buttons have special handling below to ensure they *do*
-        // apply a distinct bg to their active (pressed) button, even when disabled.
+        // highlight on hover for a disabled button. Note that :active pseudo-selector here is
+        // triggered while button is being "held down" by user.
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-button-bg-lighter)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-button-bg-lighter)}
           &:active {background-color: var(--xh-button-bg-darkest)}
-        }
-
-        &.xh-button--active {
-          background-color: var(--xh-button-active-bg);
-          box-shadow: var(--xh-button-active-box-shadow);
-          background-image: none; // mimic bp3 active state
-
-          // Make sure these states replicate the active state
-          // so as to make it look like there is no reaction
-          &:hover {background-color: var(--xh-button-active-bg)}
-          &:active {background-color: var(--xh-button-active-bg)}
         }
       }
 
       &.xh-button--intent-primary {
         color: white;
         background-color: var(--xh-intent-primary);
+        &.xh-button--active {background-color: var(--xh-intent-primary-darkest)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-primary-darker)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-primary-darker)}
           &:active {background-color: var(--xh-intent-primary-darkest)}
         }
       }
@@ -129,8 +123,9 @@
       &.xh-button--intent-success {
         color: white;
         background-color: var(--xh-intent-success);
+        &.xh-button--active {background-color: var(--xh-intent-success-darkest)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-success-darker)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-success-darker)}
           &:active {background-color: var(--xh-intent-success-darkest)}
         }
       }
@@ -138,8 +133,9 @@
       &.xh-button--intent-warning {
         color: white;
         background-color: var(--xh-intent-warning);
+        &.xh-button--active {background-color: var(--xh-intent-warning-darkest)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-warning-darker)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-warning-darker)}
           &:active {background-color: var(--xh-intent-warning-darkest)}
         }
       }
@@ -147,8 +143,9 @@
       &.xh-button--intent-danger {
         color: white;
         background-color: var(--xh-intent-danger);
+        &.xh-button--active {background-color: var(--xh-intent-danger-darkest)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-danger-darker)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-danger-darker)}
           &:active {background-color: var(--xh-intent-danger-darkest)}
         }
       }
@@ -161,19 +158,10 @@
         color: var(--xh-button-text-color);
         background-color: transparent;
         border-color: var(--xh-button-border-color);
+        &.xh-button--active {background-color: var(--xh-button-active-bg)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-button-bg-darker)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-button-bg-darker)}
           &:active {background-color: var(--xh-button-bg-darkest)}
-        }
-
-        &.xh-button--active {
-          background-color: var(--xh-button-active-bg);
-          background-image: none; // mimic bp3 active state
-
-          // Make sure these states replicate the active state
-          // so as to make it look like there is no reaction
-          &:hover {background-color: var(--xh-button-active-bg)}
-          &:active {background-color: var(--xh-button-active-bg)}
         }
       }
 
@@ -181,8 +169,9 @@
         color: var(--xh-intent-primary-darker);
         background-color: transparent;
         border-color: var(--xh-intent-primary);
+        &.xh-button--active {background-color: var(--xh-intent-primary-trans2)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-primary-trans1)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-primary-trans1)}
           &:active {background-color: var(--xh-intent-primary-trans2)}
         }
       }
@@ -191,8 +180,9 @@
         color: var(--xh-intent-success-darker);
         background-color: transparent;
         border-color: var(--xh-intent-success);
+        &.xh-button--active {background-color: var(--xh-intent-success-trans2)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-success-trans1)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-success-trans1)}
           &:active {background-color: var(--xh-intent-success-trans2)}
         }
       }
@@ -201,8 +191,9 @@
         color: var(--xh-intent-warning-darker);
         background-color: transparent;
         border-color: var(--xh-intent-warning);
+        &.xh-button--active {background-color: var(--xh-intent-warning-trans2)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-warning-trans1)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-warning-trans1)}
           &:active {background-color: var(--xh-intent-warning-trans2)}
         }
       }
@@ -211,42 +202,11 @@
         color: var(--xh-intent-danger-darker);
         background-color: transparent;
         border-color: var(--xh-intent-danger);
+        &.xh-button--active {background-color: var(--xh-intent-danger-trans2)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-danger-trans1)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-danger-trans1)}
           &:active {background-color: var(--xh-intent-danger-trans2)}
         }
-      }
-    }
-  }
-
-  //------------------------
-  // Button group (input)
-  // Special handling for active (depressed) button colors.
-  //------------------------
-  .xh-button-group {
-    // Note addition of .bp3-active here.
-    .xh-button.bp3-button.bp3-active {
-      &.xh-button--standard {
-        &.xh-button--intent-none {
-          color: var(--xh-button-active-text-color);
-          background-color: var(--xh-button-active-bg);
-        }
-        &.xh-button--intent-primary {background-color: var(--xh-intent-primary-darkest)}
-        &.xh-button--intent-success {background-color: var(--xh-intent-success-darkest)}
-        &.xh-button--intent-warning {background-color: var(--xh-intent-warning-darkest)}
-        &.xh-button--intent-danger {background-color: var(--xh-intent-danger-darkest)}
-      }
-
-      &.xh-button--minimal,
-      &.xh-button--outlined {
-        &.xh-button--intent-none {
-          color: var(--xh-button-active-text-color);
-          background-color: var(--xh-button-active-bg);
-        }
-        &.xh-button--intent-primary {background-color: var(--xh-intent-primary-trans2)}
-        &.xh-button--intent-success {background-color: var(--xh-intent-success-trans2)}
-        &.xh-button--intent-warning {background-color: var(--xh-intent-warning-trans2)}
-        &.xh-button--intent-danger {background-color: var(--xh-intent-danger-trans2)}
       }
     }
   }
@@ -263,8 +223,9 @@
       &.xh-button--intent-none {
         color: var(--xh-button-text-color);
         background-color: var(--xh-button-bg);
+        &.xh-button--active {background-color: var(--xh-button-active-bg)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-button-bg-darker)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-button-bg-darker)}
           &:active {background-color: var(--xh-button-bg-darkest)}
         }
       }
@@ -272,8 +233,9 @@
       &.xh-button--intent-primary {
         color: white;
         background-color: var(--xh-intent-primary);
+        &.xh-button--active {background-color: var(--xh-intent-primary-darkest)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-primary-darker)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-primary-darker)}
           &:active {background-color: var(--xh-intent-primary-darkest)}
         }
       }
@@ -281,8 +243,9 @@
       &.xh-button--intent-success {
         color: white;
         background-color: var(--xh-intent-success);
+        &.xh-button--active {background-color: var(--xh-intent-success-darkest)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-success-darker)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-success-darker)}
           &:active {background-color: var(--xh-intent-success-darkest)}
         }
       }
@@ -290,8 +253,9 @@
       &.xh-button--intent-warning {
         color: white;
         background-color: var(--xh-intent-warning);
+        &.xh-button--active {background-color: var(--xh-intent-warning-darkest)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-warning-darker)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-warning-darker)}
           &:active {background-color: var(--xh-intent-warning-darkest)}
         }
       }
@@ -299,8 +263,9 @@
       &.xh-button--intent-danger {
         color: white;
         background-color: var(--xh-intent-danger);
+        &.xh-button--active {background-color: var(--xh-intent-danger-darkest)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-danger-darker)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-danger-darker)}
           &:active {background-color: var(--xh-intent-danger-darkest)}
         }
       }
@@ -313,8 +278,9 @@
         color: var(--xh-button-text-color);
         background-color: transparent;
         border-color: var(--xh-button-border-color);
+        &.xh-button--active {background-color: var(--xh-button-active-bg)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-button-bg-lighter)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-button-bg-lighter)}
           &:active {background-color: var(--xh-button-bg-lightest)}
         }
       }
@@ -323,8 +289,9 @@
         color: var(--xh-intent-primary-lighter);
         background-color: transparent;
         border-color: var(--xh-intent-primary-lighter);
+        &.xh-button--active {background-color: var(--xh-intent-primary-trans2)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-primary-trans1)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-primary-trans1)}
           &:active {background-color: var(--xh-intent-primary-trans2)}
         }
       }
@@ -333,8 +300,9 @@
         color: var(--xh-intent-success-lighter);
         background-color: transparent;
         border-color: var(--xh-intent-success-lighter);
+        &.xh-button--active {background-color: var(--xh-intent-success-trans2)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-success-trans1)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-success-trans1)}
           &:active {background-color: var(--xh-intent-success-trans2)}
         }
       }
@@ -343,8 +311,9 @@
         color: var(--xh-intent-warning-lighter);
         background-color: transparent;
         border-color: var(--xh-intent-warning-lighter);
+        &.xh-button--active {background-color: var(--xh-intent-warning-trans2)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-warning-trans1)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-warning-trans1)}
           &:active {background-color: var(--xh-intent-warning-trans2)}
         }
       }
@@ -353,40 +322,11 @@
         color: var(--xh-intent-danger-lighter);
         background-color: transparent;
         border-color: var(--xh-intent-danger-lighter);
+        &.xh-button--active {background-color: var(--xh-intent-danger-trans2)}
         &.xh-button--enabled {
-          &:hover {background-color: var(--xh-intent-danger-trans1)}
+          &:hover:not(:active):not(.xh-button--active) {background-color: var(--xh-intent-danger-trans1)}
           &:active {background-color: var(--xh-intent-danger-trans2)}
         }
-      }
-    }
-  }
-
-  //------------------------
-  // Dark - Button group (input)
-  //------------------------
-  .xh-button-group {
-    .xh-button.bp3-button.bp3-active {
-      &.xh-button--standard {
-        &.xh-button--intent-none {
-          color: var(--xh-button-active-text-color);
-          background-color: var(--xh-button-active-bg);
-        }
-        &.xh-button--intent-primary {background-color: var(--xh-intent-primary-darkest)}
-        &.xh-button--intent-success {background-color: var(--xh-intent-success-darkest)}
-        &.xh-button--intent-warning {background-color: var(--xh-intent-warning-darkest)}
-        &.xh-button--intent-danger {background-color: var(--xh-intent-danger-darkest)}
-      }
-
-      &.xh-button--minimal,
-      &.xh-button--outlined {
-        &.xh-button--intent-none {
-          color: var(--xh-button-active-text-color);
-          background-color: var(--xh-button-bg-lightest);
-        }
-        &.xh-button--intent-primary {background-color: var(--xh-intent-primary-trans2)}
-        &.xh-button--intent-success {background-color: var(--xh-intent-success-trans2)}
-        &.xh-button--intent-warning {background-color: var(--xh-intent-warning-trans2)}
-        &.xh-button--intent-danger {background-color: var(--xh-intent-danger-trans2)}
       }
     }
   }

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -246,6 +246,7 @@ body {
   // Buttons - override available to color active button in buttonGroups w/standard (null/neutral) intent styling.
   --xh-button-active-bg: var(--button-active-bg, var(--xh-button-bg-darkest));
   --xh-button-active-text-color: var(--button-active-text-color, var(--xh-button-text-color));
+  --xh-button-active-box-shadow: var(--button-active-box-shadow, #{inset 0 0 0 1px rgba(16, 22, 26, 0.2), inset 0 1px 2px rgba(16, 22, 26, 0.2)});
 
   &.xh-dark {
     // This breaks the standard of having the active button bg default to the pressed bg, but in


### PR DESCRIPTION
This change sets the new `xh-button--active` css class on a button with prop `active:true`.

The class only has rules in it for buttons with `intent:none`.  If an app needs another intent to show a permanent active state the app can customize for that need.

Minimal, Standard, and Outline button types with intent:none all can now show a permanent active state.



Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes: not a breaking change.
- [x] Updated doc comments.
- [x] Reviewed and tested on mobile: not required.
- [x] Created Toolbox branch: `activeButton` branch.  PR: https://github.com/xh/toolbox/pull/432

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

