### PR TITLE
SplitTreeMap improvements

### DIFF
--- a/desktop/cmp/treemap/SplitTreeMap.scss
+++ b/desktop/cmp/treemap/SplitTreeMap.scss
@@ -1,4 +1,46 @@
 .xh-split-treemap {
+  &__map-holder {
+    flex-shrink: 0 !important;
+    flex-basis: 10px !important;
+  }
+
+  &__header {
+    align-items: center;
+    flex: none;
+    user-select: none;
+    background-color: var(--xh-title-bg);
+    color: var(--xh-title-text-color);
+
+    &__title {
+      display: flex;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-family: var(--xh-title-font-family);
+      font-size: var(--xh-title-compact-font-size-px);
+    }
+
+    // Vertical mode
+    .xh-vframe > & {
+      padding: 0 0 0 var(--xh-pad-half-px);
+      height: var(--xh-title-compact-height-px);
+    }
+
+    // Horizontal mode
+    .xh-hframe > & {
+      padding: var(--xh-pad-half-px) 0 0 0;
+      width: var(--xh-title-compact-height-px);
+      flex-direction: column-reverse !important;
+      justify-content: flex-end;
+
+      .xh-split-treemap__header__title {
+        writing-mode: vertical-lr;
+        -ms-block-progression: lr;
+        transform: rotate(180deg);
+        width: calc(1em + 5px);
+      }
+    }
+  }
+
   &__mask-holder {
     position: absolute;
     top: 0;

--- a/desktop/cmp/treemap/SplitTreeMapModel.js
+++ b/desktop/cmp/treemap/SplitTreeMapModel.js
@@ -86,11 +86,16 @@ export class SplitTreeMapModel extends HoistModel {
         return this.primaryMapModel.isMasking || this.secondaryMapModel.isMasking;
     }
 
+    @computed
+    get empty() {
+        return this.primaryMapModel.empty && this.secondaryMapModel.empty;
+    }
+
     // Simple getters and methods trampolined from underlying TreeMapModels.
     // Where possible, we consult only the primary map model, as we don't expect the two to become out of sync.
-    get hasData()           {return this.primaryMapModel.hasData}
     get expandState()       {return this.primaryMapModel.expandState}
     get error()             {return this.primaryMapModel.error}
+    get emptyText()         {return this.primaryMapModel.emptyText}
     get highchartsConfig()  {return this.primaryMapModel.highchartsConfig}
     get labelField()        {return this.primaryMapModel.labelField}
     get heatField()         {return this.primaryMapModel.heatField}

--- a/desktop/cmp/treemap/TreeMap.js
+++ b/desktop/cmp/treemap/TreeMap.js
@@ -60,11 +60,11 @@ export const [TreeMap, treeMap] = hoistCmp.withFactory({
 
         // Render child item - note this will NOT render the actual HighCharts viz - only a shell
         // div to hold one. The chart itself will be rendered once the shell's ref resolves.
-        const {error, emptyText, hasData, isMasking} = model;
+        const {error, empty, emptyText, isMasking} = model;
         let items;
         if (error) {
             items = errorMessage({error});
-        } else if (!hasData) {
+        } else if (empty) {
             items = placeholder(emptyText);
         } else {
             items = [

--- a/desktop/cmp/treemap/TreeMapModel.js
+++ b/desktop/cmp/treemap/TreeMapModel.js
@@ -52,7 +52,7 @@ export class TreeMapModel extends HoistModel {
     onDoubleClick;
     /** @member {(boolean|TreeMapModel~tooltipFn)} */
     tooltip;
-    /** @member {string} */
+    /** @member {(Element|string)} */
     emptyText;
 
     //------------------------
@@ -213,8 +213,8 @@ export class TreeMapModel extends HoistModel {
     }
 
     @computed
-    get hasData() {
-        return !isEmpty(this.data);
+    get empty() {
+        return isEmpty(this.data);
     }
 
     @computed


### PR DESCRIPTION
Issue https://github.com/xh/hoist-react/issues/2442:
+ Refactor SplitTreeMap so that titles do no factor into flex weighting.
+ Ensure non-empty sides of a SplitTreeMap have a minimum size.
+ Rotate titles in a horizontal SplitTreeMap so that sides can be sized properly.

Issue https://github.com/xh/hoist-react/issues/2437:
+ Roll up TreeMapModel emptyText into SplitTreeMap.

Other cleanups:
+ Rename TreeMapModel.hasData > TreeMapModel.empty, to match GridModel

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

