### PR TITLE
Default `autoComplete` to 'off' (Fixes #2484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ should be sure to test their forms carefully.
 ### 🐞 Bug Fixes
 
 * Fix disable behavior for Hoist-provided button components using popover.
+* Fix turning off autocomplete for `TextInput` by default.
 
 ### ⚙️ Technical
 

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -34,9 +34,9 @@ TextInput.propTypes = {
     /**
      *  HTML `autocomplete` attribute to set on underlying <input> element.
      *
-     *  Defaults to non-valid value 'nope' for fields of type text and 'new-password' for fields
-     *  of type 'password' to defeat browser auto-completion, which is typically not desired in
-     *  Hoist applications. Set to 'on' or a more specific autocomplete token to enable.
+     *  Defaults to 'off' for fields of type text and 'new-password' for fields of type 'password'
+     *  to defeat browser auto-completion, which is typically not desired in Hoist applications.
+     *  Set to 'on' or a more specific autocomplete token to enable.
      *
      * @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls%3A-the-autocomplete-attribute
      * @see https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
@@ -125,7 +125,7 @@ const cmp = hoistCmp.factory(
             item: inputGroup({
                 value: model.renderValue || '',
 
-                autoComplete: withDefault(props.autoComplete, props.type === 'password' ? 'new-password' : 'nope'),
+                autoComplete: withDefault(props.autoComplete, props.type === 'password' ? 'new-password' : 'off'),
                 autoFocus: props.autoFocus,
                 disabled: props.disabled,
                 inputRef: composeRefs(model.inputRef, props.inputRef),

--- a/mobile/cmp/input/TextInput.js
+++ b/mobile/cmp/input/TextInput.js
@@ -29,9 +29,9 @@ TextInput.propTypes = {
     /**
      *  HTML `autocomplete` attribute to set on underlying <input> element.
      *
-     *  Defaults to non-valid value 'nope' for fields of type text and 'new-password' for fields
-     *  of type 'password' to defeat browser auto-completion, which is typically not desired in
-     *  Hoist applications. Set to 'on' or a more specific autocomplete token to enable.
+     *  Defaults to 'off' for fields of type text and 'new-password' for fields of type 'password'
+     *  to defeat browser auto-completion, which is typically not desired in Hoist applications.
+     *  Set to 'on' or a more specific autocomplete token to enable.
      *
      * @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls%3A-the-autocomplete-attribute
      * See https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
@@ -100,7 +100,7 @@ const cmp = hoistCmp.factory(
         return input({
             value: model.renderValue || '',
 
-            autoComplete: withDefault(props.autoComplete, props.type === 'password' ? 'new-password' : 'nope'),
+            autoComplete: withDefault(props.autoComplete, props.type === 'password' ? 'new-password' : 'off'),
             disabled: props.disabled,
             modifier: props.modifier,
             placeholder: props.placeholder,


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

