### PR TITLE
Don't create a root row when there are no leaves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v38.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Fix issue where a `View` would create a root row even if there were no leaf rows
+
 [Commit Log](https://github.com/xh/hoist-react/compare/v37.0.0...develop)
 
 ## v37.0.0 - 2020-12-15

--- a/data/cube/View.js
+++ b/data/cube/View.js
@@ -170,15 +170,22 @@ export class View {
             {dimensions, includeRoot, cube} = query,
             rootId = query.filtersAsString();
 
-        const leafMap = this.generateLeaves(cube.store.records),
-            leafArray = Array.from(leafMap.values());
+        const leafMap = this.generateLeaves(cube.store.records);
+        this._leafMap = leafMap;
+
+        if (leafMap.size === 0) {
+            this._rows = [];
+            return;
+        }
+
+        const leafArray = Array.from(leafMap.values());
         let newRows = this.groupAndInsertLeaves(leafArray, dimensions, rootId, {});
         if (includeRoot) {
             newRows = [createAggregateRow(this, rootId, newRows, null, 'Total', {})];
         } else if (!query.includeLeaves && newRows[0]?._meta.isLeaf) {
             newRows = []; // degenerate case, no visible rows
         }
-        this._leafMap = leafMap;
+
         this._rows = newRows;
     }
 

--- a/data/cube/View.js
+++ b/data/cube/View.js
@@ -170,27 +170,21 @@ export class View {
             {dimensions, includeRoot, cube} = query,
             rootId = query.filtersAsString();
 
-        const leafMap = this.generateLeaves(cube.store.records);
-        this._leafMap = leafMap;
-
-        if (leafMap.size === 0) {
-            this._rows = [];
-            return;
-        }
-
-        const leafArray = Array.from(leafMap.values());
+        const leafMap = this.generateLeaves(cube.store.records),
+            leafArray = Array.from(leafMap.values());
         let newRows = this.groupAndInsertLeaves(leafArray, dimensions, rootId, {});
-        if (includeRoot) {
+        if (includeRoot && !isEmpty(newRows)) {
             newRows = [createAggregateRow(this, rootId, newRows, null, 'Total', {})];
         } else if (!query.includeLeaves && newRows[0]?._meta.isLeaf) {
             newRows = []; // degenerate case, no visible rows
         }
-
+        this._leafMap = leafMap;
         this._rows = newRows;
     }
 
     groupAndInsertLeaves(leaves, dimensions, parentId, appliedDimensions) {
-        if (isEmpty(dimensions)) return leaves;
+        if (isEmpty(dimensions) || isEmpty(leaves)) return leaves;
+
 
         const dim = dimensions[0],
             dimName = dim.name,


### PR DESCRIPTION
This can often result in an undesired total row in a grid after clearing the grid data if you are processing the root row from the view as your summary record. Doesn't seem like there is any reason for us to have a root row with no children.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

