### PR TITLE
GoldenLayout root drop zones.

### DIFF
--- a/kit/golden-layout/index.js
+++ b/kit/golden-layout/index.js
@@ -116,6 +116,34 @@ class DragListenerPatched extends DragListener {
 }
 GoldenLayout['__lm'].utils.DragListener = DragListenerPatched;
 
+// When creating drop zones in the root component, GoldenLayout (v1.5.9) assumes
+// that the root component is full screen (i.e. the origin is 0,0).
+//
+// That means that if a dashboard is not positioned at or near 0,0 in the document,
+// the left and top root drag areas do not work.
+//
+// The below patch fixes this by adding in the current x and y offset to the root
+// areas when appropriate.
+//
+// See https://github.com/golden-layout/golden-layout/issues/459
+// See https://github.com/golden-layout/golden-layout/pull/457
+GoldenLayout['__lm'].LayoutManager.prototype._$createRootItemAreas = function() {
+    const sides = {y2: 'y1', x2: 'x1', y1: 'y2', x1: 'x2'},
+        areaSize = 50;
+
+    for (const side in sides) {
+        const area = this.root._$getArea();
+        area.side = side;
+        if (sides[side][1] === '2') {
+            area[side] = area[sides[side]] - areaSize;
+        } else {
+            area[side] = area[sides[side]] + areaSize;
+        }
+        area.surface = (area.x2 - area.x1) * (area.y2 - area.y1);
+        this._itemAreas.push(area);
+    }
+};
+
 // Overwrite jquery's 'touchmove' handler wiring, to ensure 'touchmove' handlers are non-passive.
 // This is required to suppress an error thrown by trying to preventDefault() a passive event.
 jquery.event.special.touchmove = {


### PR DESCRIPTION
Fix an issue with GoldenLayout not being able to create drop zones in the root component.

GoldenLayout's  code assumes that the root component is full screen (i.e. the origin is 0,0).

That means that if a dashboard is not positioned at or near 0,0 in the document, the left and top root drag areas do not work. It worked on the Toolbox home screen because the main navbar is 42px high, thus offering a thin 8px drop zone from the top edge of the screen.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

