### PR TITLE
Improve node expand/collapse via keyboard

### DIFF
--- a/cmp/ag-grid/impl/RowKeyNavSupport.js
+++ b/cmp/ag-grid/impl/RowKeyNavSupport.js
@@ -18,12 +18,14 @@ export class RowKeyNavSupport {
 
     navigateToNextCell(agParams) {
         const {nextCellPosition, previousCellPosition, event, key} = agParams,
-            {agApi} = this.agGridModel,
+            {agApi, showCellFocus} = this.agGridModel,
             shiftKey = event.shiftKey,
-            prevIndex = previousCellPosition ? previousCellPosition.rowIndex : null,
-            nextIndex = nextCellPosition ? nextCellPosition.rowIndex : null,
+            nextIndex = nextCellPosition?.rowIndex ?? null,
+            prevIndex =  previousCellPosition?.rowIndex ?? null,
+            prevIsTreeCol = previousCellPosition?.column.colDef.xhColumn.isTreeColumn,
             prevNode = prevIndex != null ? agApi.getDisplayedRowAtIndex(prevIndex) : null,
             prevNodeIsParent = prevNode && prevNode.allChildrenCount,
+            canExpandCollapse = prevNodeIsParent && (!showCellFocus || prevIsTreeCol),
             KEY_UP = 38, KEY_DOWN = 40, KEY_LEFT = 37, KEY_RIGHT = 39;
 
         switch (key) {
@@ -56,10 +58,16 @@ export class RowKeyNavSupport {
                 }
                 return nextCellPosition;
             case KEY_LEFT:
-                if (prevNodeIsParent && prevNode.expanded) prevNode.setExpanded(false);
+                if (canExpandCollapse && prevNode.expanded) {
+                    prevNode.setExpanded(false);
+                    return;
+                }
                 return nextCellPosition;
             case KEY_RIGHT:
-                if (prevNodeIsParent && !prevNode.expanded) prevNode.setExpanded(true);
+                if (canExpandCollapse && !prevNode.expanded) {
+                    prevNode.setExpanded(true);
+                    return;
+                }
                 return nextCellPosition;
             default:
         }

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -349,6 +349,7 @@ export class Column {
     getAgSpec() {
         const {gridModel, field, headerName, displayName, agOptions} = this,
             ret = {
+                xhColumn: this,
                 field,
                 colId: this.colId,
                 // headerValueGetter should always return a string


### PR DESCRIPTION
Fixes issues with expand/collapse key stroke would also scroll grid!

+ Install back-pointer to Hoist Column from Ag column
+ Never shift cell focus after doing key-based expand/collapse
+ More selectively do key-based expand/collapse when showing cell focus

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

