### PR TITLE
Refresh row height on data change when autoheight = true

### DIFF
--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -542,7 +542,7 @@ export class AgGridModel extends HoistModel {
     /**
      * Required height of row as determined by content in visible autoHeight columns.
      *
-     *  If autoHeight not enabled for any visible columns, this method will return null.
+     * If autoHeight not enabled for any visible columns, this method will return null.
      *
      * @param {Row} node - agGrid node.
      * @returns {Number} - pixel height for row or null.

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -410,7 +410,7 @@ class LocalModel extends HoistModel {
 
                     if (transaction?.update) {
                         // Refresh cells in columns with complex renderers
-                        const refreshCols = model.columns.filter(c => !c.hidden && c.rendererIsComplex);
+                        const refreshCols = model.getVisibleLeafColumns().filter(c => c.rendererIsComplex);
                         if (refreshCols) {
                             const rowNodes = compact(transaction.update.map(r => agApi.getRowNode(r.id))),
                                 columns = refreshCols.map(c => c.colId);
@@ -418,7 +418,7 @@ class LocalModel extends HoistModel {
                         }
 
                         // Refresh row heights if autoHeight is enabled
-                        if (agApi.gridOptionsWrapper.columnController.isAutoRowHeightActive()) {
+                        if (model.getVisibleLeafColumns().some(c => c.autoHeight)) {
                             agApi.resetRowHeights();
                         }
                     }

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -409,11 +409,17 @@ class LocalModel extends HoistModel {
                     this.updatePinnedSummaryRowData();
 
                     if (transaction?.update) {
+                        // Refresh cells in columns with complex renderers
                         const refreshCols = model.columns.filter(c => !c.hidden && c.rendererIsComplex);
                         if (refreshCols) {
                             const rowNodes = compact(transaction.update.map(r => agApi.getRowNode(r.id))),
                                 columns = refreshCols.map(c => c.colId);
                             agApi.refreshCells({rowNodes, columns, force: true});
+                        }
+
+                        // Refresh row heights if autoHeight is enabled
+                        if (agApi.gridOptionsWrapper.columnController.isAutoRowHeightActive()) {
+                            agApi.resetRowHeights();
                         }
                     }
 

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -300,7 +300,7 @@ export class Column {
         this.autoHeight = withDefault(autoHeight, false);
         warnIf(
             autoHeight && elementRenderer,
-            'autoHeight is ignored when an elementRenderer is defined.  Row heights will not change to accommodate cell content for this column.'
+            'autoHeight is ignored when an elementRenderer is defined. Row heights will not change to accommodate cell content for this column.'
         );
         this.tooltip = tooltip;
         this.tooltipElement = tooltipElement;


### PR DESCRIPTION
Refresh row heights for auto height columns on data change.

See issue: https://github.com/xh/hoist-react/issues/2465
See toolbox PR: https://github.com/xh/toolbox/pull/485


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

