### PR TITLE
Support `onRowClicked` in Dataview

### DIFF
--- a/cmp/dataview/DataView.js
+++ b/cmp/dataview/DataView.js
@@ -26,7 +26,7 @@ export const [DataView, dataView] = hoistCmp.withFactory({
         apiRemoved(props.itemHeight, 'itemHeight', 'Specify itemHeight on the DataViewModel instead.');
         apiRemoved(props.rowCls, 'rowCls', 'Specify rowClassFn on the DataViewModel instead.');
 
-        const [layoutProps, {onRowDoubleClicked}] = splitLayoutProps(props);
+        const [layoutProps, {onRowClicked, onRowDoubleClicked}] = splitLayoutProps(props);
         const localModel = useLocalModel(() => new LocalModel(model));
 
         return grid({
@@ -35,6 +35,7 @@ export const [DataView, dataView] = hoistCmp.withFactory({
             ref,
             model: model.gridModel,
             agOptions: localModel.agOptions,
+            onRowClicked,
             onRowDoubleClicked
         });
     }
@@ -43,6 +44,12 @@ export const [DataView, dataView] = hoistCmp.withFactory({
 DataView.propTypes = {
     /** Primary component model instance. */
     model: PT.oneOfType([PT.instanceOf(DataViewModel), PT.object]),
+
+    /**
+     * Callback when a row is clicked. Function will receive an event with a data node
+     * containing the row's data. (Note that this may be null - e.g. for clicks on group rows.)
+     */
+    onRowClicked: PT.func,
 
     /**
      * Callback to call when a row is double clicked. Function will receive an event


### PR DESCRIPTION
Do we know why DataView currently only supports `onRowDoubleClicked`?

It seems it should also support `onRowClicked`, unless there is a good reason not to, particularly for mobile emulation where `onRowDoubleClicked` doesn't fire. (https://github.com/xh/hoist-react/issues/1762)

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

