### PR TITLE
Use React.Children object over castArray

### DIFF
--- a/cmp/layout/Box.js
+++ b/cmp/layout/Box.js
@@ -6,7 +6,7 @@
  */
 import {hoistCmp} from '@xh/hoist/core';
 import {splitLayoutProps} from '@xh/hoist/utils/react';
-import {castArray, merge} from 'lodash';
+import {merge} from 'lodash';
 import {div} from './Tags';
 
 /**
@@ -35,7 +35,7 @@ export const [Box, box] = hoistCmp.withFactory({
         return div({
             ref,
             ...restProps,
-            items: castArray(children)
+            items: children
         });
     }
 });

--- a/cmp/layout/TileFrame.js
+++ b/cmp/layout/TileFrame.js
@@ -8,9 +8,10 @@ import {hoistCmp, useLocalModel, HoistModel} from '@xh/hoist/core';
 import {frame, box} from '@xh/hoist/cmp/layout';
 import {useOnResize} from '@xh/hoist/utils/react';
 import {useState} from 'react';
-import {minBy, castArray, isEqual} from 'lodash';
+import {minBy, isEqual} from 'lodash';
 import composeRefs from '@seznam/compose-react-refs';
 import PT from 'prop-types';
+import {Children} from 'react';
 
 import './TileFrame.scss';
 
@@ -45,7 +46,7 @@ export const [TileFrame, tileFrame] = hoistCmp.withFactory({
             [width, setWidth] = useState(),
             [height, setHeight] = useState();
 
-        children = castArray(children);
+        children = Children.toArray(children);
 
         localModel.setParams({
             count: children.length,

--- a/core/elem.js
+++ b/core/elem.js
@@ -4,7 +4,7 @@
  *
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
-import {castArray, isArray, isPlainObject} from 'lodash';
+import {castArray, isArray, isNil, isPlainObject} from 'lodash';
 import {createElement, isValidElement} from 'react';
 
 /**
@@ -41,8 +41,8 @@ export function elem(type, config = {}) {
     if (omit) return null;
 
     // 2) Read children from item[s] config.
-    const itemConfig = item || items,
-        children = (itemConfig === undefined ? [] : castArray(itemConfig));
+    const itemConfig = item ?? items,
+        children = (isNil(itemConfig) ? [] : castArray(itemConfig));
 
     // 3) Recapture API props that needed '$' prefix to avoid conflicts.
     ['$omit', '$item', '$items'].forEach(key => {

--- a/desktop/cmp/input/ButtonGroupInput.js
+++ b/desktop/cmp/input/ButtonGroupInput.js
@@ -9,9 +9,9 @@ import {hoistCmp} from '@xh/hoist/core';
 import {Button, ButtonGroup, buttonGroup} from '@xh/hoist/desktop/cmp/button';
 import {throwIf, withDefault} from '@xh/hoist/utils/js';
 import {getLayoutProps, getNonLayoutProps} from '@xh/hoist/utils/react';
-import {castArray, filter} from 'lodash';
+import {filter} from 'lodash';
 import PT from 'prop-types';
-import {cloneElement} from 'react';
+import {cloneElement, Children} from 'react';
 
 /**
  * A segmented group of buttons, one of which is depressed to indicate the input's current value.
@@ -86,9 +86,7 @@ const cmp = hoistCmp.factory(
             ...buttonGroupProps
         } = getNonLayoutProps(props);
 
-        const buttons = castArray(children).map(button => {
-            if (!button) return null;
-
+        const buttons = Children.map(children, button => {
             const {value} = button.props,
                 btnDisabled = disabled || button.props.disabled;
 

--- a/desktop/cmp/panel/Panel.js
+++ b/desktop/cmp/panel/Panel.js
@@ -19,9 +19,9 @@ import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {useContextMenu, useHotkeys} from '@xh/hoist/desktop/hooks';
 import {PendingTaskModel} from '@xh/hoist/utils/async';
 import {splitLayoutProps} from '@xh/hoist/utils/react';
-import {castArray, omitBy} from 'lodash';
+import {omitBy} from 'lodash';
 import PT from 'prop-types';
-import {isValidElement, useRef} from 'react';
+import {isValidElement, useRef, Children} from 'react';
 import {panelHeader} from './impl/PanelHeader';
 import {resizeContainer} from './impl/ResizeContainer';
 import './Panel.scss';
@@ -106,7 +106,7 @@ export const [Panel, panel] = hoistCmp.withFactory({
                 style: {display: collapsed ? 'none' : 'flex'},
                 items: [
                     parseToolbar(tbar),
-                    ...(castArray(children)),
+                    ...Children.toArray(children),
                     parseToolbar(bbar)
                 ]
             });

--- a/desktop/cmp/toolbar/Toolbar.js
+++ b/desktop/cmp/toolbar/Toolbar.js
@@ -12,11 +12,11 @@ import {overflowList, popover} from '@xh/hoist/kit/blueprint';
 import {filterConsecutiveToolbarSeparators} from '@xh/hoist/utils/impl';
 import {throwIf} from '@xh/hoist/utils/js';
 import classNames from 'classnames';
-import {castArray} from 'lodash';
+import {isEmpty} from 'lodash';
 import PT from 'prop-types';
-import {Children} from 'react';
 import './Toolbar.scss';
 import {toolbarSeparator} from './ToolbarSep';
+import {Children} from 'react';
 
 /**
  * A toolbar with built-in styling and padding.
@@ -39,14 +39,12 @@ export const [Toolbar, toolbar] = hoistCmp.withFactory({
     }, ref) {
         throwIf(vertical && enableOverflowMenu, 'Overflow menu not available for vertical toolbars.');
 
-        const items = castArray(children)
+        const items = Children.toArray(children)
             .filter(filterConsecutiveToolbarSeparators())
-            .map(it => {
-                return it === '-' ? toolbarSeparator() : it;
-            });
+            .map(it => it === '-' ? toolbarSeparator() : it);
 
         const container = vertical ? vbox : hbox,
-            overflow = enableOverflowMenu && Children.count(items) > 0;
+            overflow = enableOverflowMenu && !isEmpty(items);
 
         return container({
             ref,
@@ -100,7 +98,7 @@ const overflowBox = hoistCmp.factory({
     model: false, observer: false, memo: false,
     render({children, minVisibleItems, collapseFrom}) {
         return overflowList({
-            $items: Children.toArray(children),
+            $items: children,
             minVisibleItems,
             collapseFrom,
             visibleItemRenderer: (item) => item,

--- a/mobile/cmp/button/ButtonGroup.js
+++ b/mobile/cmp/button/ButtonGroup.js
@@ -23,7 +23,7 @@ export const [ButtonGroup, buttonGroup] = hoistCmp.withFactory({
         const items = Children.toArray(children);
 
         items.forEach(button => {
-            throwIf(button && button.type !== Button, 'ButtonGroup child must be a Button.');
+            throwIf(button.type !== Button, 'ButtonGroup child must be a Button.');
         });
 
         return hbox({

--- a/mobile/cmp/input/ButtonGroupInput.js
+++ b/mobile/cmp/input/ButtonGroupInput.js
@@ -9,9 +9,8 @@ import {hoistCmp} from '@xh/hoist/core';
 import {Button, buttonGroup} from '@xh/hoist/mobile/cmp/button';
 import {throwIf, withDefault} from '@xh/hoist/utils/js';
 import {getLayoutProps, getNonLayoutProps} from '@xh/hoist/utils/react';
-import {castArray} from 'lodash';
 import PT from 'prop-types';
-import {cloneElement} from 'react';
+import {cloneElement, Children} from 'react';
 import './ButtonGroupInput.scss';
 
 /**
@@ -55,9 +54,7 @@ const cmp = hoistCmp.factory(
 
         const {children, disabled, enableClear, tabIndex = 0, ...rest} = getNonLayoutProps(props);
 
-        const buttons = castArray(children).map(button => {
-            if (!button) return null;
-
+        const buttons = Children.map(children, button => {
             const {value} = button.props,
                 btnDisabled = disabled || button.props.disabled;
 

--- a/mobile/cmp/panel/DialogPanel.js
+++ b/mobile/cmp/panel/DialogPanel.js
@@ -6,7 +6,6 @@
  */
 import {hoistCmp} from '@xh/hoist/core';
 import {dialog} from '@xh/hoist/kit/onsen';
