### PR TITLE
TreeMap display on missing heat values.

### DIFF
--- a/desktop/cmp/treemap/TreeMapModel.js
+++ b/desktop/cmp/treemap/TreeMapModel.js
@@ -251,6 +251,7 @@ export class TreeMapModel extends HoistModel {
                 record,
                 name,
                 heatValue,
+                originalValue: value,
                 value: Math.abs(value)
             };
 
@@ -306,12 +307,18 @@ export class TreeMapModel extends HoistModel {
             if (this.valueIsValid(val)) heatValues.push(val);
         });
 
-        // 2) Split heat values into positive and negative
+        // 2) If we have no heat values, fall back to colorMode 'wash' based on value
+        if (isEmpty(heatValues)) {
+            data.forEach(it => it.colorValue = it.originalValue > 0 ? 0.8 : 0.2);
+            return data;
+        }
+
+        // 3) Split heat values into positive and negative
         let [posHeatValues, negHeatValues] = partition(heatValues, it => it > 0);
         posHeatValues = sortBy(posHeatValues);
         negHeatValues = sortBy(negHeatValues.map(Math.abs));
 
-        // 3) Calculate bounds and midpoints for each range
+        // 4) Calculate bounds and midpoints for each range
         let minPosHeat = 0, midPosHeat = 0, maxPosHeat = 0, minNegHeat = 0, midNegHeat = 0, maxNegHeat = 0;
         if (posHeatValues.length) {
             minPosHeat = posHeatValues[0];
@@ -324,7 +331,7 @@ export class TreeMapModel extends HoistModel {
             maxNegHeat = negHeatValues[negHeatValues.length - 1];
         }
 
-        // 4) Transform heatValue into a normalized colorValue, according to the colorMode.
+        // 5) Transform heatValue into a normalized colorValue, according to the colorMode.
         data.forEach(it => {
             const {heatValue} = it;
 


### PR DESCRIPTION
When TreeMap's colorMode is `linear` or `balanced`, but it has no heat values due to undeclared `heatField` or missing data, fall back to `wash` colorMode (using value to determine positive / negative). Users can use colorMode `none` if they want the grey coloring.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

