### PR TITLE
Fix streaming update bug in Cube

### DIFF
--- a/data/cube/row/BaseRow.js
+++ b/data/cube/row/BaseRow.js
@@ -124,12 +124,10 @@ export class BaseRow {
             if (canAggregate[name]) {
                 const oldValue = data[name],
                     newValue = field.aggregator.replace(children, oldValue, update);
-                if (oldValue !== newValue) {
-                    update.oldValue = oldValue;
-                    update.newValue = newValue;
-                    myUpdates.push(update);
-                    data[name] = newValue;
-                }
+                update.oldValue = oldValue;
+                update.newValue = newValue;
+                myUpdates.push(update);
+                data[name] = newValue;
             }
         });
 


### PR DESCRIPTION
We need to Flow aggregation updates all the way to the root, even if there is no change at an intermediate level.

Colin and I discovered this problem in a client app where aggregates on certain dimensions always aggregated to *null* but dimensions above them could still compute aggregates.

Without the changes in this PR, the dimension with null aggregates prevent the update of all aggregates for dimensions above them in the tree.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

