### PR TITLE
Unescape encoded characters after DOMPurify sanitization

### DIFF
--- a/data/Field.js
+++ b/data/Field.js
@@ -9,7 +9,7 @@ import {XH} from '@xh/hoist/core';
 import {isLocalDate, LocalDate} from '@xh/hoist/utils/datetime';
 import {withDefault} from '@xh/hoist/utils/js';
 import equal from 'fast-deep-equal';
-import {isDate, isString, toNumber, isFinite, startCase} from 'lodash';
+import {isDate, isString, toNumber, isFinite, startCase, unescape} from 'lodash';
 import DOMPurify from 'dompurify';
 
 /**
@@ -66,7 +66,10 @@ export function parseFieldValue(val, type, defaultValue = null, disableXssProtec
     if (val === undefined || val === null) val = defaultValue;
     if (val === null) return val;
 
-    if (!disableXssProtection && isString(val)) val = DOMPurify.sanitize(val);
+    if (!disableXssProtection && isString(val)) {
+        val = DOMPurify.sanitize(val);
+        val = unescape(val); // Unescape characters (i.e. '<', '>', '&', ''','"') after sanitization
+    }
 
     const FT = FieldType;
     switch (type) {


### PR DESCRIPTION
DomPurify.sanitize will escape characters '<', '>', '&' when it interprets '<' character as an opening angle bracket. 
This could be problematic for records that might contain this character in one of its fields during an update. Upon creation, characters are saved to the db correctly unescaped, but it will return to the client escaped -- and if left unchanged, its new escaped value will be written to the db.

This PR ensures that these characters are unescaped after the sanitize method is run.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [N/A] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

