### PR TITLE
Track tab id if its title is an element

### DIFF
--- a/cmp/tab/TabContainerModel.js
+++ b/cmp/tab/TabContainerModel.js
@@ -7,7 +7,7 @@
 import {HoistModel, managed, PersistenceProvider, RefreshMode, RenderMode, XH} from '@xh/hoist/core';
 import {action, observable, makeObservable} from '@xh/hoist/mobx';
 import {ensureUniqueBy, apiRemoved, throwIf} from '@xh/hoist/utils/js';
-import {find, isUndefined, without, difference} from 'lodash';
+import {find, isString, isUndefined, without, difference} from 'lodash';
 import {TabModel} from './TabModel';
 
 /**
@@ -120,10 +120,11 @@ export class TabContainerModel extends HoistModel {
             this.addReaction({
                 track: () => this.activeTab,
                 run: (activeTab) => {
-                    const {route} = this;
+                    const {route} = this,
+                        {title, id} = activeTab;
                     XH.track({
                         category: 'Navigation',
-                        message: `Viewed ${activeTab.title} tab`,
+                        message: `Viewed ${isString(title) ? title : id} tab`,
                         // If using routing, data field specifies route for non-top-level tabs.
                         data: route && route !== 'default' ? {route: route} : null
                     });


### PR DESCRIPTION
Since `TabModel` supports titles that are elements, when tracking is enabled for `TabContainerModel`, we should fall back to tracking its id.

Hoist P/R Checklist
-------------------
**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [N/A] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [N/A] Updated doc comments / prop-types, or determined not required.
- [N/A] Reviewed and tested on Mobile, or determined not required.
- [N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

