### PR TITLE
Set default popoverBoundary to 'viewport' in DateInput

### DIFF
--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -395,7 +395,7 @@ const cmp = hoistCmp.factory(
                 autoFocus: false,
                 enforceFocus: false,
                 position: props.popoverPosition ?? 'auto',
-                boundary: props.popoverBoundary ?? 'scrollParent',
+                boundary: props.popoverBoundary ?? 'viewport',
                 popoverRef: (v) => {model.popoverRef.current = v},  // Workaround for #2272
                 onClose: model.onPopoverClose,
                 onInteraction: (nextOpenState) => {

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -112,6 +112,7 @@ DateInput.propTypes = {
         'auto'
     ]),
 
+    /** Defaults to viewport. */
     popoverBoundary: PT.oneOf(['scrollParent', 'viewport', 'window']),
 
     /** True to select contents when control receives focus. */

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -112,7 +112,7 @@ DateInput.propTypes = {
         'auto'
     ]),
 
-    /** Defaults to viewport. */
+    /** Boundary for calendar popover, as per Blueprint docs. Defaults to viewport. */
     popoverBoundary: PT.oneOf(['scrollParent', 'viewport', 'window']),
 
     /** True to select contents when control receives focus. */


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [N/R] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [N/R] Reviewed and tested on Mobile, or determined not required.
- [N/R] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

