### PR TITLE
Enable tab overflow in admin.

### DIFF
--- a/admin/App.js
+++ b/admin/App.js
@@ -32,7 +32,7 @@ const tbar = hoistCmp.factory(
     () => appBar({
         icon: Icon.gears({size: '2x', prefix: 'fal'}),
         leftItems: [
-            tabSwitcher()
+            tabSwitcher({enableOverflow: true})
         ],
         rightItems: [
             button({

--- a/desktop/cmp/tab/TabSwitcher.js
+++ b/desktop/cmp/tab/TabSwitcher.js
@@ -26,6 +26,10 @@ import composeRefs from '@seznam/compose-react-refs';
  * For 'top' or 'bottom' orientations this switcher will be rendered in horizontal mode.
  * For 'left' or 'right' orientations this switcher will be rendered in vertical mode.
  *
+ * Overflowing tabs can be displayed in a dropdown menu if `enableOverflow` is true.
+ * Note that in order for tabs to overflow, the TabSwitcher or it's wrapper must have a
+ * a maximum width.
+ *
  * @see TabContainer
  * @see TabContainerModel
  */
@@ -160,13 +164,14 @@ const overflowMenu = hoistCmp.factory({
         if (isEmpty(tabs)) return null;
 
         const items = tabs.map(tab => {
-            const {id, title: text, icon, disabled} = tab;
+            const {id, title: text, icon, disabled, showRemoveAction} = tab;
             return menuItem({
                 icon,
                 text,
                 disabled,
                 onClick: () => model.activateTab(id),
                 labelElement: button({
+                    omit: !showRemoveAction,
                     icon: Icon.x(),
                     onClick: (e) => {
                         model.removeTab(id);

--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -33,6 +33,7 @@
   }
 
   .bp3-navbar-group {
+    overflow: hidden;
     height: var(--xh-navbar-height-px);
 
     .bp3-navbar-divider {


### PR DESCRIPTION
See issue https://github.com/xh/hoist-react/issues/2195

Also, fix issue where close button shown in overflow menu even if tab can not be removed.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

