### PR TITLE
Minor updates to FilterChooser suggestions

### DIFF
--- a/cmp/filter/impl/QueryEngine.js
+++ b/cmp/filter/impl/QueryEngine.js
@@ -68,20 +68,20 @@ export class QueryEngine {
     // 1) No op yet, so field not fixed -- get field or value matches.
     //------------------------------------------------------------------------
     openSearching(q) {
-        // Get main field suggestions
+        // Suggest matching *fields* for the user to select on their way to a more targeted query.
         let ret = this.getFieldOpts(q.field);
 
-        // Potentially provide some additional match ideas
+        // If a single field matches, reasonable to assume user is looking to search on it.
+        // Suggest *all values from that field* for immediate selection with the = operator.
         if (ret.length === 1) {
-            // user clearly on a path to a single field, drilldown on it with = and an empty search
             ret.push(...this.getValueMatchesForField('=', '', ret[0].fieldSpec));
-        } else {
-            // field search ongoing with options above.
-            // But in case user looking for values, try a general search with = and the text given
-            this.fieldSpecs.forEach(spec => {
-                ret.push(...this.getValueMatchesForField('=', q.field, spec));
-            });
         }
+
+        // Also suggest *matching values* across all suggest-enabled fields to support the user
+        // searching for a value directly, without them needing to type or select a field name.
+        this.fieldSpecs.forEach(spec => {
+            ret.push(...this.getValueMatchesForField('=', q.field, spec));
+        });
 
         ret = this.sortAndTruncate(ret);
 

--- a/desktop/cmp/filter/FilterChooser.js
+++ b/desktop/cmp/filter/FilterChooser.js
@@ -53,7 +53,7 @@ export const [FilterChooser, filterChooser] = hoistCmp.withFactory({
                     options: selectOptions,
                     optionRenderer,
                     rsOptions: {
-                        defaultOptions: [],
+                        defaultOptions: false,
                         openMenuOnClick: false,
                         openMenuOnFocus: false,
                         isOptionDisabled: (opt) => opt.type === 'msg',


### PR DESCRIPTION
+ Continue to suggest matching values across all fields, even if query matches a single field.
+ Field names and (different) field values can overlap - previously once your input matched a single field name you would no longer get other, also valid value matches, making the behavior difficult to understand.
+ Pass `rsOptions.defaultOptions:false` vs `[]` to suppress weird display of empty suggest box when user has deleted all of their query.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required. N/A
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. N/A
- [x] Updated doc comments / prop-types, or determined not required. N/A
- [x] Reviewed and tested on Mobile, or determined not required. N/A
- [x] Created Toolbox branch / PR, or determined not required. N/A

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

