### PR TITLE
Add GridModel.getIsReadyAsync()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### 🐞 Bug Fixes
 
 * Fixed an issue preventing export of very large (>100k rows) grids.
+* Improved `GridModel` async selection methods to ensure they do not wait forever if grid does not
+  mount.
 
 ### 🎁 New Features
 

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -471,7 +471,7 @@ export class GridModel extends HoistModel {
      */
     async selectFirstAsync({ensureVisible = true} = {}) {
         const {selModel} = this,
-            isReady = await this.getIsReadyAsync();
+            isReady = await this.whenReadyAsync();
 
         // No-op if grid failed to enter ready state.
         if (!isReady) return;
@@ -513,7 +513,7 @@ export class GridModel extends HoistModel {
      * render all pending data changes.
      */
     async ensureSelectionVisibleAsync() {
-        const isReady = await this.getIsReadyAsync();
+        const isReady = await this.whenReadyAsync();
 
         // No-op if grid failed to enter ready state.
         if (!isReady) return;
@@ -1026,7 +1026,7 @@ export class GridModel extends HoistModel {
      * @param {number} [timeout] - timeout in ms
      * @return {Promise<boolean>} - latest ready state of grid
      */
-    async getIsReadyAsync(timeout = 3 * SECONDS) {
+    async whenReadyAsync(timeout = 3 * SECONDS) {
         try {
             await when(() => this.isReady, {timeout});
         } catch (ignored) {

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -12,18 +12,20 @@ import {FieldType, Store, StoreSelectionModel} from '@xh/hoist/data';
 import {ColChooserModel as DesktopColChooserModel} from '@xh/hoist/dynamics/desktop';
 import {ColChooserModel as MobileColChooserModel} from '@xh/hoist/dynamics/mobile';
 import {Icon} from '@xh/hoist/icon';
-import {action, observable, makeObservable, when} from '@xh/hoist/mobx';
+import {action, makeObservable, observable, when} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
+import {SECONDS} from '@xh/hoist/utils/datetime';
 import {
     apiDeprecated,
     apiRemoved,
     debounced,
     deepFreeze,
     ensureUnique,
+    logWithDebug,
     throwIf,
     warnIf,
-    withDefault,
-    logWithDebug
+    withDebug,
+    withDefault
 } from '@xh/hoist/utils/js';
 import equal from 'fast-deep-equal';
 import {
@@ -468,10 +470,11 @@ export class GridModel extends HoistModel {
      *      collapsed node or outside of the visible scroll window. Default true.
      */
     async selectFirstAsync({ensureVisible = true} = {}) {
-        const {selModel} = this;
+        const {selModel} = this,
+            isReady = await this.getIsReadyAsync();
 
-        // await always async, allowing grid to render changes pending at time of call
-        await when(() => this.isReady);
+        // No-op if grid failed to enter ready state.
+        if (!isReady) return;
 
         // Get first displayed row with data - i.e. backed by a record, not a full-width group row.
         const id = this.agGridModel.getFirstSelectableRowNodeId();
@@ -510,11 +513,13 @@ export class GridModel extends HoistModel {
      * render all pending data changes.
      */
     async ensureSelectionVisibleAsync() {
-        // await always async, allowing grid to render changes pending at time of call
-        await when(() => this.isReady);
+        const isReady = await this.getIsReadyAsync();
 
-        const {records} = this.selModel,
-            {agApi} = this,
+        // No-op if grid failed to enter ready state.
+        if (!isReady) return;
+
+        const {agApi, selModel} = this,
+            {records} = selModel,
             indices = [];
 
         // 1) Expand any selected nodes that are collapsed
@@ -1012,6 +1017,23 @@ export class GridModel extends HoistModel {
                 agApi.hideOverlay();
             }
         }
+    }
+
+    /**
+     * Returns true as soon as the underlying agGridModel is ready, waiting a limited period
+     * of time if needed to allow the component to initialize. Returns false if grid not ready
+     * by end of timeout to ensure caller does not wait forever (if e.g. grid is not mounted).
+     * @param {number} [timeout] - timeout in ms
+     * @return {Promise<boolean>} - latest ready state of grid
+     */
+    async getIsReadyAsync(timeout = 3 * SECONDS) {
+        try {
+            await when(() => this.isReady, {timeout});
+        } catch (ignored) {
+            withDebug(`Grid failed to enter ready state after waiting ${timeout}ms`, null, this);
+        }
+
+        return this.isReady;
     }
 
     /** @deprecated */


### PR DESCRIPTION
+ Improves `GridModel` async selection methods to ensure they do not wait forever if grid does not mount.
+ Fixes #2507

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

