### PR TITLE
[WIP] Ag-grid column header filter support

### DIFF
--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -233,6 +233,7 @@ class LocalModel extends HoistModel {
             onColumnRowGroupChanged: this.onColumnRowGroupChanged,
             onColumnPinned: this.onColumnPinned,
             onColumnVisible: this.onColumnVisible,
+            onFilterChanged: this.onFilterChanged,
             processCellForClipboard: this.processCellForClipboard,
             defaultGroupSortComparator: model.groupSortFn ? this.groupSortComparator : undefined,
             groupDefaultExpanded: 1,
@@ -670,6 +671,11 @@ class LocalModel extends HoistModel {
         }
         ev.api.resetRowHeights();
     };
+
+    onFilterChanged = (ev) => {
+        this.model.noteAgFilterChanged(ev.api.getFilterModel());
+        this.syncSelection();
+    }
 
     groupSortComparator = (nodeA, nodeB) => {
         const gridModel = this.model;

--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -66,6 +66,13 @@
     .xh-grid-header-menu-icon {
       cursor: pointer;
     }
+
+    // Ref to position grid header menu to right of display name
+    .xh-grid-header-menu-ref {
+      margin-top: var(--xh-pad-double-px);
+      margin-right: var(--xh-pad-half-px);
+      width: 0;
+    }
   }
 
   .xh-column-header-align-right {
@@ -311,5 +318,51 @@
   &--tiny {
     font-size: var(--xh-grid-tiny-header-font-size-px);
     padding: 0 var(--xh-grid-tiny-header-lr-pad-px);
+  }
+}
+
+
+//-------------------------
+// Grid Header Filter Menu
+//-------------------------
+.ag-filter {
+  & * {
+    font-family: var(--xh-button-font-family);
+  }
+}
+
+.ag-theme-balham .ag-mini-filter,
+.ag-theme-balham-dark .ag-mini-filter {
+  height: 25px;
+
+  .ag-text-field-input {
+    height: 25px;
+  }
+}
+
+.ag-filter-filter {
+  height: 25px;
+
+  .ag-input-field-input {
+    height: 25px;
+  }
+}
+
+.ag-theme-balham .ag-filter-apply-panel,
+.ag-theme-balham-dark .ag-filter-apply-panel {
+  padding: var(--xh-pad-half-px);
+
+  .ag-filter-apply-panel-button {
+    font-family: var(--xh-button-font-family);
+    font-size: var(--xh-button-font-size-small);
+    color: var(--xh-text-color);
+    background-color: transparent;
+    border: var(--xh-border-solid);
+    border-radius: var(--xh-border-radius-px);
+    height: 25px;
+  }
+
+  .ag-filter-apply-panel-button:hover {
+    background-color: var(--xh-button-active-bg);
   }
 }

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -120,6 +120,8 @@ export class GridModel extends HoistModel {
     @observable.ref columnState = [];
     /** @member {Object} */
     @observable.ref expandState = {};
+    /** @member {Object} */
+    @observable.ref agFilterModel = {}
     /** @member {GridSorter[]} */
     @observable.ref sortBy = [];
     /** @member {string[]} */
@@ -736,6 +738,11 @@ export class GridModel extends HoistModel {
         if (isReady) {
             selModel.select(agGridModel.getSelectedRowNodeIds());
         }
+    }
+
+    @action
+    noteAgFilterChanged(agFilterModel) {
+        this.agFilterModel = agFilterModel;
     }
 
     /**

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -145,6 +145,7 @@ export class Column {
      *      of field name as a dot-separated path - e.g. `'country.name'` - where the default
      *      `getValueFn` will expect the field to be an object and render a nested property.
      *      False to support field names that contain dots *without* triggering this behavior.
+     * @param {boolean} [c.enableFilter] - true to enable ag-grid filter menu.
      * @param {Object} [c.agOptions] - "escape hatch" object to pass directly to Ag-Grid for
      *      desktop implementations. Note these options may be used / overwritten by the framework
      *      itself, and are not all guaranteed to be compatible with its usages of Ag-Grid.
@@ -202,6 +203,7 @@ export class Column {
         setValueFn,
         getValueFn,
         enableDotSeparatedFieldPath,
+        enableFilter,
         agOptions,
         ...rest
     }, gridModel) {
@@ -308,6 +310,8 @@ export class Column {
         this.editable = editable;
         this.setValueFn = withDefault(setValueFn, this.defaultSetValueFn);
         this.getValueFn = withDefault(getValueFn, this.defaultGetValueFn);
+
+        this.enableFilter = enableFilter;
 
         this.gridModel = gridModel;
         this.agOptions = agOptions ? clone(agOptions) : {};
@@ -495,7 +499,7 @@ export class Column {
             );
         } else if (!agOptions.cellRenderer && !agOptions.cellRendererFramework) {
             // By always providing a minimal cell pass-through cellRenderer, we can ensure the
-            // cell contents are wrapped in a span by Ag-Grid. Our flexbox enabled cell styling
+            // cell contents are wrapped in a span by Ag-Grid. Our flbled cell styling
             // requires all cells to have an inner element to work properly. We check agOptions
             // in case the dev has specified either renderer option directly against the ag-Grid
             // API (done sometimes with components for performance reasons).
@@ -539,6 +543,11 @@ export class Column {
         if (this.autoHeight) {
             ret.autoHeight = true;
             ret.wrapText = true;
+        }
+
+        if (this.enableFilter) {
+            ret.suppressMenu = false;
+            ret.filter = 'agSetColumnFilter';
         }
 
         // Finally, apply explicit app requests.  The customer is always right....

--- a/cmp/grid/helpers/GridCountLabel.js
+++ b/cmp/grid/helpers/GridCountLabel.js
@@ -9,10 +9,12 @@ import {box} from '@xh/hoist/cmp/layout';
 import {hoistCmp, useContextModel} from '@xh/hoist/core';
 import {fmtNumber} from '@xh/hoist/format';
 import {pluralize, singularize, withDefault} from '@xh/hoist/utils/js';
+import {isEmpty} from 'lodash';
 import PT from 'prop-types';
 
 /**
  * Displays the number of records loaded into a grid's store + (configurable) selection count.
+ * If ag-grid filter model is applied, the count reports agApi.displayedRowCount, instead of the store count
  *
  * Alternative to more general {@see StoreCountLabel}.
  */
@@ -35,12 +37,16 @@ export const [GridCountLabel, gridCountLabel] = hoistCmp.withFactory({
             return '';
         }
 
-        const {store, selection} = gridModel;
+        const {store, selection, agFilterModel} = gridModel;
 
         const fmtCount = (count) => fmtNumber(count, {precision: 0}),
             recCountString = () => {
-                const count = includeChildren ? store.count : store.rootCount,
+                let count = includeChildren ? store.count : store.rootCount,
                     unitLabel = count === 1 ? singularize(unit) : pluralize(unit);
+
+                if (!isEmpty(agFilterModel)) {
+                    count = gridModel.agApi?.getDisplayedRowCount();
+                }
 
                 return `${fmtCount(count)} ${unitLabel}`;
             },

--- a/cmp/grid/impl/ColumnHeader.js
+++ b/cmp/grid/impl/ColumnHeader.js
@@ -6,6 +6,7 @@
  */
 import {div, span} from '@xh/hoist/cmp/layout';
 import {hoistCmp, HoistModel, useLocalModel, XH} from '@xh/hoist/core';
+import {useContextMenu} from '@xh/hoist/desktop/hooks';
 import {Icon} from '@xh/hoist/icon';
 import {bindable, computed, makeObservable} from '@xh/hoist/mobx';
 import {createObservableRef} from '@xh/hoist/utils/react';
@@ -45,11 +46,11 @@ export const columnHeader = hoistCmp.factory({
             return div({className: 'xh-grid-header-sort-icon', item: icon});
         };
 
-        const menuIcon = () => {
+        const filterIcon = () => {
             if (!props.enableMenu) return null;
             return div({
-                className: 'xh-grid-header-menu-icon',
-                item: impl.isFiltered ? Icon.filter() : Icon.bars(),
+                className: impl.isFiltered ? 'xh-grid-header-menu-icon' : 'xh-grid-header-menu-ref',
+                item: impl.isFiltered ? Icon.filter() : null,
                 ref: impl.menuButtonRef,
                 onClick: (e) => {
                     e.stopPropagation();
@@ -89,7 +90,7 @@ export const columnHeader = hoistCmp.factory({
             };
         }
 
-        return div({
+        let headerCmp = div({
             className: classNames(props.className, extraClasses),
 
             onClick:        isDesktop  ? impl.onClick : null,
@@ -101,9 +102,20 @@ export const columnHeader = hoistCmp.factory({
             items: [
                 span({onMouseEnter, item: headerElem}),
                 sortIcon(),
-                menuIcon()
+                filterIcon()
             ]
         });
+
+        if (props.enableMenu) {
+            const contextMenu = [{
+                icon: Icon.filter(),
+                text: `Filter on ${props.displayName}`,
+                actionFn: () => props.showColumnMenu(impl.menuButtonRef.current)
+            }];
+            return useContextMenu(headerCmp, contextMenu);
+        }
+
+        return headerCmp;
     }
 });
 

--- a/desktop/hooks/UseContextMenu.js
+++ b/desktop/hooks/UseContextMenu.js
@@ -48,6 +48,5 @@ export function useContextMenu(child, contextMenu) {
             ContextMenu.show(contextMenuOutput, {left: e.clientX, top: e.clientY}, null, XH.darkTheme);
         }
     };
-
     return cloneElement(child, {onContextMenu});
 }


### PR DESCRIPTION
- Allows ag-grid menu to be called via context menu in col header
- Additional params for Column config: enableFilter, filter, and filterParams
- Set reasonable defaults for filter and filterParams based on field type
- GridCountLabel reports correct displayed row count if col header filter applied

Many more TODOs, including:
- Handle other menu tabs in ag-grid menu (how do we want to label/display header context menu item(s))
- Handle grid selection count with local filters
- Figure out if an app is on community vs enterprise to switch btwn agTextColumnFilter and agSetColumnFilter default filter