### PR TITLE
Fix misaligned right icons within inputs

### DIFF
--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -334,12 +334,6 @@ textarea.bp3-input,
   z-index: 16;
 }
 
-// Avoid misaligned rightIcon within inputs.
-.bp3-button svg:not(.bp3-icon):first-child:last-child,
-.bp3-button .bp3-spinner + svg:not(.bp3-icon):last-child {
-  margin-left: 0;
-}
-
 // Controls ship with default bottom and (inline) right margins. We expose variables
 // to customize and default those to 0 to avoid adding margins by default.
 // Hoist theme text-color applied to elements not styled with a more specific selector.


### PR DESCRIPTION
Resolves https://github.com/xh/hoist-react/issues/2299

It seems like this style rule was the culprit, and I could not find any case where removing it was problematic for any other bp3 icons or spinner.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [N/A] Added CHANGELOG entry, or determined not required.
- [N/A] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [N/A] Updated doc comments / prop-types, or determined not required.
- [N/A] Reviewed and tested on Mobile, or determined not required.
- [N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

