### PR TITLE
GroupingChooser tweaks

### DIFF
--- a/cmp/filter/FilterChooserModel.js
+++ b/cmp/filter/FilterChooserModel.js
@@ -24,7 +24,8 @@ import {
     sortBy,
     flatMap,
     forEach,
-    isArray
+    isArray,
+    isFunction
 } from 'lodash';
 
 @HoistModel
@@ -78,10 +79,12 @@ export class FilterChooserModel {
      *      value changes. May be the same as `sourceStore`. Leave undefined if you wish to combine
      *      this model's values with other filters, send it to the server, or otherwise observe
      *      and handle value changes manually.
-     * @param {(Filter|* |[])} [c.initialValue] -  Configuration for a filter appropriate to be
-     *      rendered and managed by FilterChooser. Note that FilterChooser currently can only
-     *      edit and create a flat collection of FieldFilters, to be 'AND'ed together.
-     * @param {Filter[]} [c.initialFavorites] - initial favorites, an array of filter configurations.
+     * @param {(Filter|* |[]|function)} [c.initialValue] - Configuration for a filter appropriate
+     *      to be rendered and managed by FilterChooser, or a function to produce the same.
+     *      Note that FilterChooser currently can only edit and create a flat collection of
+     *      FieldFilters, to be 'AND'ed together.
+     * @param {(Filter[]|function)} [c.initialFavorites] - initial favorites as an array of filter
+     *      configurations, or a function to produce such an array.
      * @param {number} [c.maxResults] - maximum number of dropdown options to show before truncating.
      * @param {FilterChooserPersistOptions} [c.persistWith] - options governing persistence.
      */
@@ -109,7 +112,9 @@ export class FilterChooserModel {
                 this.persistFavorites = persistWith.persistFavorites ?? true;
 
                 const state = this.provider.read();
-                if (this.persistValue && state?.value) initialValue = state.value;
+                if (this.persistValue && state?.value) {
+                    initialValue = state.value;
+                }
                 if (this.persistFavorites && state?.favorites) {
                     initialFavorites = state.favorites.map(f => parseFilter(f));
                 }
@@ -125,8 +130,8 @@ export class FilterChooserModel {
             }
         }
 
-        this.setValue(initialValue);
-        this.setFavorites(initialFavorites);
+        this.setValue(isFunction(initialValue) ? initialValue() : initialValue);
+        this.setFavorites(isFunction(initialFavorites) ? initialFavorites() : initialFavorites);
 
         if (targetStore) {
             this.addReaction({

--- a/cmp/filter/FilterChooserModel.js
+++ b/cmp/filter/FilterChooserModel.js
@@ -104,6 +104,9 @@ export class FilterChooserModel {
         this.maxResults = maxResults;
         this.queryEngine = new QueryEngine(this);
 
+        let value = isFunction(initialValue) ? initialValue() : initialValue,
+            favorites = isFunction(initialFavorites) ? initialFavorites() : initialFavorites;
+
         // Read state from provider -- fail gently
         if (persistWith) {
             try {
@@ -113,10 +116,10 @@ export class FilterChooserModel {
 
                 const state = this.provider.read();
                 if (this.persistValue && state?.value) {
-                    initialValue = state.value;
+                    value = state.value;
                 }
                 if (this.persistFavorites && state?.favorites) {
-                    initialFavorites = state.favorites.map(f => parseFilter(f));
+                    favorites = state.favorites.map(f => parseFilter(f));
                 }
 
                 this.addReaction({
@@ -130,8 +133,8 @@ export class FilterChooserModel {
             }
         }
 
-        this.setValue(isFunction(initialValue) ? initialValue() : initialValue);
-        this.setFavorites(isFunction(initialFavorites) ? initialFavorites() : initialFavorites);
+        this.setValue(value);
+        this.setFavorites(favorites);
 
         if (targetStore) {
             this.addReaction({

--- a/cmp/grouping/GroupingChooserModel.js
+++ b/cmp/grouping/GroupingChooserModel.js
@@ -145,6 +145,7 @@ export class GroupingChooserModel {
         this.pendingValue = this.value;
         this.editorIsOpen = true;
         this.favoritesIsOpen = false;
+        this.showAddControl = isEmpty(this.value);
     }
 
     @action

--- a/cmp/grouping/GroupingChooserModel.js
+++ b/cmp/grouping/GroupingChooserModel.js
@@ -37,7 +37,7 @@ export class GroupingChooserModel {
     @observable.ref pendingValue = [];
     @observable editorIsOpen = false;
     @observable favoritesIsOpen = false;
-    @observable showAddControl = false;
+    @observable addControlShown = false;
 
     popoverRef = createObservableRef();
 
@@ -145,7 +145,7 @@ export class GroupingChooserModel {
         this.pendingValue = this.value;
         this.editorIsOpen = true;
         this.favoritesIsOpen = false;
-        this.showAddControl = isEmpty(this.value);
+        this.addControlShown = isEmpty(this.value);
     }
 
     @action
@@ -158,12 +158,12 @@ export class GroupingChooserModel {
     closePopover() {
         this.editorIsOpen = false;
         this.favoritesIsOpen = false;
-        this.showAddControl = false;
+        this.addControlShown = false;
     }
 
     @action
-    toggleAddControl() {
-        this.showAddControl = !this.showAddControl;
+    showAddControl() {
+        this.addControlShown = true;
     }
 
     //-------------------------
@@ -173,7 +173,7 @@ export class GroupingChooserModel {
     addPendingDim(dimName) {
         if (!dimName) return;
         this.pendingValue = [...this.pendingValue, dimName];
-        this.showAddControl = false;
+        this.addControlShown = false;
     }
 
     @action
@@ -190,7 +190,7 @@ export class GroupingChooserModel {
         this.pendingValue = pendingValue;
 
         if (isEmpty(this.pendingValue)) {
-            this.showAddControl = true;
+            this.addControlShown = true;
         }
     }
 

--- a/cmp/grouping/GroupingChooserModel.js
+++ b/cmp/grouping/GroupingChooserModel.js
@@ -93,6 +93,13 @@ export class GroupingChooserModel {
 
         throwIf(isEmpty(this.dimensions), 'Must provide valid dimensions available for selection.');
 
+        // Read and validate value and favorites
+        let value = isFunction(initialValue) ? initialValue() : initialValue,
+            favorites = isFunction(initialFavorites) ? initialFavorites() : initialFavorites;
+
+        throwIf(isEmpty(value) && !this.allowEmpty, 'Initial value cannot be empty.');
+        throwIf(!this.validateValue(value), 'Initial value is invalid.');
+
         // Read state from provider -- fail gently
         if (persistWith) {
             try {
@@ -102,10 +109,10 @@ export class GroupingChooserModel {
 
                 const state = cloneDeep(this.provider.read());
                 if (this.persistValue && state?.value && this.validateValue(state?.value)) {
-                    initialValue = state.value;
+                    value = state.value;
                 }
                 if (this.persistFavorites && state?.favorites) {
-                    initialFavorites = state.favorites;
+                    favorites = state.favorites;
                 }
 
                 this.addReaction({
@@ -119,8 +126,8 @@ export class GroupingChooserModel {
             }
         }
 
-        this.setValue(isFunction(initialValue) ? initialValue() : initialValue);
-        this.setFavorites(isFunction(initialFavorites) ? initialFavorites() : initialFavorites);
+        this.setValue(value);
+        this.setFavorites(favorites);
     }
 
     @action

--- a/desktop/cmp/filter/FilterChooser.js
+++ b/desktop/cmp/filter/FilterChooser.js
@@ -162,13 +162,10 @@ const messageOption = hoistCmp.factory({
 //------------------
 function favoritesIcon(model) {
     if (!model.persistFavorites) return null;
-    const isFavorite = model.isFavorite(model.value);
     return Icon.favorite({
-        prefix: isFavorite ? 'fas' : 'far',
         className: classNames(
             'xh-select__indicator',
-            'xh-filter-chooser-favorite-icon',
-            isFavorite ? 'xh-filter-chooser-favorite-icon--active' : null
+            'xh-filter-chooser-favorite-icon'
         ),
         onClick: (e) => {
             model.openFavoritesMenu();

--- a/desktop/cmp/filter/FilterChooser.js
+++ b/desktop/cmp/filter/FilterChooser.js
@@ -182,7 +182,7 @@ const favoritesMenu = hoistCmp.factory({
             items = [];
 
         if (isEmpty(options)) {
-            items.push(menuItem({text: 'You have not yet saved any favorites...', disabled: true}));
+            items.push(menuItem({text: 'No favorites saved...', disabled: true}));
         } else {
             items.push(...options.map(it => favoriteMenuItem(it)));
         }

--- a/desktop/cmp/filter/FilterChooser.js
+++ b/desktop/cmp/filter/FilterChooser.js
@@ -178,7 +178,7 @@ const favoritesMenu = hoistCmp.factory({
     render({model}) {
         const options = getFavoritesOptions(model),
             isFavorite = model.isFavorite(model.value),
-            addDisabled = isEmpty(model.value) || isFavorite,
+            omitAdd = isEmpty(model.value) || isFavorite,
             items = [];
 
         if (isEmpty(options)) {
@@ -188,11 +188,11 @@ const favoritesMenu = hoistCmp.factory({
         }
 
         items.push(
-            menuDivider(),
+            menuDivider({omit: omitAdd}),
             menuItem({
-                icon: Icon.add({className: addDisabled ? '' : 'xh-intent-success'}),
+                icon: Icon.add({className: 'xh-intent-success'}),
                 text: 'Add current',
-                disabled: addDisabled,
+                omit: omitAdd,
                 onClick: () => model.addFavorite(model.value)
             })
         );

--- a/desktop/cmp/filter/FilterChooser.scss
+++ b/desktop/cmp/filter/FilterChooser.scss
@@ -73,9 +73,6 @@
 
 .xh-filter-chooser-favorite-icon {
   margin-left: var(--xh-pad-half-px);
-  &--active {
-    color: var(--xh-orange) !important;
-  }
 }
 
 .xh-filter-chooser-favorite {

--- a/desktop/cmp/grouping/GroupingChooser.js
+++ b/desktop/cmp/grouping/GroupingChooser.js
@@ -248,7 +248,6 @@ const addDimensionControl = hoistCmp.factory({
                     flex: 1,
                     width: null,
                     autoFocus: true,
-                    openMenuOnFocus: true,
                     hideDropdownIndicator: true,
                     hideSelectedOptionCheck: true,
                     onChange: (newDim) => model.addPendingDim(newDim)
@@ -269,6 +268,7 @@ const bbar = hoistCmp.factory({
                 button({
                     icon: Icon.add(),
                     intent: 'success',
+                    omit: model.showAddControl,
                     disabled: !!addDisabled,
                     title: addDisabledMsg,
                     onClick: () => model.toggleAddControl()
@@ -332,7 +332,7 @@ const favoritesMenu = hoistCmp.factory({
     render({model}) {
         const options = model.favoritesOptions,
             isFavorite = model.isFavorite(model.value),
-            addDisabled = isEmpty(model.value) || isFavorite,
+            omitAdd = isEmpty(model.value) || isFavorite,
             items = [];
 
         if (isEmpty(options)) {
@@ -344,9 +344,9 @@ const favoritesMenu = hoistCmp.factory({
         items.push(
             menuDivider(),
             menuItem({
-                icon: Icon.add({className: addDisabled ? '' : 'xh-intent-success'}),
+                icon: Icon.add({className: 'xh-intent-success'}),
                 text: 'Add current',
-                disabled: addDisabled,
+                omit: omitAdd,
                 onClick: () => model.addFavorite(model.value)
             })
         );

--- a/desktop/cmp/grouping/GroupingChooser.js
+++ b/desktop/cmp/grouping/GroupingChooser.js
@@ -342,7 +342,7 @@ const favoritesMenu = hoistCmp.factory({
         }
 
         items.push(
-            menuDivider(),
+            menuDivider({omit: omitAdd}),
             menuItem({
                 icon: Icon.add({className: 'xh-intent-success'}),
                 text: 'Add current',

--- a/desktop/cmp/grouping/GroupingChooser.js
+++ b/desktop/cmp/grouping/GroupingChooser.js
@@ -14,7 +14,7 @@ import {Icon} from '@xh/hoist/icon';
 import {popover, menu, menuDivider, menuItem} from '@xh/hoist/kit/blueprint';
 import {dragDropContext, draggable, droppable} from '@xh/hoist/kit/react-beautiful-dnd';
 import {splitLayoutProps} from '@xh/hoist/utils/react';
-import {compact, isEmpty, isNil, sortBy} from 'lodash';
+import {compact, isEmpty, sortBy} from 'lodash';
 import classNames from 'classnames';
 import PT from 'prop-types';
 
@@ -41,10 +41,6 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
             isOpen = editorIsOpen || favoritesIsOpen,
             label = isEmpty(value) ? emptyText : model.getValueLabel(value),
             [layoutProps, buttonProps] = splitLayoutProps(rest);
-
-        if (isNil(layoutProps.width) && isNil(layoutProps.flex)) {
-            layoutProps.width = 220;
-        }
 
         return box({
             className,
@@ -321,13 +317,9 @@ function getDimOptions(dims, model) {
 const favoritesIcon = hoistCmp.factory({
     render({model}) {
         if (!model.persistFavorites) return null;
-        const isFavorite = model.isFavorite(model.value);
         return div({
-            item: Icon.favorite({prefix: isFavorite ? 'fas' : 'far'}),
-            className: classNames(
-                'xh-grouping-chooser__favorite-icon',
-                isFavorite ? 'xh-grouping-chooser__favorite-icon--active' : null
-            ),
+            item: Icon.favorite(),
+            className: 'xh-grouping-chooser__favorite-icon',
             onClick: (e) => {
                 model.openFavoritesMenu();
                 e.stopPropagation();

--- a/desktop/cmp/grouping/GroupingChooser.js
+++ b/desktop/cmp/grouping/GroupingChooser.js
@@ -336,7 +336,7 @@ const favoritesMenu = hoistCmp.factory({
             items = [];
 
         if (isEmpty(options)) {
-            items.push(menuItem({text: 'You have not yet saved any favorites...', disabled: true}));
+            items.push(menuItem({text: 'No favorites saved...', disabled: true}));
         } else {
             items.push(...options.map(it => favoriteMenuItem(it)));
         }

--- a/desktop/cmp/grouping/GroupingChooser.js
+++ b/desktop/cmp/grouping/GroupingChooser.js
@@ -230,7 +230,7 @@ const dimensionRow = hoistCmp.factory({
 
 const addDimensionControl = hoistCmp.factory({
     render({model}) {
-        if (!model.showAddControl || model.addDisabledMsg) return null;
+        if (!model.addControlShown || model.addDisabledMsg) return null;
         const options = getDimOptions(model.availableDims, model);
         return div({
             className: 'xh-grouping-chooser__add-control',
@@ -268,10 +268,10 @@ const bbar = hoistCmp.factory({
                 button({
                     icon: Icon.add(),
                     intent: 'success',
-                    omit: model.showAddControl,
+                    omit: model.addControlShown,
                     disabled: !!addDisabled,
                     title: addDisabledMsg,
-                    onClick: () => model.toggleAddControl()
+                    onClick: () => model.showAddControl()
                 }),
                 filler(),
                 button({

--- a/desktop/cmp/grouping/GroupingChooser.scss
+++ b/desktop/cmp/grouping/GroupingChooser.scss
@@ -25,7 +25,7 @@
 
     // We must account for the favorites icon when eliding text
     &--with-favorites {
-      padding-right: 25px !important;
+      padding-right: 30px !important;
     }
   }
 
@@ -124,8 +124,8 @@
       color: var(--xh-text-color);
     }
 
-    &--active {
-      color: var(--xh-orange) !important;
+    & > .svg-inline--fa {
+      width: 12px;
     }
   }
 

--- a/kit/golden-layout/index.js
+++ b/kit/golden-layout/index.js
@@ -116,6 +116,34 @@ class DragListenerPatched extends DragListener {
 }
 GoldenLayout['__lm'].utils.DragListener = DragListenerPatched;
 
+// When creating drop zones in the root component, GoldenLayout (v1.5.9) assumes
+// that the root component is full screen (i.e. the origin is 0,0).
+//
+// That means that if a dashboard is not positioned at or near 0,0 in the document,
+// the left and top root drag areas do not work.
+//
+// The below patch fixes this by adding in the current x and y offset to the root
+// areas when appropriate.
+//
+// See https://github.com/golden-layout/golden-layout/issues/459
+// See https://github.com/golden-layout/golden-layout/pull/457
+GoldenLayout['__lm'].LayoutManager.prototype._$createRootItemAreas = function() {
+    const sides = {y2: 'y1', x2: 'x1', y1: 'y2', x1: 'x2'},
+        areaSize = 50;
+
+    for (const side in sides) {
+        const area = this.root._$getArea();
+        area.side = side;
+        if (sides[side][1] === '2') {
+            area[side] = area[sides[side]] - areaSize;
+        } else {
+            area[side] = area[sides[side]] + areaSize;
+        }
+        area.surface = (area.x2 - area.x1) * (area.y2 - area.y1);
+        this._itemAreas.push(area);
+    }
+};
+
 // Overwrite jquery's 'touchmove' handler wiring, to ensure 'touchmove' handlers are non-passive.
 // This is required to suppress an error thrown by trying to preventDefault() a passive event.
 jquery.event.special.touchmove = {

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -105,6 +105,7 @@ const popoverCmp = hoistCmp.factory(
                     button({
                         icon: Icon.add(),
                         disabled: !!addDimDisabled,
+                        omit: model.showAddControl,
                         onClick: () => model.toggleAddControl()
                     }),
                     filler(),
@@ -224,7 +225,6 @@ const addDimensionControl = hoistCmp.factory({
                     flex: 1,
                     width: null,
                     autoFocus: true,
-                    openMenuOnFocus: true,
                     hideDropdownIndicator: true,
                     hideSelectedOptionCheck: true,
                     onChange: (newDim) => model.addPendingDim(newDim)
@@ -264,7 +264,7 @@ const favoritesMenu = hoistCmp.factory({
         const options = model.favoritesOptions;
 
         if (isEmpty(options)) {
-            return placeholder('You have not yet saved any favorites...');
+            return placeholder('No favorites saved...');
         }
 
         const items = options.map(it => favoriteMenuItem(it));

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -5,7 +5,7 @@
  * Copyright © 2020 Extremely Heavy Industries Inc.
  */
 import {GroupingChooserModel} from '@xh/hoist/cmp/grouping';
-import {div, hbox, vbox, filler, box, placeholder} from '@xh/hoist/cmp/layout';
+import {div, hbox, vbox, filler, box, placeholder, span} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {button, Button} from '@xh/hoist/mobile/cmp/button';
@@ -47,7 +47,7 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
                 popoverCmp({popoverTitle, popoverWidth}),
                 button({
                     className: 'xh-grouping-chooser-button',
-                    item: label,
+                    item: span(label),
                     ...buttonProps,
                     onClick: () => model.showEditor()
                 }),

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -287,7 +287,7 @@ const favoriteMenuItem = hoistCmp.factory({
                     }
                 }),
                 button({
-                    icon: Icon.delete({className: 'xh-intent-danger'}),
+                    icon: Icon.delete(),
                     modifier: 'quiet',
                     onClick: () => model.removeFavorite(value)
                 })

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -105,8 +105,8 @@ const popoverCmp = hoistCmp.factory(
                     button({
                         icon: Icon.add(),
                         disabled: !!addDimDisabled,
-                        omit: model.showAddControl,
-                        onClick: () => model.toggleAddControl()
+                        omit: model.addControlShown,
+                        onClick: () => model.showAddControl()
                     }),
                     filler(),
                     button({
@@ -211,7 +211,7 @@ const dimensionRow = hoistCmp.factory({
 
 const addDimensionControl = hoistCmp.factory({
     render({model}) {
-        if (!model.showAddControl || model.addDisabledMsg) return null;
+        if (!model.addControlShown || model.addDisabledMsg) return null;
         const options = getDimOptions(model.availableDims, model);
         return div({
             className: 'xh-grouping-chooser__add-control',

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -250,14 +250,10 @@ function getDimOptions(dims, model) {
 const favoritesButton = hoistCmp.factory({
     render({model}) {
         if (!model.persistFavorites) return null;
-        const isFavorite = model.isFavorite(model.value);
         return button({
-            icon: Icon.favorite({prefix: isFavorite ? 'fas' : 'far'}),
+            icon: Icon.favorite(),
             modifier: 'quiet',
-            className: classNames(
-                'xh-grouping-chooser__favorite-button',
-                isFavorite ? 'xh-grouping-chooser__favorite-button--active' : null
-            ),
+            className: 'xh-grouping-chooser__favorite-button',
             onClick: () => model.openFavoritesMenu()
         });
     }

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -96,7 +96,7 @@ const popoverCmp = hoistCmp.factory(
                     button({
                         icon: Icon.add(),
                         flex: 1,
-                        text: 'Add current grouping to favorites',
+                        text: 'Add current',
                         disabled: addFavoriteDisabled,
                         onClick: () => model.addFavorite(model.value)
                     })

--- a/mobile/cmp/grouping/GroupingChooser.scss
+++ b/mobile/cmp/grouping/GroupingChooser.scss
@@ -44,10 +44,6 @@
     padding: var(--xh-pad-half-px);
   }
 
-  &__favorite-button--active {
-    color: var(--xh-orange) !important;
-  }
-
   &__favorite {
     height: 35px;
     align-items: center;

--- a/mobile/cmp/grouping/GroupingChooser.scss
+++ b/mobile/cmp/grouping/GroupingChooser.scss
@@ -7,6 +7,13 @@
 .xh-grouping-chooser {
   .xh-grouping-chooser-button {
     width: 100%;
+    justify-content: flex-start;
+
+    span {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
   }
 
   &__row {


### PR DESCRIPTION
+ Add `allowEmpty` config to support setting empty values.
+ `initialValue` and `initialFavorites` can be functions.
+ Removed problematic default sizing on GroupingChooser. By default, its size is set by its label content, and devs can use LayoutSupport to enforce min/max/fixed widths.
+ Tweak favorite star styling, to be consistent size and not orange.
+ Tweak max depth messaging.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

