### PR TITLE
Add support for additional dash container context menu items 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * New `GridModel.treeStyle` config enables more distinctive styling of tree grids, with optional
   background highlighting and ledger-line style borders on group rows.
-* New `extraMenuItems` config supports custom app menu items in Dashboards
+* New `DashContainerModel.extraMenuItems` config supports custom app menu items in Dashboards
 * An About item has been added to the default app menu.
 
 ### 🐞 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * New `GridModel.treeStyle` config enables more distinctive styling of tree grids, with optional
   background highlighting and ledger-line style borders on group rows.
+* New `DashContainerModel.extraMenuItems` config supports additional `DashContainerContextMenu` items.
 
 ### 🐞 Bug Fixes
 

--- a/desktop/cmp/dash/DashContainerModel.js
+++ b/desktop/cmp/dash/DashContainerModel.js
@@ -121,22 +121,26 @@ export class DashContainerModel {
     modelLookupContext;
 
     /**
-     * @param {DashViewSpec[]} viewSpecs - A collection of viewSpecs, each describing a type of view
+     * @param {Object} c - DashContainerModel configuration.
+     * @param {DashViewSpec[]} c.viewSpecs - A collection of viewSpecs, each describing a type of view
      *      that can be displayed in this container
-     * @param {Object} [viewSpecDefaults] - Properties to be set on all viewSpecs.  Merges deeply.
-     * @param {Object[]} [initialState] - Default layout state for this container.
-     * @param {RenderMode} [renderMode] - strategy for rendering DashViews. Can be set
+     * @param {Object} [c.viewSpecDefaults] - Properties to be set on all viewSpecs.  Merges deeply.
+     * @param {Object[]} [c.initialState] - Default layout state for this container.
+     * @param {RenderMode} [c.renderMode] - strategy for rendering DashViews. Can be set
      *      per-view via `DashViewSpec.renderMode`. See enum for description of supported modes.
-     * @param {RefreshMode} [refreshMode] - strategy for refreshing DashViews. Can be set
+     * @param {RefreshMode} [c.refreshMode] - strategy for refreshing DashViews. Can be set
      *      per-view via `DashViewSpec.refreshMode`. See enum for description of supported modes.
-     * @param {boolean} [layoutLocked] - prevent re-arranging views by dragging and dropping.
-     * @param {boolean} [contentLocked] - prevent adding and removing views.
-     * @param {boolean} [renameLocked] - prevent renaming views.
-     * @param {Object} [goldenLayoutSettings] - custom settings to be passed to the GoldenLayout instance.
+     * @param {boolean} [c.layoutLocked] - prevent re-arranging views by dragging and dropping.
+     * @param {boolean} [c.contentLocked] - prevent adding and removing views.
+     * @param {boolean} [c.renameLocked] - prevent renaming views.
+     * @param {Object} [c.goldenLayoutSettings] - custom settings to be passed to the GoldenLayout instance.
      *      @see http://golden-layout.com/docs/Config.html
      * @param {PersistOptions} [c.persistWith] - options governing persistence
-     * @param {string} [emptyText] - text to display when the container is empty
-     * @param {string} [addViewButtonText] - text to display on the add view button
+     * @param {string} [c.emptyText] - text to display when the container is empty
+     * @param {string} [c.addViewButtonText] - text to display on the add view button
+     * @param {Array} [c.extraMenuItems] - array of RecordActions, configs or token strings, with
+     *      which to create additional dash context menu items. Extra menu items will appear
+     *      in the menu section above the 'Add' action, including when the dash container is empty.
      */
     constructor({
         viewSpecs,
@@ -150,7 +154,8 @@ export class DashContainerModel {
         goldenLayoutSettings,
         persistWith = null,
         emptyText = 'No views have been added to the container.',
-        addViewButtonText = 'Add View'
+        addViewButtonText = 'Add View',
+        extraMenuItems
     }) {
         viewSpecs = viewSpecs.filter(it => !it.omit);
         ensureUniqueBy(viewSpecs, 'id');
@@ -167,6 +172,7 @@ export class DashContainerModel {
         this.goldenLayoutSettings = goldenLayoutSettings;
         this.emptyText = emptyText;
         this.addViewButtonText = addViewButtonText;
+        this.extraMenuItems = extraMenuItems;
 
         // Read state from provider -- fail gently
         let persistState = null;

--- a/desktop/cmp/dash/impl/DashContainerContextMenu.js
+++ b/desktop/cmp/dash/impl/DashContainerContextMenu.js
@@ -31,6 +31,7 @@ export const dashContainerContextMenu = hoistCmp.factory({
 //---------------------------
 function createMenuItems(props) {
     const {dashContainerModel, viewModel} = props,
+        {extraMenuItems} = dashContainerModel,
         ret = [];
 
     // Add context sensitive items if clicked on a tab
@@ -58,6 +59,12 @@ function createMenuItems(props) {
             '-'
         );
     }
+
+    if (extraMenuItems) {
+        extraMenuItems.forEach(it => ret.push(it));
+        ret.push('-');
+    }
+
     const addMenuItems = createAddMenuItems(props);
     ret.push({
         text: 'Add',

--- a/desktop/cmp/dash/impl/DashContainerContextMenu.js
+++ b/desktop/cmp/dash/impl/DashContainerContextMenu.js
@@ -60,11 +60,6 @@ function createMenuItems(props) {
         );
     }
 
-    if (extraMenuItems) {
-        extraMenuItems.forEach(it => ret.push(it));
-        ret.push('-');
-    }
-
     const addMenuItems = createAddMenuItems(props);
     ret.push({
         text: 'Add',
@@ -72,6 +67,12 @@ function createMenuItems(props) {
         disabled: isEmpty(addMenuItems),
         items: addMenuItems
     });
+
+
+    if (extraMenuItems) {
+        ret.push('-');
+        extraMenuItems.forEach(it => ret.push(it));
+    }
 
     return ret;
 }


### PR DESCRIPTION
This PR addresses https://github.com/xh/hoist-react/issues/2145
Toolbox gets 'Restore Dash Defaults' extra item in Toolbox PR https://github.com/xh/toolbox/pull/436

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

