### PR TITLE
Fix SplitTreeMap flex ratio.

### DIFF
--- a/desktop/cmp/treemap/SplitTreeMap.js
+++ b/desktop/cmp/treemap/SplitTreeMap.js
@@ -36,11 +36,11 @@ export const [SplitTreeMap, splitTreeMap]  = hoistCmp.withFactory({
         });
     }
 });
+
 SplitTreeMap.propTypes = {
     /** Primary component model instance. */
     model: PT.oneOfType([PT.instanceOf(SplitTreeMapModel), PT.object])
 };
-
 
 const childMaps = hoistCmp.factory(
     ({model}) => {

--- a/desktop/cmp/treemap/TreeMap.scss
+++ b/desktop/cmp/treemap/TreeMap.scss
@@ -1,6 +1,11 @@
 .xh-treemap {
   &__chart-holder {
-    margin: auto;
+    // Positioned absolute within container so it doesn't affect outer flex
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
   }
 
   text > tspan {

--- a/desktop/cmp/treemap/TreeMapModel.js
+++ b/desktop/cmp/treemap/TreeMapModel.js
@@ -174,10 +174,10 @@ export class TreeMapModel extends HoistModel {
 
     @computed
     get total() {
-        return sumBy(this.data, it => {
-            // Only include root records that pass the filter
-            if (it.parent || (this._filter && !this._filter(it.record))) return 0;
-            return it.value;
+        const {valueField} = this;
+        return sumBy(this.store.rootRecords, record => {
+            if (this._filter && !this._filter(record)) return 0;
+            return Math.abs(record.data[valueField]);
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/xh/hoist-react/issues/2336

+ TreeMap's chart holder does not participate in flex box, allowing the outer flex to take precedence over internal chart size.
+ Compute TreeMapModel.total using store records rather than internal data

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

