### PR TITLE
FilterChooser height improvements

### DIFF
--- a/desktop/cmp/filter/FilterChooser.js
+++ b/desktop/cmp/filter/FilterChooser.js
@@ -36,6 +36,7 @@ export const [FilterChooser, filterChooser] = hoistCmp.withFactory({
             item: popover({
                 item: select({
                     flex: 1,
+                    height: layoutProps?.height,
                     bind: 'selectValue',
                     ref: inputRef,
 
@@ -58,7 +59,10 @@ export const [FilterChooser, filterChooser] = hoistCmp.withFactory({
                         noOptionsMessage: () => null,
                         loadingMessage: () => null,
                         styles: {
-                            menuList: (base) => ({...base, maxHeight: 'unset'})
+                            menuList: (base) => ({
+                                ...base,
+                                maxHeight: withDefault(chooserProps.maxMenuHeight, 'unset')
+                            })
                         },
                         components: {
                             DropdownIndicator: () => favoritesIcon(model)
@@ -89,6 +93,9 @@ FilterChooser.propTypes = {
 
     /** Icon to display inline on the left side of the input. */
     leftIcon: PT.element,
+
+    /** Max-height (in pixels) of menu list */
+    maxMenuHeight: PT.number,
 
     /** Placement of the dropdown menu relative to the input control. */
     menuPlacement: PT.oneOf(['auto', 'top', 'bottom']),

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -224,7 +224,7 @@ export class Select extends HoistInput {
 
     render() {
         const props = this.getNonLayoutProps(),
-            {width, ...layoutProps} = this.getLayoutProps(),
+            {width, height, ...layoutProps} = this.getLayoutProps(),
             rsProps = {
                 value: this.renderValue,
 
@@ -297,7 +297,7 @@ export class Select extends HoistInput {
         merge(rsProps, props.rsOptions);
         return box({
             item: factory(rsProps),
-            className: this.getClassName(),
+            className: this.getClassName(height ? 'xh-select--has-height' : null),
             onKeyDown: (e) => {
                 // Esc. and Enter can be listened for by parents -- stop the keydown event
                 // propagation only if react-select already likely to have used for menu management.
@@ -308,7 +308,8 @@ export class Select extends HoistInput {
                 }
             },
             ...layoutProps,
-            width: withDefault(width, 200)
+            width: withDefault(width, 200),
+            height: height
         });
     }
 

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -108,6 +108,41 @@
   }
 }
 
+.xh-select--has-height {
+  > div {
+    height: 100%;
+  }
+
+  // This ".xh-select" is the prefix for nested BEM values below, not itself a level of nesting.
+  .xh-select {
+    &__control {
+      height: 100%;
+
+      &__left-icon {
+        height: 100%;
+        padding-top: 7px;
+      }
+    }
+
+    &__placeholder {
+      height: 100%;
+      padding-top: var(--xh-pad-half-px);
+    }
+
+    &__value-container {
+      align-content: flex-start;
+      margin: 1px;
+      height: calc(100% - 2px);
+      overflow-y: auto !important;
+    }
+
+    &__indicators {
+      padding-top: var(--xh-pad-half-px);
+      flex-direction: column;
+    }
+  }
+}
+
 // The menu is rendered under the xh-app body, not within the control DOM.
 .xh-app {
   .xh-select {

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -137,7 +137,9 @@
     }
 
     &__indicators {
-      padding-top: var(--xh-pad-half-px);
+      position: absolute;
+      top: var(--xh-pad-half-px);
+      right: var(--xh-pad-half-px);
       flex-direction: column;
     }
   }


### PR DESCRIPTION
FilterChooser height improvements.

+ Select & FilterChooser support specified height
+ FilterChooser supports `maxMenuHeight` prop

See ticket: https://github.com/xh/hoist-react/issues/2043
See toolbox branch for example usages: https://github.com/xh/toolbox/tree/filterChooserHeight

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

