### PR TITLE
Return a ref to the HoistInputModel from HoistInputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,13 @@
   * Use `switcher: false` to not include a TabSwitcher. (previously `switcherPosition: 'none'`)
   * Use `switcher: {...}` to provide customisation props for the `TabSwitcher`. See `TabSwitcher`
     documentation for more information.
-* The `HoistInput` base class has been removed. Application components extending `HoistInput` should
-  use the `useHoistInputModel` hook instead. This change marks the completion of our efforts to
-  remove all internal uses of React class-based Components in Hoist.
+* The `HoistInput` base class has been removed.   This change marks the completion of our efforts
+ to remove all internal uses of React class-based Components in Hoist.  The following adjustments are
+ required:
+   * Application components extending `HoistInput` should use the `useHoistInputModel` hook instead.
+   * Applications getting ref's to `HoistInputs` should be aware that these ref's now return a ref to
+   a `HoistInputModel`.   In order to get the dom element associated with the component use the new
+   `domRef` property of that model rather than `HoistComponent.getDOMNode()` method.
 
 ### 🐞 Bug Fixes
 

--- a/cmp/input/HoistInputModel.js
+++ b/cmp/input/HoistInputModel.js
@@ -10,7 +10,7 @@ import {action, computed, observable, bindable} from '@xh/hoist/mobx';
 import classNames from 'classnames';
 import {isEqual} from 'lodash';
 import {useEffect, useImperativeHandle} from 'react';
-import {createObservableRef} from '@xh/hoist/core/utils/react';
+import {createObservableRef} from '@xh/hoist/utils/react';
 import './HoistInput.scss';
 
 

--- a/cmp/input/HoistInputModel.js
+++ b/cmp/input/HoistInputModel.js
@@ -9,7 +9,8 @@ import {FieldModel} from '@xh/hoist/cmp/form';
 import {action, computed, observable, bindable} from '@xh/hoist/mobx';
 import classNames from 'classnames';
 import {isEqual} from 'lodash';
-import {createRef, useEffect, useImperativeHandle} from 'react';
+import {useEffect, useImperativeHandle} from 'react';
+import {createObservableRef} from '@xh/hoist/core/utils/react';
 import './HoistInput.scss';
 
 
@@ -47,8 +48,8 @@ import './HoistInput.scss';
  * Note: Passing a ref to a HoistInput will give you a reference to its underlying HoistInputModel.
  * This model is mostly used for implementation purposes, but it is also intended to
  * provide a limited API for application use.  It currently provides access to the underlying DOM
- * element of the rendered input via its `domRef`.  In future versions of Hoist, we intend to
- * provide additional public APIs on this model, especially for focus management.
+ * element of the rendered input via its `domRef` and a new `focus()` method that will
+ * cause the control to take focus, if supported.
  *
  * To create an instance of an Input component using this model use the hook
  * {@see useHoistInputModel}.
@@ -60,7 +61,8 @@ export class HoistInputModel {
      * Ref to rendered DOM element
      * @member {Element}
      */
-    domRef = createRef();
+    domRef = createObservableRef();
+
 
     /**
      * Does this input have the focus ?
@@ -88,6 +90,10 @@ export class HoistInputModel {
         this.props = props;
         this.model = props.model;
         this.addReaction(this.externalValueReaction());
+    }
+
+    focus() {
+
     }
 
     //------------------------------


### PR DESCRIPTION
This change preserves the status quo for refs returned from our HoistInputs, but hopefully provides a reasonable path forward as well for some enhanced imperative access around focus management.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

