### PR TITLE
Use approximate rendered value for StoreFilterField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,17 +33,19 @@ decorators, in favor of a simpler inheritance-based approach to defining models 
 ### 🎁 New Features
 
 * New utility method `getOrCreate` for easy caching of properties on objects.
-* The `Menu` system on mobile has been reworked to be more consistent with desktop.
-  A new `MenuButton` component has been added to the mobile framework, which renders a `Menu`
-  of `MenuItems` next to the `MenuButton`. This change also includes the removal of
-  `AppMenuModel` (see Breaking Changes)
+* The `Menu` system on mobile has been reworked to be more consistent with desktop. A new
+  `MenuButton` component has been added to the mobile framework, which renders a `Menu` of
+  `MenuItems` next to the `MenuButton`. This change also includes the removal of `AppMenuModel` (see
+  Breaking Changes).
 * Added `ExpandCollapseButton` to the mobile toolkit, to expand / collapse all rows in a tree grid.
-* Added `Popover` to the mobile toolkit, a component to display floating content next to a target element.
-  Its API is based on the Blueprint `Popover` component used on desktop.
+* Added `Popover` to the mobile toolkit, a component to display floating content next to a target
+  element. Its API is based on the Blueprint `Popover` component used on desktop.
+* `StoreFilterField` now matches the rendered string values for `date` and `localDate` fields when
+  linked to a properly configured `GridModel`.
 
 ### 💥 Breaking Changes
 
-* All `HoistModel` and `HoistService` classes will have to be adjusted as described above.
+* All `HoistModel` and `HoistService` classes must be adjusted as described above.
 * `@HoistComponent` has been deprecated and moved to `@xh\hoist\deprecated`
 * Hoist grids now require ag-Grid v25.0.1 or higher - if your app uses ag-Grid, update your ag-Grid
   dependency in your app's `package.json` file.
@@ -52,8 +54,9 @@ decorators, in favor of a simpler inheritance-based approach to defining models 
   wish to select for your component. `Uses` will throw if given any string other than "*", making
   the need for any updates clear.
 * The `Ref` class, deprecated in v26, has now been removed. Use `createObservableRef` instead.
-* `AppMenuModel` has been removed. The `AppMenuButton` is now configured via `AppBar.appMenuButtonProps`.
-  As with desktop, menu items can be added with `AppBar.appMenuButtonProps.extraItems[]`
+* `AppMenuModel` has been removed. The `AppMenuButton` is now configured via
+  `AppBar.appMenuButtonProps`. As with desktop, menu items can be added with
+  `AppBar.appMenuButtonProps.extraItems[]`
 
 ### ⚙️ Technical
 
@@ -1458,9 +1461,8 @@ _"The one with the hooks."_
 
 **Hoist now fully supports React functional components and hooks.** The new `hoistComponent`
 function is now the recommended method for defining new components and their corresponding element
-factories. See that (within [HoistComponentFunctional.js](core/HoistComponentFunctional.js)) and the
-new `useLocalModel()` and `useContextModel()` hooks (within [core/hooks](core/hooks)) for more
-information.
+factories. See that (within HoistComponentFunctional.js) and the new `useLocalModel()` and
+`useContextModel()` hooks (within [core/hooks](core/hooks)) for more information.
 
 Along with the performance benefits and the ability to use React hooks, Hoist functional components
 are designed to read and write their models via context. This allows a much less verbose

