### PR TITLE
Fix action col width calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Ensure that `Button`s with `active: true` set directly (outside of a `ButtonGroupInput`) get the
   correct active/pressed styling.
 * Fixed regression in `Column.tooltip` function displaying escaped HTML characters.
+* Fixed issue where the utility method `calcActionColWidth` was not correctly incorporating the
+  padding in the returned value.
 
 ### ⚙️ Technical
 

--- a/desktop/cmp/grid/columns/Actions.js
+++ b/desktop/cmp/grid/columns/Actions.js
@@ -100,7 +100,11 @@ export const actionCol = {
  *      Default small minimal buttons with an icon will be 24px
  * @returns {number} - the width in pixels
  */
-export function calcActionColWidth(count, cellPadding = 5, buttonWidth = 24) {
+export function calcActionColWidth(
+    count,
+    cellPadding = 5,  // This value needs to be kept in sync with $action-col-pad-px
+    buttonWidth = 24
+) {
     // add 1 to cellPadding to account for 1px transparent border in default theme
     return (count * buttonWidth) + ((cellPadding + 1) * 2);
 }

--- a/desktop/cmp/grid/columns/Actions.js
+++ b/desktop/cmp/grid/columns/Actions.js
@@ -7,7 +7,8 @@
 import {RecordAction} from '@xh/hoist/data';
 import {convertIconToHtml} from '@xh/hoist/icon';
 import {isEmpty} from 'lodash';
-import {actionColPad} from './Actions.scss';
+
+import './Actions.scss';
 
 /**
  * A column definition partial for adding an "action column" to a grid. An action column displays
@@ -99,7 +100,7 @@ export const actionCol = {
  *      Default small minimal buttons with an icon will be 24px
  * @returns {number} - the width in pixels
  */
-export function calcActionColWidth(count, cellPadding = Number(actionColPad), buttonWidth = 24) {
+export function calcActionColWidth(count, cellPadding = 5, buttonWidth = 24) {
     // add 1 to cellPadding to account for 1px transparent border in default theme
     return (count * buttonWidth) + ((cellPadding + 1) * 2);
 }

--- a/desktop/cmp/grid/columns/Actions.js
+++ b/desktop/cmp/grid/columns/Actions.js
@@ -95,16 +95,12 @@ export const actionCol = {
 /**
  * Calculates the width for an action column
  * @param {number} count - number of actions
- * @param {number} [cellPadding] - left and right padding (in pixels) for grid cells.
+ * @param {number} [cellPadding] - desired left and right padding (in pixels) for the action cell.
  * @param {number} [buttonWidth] - width (in pixels) of the action buttons.
  *      Default small minimal buttons with an icon will be 24px
  * @returns {number} - the width in pixels
  */
-export function calcActionColWidth(
-    count,
-    cellPadding = 5,  // This value needs to be kept in sync with $action-col-pad-px
-    buttonWidth = 24
-) {
+export function calcActionColWidth(count, cellPadding = 5, buttonWidth = 24) {
     // add 1 to cellPadding to account for 1px transparent border in default theme
     return (count * buttonWidth) + ((cellPadding + 1) * 2);
 }

--- a/desktop/cmp/grid/columns/Actions.scss
+++ b/desktop/cmp/grid/columns/Actions.scss
@@ -5,14 +5,7 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 
-// This value needs to be kept in sync with the arg for calcActionColWidth in Actions.js
-$action-col-pad-px: 5px;
-
 .xh-action-col-cell {
-  &.ag-cell {
-    padding: 0 $action-col-pad-px;
-  }
-
   .xh-show-on-hover {
     .xh-record-action-button {
       visibility: hidden;
@@ -37,7 +30,6 @@ $action-col-pad-px: 5px;
       button.xh-record-action-button {
         min-height: 28px;
         max-height: 28px;
-        padding-top: 4px;
 
         svg.svg-inline--fa {
           width: 1.2em;
@@ -51,7 +43,6 @@ $action-col-pad-px: 5px;
       button.xh-record-action-button {
         min-height: 20px;
         max-height: 20px;
-        padding-top: 4px;
 
         svg.svg-inline--fa {
           width: 0.9em;
@@ -63,7 +54,6 @@ $action-col-pad-px: 5px;
   &--tiny {
     .xh-action-col-cell {
       button.xh-record-action-button {
-        padding-top: 1px;
         max-height: 14px;
         min-height: 14px;
 

--- a/desktop/cmp/grid/columns/Actions.scss
+++ b/desktop/cmp/grid/columns/Actions.scss
@@ -5,15 +5,8 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 
-$action-col-pad: 5;
-$action-col-pad-px: $action-col-pad * 1px;
-
-// This CSS-modules export makes this value accessible from JS -note the import in Actions.js.
-//noinspection CssInvalidPseudoSelector
-:export {
-  /* stylelint-disable-next-line property-case */
-  actionColPad: $action-col-pad;
-}
+// This value needs to be kept in sync with the arg for calcActionColWidth in Actions.js
+$action-col-pad-px: 5px;
 
 .xh-action-col-cell {
   &.ag-cell {


### PR DESCRIPTION
Am not sure why the sass import broke, but it really seemed like an unnecessary complication in this case so opted to just hardcode the padding value in the js code, and added a comment so we remember to keep the 2 places we have that value in sync.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

