### PR TITLE
Improvements to exception serialization to better handle `LocalDate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## v41.0.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+* Improvements to exception serialization to better handle `LocalDate` and similar custom JS classes.
+
 ### 📚 Libraries
 * @mobx `6.1.8 -> 6.3.0`
+
+
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v40.0.0...develop)
 

--- a/utils/js/LangUtils.js
+++ b/utils/js/LangUtils.js
@@ -54,8 +54,7 @@ export function deepFreeze(obj) {
 
 /**
  * Output a deep copy of an object up to a given depth, beyond which child objects will be
- * replaced by a placeholder string. Typically used prior to stringifying potentially recursive
- * or deeply nested objects.
+ * replaced by a placeholder string.
  *
  * @param {Object} obj
  * @param {number} depth - maximum depth within the object tree that will be returned.


### PR DESCRIPTION
Precipitated by issues with LocalDate in params to server that were being serialized strangely.

At this point, we could honestly remove the method `trimToDepth` --- I am not sure it ever really made sense for it to be in our API.  I certainly didn't want to include these somewhat ad-hoc semantics into the public method.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