--- a/cmp/grid/impl/ColumnWidthCalculator.js
+++ b/cmp/grid/impl/ColumnWidthCalculator.js
@@ -93,15 +93,15 @@ export class ColumnWidthCalculator {
 
     calcLevelWidth(gridModel, records, column, options, indentationPx = 0) {
         const {field, getValueFn, renderer} = column,
-            {bufferPx} = options,
-            useRenderer = isFunction(renderer);
+            {bufferPx} = options;
 
         // 1) Get unique values
         const values = new Set();
         records.forEach(record => {
             if (!record) return;
-            const rawValue = getValueFn({record, field, column, gridModel}),
-                value = useRenderer ? renderer(rawValue, {record, column, gridModel}) : rawValue;
+            const ctx = {record, field, column, gridModel, store: gridModel.store},
+                rawValue = getValueFn(ctx),
+                value = renderer ? renderer(rawValue, ctx) : rawValue;
             values.add(value);
         });
 
@@ -117,7 +117,7 @@ export class ColumnWidthCalculator {
 
         // 4) Render to a hidden cell to calculate the max displayed width
         return reduce(longestValues, (currMax, value) => {
-            const width = this.getCellWidth(value, useRenderer) + indentationPx + bufferPx;
+            const width = this.getCellWidth(value, renderer) + indentationPx + bufferPx;
             return Math.max(currMax, width);
         }, 0);
     }
@@ -191,9 +191,9 @@ export class ColumnWidthCalculator {
     //------------------
     // Autosize cell
     //------------------
-    getCellWidth(value, useRenderer) {
+    getCellWidth(value, renderer) {
         const cellEl = this.getCellEl();
-        if (useRenderer) {
+        if (renderer) {
             cellEl.innerHTML = value;
         } else if (cellEl.childNodes.length === 1 && cellEl.firstChild?.nodeType === 3) {
             // If we're not rendering html and the cell's first and only child is already a TextNode,

--- a/cmp/store/impl/StoreFilterFieldImplModel.js
+++ b/cmp/store/impl/StoreFilterFieldImplModel.js
@@ -4,33 +4,35 @@
  *
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
-import {XH, HoistModel} from '@xh/hoist/core';
+import {HoistModel, XH} from '@xh/hoist/core';
+import {FieldType} from '@xh/hoist/data';
 import {action, makeObservable} from '@xh/hoist/mobx';
-import {throwIf, warnIf} from '@xh/hoist/utils/js';
+import {stripTags, throwIf, warnIf} from '@xh/hoist/utils/js';
 import {
     debounce,
     escapeRegExp,
+    filter,
+    flatMap,
     get,
     intersection,
     isArray,
     isEmpty,
     isEqual,
-    without,
     isUndefined,
-    flatMap,
-    filter
+    without
 } from 'lodash';
-import {stripTags} from '../../../utils/js';
 
 export class StoreFilterFieldImplModel extends HoistModel {
 
     model;
     bind;
+
+    /** @type {GridModel} */
     gridModel;
+    /** @type {Store} */
     store;
 
     filterBuffer;
-    filterOptions;
     onFilterChange;
     includeFields;
     excludeFields;
@@ -45,7 +47,6 @@ export class StoreFilterFieldImplModel extends HoistModel {
         store,
         filterBuffer = 200,
         onFilterChange,
-        filterOptions,
         includeFields,
         excludeFields,
         matchMode = 'startWord'
@@ -58,7 +59,6 @@ export class StoreFilterFieldImplModel extends HoistModel {
         this.store = store;
         this.filterBuffer = filterBuffer;
         this.onFilterChange = onFilterChange;
-        this.filterOptions = filterOptions;
         this.includeFields = includeFields;
         this.excludeFields = excludeFields;
         this.matchMode = matchMode;
@@ -80,7 +80,6 @@ export class StoreFilterFieldImplModel extends HoistModel {
     // We allow these to be dynamic by updating on every render.
     updateFilterProps({
         onFilterChange,
-        filterOptions,
         includeFields,
         excludeFields
     }) {
@@ -88,11 +87,7 @@ export class StoreFilterFieldImplModel extends HoistModel {
         this.onFilterChange = onFilterChange;
 
         // ...other changes require re-generation
-        if (!isEqual(
-            [filterOptions, includeFields, excludeFields],
-            [this.filterOptions, this.includeFields, this.excludeFields])
-        ) {
-            this.filterOptions = filterOptions;
+        if (!isEqual([includeFields, excludeFields], [this.includeFields, this.excludeFields])) {
             this.includeFields = includeFields;
             this.excludeFields = excludeFields;
             this.regenerateFilter();
@@ -143,7 +138,7 @@ export class StoreFilterFieldImplModel extends HoistModel {
         this.filter = newFilter;
         if (!initializing && this.onFilterChange) this.onFilterChange(newFilter);
 
-        // Only respect the buffer for non-null changes.  Allows immediate initialization and quick clearing
+        // Only respect the buffer for non-null changes. Allows immediate initialization and quick clearing.
         if (!initializing && newFilter) {
             this.bufferedApplyFilter();
         } else {
@@ -202,33 +197,43 @@ export class StoreFilterFieldImplModel extends HoistModel {
                 );
             });
         }
+
         return ret;
     }
 
-
     getValGetters(fieldName) {
         const {gridModel} = this,
-            {store} = gridModel,
-            field = store.getField(fieldName);
+            {DATE, LOCAL_DATE} = FieldType;
 
-        // For dates, need rendered value for any hope of string matching.
-        // This can be expensive, so currently applying to dates only.
-        if (field?.type === 'date' || field?.type === 'localDate') {
-            if (!gridModel) return [];
-            const cols = filter(gridModel.getVisibleLeafColumns(), {field: fieldName});
-            if (!cols) return [];
-            return cols.map(column => {
-                const {renderer, getValueFn} = column;
-                return (record) => {
-                    const ctx = {record, field, column, gridModel, store},
-                        ret = getValueFn(ctx);
+        // If a GridModel has been configured, the user is looking at rendered values in a grid and
+        // would reasonably expect the filter to work off what they see. Rendering can be expensive,
+        // so currently supported for Date-type fields only. (Dates *require* a rendered value to
+        // have any hope of matching.) This could be extended to other types if needed, perhaps
+        // with a flag to manage performance tradeoffs.
+        if (gridModel) {
+            const {store} = gridModel,
+                field = store.getField(fieldName);
 
-                    return renderer ? stripTags(renderer(ret, ctx)) : ret;
-                };
-            });
+            if (field?.type === DATE || field?.type === LOCAL_DATE) {
+                const cols = filter(gridModel.getLeafColumns(), {field: fieldName});
+
+                // Empty return if no columns - even if this field has been force-included,
+                // we can't match it if we can't render it.
+                if (!cols) return [];
+
+                return cols.map(column => {
+                    const {renderer, getValueFn} = column;
+                    return (record) => {
+                        const ctx = {record, field, column, gridModel, store},
+                            ret = getValueFn(ctx);
+
+                        return renderer ? stripTags(renderer(ret, ctx)) : ret;
+                    };
+                });
+            }
         }
 
-        // Otherwise just match raw
+        // Otherwise just match raw.
         // Use expensive get() only when needed to support dot-separated paths.
         return fieldName.includes('.') ? (rec) => get(rec.data, fieldName) : (rec) => rec.data[fieldName];
     }

--- a/cmp/store/impl/StoreFilterFieldImplModel.js
+++ b/cmp/store/impl/StoreFilterFieldImplModel.js
@@ -215,7 +215,7 @@ export class StoreFilterFieldImplModel extends HoistModel {
                 field = store.getField(fieldName);
 
             if (field?.type === DATE || field?.type === LOCAL_DATE) {
-                const cols = filter(gridModel.getLeafColumns(), {field: fieldName});
+                const cols = filter(gridModel.getVisibleLeafColumns(), {field: fieldName});
 
                 // Empty return if no columns - even if this field has been force-included,
                 // we can't match it if we can't render it.

--- a/data/Store.js
+++ b/data/Store.js
@@ -57,7 +57,7 @@ export class Store extends HoistBase {
     @observable.ref _filtered;
     _loadRootAsSummary = false;
 
-    /** @private -- used internally by any StoreFilterField that is bound to this store. */
+    /** @package - used internally by any StoreFilterField that is bound to this store. */
     @bindable xhFilterText = null;
 
     /**


### PR DESCRIPTION
UPDATE:  Using rendered value only for dates for now, for performance reasons.

This isn't perfect, and in some cases may not be exactly what you want -- but on balance I think it handles things better --
WYSYG

+ Most Importantly searching for Date strings now works as your would expect.
+ Ledger format numbers work better -- no need to use '-' when you see '('.
+ Performance sees reasonable - tested on 50k, 7 column grid.

One potential downside is that searching for numbers now requires you to type the comma.    This is also probably the most significant behavioral difference.  If we think that is a bug, we could handle numeric fields differently, but I would be inclined to have the search work consistently on the rendered string for all fields.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

