### PR TITLE
Fix: TextInput does not pass DOM props onto the HTML input element

### DIFF
--- a/desktop/cmp/input/CodeInput.js
+++ b/desktop/cmp/input/CodeInput.js
@@ -5,7 +5,7 @@
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
 import {HoistInputModel, HoistInputPropTypes, useHoistInputModel} from '@xh/hoist/cmp/input';
-import {box, filler, fragment, frame, hbox, vbox, div, label, span} from '@xh/hoist/cmp/layout';
+import {box, filler, fragment, hbox, vbox, div, label, span} from '@xh/hoist/cmp/layout';
 import {hoistCmp, XH} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {clipboardButton} from '@xh/hoist/desktop/cmp/clipboard';
@@ -482,29 +482,25 @@ const searchInputCmp = hoistCmp.factory(
         const {cursor, currentMatchIdx, matchCount} = model;
 
         return fragment(
-            // Frame wrapper added due to issues with textInput not supporting all layout props as it should.
-            frame({
-                flex: 1,
+            textInput({
                 maxWidth: 400,
-                item: textInput({
-                    width: null,
-                    flex: 1,
-                    model: this,
-                    bind: 'query',
-                    leftIcon: Icon.search(),
-                    enableClear: true,
-                    commitOnChange: true,
-                    onKeyDown: (e) => {
-                        if (e.key !== 'Enter') return;
-                        if (!cursor) {
-                            model.findAll();
-                        } else if (e.shiftKey) {
-                            model.findPrevious();
-                        } else {
-                            model.findNext();
-                        }
+                width: null,
+                flex: 1,
+                model: this,
+                bind: 'query',
+                leftIcon: Icon.search(),
+                enableClear: true,
+                commitOnChange: true,
+                onKeyDown: (e) => {
+                    if (e.key !== 'Enter') return;
+                    if (!cursor) {
+                        model.findAll();
+                    } else if (e.shiftKey) {
+                        model.findPrevious();
+                    } else {
+                        model.findNext();
                     }
-                })
+                }
             }),
             label({
                 className: 'xh-code-input__label',

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -119,7 +119,7 @@ const cmp = hoistCmp.factory(
     ({model, className, ...props}, ref) => {
         const {width, flex, ...layoutProps} = getLayoutProps(props),
             // remove layoutProps, props not recognized as DOM elements, and props not accepted on BP's inputGroup component
-            {commitOnChange, enableClear, onCommit, selectOnFocus, textAlign, ...rest} = getNonLayoutProps(props);
+            {bind, commitOnChange, enableClear, onCommit, selectOnFocus, textAlign, ...rest} = getNonLayoutProps(props);
 
         const isClearable = !isEmpty(model.internalValue);
 

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -11,7 +11,7 @@ import {button} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {inputGroup} from '@xh/hoist/kit/blueprint';
 import {withDefault} from '@xh/hoist/utils/js';
-import {getLayoutProps} from '@xh/hoist/utils/react';
+import {getLayoutProps, getNonLayoutProps} from '@xh/hoist/utils/react';
 import {isEmpty} from 'lodash';
 import composeRefs from '@seznam/compose-react-refs';
 import PT from 'prop-types';
@@ -117,32 +117,30 @@ class Model extends HoistInputModel {
 
 const cmp = hoistCmp.factory(
     ({model, className, ...props}, ref) => {
-        const {width, flex, ...layoutProps} = getLayoutProps(props);
+        const {width, flex, ...layoutProps} = getLayoutProps(props),
+            // remove layoutProps, props not recognized as DOM elements, and props not accepted on BP's inputGroup component
+            {commitOnChange, enableClear, onCommit, selectOnFocus, textAlign, ...rest} = getNonLayoutProps(props);
 
         const isClearable = !isEmpty(model.internalValue);
 
         return div({
             item: inputGroup({
+                ...rest,
+
+                // overwrite some of the ...rest props with Hoist's customizations
                 value: model.renderValue || '',
 
-                autoComplete: withDefault(props.autoComplete, props.type === 'password' ? 'new-password' : 'nope'),
-                autoFocus: props.autoFocus,
-                disabled: props.disabled,
-                inputRef: composeRefs(model.inputRef, props.inputRef),
-                leftIcon: props.leftIcon,
-                placeholder: props.placeholder,
-                rightElement: props.rightElement ||
-                    (props.enableClear && !props.disabled && isClearable ? clearButton() : null),
-                round: withDefault(props.round, false),
-                spellCheck: withDefault(props.spellCheck, false),
-                tabIndex: props.tabIndex,
-                type: props.type,
+                autoComplete: withDefault(rest.autoComplete, rest.type === 'password' ? 'new-password' : 'nope'),
+                inputRef: composeRefs(model.inputRef, rest.inputRef),
+                rightElement: rest.rightElement ||
+                    (enableClear && !rest.disabled && isClearable ? clearButton() : null),
+                round: withDefault(rest.round, false),
+                spellCheck: withDefault(rest.spellCheck, false),
 
-                id: props.id,
                 style: {
-                    ...props.style,
+                    ...rest.style,
                     ...layoutProps,
-                    textAlign: withDefault(props.textAlign, 'left')
+                    textAlign: withDefault(textAlign, 'left')
                 },
 
                 onChange: model.onChange,

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -137,9 +137,13 @@ const cmp = hoistCmp.factory(
                 round: withDefault(rest.round, false),
                 spellCheck: withDefault(rest.spellCheck, false),
 
+                // These styles get passed onto the HTML INPUT element, 
+                // they are not placed on the DIV created by Blueprint's InputGroup component.
                 style: {
                     ...rest.style,
                     ...layoutProps,
+                    width: withDefault(width, 200),
+                    flex: withDefault(flex, null),
                     textAlign: withDefault(textAlign, 'left')
                 },
 
@@ -150,6 +154,7 @@ const cmp = hoistCmp.factory(
             className,
             style: {
                 width: withDefault(width, 200),
+                maxWidth: layoutProps.maxWidth,
                 flex: withDefault(flex, null)
             },
 


### PR DESCRIPTION
This fixes issue: https://github.com/xh/hoist-react/issues/2289
Which was raised most recently by @petradish when coding an onPaste event handler.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [ ] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [ ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

