### PR TITLE
TileFrame V2

### DIFF
--- a/cmp/layout/TileFrame.js
+++ b/cmp/layout/TileFrame.js
@@ -165,8 +165,9 @@ class LocalModel extends HoistModel {
         if (minTileHeight && layout.tileHeight < minTileHeight) layout.tileHeight = minTileHeight;
         if (maxTileHeight && layout.tileHeight > maxTileHeight) layout.tileHeight = maxTileHeight;
 
-        // 3) Invalidate layouts that are wider than the container
-        if (this.hasWidthConstraints && this.getRequiredWidth(layout) > width) return null;
+        // 3) Invalidate multi-column layouts that are wider than the container.
+        // The single column layout is always valid as a fallback for when your minTileWidth exceeds the container width
+        if (minTileWidth && layout.cols > 1 && this.getRequiredWidth(layout) > width) return null;
 
         const score = this.scoreLayout(layout);
         return {layout, score};
@@ -212,10 +213,10 @@ class LocalModel extends HoistModel {
     // Returns a value normalised between 0-1 representing how much of the available width
     // is empty. A higher score indicates more empty space.
     getWidthFillingScore(layout) {
-        if (!this.hasWidthConstraints) return 0;
+        const {minTileWidth, maxTileWidth, width} = this.params;
+        if (!minTileWidth && !maxTileWidth) return 0;
 
-        const {width} = this.params,
-            requiredWidth = this.getRequiredWidth(layout),
+        const requiredWidth = this.getRequiredWidth(layout),
             excessWidth = Math.max(0, width - requiredWidth);
 
         return (excessWidth / width) * 10;
@@ -223,10 +224,5 @@ class LocalModel extends HoistModel {
 
     getRequiredWidth(layout) {
         return (layout.tileWidth * layout.cols) + ((layout.cols + 1) * this.params.spacing);
-    }
-
-    get hasWidthConstraints() {
-        const {minTileWidth, maxTileWidth} = this.params;
-        return minTileWidth || maxTileWidth;
     }
 }


### PR DESCRIPTION
Adjust TileFrame logic to avoid degenerate single column cases caused by width constraints, e.g.:

![image](https://user-images.githubusercontent.com/3017757/121892912-40cb3a80-cd15-11eb-93a0-71508b1bb6fa.png)

+ Don't invalidate layouts based on constraints, and remove "fallback layout" concept
+ Add weighted "Width Filling Score" to counter tendency to list tiles in single column

Note that this PR removes the `minTileRatio` and `maxTileRatio` constraints - I couldn't think of a way to adjust a layout to enforce these constraints (how to decide which dimension do you change? What is that then validates a size constraint? etc). If we can come up with a reasonable way to enforce them I'm happy to restore, but I think in most cases the width / height constraints should be sufficient.

See Toolbox PR: https://github.com/xh/toolbox/pull/491

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

