### PR TITLE
Increase specificity of group leaf indent override

### DIFF
--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -109,49 +109,17 @@
 .xh-grid--hierarchical:not(.xh-data-view) {
   // Generate indentations for tree grids with hierarchical data.
   .ag-ltr {
-    .ag-row-group-indent-0 {
-      padding-left: calc(0 * var(--xh-grid-tree-indent));
-    }
+    @for $i from 1 to 20 {
+      .ag-row-group-indent-#{$i} {
+        padding-left: calc(#{$i} * var(--xh-grid-tree-indent));
+      }
 
-    .ag-row-group-indent-1 {
-      padding-left: calc(1 * var(--xh-grid-tree-indent));
+      .ag-row-level-#{$i} {
+        .ag-row-group-leaf-indent {
+          margin-left: var(--xh-grid-tree-indent);
+        }
+      }
     }
-
-    .ag-row-group-indent-2 {
-      padding-left: calc(2 * var(--xh-grid-tree-indent));
-    }
-
-    .ag-row-group-indent-3 {
-      padding-left: calc(3 * var(--xh-grid-tree-indent));
-    }
-
-    .ag-row-group-indent-4 {
-      padding-left: calc(4 * var(--xh-grid-tree-indent));
-    }
-
-    .ag-row-group-indent-5 {
-      padding-left: calc(5 * var(--xh-grid-tree-indent));
-    }
-
-    .ag-row-group-indent-6 {
-      padding-left: calc(6 * var(--xh-grid-tree-indent));
-    }
-
-    .ag-row-group-indent-7 {
-      padding-left: calc(7 * var(--xh-grid-tree-indent));
-    }
-
-    .ag-row-group-indent-8 {
-      padding-left: calc(8 * var(--xh-grid-tree-indent));
-    }
-
-    .ag-row-group-indent-9 {
-      padding-left: calc(9 * var(--xh-grid-tree-indent));
-    }
-  }
-
-  .ag-ltr .ag-row-group-leaf-indent {
-    margin-left: var(--xh-grid-tree-indent);
   }
 
   .ag-group-contracted + .ag-group-value:not(:empty) {

--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -109,7 +109,7 @@
 .xh-grid--hierarchical:not(.xh-data-view) {
   // Generate indentations for tree grids with hierarchical data.
   .ag-ltr {
-    @for $i from 1 to 20 {
+    @for $i from 0 to 20 {
       .ag-row-group-indent-#{$i} {
         padding-left: calc(#{$i} * var(--xh-grid-tree-indent));
       }


### PR DESCRIPTION
Resolves #2293 
+ Dry up .ag-row-group-indent selector
+ $i loops from 1-20 (only those indices are supported by ag-grid)

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [N/A] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [N/A] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