-import {castArray} from 'lodash';
 import PT from 'prop-types';
 import './DialogPanel.scss';
 import {panel, Panel} from './Panel';
@@ -22,7 +21,6 @@ export const [DialogPanel, dialogPanel] = hoistCmp.withFactory({
     className: 'xh-dialog xh-dialog-panel',
     memo: false, model: false, observer: false,
 
-
     render({className, isOpen, children, ...rest}) {
 
         if (!isOpen) return null;
@@ -32,7 +30,7 @@ export const [DialogPanel, dialogPanel] = hoistCmp.withFactory({
             isCancelable: false,
             className,
             items: panel({
-                items: castArray(children),
+                items: children,
                 ...rest
             })
         });

--- a/mobile/cmp/panel/Panel.js
+++ b/mobile/cmp/panel/Panel.js
@@ -12,7 +12,7 @@ import {toolbar} from '@xh/hoist/mobile/cmp/toolbar';
 import {PendingTaskModel} from '@xh/hoist/utils/async';
 import {splitLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
-import {castArray, omitBy} from 'lodash';
+import {omitBy} from 'lodash';
 import PT from 'prop-types';
 import {isValidElement} from 'react';
 import {panelHeader} from './impl/PanelHeader';
@@ -60,7 +60,7 @@ export const [Panel, panel] = hoistCmp.withFactory({
         const coreContentsEl = scrollable ? div : vbox,
             coreContents = coreContentsEl({
                 className: 'xh-panel__content',
-                items: castArray(children)
+                items: children
             });
 
         // 3) Prepare combined layout.


### PR DESCRIPTION
 -- Best Practice
 -- More consistently skip non-renderable element children (null/undefined/false)
 -- Avoid extra calls to toArray()/castArray
 -- Omit null children from component logic in Toolbar/Tile

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

