### PR TITLE
Improve support for SubMenus in AppMenu

### DIFF
--- a/desktop/cmp/button/AppMenuButton.js
+++ b/desktop/cmp/button/AppMenuButton.js
@@ -44,10 +44,12 @@ AppMenuButton.propTypes = {
     className: PT.string,
 
     /**
-     * Array of app-specific menu items. Can contain `MenuItem` configs, React Elements, or the
-     * special string token '-' (to render a `MenuDivider`).
+     * Array of extra menu items. Can contain:
+     *  + `MenuItems` or configs to create them.
+     *  + `MenuDividers` or the special string token '-'.
+     *  + React Elements or strings, which will be interpreted as the `text` property for a MenuItem.
      */
-    extraItems: PT.array,
+    extraItems: PT.arrayOf(PT.oneOfType([PT.object, PT.string, PT.element])),
 
     /** True to hide the About button */
     hideAboutItem: PT.bool,
@@ -175,6 +177,7 @@ function parseMenuItems(items) {
                     menuItem({text: it});
             }
 
+            // Create menuItem from config, recursively parsing any submenus
             const cfg = {...it};
             if (!isEmpty(cfg.items)) {
                 cfg.items = parseMenuItems(cfg.items);

--- a/desktop/cmp/contextmenu/ContextMenu.js
+++ b/desktop/cmp/contextmenu/ContextMenu.js
@@ -34,7 +34,10 @@ export const [ContextMenu, contextMenu] = hoistCmp.withFactory({
 
 ContextMenu.propTypes = {
     /**
-     *  Array of ContextMenuItems, configs to create them, Elements, or '-' (divider).
+     * Array of:
+     *  + `ContextMenuItems` or configs to create them.
+     *  + `MenuDividers` or the special string token '-'.
+     *  + React Elements or strings, which will be interpreted as the `text` property for a MenuItem.
      */
     menuItems: PT.arrayOf(PT.oneOfType([PT.object, PT.string, PT.element])).isRequired
 };


### PR DESCRIPTION
Brings our AppMenu API in line with our other menu implementations.

+ Recursively parse AppMenu items to build submenus from configs. #2393
+ Don't automatically open submenus. #2394

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

