### PR TITLE
GridModel's emptyText before load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ dedicated `error` prop.
   The values produced by this property will also be passed to the custom comparator if it is defined.
 * `TreeMapModel` and `SplitTreeMapModel` now support a `maxHeat` property, which can be used to provide
   a stable absolute maximum brightness (positive or negative) within the entire TreeMap.
-* `GridModel` now supports a `hideEmptyTextBeforeLoad` property, which prevents showing the empty text
-  until the store has been loaded at least once.
+* `GridModel` now supports a `hideEmptyTextBeforeLoad` property, which prevents showing the `emptyText`
+  until the store has been loaded at least once. Apps that depend on showing `emptyText` before first
+  load should set this property to `false`.
 
 ### 💥 Breaking Changes
 * `DimensionChooser` has been removed from the framework. This component was deprecated in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ dedicated `error` prop.
   The values produced by this property will also be passed to the custom comparator if it is defined.
 * `TreeMapModel` and `SplitTreeMapModel` now support a `maxHeat` property, which can be used to provide
   a stable absolute maximum brightness (positive or negative) within the entire TreeMap.
+* `GridModel` now supports a `hideEmptyTextBeforeLoad` property, which prevents showing the empty text
+  until the store has been loaded at least once.
 
 ### 💥 Breaking Changes
 * `DimensionChooser` has been removed from the framework. This component was deprecated in

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -172,6 +172,13 @@ class LocalModel extends HoistModel {
         return model.treeMode && model.store.allRootCount !== model.store.allCount;
     }
 
+    @computed
+    get emptyText() {
+        const {store, hideEmptyTextBeforeLoad, emptyText} = this.model;
+        if (hideEmptyTextBeforeLoad && !store.lastLoaded) return null;
+        return emptyText;
+    }
+
     constructor(model, props) {
         super();
         this.model = model;
@@ -219,7 +226,7 @@ class LocalModel extends HoistModel {
             tooltipShowDelay: 0,
             getRowHeight: ({node}) => this.getRowHeight(node),
             getRowClass: ({data}) => model.rowClassFn ? model.rowClassFn(data) : null,
-            noRowsOverlayComponentFramework: observer(() => div(model.emptyText)),
+            noRowsOverlayComponentFramework: observer(() => div(this.emptyText)),
             onRowClicked: (e) => {
                 this.onRowClicked(e);
                 if (props.onRowClicked) props.onRowClicked(e);

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -184,8 +184,8 @@ export class GridModel extends HoistModel {
      * @param {GridModelPersistOptions} [c.persistWith] - options governing persistence.
      * @param {?string} [c.emptyText] - text/HTML to display if grid has no records.
      *      Defaults to null, in which case no empty text will be shown.
-     * @param {boolean} [c.hideEmptyTextBeforeLoad] - true to hide empty text until after the Store
-     *      has been loaded at least once.
+     * @param {boolean} [c.hideEmptyTextBeforeLoad] - true (default) to hide empty text until
+     *      after the Store has been loaded at least once.
      * @param {(string|string[]|Object|Object[])} [c.sortBy] - colId(s) or sorter config(s) with
      *      colId and sort direction.
      * @param {(string|string[])} [c.groupBy] - Column ID(s) by which to do full-width row grouping.
@@ -246,7 +246,7 @@ export class GridModel extends HoistModel {
         selModel,
         colChooserModel,
         emptyText = null,
-        hideEmptyTextBeforeLoad = false,
+        hideEmptyTextBeforeLoad = true,
         sortBy = [],
         groupBy = null,
         showGroupRowCounts = true,

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -108,6 +108,8 @@ export class GridModel extends HoistModel {
     autosizeOptions;
     /** @member {ReactNode} */
     restoreDefaultsWarning;
+    /** @member {boolean} */
+    hideEmptyTextBeforeLoad;
 
     /** @member {AgGridModel} */
     @managed agGridModel;
@@ -182,6 +184,8 @@ export class GridModel extends HoistModel {
      * @param {GridModelPersistOptions} [c.persistWith] - options governing persistence.
      * @param {?string} [c.emptyText] - text/HTML to display if grid has no records.
      *      Defaults to null, in which case no empty text will be shown.
+     * @param {boolean} [c.hideEmptyTextBeforeLoad] - true to hide empty text until after the Store
+     *      has been loaded at least once.
      * @param {(string|string[]|Object|Object[])} [c.sortBy] - colId(s) or sorter config(s) with
      *      colId and sort direction.
      * @param {(string|string[])} [c.groupBy] - Column ID(s) by which to do full-width row grouping.
@@ -242,6 +246,7 @@ export class GridModel extends HoistModel {
         selModel,
         colChooserModel,
         emptyText = null,
+        hideEmptyTextBeforeLoad = false,
         sortBy = [],
         groupBy = null,
         showGroupRowCounts = true,
@@ -286,6 +291,7 @@ export class GridModel extends HoistModel {
         this.showSummary = showSummary;
 
         this.emptyText = emptyText;
+        this.hideEmptyTextBeforeLoad = hideEmptyTextBeforeLoad;
         this.rowClassFn = rowClassFn;
         this.groupRowHeight = groupRowHeight;
         this.groupRowRenderer = groupRowRenderer;
@@ -351,7 +357,6 @@ export class GridModel extends HoistModel {
      * @return {boolean} true if defaults were restored
      */
     async restoreDefaultsAsync() {
-
         if (this.restoreDefaultsWarning) {
             const confirmed = await XH.confirm({
                 title: 'Please Confirm',
@@ -366,7 +371,6 @@ export class GridModel extends HoistModel {
         }
 
         const {columns, sortBy, groupBy} = this._defaultState;
-
         this.setColumns(columns);
         this.setSortBy(sortBy);
         this.setGroupBy(groupBy);
@@ -456,7 +460,6 @@ export class GridModel extends HoistModel {
     async preSelectFirstAsync() {
         if (!this.hasSelection) return this.selectFirstAsync();
     }
-
 
     /** Deselect all rows. */
     clearSelection() {


### PR DESCRIPTION
Include a flag to hide GridModel empty text until after the Store has first been loaded.
See issue https://github.com/xh/hoist-react/issues/2438

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

