### PR TITLE
TabContainerModel adjusts the active tab before removing the tab

### DIFF
--- a/cmp/tab/TabContainerModel.js
+++ b/cmp/tab/TabContainerModel.js
@@ -195,10 +195,10 @@ export class TabContainerModel extends HoistModel {
             toActivate = this.nextTab ?? this.prevTab;
         }
         if (toRemove) {
-            this.setTabs(without(tabs, toRemove));
             if (toActivate) {
                 this.activateTab(toActivate);
             }
+            this.setTabs(without(tabs, toRemove));
         }
     }
 


### PR DESCRIPTION
If you remove the currently active tab, the active tab jumps to the first tab briefly before settling on the next / previous tab.

It wasn't causing any problems, but the behaviour didn't seem right and was causing bogus track statements from the TabContainerModel. Activating the desired tab *before* modifying the tabs fixes this.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

