### PR TITLE
GroupingChooser tweaks for usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ decorators, in favor of a simpler inheritance-based approach to defining models 
   element. Its API is based on the Blueprint `Popover` component used on desktop.
 * `StoreFilterField` now matches the rendered string values for `date` and `localDate` fields when
   linked to a properly configured `GridModel`.
+* `GroupingChooser` gets several minor usability improvements + clearer support for an empty /
+  ungrouped state, when so enabled.
 
 ### 💥 Breaking Changes
 

--- a/cmp/grouping/GroupingChooserModel.js
+++ b/cmp/grouping/GroupingChooserModel.js
@@ -164,7 +164,11 @@ export class GroupingChooserModel extends HoistModel {
 
     @action
     showAddControl() {
-        this.addControlShown = true;
+        if (this.availableDims.length === 1) {
+            this.addPendingDim(this.availableDims[0]);
+        } else {
+            this.addControlShown = true;
+        }
     }
 
     //-------------------------

--- a/cmp/grouping/GroupingChooserModel.js
+++ b/cmp/grouping/GroupingChooserModel.js
@@ -36,7 +36,7 @@ export class GroupingChooserModel extends HoistModel {
     @observable.ref pendingValue = [];
     @observable editorIsOpen = false;
     @observable favoritesIsOpen = false;
-    @observable addControlShown = false;
+    @observable isAddMode = false;
 
     popoverRef = createObservableRef();
 
@@ -62,6 +62,10 @@ export class GroupingChooserModel extends HoistModel {
         if (isEmpty(this.availableDims)) return 'All dimensions added';
         if (this.atMaxDepth) return `Maximum ${this.maxDepth} dimensions added`;
         return null;
+    }
+
+    get addControlShown() {
+        return this.isAddMode && !this.addDisabledMsg;
     }
 
     /**
@@ -146,7 +150,7 @@ export class GroupingChooserModel extends HoistModel {
         this.pendingValue = this.value;
         this.editorIsOpen = true;
         this.favoritesIsOpen = false;
-        this.addControlShown = isEmpty(this.value) && !this.allowEmpty;
+        this.isAddMode = isEmpty(this.value) && !this.allowEmpty;
     }
 
     @action
@@ -159,15 +163,14 @@ export class GroupingChooserModel extends HoistModel {
     closePopover() {
         this.editorIsOpen = false;
         this.favoritesIsOpen = false;
-        this.addControlShown = false;
     }
 
     @action
-    showAddControl() {
+    addLevel() {
         if (this.availableDims.length === 1) {
             this.addPendingDim(this.availableDims[0]);
         } else {
-            this.addControlShown = true;
+            this.isAddMode = true;
         }
     }
 
@@ -178,7 +181,7 @@ export class GroupingChooserModel extends HoistModel {
     addPendingDim(dimName) {
         if (!dimName) return;
         this.pendingValue = [...this.pendingValue, dimName];
-        this.addControlShown = false;
+        this.isAddMode = false;
     }
 
     @action
@@ -194,8 +197,8 @@ export class GroupingChooserModel extends HoistModel {
         pendingValue.splice(idx, 1);
         this.pendingValue = pendingValue;
 
-        if (isEmpty(this.pendingValue) && !this.allowEmpty) {
-            this.addControlShown = true;
+        if (isEmpty(pendingValue) && !this.allowEmpty) {
+            this.isAddMode = true;
         }
     }
 

--- a/desktop/cmp/grouping/GroupingChooser.js
+++ b/desktop/cmp/grouping/GroupingChooser.js
@@ -4,24 +4,25 @@
  *
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
-
-import {hoistCmp, uses} from '@xh/hoist/core';
 import {GroupingChooserModel} from '@xh/hoist/cmp/grouping';
-import {div, fragment, vbox, hbox, filler, box} from '@xh/hoist/cmp/layout';
+import {box, div, filler, fragment, vbox} from '@xh/hoist/cmp/layout';
+import {hoistCmp, uses} from '@xh/hoist/core';
 import {button, Button} from '@xh/hoist/desktop/cmp/button';
 import {select, Select} from '@xh/hoist/desktop/cmp/input';
+import {toolbar, toolbarSep} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
-import {popover, menu, menuDivider, menuItem} from '@xh/hoist/kit/blueprint';
+import {menu, menuDivider, menuItem, popover} from '@xh/hoist/kit/blueprint';
 import {dragDropContext, draggable, droppable} from '@xh/hoist/kit/react-beautiful-dnd';
 import {splitLayoutProps} from '@xh/hoist/utils/react';
-import {compact, isEmpty, sortBy} from 'lodash';
 import classNames from 'classnames';
+import {compact, isEmpty, sortBy} from 'lodash';
 import PT from 'prop-types';
-
 import './GroupingChooser.scss';
 
 /**
- * Control for selecting a list of dimensions for grouping APIs.
+ * Control for selecting a list of dimensions for grouping APIs, with built-in support for
+ * drag-and-drop reordering and user-managed favorites.
+ *
  * @see GroupingChooserModel
  */
 export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
@@ -216,6 +217,7 @@ const dimensionRow = hoistCmp.factory({
                         }),
                         button({
                             icon: Icon.delete(),
+                            intent: 'danger',
                             className: 'xh-grouping-chooser__row__remove-btn',
                             onClick: () => model.removePendingDimAtIdx(idx)
                         })
@@ -252,6 +254,7 @@ const addDimensionControl = hoistCmp.factory({
                     flex: 1,
                     width: null,
                     autoFocus: true,
+                    openMenuOnFocus: true,
                     hideDropdownIndicator: true,
                     hideSelectedOptionCheck: true,
                     onChange: (newDim) => model.addPendingDim(newDim)
@@ -266,11 +269,12 @@ const bbar = hoistCmp.factory({
         const {addDisabledMsg, isValid} = model,
             addDisabled = !!addDisabledMsg;
 
-        return hbox({
+        return toolbar({
             className: 'xh-grouping-chooser__btn-row',
             items: [
                 button({
                     icon: Icon.add(),
+                    text: 'Add Level',
                     intent: 'success',
                     omit: model.addControlShown,
                     disabled: !!addDisabled,
@@ -280,11 +284,14 @@ const bbar = hoistCmp.factory({
                 filler(),
                 button({
                     icon: Icon.close(),
+                    title: 'Cancel',
                     intent: 'danger',
                     onClick: () => model.closePopover()
                 }),
+                toolbarSep(),
                 button({
                     icon: Icon.check(),
+                    text: 'Apply',
                     intent: 'success',
                     disabled: !isValid,
                     onClick: () => model.commitPendingValueAndClose()

--- a/desktop/cmp/grouping/GroupingChooser.scss
+++ b/desktop/cmp/grouping/GroupingChooser.scss
@@ -76,6 +76,14 @@
       flex: 1;
     }
 
+    &__remove-btn {
+      opacity: 0;
+    }
+
+    &:hover .xh-grouping-chooser__row__remove-btn {
+      opacity: 1;
+    }
+
     &--dragging {
       border: var(--xh-border-solid);
       box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
@@ -104,8 +112,8 @@
   }
 
   &__btn-row {
-    border-top: var(--xh-border-solid);
-    background-color: var(--xh-tbar-bg);
+    min-height: unset !important;
+    padding: 2px var(--xh-tbar-item-pad-px);
   }
 
   &__favorite-icon {

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -45,7 +45,7 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
             className,
             ...layoutProps,
             items: [
-                popoverCmp({popoverTitle, popoverWidth}),
+                popoverCmp({popoverTitle, popoverWidth, emptyText}),
                 button({
                     className: 'xh-grouping-chooser-button',
                     item: span(label),
@@ -78,11 +78,10 @@ GroupingChooser.propTypes = {
 // Popover
 //---------------------------
 const popoverCmp = hoistCmp.factory(
-    ({model, popoverTitle, popoverWidth}) => {
-        const {editorIsOpen, favoritesIsOpen, isValid, value} = model,
+    ({model, popoverTitle, popoverWidth, emptyText}) => {
+        const {editorIsOpen, favoritesIsOpen, isAddMode, addDisabledMsg, isValid, value} = model,
             isOpen = editorIsOpen || favoritesIsOpen,
-            addFavoriteDisabled = isEmpty(value) || !!model.isFavorite(value),
-            addDimDisabled = !!model.addDisabledMsg;
+            addFavoriteDisabled = isEmpty(value) || !!model.isFavorite(value);
 
         return dialog({
             isOpen,
@@ -90,7 +89,7 @@ const popoverCmp = hoistCmp.factory(
             icon: favoritesIsOpen ? Icon.favorite({prefix: 'fas'}) : Icon.treeList(),
             className: 'xh-grouping-chooser-popover',
             width: popoverWidth,
-            content: favoritesIsOpen ? favoritesMenu() : editor(),
+            content: favoritesIsOpen ? favoritesMenu() : editor({emptyText}),
             onCancel: () => model.commitPendingValueAndClose(),
             buttons: favoritesIsOpen ?
                 [
@@ -105,9 +104,10 @@ const popoverCmp = hoistCmp.factory(
                 [
                     button({
                         icon: Icon.add(),
-                        disabled: !!addDimDisabled,
-                        omit: model.addControlShown,
-                        onClick: () => model.showAddControl()
+                        text: 'Add',
+                        disabled: !!addDisabledMsg,
+                        omit: isAddMode,
+                        onClick: () => model.addLevel()
                     }),
                     filler(),
                     button({
@@ -117,6 +117,7 @@ const popoverCmp = hoistCmp.factory(
                     }),
                     button({
                         icon: Icon.check(),
+                        text: 'Apply',
                         disabled: !isValid,
                         onClick: () => model.commitPendingValueAndClose()
                     })
@@ -129,37 +130,40 @@ const popoverCmp = hoistCmp.factory(
 // Editor
 //------------------
 const editor = hoistCmp.factory({
-    render({model}) {
+    render({model, emptyText}) {
         return vbox(
-            dragDropContext({
-                onDragEnd: (result) => model.onDragEnd(result),
-                item: droppable({
-                    droppableId: 'dimension-list',
-                    item: (dndProps) => dimensionList({
-                        ref: dndProps.innerRef,
-                        placeholder: dndProps.placeholder
-                    })
-                })
-            }),
-            addDimensionControl()
+            dimensionList({emptyText}),
+            addDimensionControl({omit: !model.addControlShown})
         );
     }
 });
 
 const dimensionList = hoistCmp.factory({
-    render({model, placeholder}, ref) {
-        return div({
-            ref,
-            className: 'xh-grouping-chooser__list',
-            items: [
-                ...model.pendingValue.map((dimension, idx) => {
-                    return dimensionRow({dimension, idx});
-                }),
-                placeholder
-            ]
+    render({model, emptyText}) {
+        if (!model.addControlShown && isEmpty(model.pendingValue)) {
+            return hbox({
+                className: 'xh-grouping-chooser__row',
+                items: [filler(), emptyText, filler()]
+            });
+        }
+
+        return dragDropContext({
+            onDragEnd: (result) => model.onDragEnd(result),
+            item: droppable({
+                droppableId: 'dimension-list',
+                item: (dndProps) => div({
+                    ref: dndProps.innerRef,
+                    className: 'xh-grouping-chooser__list',
+                    items: [
+                        ...model.pendingValue.map((dimension, idx) => dimensionRow({dimension, idx})),
+                        dndProps.placeholder
+                    ]
+                })
+            })
         });
     }
 });
+
 
 const dimensionRow = hoistCmp.factory({
     render({model, dimension, idx}) {
@@ -191,7 +195,7 @@ const dimensionRow = hoistCmp.factory({
                                 flex: 1,
                                 width: null,
                                 hideDropdownIndicator: true,
-                                disabled: isEmpty(options),
+                                disabled: options.length <= 1,
                                 onChange: (newDim) => model.replacePendingDimAtIdx(newDim, idx)
                             })
                         }),
@@ -212,7 +216,6 @@ const dimensionRow = hoistCmp.factory({
 
 const addDimensionControl = hoistCmp.factory({
     render({model}) {
-        if (!model.addControlShown || model.addDisabledMsg) return null;
         const options = getDimOptions(model.availableDims, model);
         return div({
             className: 'xh-grouping-chooser__add-control',
@@ -222,7 +225,7 @@ const addDimensionControl = hoistCmp.factory({
                     // ensure the Select loses its internal input state.
                     key: JSON.stringify(options),
                     options,
-                    placeholder: 'Add Dimension...',
+                    placeholder: 'Add...',
                     flex: 1,
                     width: null,
                     autoFocus: true,


### PR DESCRIPTION
+ Auto-expand add dim select upon show.
+ Add text to toolbar buttons to make them easier click targets.
+ If add dim button clicked and only one dim remains to add, add it immediately instead of showing select.
+ Show remove dim button on row hover only, add danger intent for general consistency.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

