### PR TITLE
Inline editor sizing modes

### DIFF
--- a/desktop/cmp/grid/editors/InlineEditors.scss
+++ b/desktop/cmp/grid/editors/InlineEditors.scss
@@ -51,6 +51,7 @@
           input {
             width: 100%;
             height: 100%;
+            font-family: var(--xh-grid-font-family);
           }
         }
 
@@ -67,5 +68,29 @@
         }
       }
     }
+  }
+
+  &--standard .xh-inline-editor input {
+    padding-left: var(--xh-grid-cell-lr-pad-px);
+    padding-right: var(--xh-grid-cell-lr-pad-px);
+    font-size: var(--xh-grid-font-size-px);
+  }
+
+  &--large .xh-inline-editor input {
+    padding-left: var(--xh-grid-large-cell-lr-pad-px);
+    padding-right: var(--xh-grid-large-cell-lr-pad-px);
+    font-size: var(--xh-grid-large-font-size-px);
+  }
+
+  &--compact .xh-inline-editor input {
+    padding-left: var(--xh-grid-compact-cell-lr-pad-px);
+    padding-right: var(--xh-grid-compact-cell-lr-pad-px);
+    font-size: var(--xh-grid-compact-font-size-px);
+  }
+
+  &--tiny .xh-inline-editor input {
+    padding-left: var(--xh-grid-tiny-cell-lr-pad-px);
+    padding-right: var(--xh-grid-tiny-cell-lr-pad-px);
+    font-size: var(--xh-grid-tiny-font-size-px);
   }
 }


### PR DESCRIPTION
Inline editors use fonts, font-sizes and padding consistent with the GridModel.sizingMode to provide more predictable switching between cell and editor. Ensures that columns sized to display their cells can also show the full input.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [ ] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [ ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

