### PR TITLE
Fix memoization warning in mobile toolkit

### DIFF
--- a/mobile/cmp/panel/Panel.js
+++ b/mobile/cmp/panel/Panel.js
@@ -25,7 +25,7 @@ import './Panel.scss';
 export const [Panel, panel] = hoistCmp.withFactory({
     displayName: 'Panel',
     className: 'xh-panel',
-    model: false, memo: false,
+    model: false,
 
     render(props, ref) {
         const contextModel = useContextModel('*');


### PR DESCRIPTION
The mobile toolkit was routinely logging the below warning, which I tracked down to the mobile Panel:

`Cannot create an observer component without "memo". Memo is built-in to MobX observable. Component will be memoized.`

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

