### PR TITLE
Tweaks to mobile ExpandCollapse button

### DIFF
--- a/mobile/cmp/button/ExpandCollapseButton.js
+++ b/mobile/cmp/button/ExpandCollapseButton.js
@@ -28,15 +28,15 @@ export const [ExpandCollapseButton, expandCollapseButton] = hoistCmp.withFactory
 
         if (!gridModel?.treeMode) {
             console.error("No GridModel available with treeMode enabled. Provide via a 'gridModel' prop, or context.");
-            return button({icon: Icon.angleDown(), disabled: true, ...props});
         }
 
         const shouldCollapse = !isEmpty(gridModel.expandState),
-            icon = shouldCollapse ? Icon.angleRight() : Icon.angleDown();
+            disabled = !gridModel.treeMode || gridModel.store.allRootCount === gridModel.store.allCount,
+            icon = shouldCollapse ? Icon.collapse() : Icon.expand();
 
         onClick = onClick ?? (() => shouldCollapse ? gridModel.collapseAll() : gridModel.expandAll());
 
-        return button({icon, onClick, ...props});
+        return button({disabled, icon, onClick, ...props});
     }
 });
 ExpandCollapseButton.propTypes = {

--- a/mobile/cmp/button/ExpandCollapseButton.js
+++ b/mobile/cmp/button/ExpandCollapseButton.js
@@ -28,10 +28,11 @@ export const [ExpandCollapseButton, expandCollapseButton] = hoistCmp.withFactory
 
         if (!gridModel?.treeMode) {
             console.error("No GridModel available with treeMode enabled. Provide via a 'gridModel' prop, or context.");
+            return button({icon: Icon.expand(), disabled: true, ...props});
         }
 
         const shouldCollapse = !isEmpty(gridModel.expandState),
-            disabled = !gridModel.treeMode || gridModel.store.allRootCount === gridModel.store.allCount,
+            disabled = gridModel.store.allRootCount === gridModel.store.allCount,
             icon = shouldCollapse ? Icon.collapse() : Icon.expand();
 
         onClick = onClick ?? (() => shouldCollapse ? gridModel.collapseAll() : gridModel.expandAll());


### PR DESCRIPTION
+ Replace icons
+ Disable the button if the grid does not contain hierarchical data

Unfortunately, I couldn't find any FontAwesome icons that seemed analogous to the icons used by the Ext JS version. Opted to use our pre-existing expand / collapse icons instead, which I feel are still a significant improvement

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

