### PR TITLE
Tweak RelativeTimestamp formatting

### DIFF
--- a/cmp/relativetimestamp/RelativeTimestamp.js
+++ b/cmp/relativetimestamp/RelativeTimestamp.js
@@ -148,6 +148,10 @@ function doFormat(opts) {
             '<1 minute' :
             moment.duration(elapsed).humanize();
 
+        // Moment outputs e.g. "a minute" instead of "1 minute". This creates some awkwardness
+        // when the leading number comes and goes - "<1 minute" -> "a minute" -> "2 minutes".
+        ret = ret.replace(/^(an|a) /, '1 ');
+
         if (short) ret = ret.replace('minute', 'min').replace('second', 'sec');
 
         ret += ' ' + (isFuture ? opts.futureSuffix : opts.pastSuffix);


### PR DESCRIPTION
+ Moment outputs e.g. "a minute" instead of "1 minute". This creates some awkwardness when the leading number comes and goes - "<1 minute" -> "a minute" -> "2 minutes".

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

