### PR TITLE
works around elementFromContent not calling the content function with its arguments

### DIFF
--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -598,17 +598,14 @@ export class Column {
 
         if (editor) {
             ret.cellEditorFramework = forwardRef((agParams, ref) => {
-                const {data} = agParams;
-                return elementFromContent(
-                    editor,
-                    {
-                        record: data,
-                        gridModel,
-                        column: this,
-                        agParams,
-                        ref
-                    }
-                );
+                const props = {
+                    record: agParams.data,
+                    gridModel,
+                    column: this,
+                    agParams,
+                    ref
+                };
+                return isFunction(editor) ? editor(props) : elementFromContent(editor, props);
             });
             ret.cellClassRules = {
                 'xh-invalid-cell': ({data: record}) => record && !isEmpty(record.errors[field])

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -7,7 +7,6 @@
 import {div, ul, li} from '@xh/hoist/cmp/layout';
 import {XH} from '@xh/hoist/core';
 import {genDisplayName} from '@xh/hoist/data';
-import {elementFromContent} from '@xh/hoist/utils/react';
 import {throwIf, warnIf, withDefault} from '@xh/hoist/utils/js';
 import {
     castArray,
@@ -22,7 +21,7 @@ import {
     isNumber,
     isString
 } from 'lodash';
-import {forwardRef, useImperativeHandle, useState} from 'react';
+import {forwardRef, useImperativeHandle, useState, createElement} from 'react';
 import classNames from 'classnames';
 import {GridSorter} from '../impl/GridSorter';
 import {ExportFormat} from './ExportFormat';
@@ -605,7 +604,10 @@ export class Column {
                     agParams,
                     ref
                 };
-                return isFunction(editor) ? editor(props) : elementFromContent(editor, props);
+                // Can be a component or elem factory/ ad-hoc render function.
+                if (editor.isHoistComponent) return createElement(editor, props);
+                if (isFunction(editor)) return editor(props);
+                throw XH.exception('Column editor must be a HoistComponent or a render function');
             });
             ret.cellClassRules = {
                 'xh-invalid-cell': ({data: record}) => record && !isEmpty(record.errors[field])

--- a/core/elem.js
+++ b/core/elem.js
@@ -70,9 +70,11 @@ export function elem(type, config = {}) {
  * @return {function}
  */
 export function elemFactory(type) {
-    return function(...args) {
+    const ret = function(...args) {
         return elem(type, normalizeArgs(args));
     };
+    ret.isElemFactory = true;
+    return ret;
 }
 
 

--- a/utils/react/ReactUtils.js
+++ b/utils/react/ReactUtils.js
@@ -31,7 +31,11 @@ export function getReactElementName(obj) {
  */
 export function elementFromContent(content, addProps) {
     if (isNil(content)) return null;
-    
+
+    if (content.isElemFactory) {
+        return content(addProps);
+    }
+
     // Note: Would be more general to look for a *react* component.
     if (content.isHoistComponent) {
         return createElement(content, addProps);


### PR DESCRIPTION
In the interest of keeping things moving, this PR works around, for the column editor use case only, the fact that elementFromContent does not execute the content function with its arguments.



Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

