### PR TITLE
Don't include nil dimensions in layout props

### DIFF
--- a/utils/react/LayoutPropUtils.js
+++ b/utils/react/LayoutPropUtils.js
@@ -4,7 +4,7 @@
  *
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
-import {forOwn, isEmpty, isNumber, isString, omit, pick} from 'lodash';
+import {forOwn, isEmpty, isNumber, isString, isNil, omit, pick} from 'lodash';
 
 
 /**
@@ -53,7 +53,9 @@ export function getLayoutProps(props) {
 
     // Dimensions: translate numbers / bare strings into pixels.
     const dimConfig = pick(ret, dimKeys);
-    forOwn(dimConfig, (v, k) => {ret[k] = toPx(v)});
+    forOwn(dimConfig, (v, k) => {
+        if (!isNil(v)) ret[k] = toPx(v);
+    });
 
     // Extra handling for margin and padding to support TLBR multi-value strings.
     if (ret.margin) ret.margin = toTlbrPx(ret.margin);


### PR DESCRIPTION
I noticed that `getLayoutProps()` was converting null dimensions to a pixel string, e.g. `height: "nullpx"`.

While it wasn't causing any display issues, I don't think this is the correct behaviour.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

