### PR TITLE
Column Chooser Autosize

### DIFF
--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -175,8 +175,7 @@ export class GridModel extends HoistModel {
      * @param {(StoreSelectionModel|Object|String)} [c.selModel] - StoreSelectionModel, or a
      *      config or string `mode` with which to create one.
      * @param {(ColChooserModelConfig|boolean)} [c.colChooserModel] - config with which to create a
-     *      ColChooserModel, or boolean `true` to enable default. Mobile apps should only specify
-     *      `true`, as colChooserModel mobile impl is not configurable.
+     *      ColChooserModel, or boolean `true` to enable default.
      * @param {?ReactNode} [c.restoreDefaultsWarning] - Confirmation warning to be presented to
      *      user before restoring default grid state. Set to null to skip user confirmation.
      * @param {GridModelPersistOptions} [c.persistWith] - options governing persistence.
@@ -1200,15 +1199,13 @@ export class GridModel extends HoistModel {
     }
 
     parseChooserModel(chooserModel) {
-        if (XH.isMobileApp) {
-            return chooserModel ? this.markManaged(new MobileColChooserModel(this)) : null;
-        }
+        const modelClass = XH.isMobileApp ? MobileColChooserModel : DesktopColChooserModel;
 
         if (isPlainObject(chooserModel)) {
-            return this.markManaged(new DesktopColChooserModel(defaults(chooserModel, {gridModel: this})));
+            return this.markManaged(new modelClass(defaults(chooserModel, {gridModel: this})));
         }
 
-        return chooserModel ? this.markManaged(new DesktopColChooserModel({gridModel: this})) : null;
+        return chooserModel ? this.markManaged(new modelClass({gridModel: this})) : null;
     }
 
     defaultGroupSortFn = (a, b) => {
@@ -1219,12 +1216,14 @@ export class GridModel extends HoistModel {
 /**
  * @typedef {Object} ColChooserModelConfig
  * @property {boolean} [commitOnChange] - Immediately render changed columns on grid (default true).
- *      Set to false to enable Save button for committing changes on save
+ *      Set to false to enable Save button for committing changes on save. Desktop only.
  * @property {boolean} [showRestoreDefaults] - show Restore Defaults button (default true).
  *      Set to false to hide Restore Grid Defaults button, which immediately
  *      commits grid defaults (all column, grouping, and sorting states).
- * @property {number} [width] - chooser width for popover and dialog.
- * @property {number} [height] - chooser height for popover and dialog.
+ * @property {boolean} [autosizeOnCommit] - Autosize grid columns after committing changes
+ *      (default false for desktop, true for mobile)
+ * @property {number} [width] - chooser width for popover and dialog. Desktop only.
+ * @property {number} [height] - chooser height for popover and dialog. Desktop only.
  */
 
 /**

--- a/desktop/cmp/grid/impl/ColChooserModel.js
+++ b/desktop/cmp/grid/impl/ColChooserModel.js
@@ -27,21 +27,23 @@ export class ColChooserModel extends HoistModel {
 
     commitOnChange;
     showRestoreDefaults;
+    autosizeOnCommit;
 
     constructor({
         gridModel,
         commitOnChange = true,
         showRestoreDefaults = true,
+        autosizeOnCommit = false,
         width = 520,
         height = 300
     }) {
         super();
         makeObservable(this);
-        this.gridModel = gridModel;
 
+        this.gridModel = gridModel;
         this.commitOnChange = commitOnChange;
         this.showRestoreDefaults = showRestoreDefaults;
-
+        this.autosizeOnCommit = autosizeOnCommit;
         this.width = width;
         this.height = height;
 
@@ -77,7 +79,7 @@ export class ColChooserModel extends HoistModel {
     }
 
     commit() {
-        const {gridModel, lrModel} = this,
+        const {gridModel, lrModel, autosizeOnCommit} = this,
             {leftValues, rightValues} = lrModel,
             cols = gridModel.columnState;
 
@@ -91,6 +93,7 @@ export class ColChooserModel extends HoistModel {
         });
 
         gridModel.applyColumnStateChanges(colChanges);
+        if (autosizeOnCommit && colChanges.length) gridModel.autosizeAsync();
     }
 
     async restoreDefaultsAsync() {

--- a/mobile/cmp/grid/impl/ColChooser.js
+++ b/mobile/cmp/grid/impl/ColChooser.js
@@ -36,7 +36,7 @@ export const [ColChooser, colChooser] = hoistCmp.withFactory({
     className: 'xh-col-chooser',
 
     render({model, className}) {
-        const {isOpen, gridModel, pinnedColumn, visibleColumns, hiddenColumns} = model;
+        const {isOpen, gridModel, pinnedColumn, visibleColumns, hiddenColumns, showRestoreDefaults} = model;
         const impl = useLocalModel(LocalModel);
         impl.model = model;
 
@@ -96,6 +96,7 @@ export const [ColChooser, colChooser] = hoistCmp.withFactory({
             }),
             bbar: [
                 button({
+                    omit: !showRestoreDefaults,
                     text: 'Reset',
                     modifier: 'quiet',
                     onClick: () => model.restoreDefaults()


### PR DESCRIPTION
Adds `autosizeOnCommit` option to ColChooserModel (default false for desktop, true for mobile). It is useful on mobile to automatically autosize after adding new columns with ColChooserModel.

This PR also allow configuring the mobile ColChooserModel, offering a more consistent story across desktop and mobile.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

