### PR TITLE
Update grid data when Store `summaryRecord` changes (fixes #2531)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   mount.
 * Fixed an issue preventing a minimal button in `panel.headerItems` to take an intent that overrides
   the panel's title text color.
+* Fixed an issue where updating summary data in a Store without also updating other data would not
+  update the data in the associated grid
 
 ### 🎁 New Features
 

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -352,7 +352,7 @@ class GridLocalModel extends HoistModel {
         const {model} = this,
             {store} = model;
         return {
-            track: () => [model.isReady, store._filtered, model.showSummary],
+            track: () => [model.isReady, store._filtered, model.showSummary, store.summaryRecord],
             run: ([isReady]) => {
                 if (isReady) this.syncData();
             }


### PR DESCRIPTION
Fixes #2531 

Most straightforward way to handle this. An alternative could be to add a new reaction to only update the pinned row data when the summary position/data changes, but I don't think that is really necessary.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

