### PR TITLE
Sync numberInput minStepSize to precision prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 
 * Fixed disable behavior for Hoist-provided button components using popover.
 * Fixed default disabling of autocomplete within `TextInput`.
+* Squelched console warning re. precision/stepSize emitted by Blueprint-based `numberInput`.
 
 ### ⚙️ Technical
 

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -12,7 +12,7 @@ import {wait} from '@xh/hoist/promise';
 import {withDefault} from '@xh/hoist/utils/js';
 import {getLayoutProps} from '@xh/hoist/utils/react';
 import composeRefs from '@seznam/compose-react-refs';
-import {isNaN, isNil, isNumber} from 'lodash';
+import {isNaN, isNil, isNumber, round} from 'lodash';
 import PT from 'prop-types';
 
 /**
@@ -190,6 +190,15 @@ const cmp = hoistCmp.factory(
     ({model, className, ...props}, ref) => {
         const {width, ...layoutProps} = getLayoutProps(props);
 
+        // BP NumberInput bases expected precision off of dps in minorStepSize, if specified.
+        // The default BP value of 0.1 for this prop emits a console warning any time the input
+        // value extends beyond 1 dp. Re-default here to sync with our `precision` prop.
+        // See https://blueprintjs.com/docs/#core/components/numeric-input.numeric-precision
+        const precision = withDefault(props.precision, 4),
+            minorStepSize = precision ?
+                withDefault(props.minorStepSize, round(Math.pow(10, -precision), precision)) :
+                null;
+
         return numericInput({
             value: model.formatRenderValue(model.renderValue),
 
@@ -202,7 +211,7 @@ const cmp = hoistCmp.factory(
             max: props.max,
             majorStepSize: props.majorStepSize,
             min: props.min,
-            minorStepSize: props.minorStepSize,
+            minorStepSize,
             placeholder: props.placeholder,
             rightElement: props.rightElement,
             stepSize: props.stepSize,


### PR DESCRIPTION
+ Fixes #2018 (console warning thrown in development mode re. "controlled value prop does not adhere to stepSize, min, and/or max constraints")

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

