### PR TITLE
Changes to Toast defaults, new XH methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
 * New `Badge` component allows a styled badge to be placed inline with text/title, e.g. to show a
   counter or status indicator within a tab title or menu item.
 * Updated `TreeMap` color scheme, with a dedicated set of colors for dark mode.
-
+* New XH convenience methods `successToast()`, `warningToast()`, and `dangerToast()` show toast
+  alerts with matching intents and appropriate icons.
+  * ⚠ Note that the default `XH.toast()` call now shows a toast with the primary (blue) intent and
+    no icon. Previously toasts displayed by default with a success (green) intent and checkmark.
 
 ### 🐞 Bug Fixes
 

--- a/appcontainer/ToastModel.js
+++ b/appcontainer/ToastModel.js
@@ -5,7 +5,6 @@
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
 import {HoistModel} from '@xh/hoist/core';
-import {Icon} from '@xh/hoist/icon';
 import {action, observable, makeObservable} from '@xh/hoist/mobx';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 
@@ -28,9 +27,9 @@ export class ToastModel extends HoistModel {
 
     constructor({
         message,
-        icon = Icon.check(),
+        icon,
         timeout = 3 * SECONDS,
-        intent = 'success',
+        intent = 'primary',
         position = null,
         containerRef = null
     }) {

--- a/appcontainer/ToastSourceModel.js
+++ b/appcontainer/ToastSourceModel.js
@@ -6,11 +6,11 @@
  */
 import {HoistModel, managed} from '@xh/hoist/core';
 import {action, observable, makeObservable} from '@xh/hoist/mobx';
+import {isString} from 'lodash';
 import {ToastModel} from './ToastModel';
 
 /**
- *  Supports displaying pop-up Toast.
- *
+ *  Supports displaying a pop-up Toast.
  *  @private
  */
 export class ToastSourceModel extends HoistModel {
@@ -25,6 +25,7 @@ export class ToastSourceModel extends HoistModel {
     }
 
     show(config) {
+        if (isString(config)) config = {message: config};
         const ret = new ToastModel(config);
         this.addModel(ret);
         return ret;

--- a/core/XH.js
+++ b/core/XH.js
@@ -7,6 +7,7 @@
 import {p} from '@xh/hoist/cmp/layout';
 import {AppSpec, AppState, elem, HoistBase} from '@xh/hoist/core';
 import {Exception} from '@xh/hoist/exception';
+import {Icon} from '@xh/hoist/icon';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {never, wait} from '@xh/hoist/promise';
 import {MINUTES} from '@xh/hoist/utils/datetime';
@@ -414,7 +415,7 @@ class XHClass extends HoistBase {
     /**
      * Show a non-modal "toast" notification that appears and then automatically dismisses.
      *
-     * @param {Object} config - options for toast instance.
+     * @param {(Object|string)} config - options for toast instance, or string message.
      * @param {(ReactNode|string)} config.message - the message to show in the toast.
      * @param {Element} [config.icon] - icon to be displayed
      * @param {number} [config.timeout] - time in milliseconds to display the toast.
@@ -425,7 +426,22 @@ class XHClass extends HoistBase {
      *      If null, the Toast will appear at the edges of the document (desktop only).
      */
     toast(config) {
-        return this.acm.toastSourceModel.show(config);
+        this.acm.toastSourceModel.show(config);
+    }
+
+    successToast(config) {
+        if (isString(config)) config = {message: config};
+        this.toast({intent: 'success', icon: Icon.success(), ...config});
+    }
+
+    warningToast(config) {
+        if (isString(config)) config = {message: config};
+        this.toast({intent: 'warning', icon: Icon.warning(), ...config});
+    }
+
+    dangerToast(config) {
+        if (isString(config)) config = {message: config};
+        this.toast({intent: 'danger', icon: Icon.danger(), ...config});
     }
 
     /**


### PR DESCRIPTION
* New XH convenience methods `successToast()`, `warningToast()`, and `dangerToast()` show toast alerts with matching intents and appropriate icons.
* Note that the default `XH.toast()` call now shows a toast with the primary (blue) intent and no icon. Previously toasts displayed by default with a success (green) intent and checkmark.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

