### PR TITLE
Restore defaulting of stripeRows to true for non-tree grids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v37.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Fix issue where grid row striping would be turned off by default for non-tree grids
+
 [Commit Log](https://github.com/xh/hoist-react/compare/v36.6.0...develop)
 
 ## v36.6.0 - 2020-10-28

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -258,7 +258,7 @@ export class GridModel {
         rowBorders = false,
         cellBorders = false,
         treeStyle = TreeStyle.HIGHLIGHTS,
-        stripeRows = (treeStyle === TreeStyle.NONE),
+        stripeRows = (!treeMode || treeStyle === TreeStyle.NONE),
         showCellFocus = false,
         hideHeaders = false,
         compact,


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

