### PR TITLE
Convert mobile ButtonGroup to functional component

### DIFF
--- a/mobile/cmp/button/ButtonGroup.js
+++ b/mobile/cmp/button/ButtonGroup.js
@@ -4,38 +4,33 @@
  *
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
+import {hoistCmp} from '@xh/hoist/core';
 import {hbox} from '@xh/hoist/cmp/layout';
-import {elemFactory, HoistComponent, LayoutSupport} from '@xh/hoist/core';
 import {Button} from '@xh/hoist/mobile/cmp/button';
 import {throwIf} from '@xh/hoist/utils/js';
-import {castArray} from 'lodash';
-import {Component} from 'react';
+import {Children} from 'react';
 import './ButtonGroup.scss';
 
 /**
  * A segmented group of buttons. Should receive a list of Buttons as a children.
  */
-@HoistComponent
-@LayoutSupport
-export class ButtonGroup extends Component {
+export const [ButtonGroup, buttonGroup] = hoistCmp.withFactory({
+    displayName: 'ButtonGroup',
+    className: 'xh-button-group',
+    model: false,
 
-    baseClassName = 'xh-button-group';
+    render({children, className, ...rest}, ref) {
+        const items = Children.toArray(children);
 
-    render() {
-        const {children, ...rest} = this.getNonLayoutProps(),
-            buttons = castArray(children);
-
-        buttons.forEach(button => {
+        items.forEach(button => {
             throwIf(button && button.type !== Button, 'ButtonGroup child must be a Button.');
         });
 
         return hbox({
-            items: buttons,
+            items,
+            className,
             ...rest,
-            ...this.getLayoutProps(),
-            className: this.getClassName()
+            ref
         });
     }
-}
-
-export const buttonGroup = elemFactory(ButtonGroup);
+});


### PR DESCRIPTION
When testing the recent input changes, I was surprised to notice that the mobile ButtonGroup (not ButtonGroupInput) was the last non-functional component. This PR addresses that, bringing it inline with the rest of the toolkit.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x]  Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

