### PR TITLE
Added LocalDate.isToday getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * New method `setDefaultTimeout` on `FetchService`.
 * New method `ChartModel.updateHighchartsConfig()` provides a more convenient API for changing
     chart display.
+* New property `LocalDate.isToday` provides a more convenient API for testing 
+    if a LocalDate is the same as the current day.
 
 ### 💥 Breaking Changes
 

--- a/utils/datetime/LocalDate.js
+++ b/utils/datetime/LocalDate.js
@@ -150,6 +150,11 @@ export class LocalDate {
     }
 
     /** @return {boolean} */
+    get isToday() {
+        return this === LocalDate.today();
+    }
+
+    /** @return {boolean} */
     @computeOnce
     get isWeekday() {
         const day = this._moment.day();


### PR DESCRIPTION
Hi,

This seems like a pretty simple new feature, unless I'm missing something about timezones.
It's pretty useful in an app I'm upgrading where I have to test if the date passed in from URL is the current day or not.

In my local env I added this test code to `toolbox/client-app/src/admin/tests/localDate/LocalDateTestModel.js`
but not sure we want to add this to toolbox.  I didn't see any other tests for the "is" getters.

```
 {
            category: 'compare',
            title: 'LocalDate.today().isToday() === true',
            input: 'LocalDate.today()',
            expected: 'true',
            testFn: () => {
                return LocalDate.today().isToday;
            }
        },
        {
            category: 'compare',
            title: 'LocalDate.get(20190601).isToday() === false',
            input: '(20190601)',
            expected: 'false',
            testFn: () => {
                return LocalDate.get('20190601').isToday;
            }
        }
```

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry.
- [x] Reviewed for breaking changes: no breaking changes.
- [x] Updated doc comments / prop-types.
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

