### PR TITLE
Support for empty grid exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## v40.0.0-SNAPSHOT - unreleasd
+## v40.0.0-SNAPSHOT - unreleased
+
+### 🎁 New Features
+* `GridExportService` supports empty grid exports. `ExportButton` is no longer disabled by default
+when bound `gridModel` is empty.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v39.0.1...develop)
 

--- a/desktop/cmp/button/ExportButton.js
+++ b/desktop/cmp/button/ExportButton.js
@@ -46,7 +46,6 @@ export const [ExportButton, exportButton] = hoistCmp.withFactory({
             icon: withDefault(icon, Icon.download()),
             title: withDefault(title, 'Export'),
             onClick,
-            disabled: withDefault(disabled, gridModel && gridModel.empty),
             ...rest
         });
     }

--- a/svc/GridExportService.js
+++ b/svc/GridExportService.js
@@ -48,11 +48,6 @@ export class GridExportService extends HoistService {
             meta = this.getColumnMetadata(exportColumns),
             rows = [];
 
-        if (records.length === 0) {
-            XH.toast({message: 'No data found to export', intent: 'danger', icon: Icon.warning()});
-            return;
-        }
-
         rows.push(this.getHeaderRow(exportColumns, type, gridModel));
 
         // If the grid includes a summary row, add it to the export payload as a root-level node
@@ -61,6 +56,8 @@ export class GridExportService extends HoistService {
                 this.getRecordRow(gridModel, summaryRecord, exportColumns, 0),
                 ...this.getRecordRowsRecursive(gridModel, records, exportColumns, 1)
             );
+        } else if (gridModel.empty) {
+            rows.push(this.getStubRow(exportColumns));
         } else {
             rows.push(...this.getRecordRowsRecursive(gridModel, records, exportColumns, 0));
         }
@@ -256,6 +253,10 @@ export class GridExportService extends HoistService {
 
         value = value.toString();
         return cellHasExportFormat ? {value, format: exportFormat} : value;
+    }
+
+    getStubRow(columns) {
+        return {data: Array.from(columns.length), depth: 0};
     }
 
     getContentType(type) {


### PR DESCRIPTION
Resolves: https://github.com/xh/hoist-react/issues/2376
+ Do not disable grid export button when empty
+ Add stub row to table when empty (and no summary record row)

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [N/R] Reviewed and tested on Mobile, or determined not required.
- [N/R] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

