### PR TITLE
Fix `groupRowInnerRenderer` deprecation warning

### DIFF
--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -241,9 +241,11 @@ class LocalModel {
             defaultGroupSortComparator: model.groupSortFn ? this.groupSortComparator : undefined,
             groupDefaultExpanded: 1,
             groupUseEntireRow: true,
-            groupRowInnerRenderer: model.groupRowRenderer,
             groupRowRendererFramework: model.groupRowElementRenderer,
-            groupRowRendererParams: {suppressCount: !model.showGroupRowCounts},
+            groupRowRendererParams: {
+                innerRenderer: model.groupRowRenderer,
+                suppressCount: !model.showGroupRowCounts
+            },
             autoGroupColumnDef: {
                 suppressSizeToFit: true // Without this the auto group col will get shrunk when we size to fit
             },


### PR DESCRIPTION
After upgrading to ag-grid v24.0, a warning appeared the console:
```
ag-Grid: since v24.0, grid properties groupRowInnerRenderer, groupRowInnerRendererFramework
and groupRowInnerRendererParams are no longer used.
```
This change fixes that warning.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

