### PR TITLE
Standardize coding of async delays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 own `timeout` option.  This allows the browser to release the associated resources associated with
 these requests.
 
+* The `start` function in `@xh/hoist/promise` has been deprecated.  Use the `wait` function instead.
+
 ### ✨ Style
 
 * The red and green color values applied in dark mode have been lightened for improved legibility.

--- a/admin/tabs/activity/tracking/charts/ChartsModel.js
+++ b/admin/tabs/activity/tracking/charts/ChartsModel.js
@@ -72,7 +72,7 @@ export class ChartsModel extends HoistModel {
 
         // Hack to get primary, non-dialog chart to re-render once dialog is dismissed.
         // Sharing chart models between chart component instances appears to be risky...
-        await wait(1);
+        await wait();
         this.chartModel.setHighchartsConfig({...this.chartModel.highchartsConfig});
     }
 

--- a/cmp/filter/FilterChooserModel.js
+++ b/cmp/filter/FilterChooserModel.js
@@ -272,7 +272,7 @@ export class FilterChooserModel extends HoistModel {
             inputValue = newVal.length > currentVal.length ? newVal : currentVal;
 
         rsSelectCmp.select.setState({inputValue, menuIsOpen: true});
-        wait(0).then(() => {
+        wait().then(() => {
             rsSelectCmp.focus();
             rsSelectCmp.handleInputChange(inputValue);
         });

--- a/cmp/form/field/BaseFieldModel.js
+++ b/cmp/form/field/BaseFieldModel.js
@@ -198,7 +198,7 @@ export class BaseFieldModel extends HoistModel {
         // Force an immediate 'Unknown' state -- the async recompute leaves the old state in place until it completed.
         // (We want that for a value change, but not reset/init)  Force the recompute only if needed.
         this._errors.fill(null);
-        wait(0).then(() => {
+        wait().then(() => {
             if (!this.isValidationPending && this.validationState === ValidationState.Unknown) {
                 this.computeValidationAsync();
             }

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -602,7 +602,7 @@ class GridLocalModel extends HoistModel {
         }
 
         if (!transaction || transaction.add || transaction.remove) {
-            wait(0).then(() => this.syncSelection());
+            wait().then(() => this.syncSelection());
         }
 
         model.noteAgExpandStateChange();

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -531,7 +531,7 @@ export class GridModel extends HoistModel {
             }
         });
 
-        await wait(0);
+        await wait();
 
         // 2) Scroll to all selected nodes
         records.forEach(({id}) => {

--- a/core/HoistBaseDecorators.js
+++ b/core/HoistBaseDecorators.js
@@ -7,7 +7,7 @@
 import {PersistenceProvider} from '@xh/hoist/core';
 
 import {cloneDeep, isUndefined} from 'lodash';
-import {start} from '@xh/hoist/promise';
+import {wait} from '@xh/hoist/promise';
 import {throwIf} from '@xh/hoist/utils/js';
 
 /**
@@ -79,7 +79,7 @@ function createPersistDescriptor(target, property, descriptor, options) {
             const persistWith = {path: property, ...this.persistWith, ...options},
                 provider = this.markManaged(PersistenceProvider.create(persistWith));
             providerState = cloneDeep(provider.read());
-            start(() => {
+            wait().then(() => {
                 this.addReaction({
                     track: () => this[property],
                     run: (data) => provider.write(data)

--- a/desktop/cmp/contextmenu/ContextMenu.js
+++ b/desktop/cmp/contextmenu/ContextMenu.js
@@ -6,7 +6,7 @@
  */
 import {hoistCmp} from '@xh/hoist/core';
 import {menu, menuDivider, menuItem} from '@xh/hoist/kit/blueprint';
-import {start} from '@xh/hoist/promise';
+import {wait} from '@xh/hoist/promise';
 import {filterConsecutiveMenuSeparators} from '@xh/hoist/utils/impl';
 import PT from 'prop-types';
 import {isValidElement} from 'react';
@@ -71,7 +71,7 @@ function parseMenuItems(items) {
             return menuItem({
                 text: item.text,
                 icon: item.icon,
-                onClick: item.actionFn ? () => start(item.actionFn) : null,    // do async to allow menu to close
+                onClick: item.actionFn ? () => wait().then(item.actionFn) : null,    // do async to allow menu to close
                 disabled: item.disabled,
                 items
             });

--- a/desktop/cmp/dash/DashContainerModel.js
+++ b/desktop/cmp/dash/DashContainerModel.js
@@ -9,7 +9,7 @@ import {convertIconToHtml, deserializeIcon} from '@xh/hoist/icon';
 import {ContextMenu} from '@xh/hoist/kit/blueprint';
 import {GoldenLayout} from '@xh/hoist/kit/golden-layout';
 import {action, observable, bindable, makeObservable} from '@xh/hoist/mobx';
-import {start} from '@xh/hoist/promise';
+import {wait} from '@xh/hoist/promise';
 import {PendingTaskModel} from '@xh/hoist/utils/async';
 import {debounced, ensureUniqueBy, throwIf} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
@@ -227,7 +227,7 @@ export class DashContainerModel extends HoistModel {
         if (!containerEl) return;
 
         // Show mask to provide user feedback
-        return start().thenAction(() => {
+        return wait().thenAction(() => {
             this.destroyGoldenLayout();
             this.goldenLayout = this.createGoldenLayout(containerEl, state);
 

--- a/desktop/cmp/grid/editors/impl/InlineEditorModel.js
+++ b/desktop/cmp/grid/editors/impl/InlineEditorModel.js
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import {isNil} from 'lodash';
 import {HoistModel, useLocalModel} from '@xh/hoist/core';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
-import {start} from '@xh/hoist/promise';
+import {wait} from '@xh/hoist/promise';
 import {createObservableRef} from '@xh/hoist/utils/react';
 
 /**
@@ -105,7 +105,7 @@ class InlineEditorModel extends HoistModel {
     focusOnRenderReaction() {
         return {
             when: () => this.inputEl,
-            run: () => start(() => this.focus()) // wait 1 tick before we can focus
+            run: () => wait().then(() => this.focus())
         };
     }
 }

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -231,7 +231,7 @@ class Model extends HoistInputModel {
 
     noteBlurred() {
         super.noteBlurred();
-        wait(1).then(() => {
+        wait().then(() => {
             if (!this.hasFocus) {
                 this.setPopoverOpen(false);
             }

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -181,7 +181,7 @@ class Model extends HoistInputModel {
         // Deferred to allow any value conversion to complete and flush into input.
         if (this.props.selectOnFocus) {
             const target = ev.target;
-            wait(1).then(() => target.select());
+            wait().then(() => target.select());
         }
     }
 }

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -308,7 +308,7 @@ class Model extends HoistInputModel {
             this.inputValue = renderValue ? renderValue.label : null;
         }
         if (this.selectOnFocus) {
-            wait(1).then(() => {
+            wait().then(() => {
                 // Delay to allow re-render. For safety, only select if still focused!
                 this.selectText();
             });

--- a/desktop/cmp/panel/PanelModel.js
+++ b/desktop/cmp/panel/PanelModel.js
@@ -15,7 +15,7 @@ import {
     XH
 } from '@xh/hoist/core';
 import {action, observable, makeObservable} from '@xh/hoist/mobx';
-import {start} from '@xh/hoist/promise';
+import {wait} from '@xh/hoist/promise';
 import {apiRemoved} from '@xh/hoist/utils/js';
 import {isNil} from 'lodash';
 import {createRef} from 'react';
@@ -256,6 +256,6 @@ export class PanelModel extends HoistModel {
 
     dispatchResize() {
         // Forces other components to redraw if required.
-        start(() => window.dispatchEvent(new Event('resize')));
+        wait().then(() => window.dispatchEvent(new Event('resize')));
     }
 }

--- a/desktop/cmp/treemap/TreeMap.js
+++ b/desktop/cmp/treemap/TreeMap.js
@@ -215,7 +215,7 @@ class LocalModel extends HoistModel {
         if (width > 0 && height > 0) {
             chart.setSize(width, height, false);
         }
-        await wait(0);
+        await wait();
 
         model.setIsMasking(false);
         this.updateLabelVisibility();

--- a/mobile/cmp/input/NumberInput.js
+++ b/mobile/cmp/input/NumberInput.js
@@ -116,7 +116,7 @@ class Model extends HoistInputModel {
         // Deferred to allow any value conversion to complete and flush into input.
         if (this.props.selectOnFocus) {
             const target = ev.target;
-            if (target && target.select) wait(1).then(() => target.select());
+            if (target && target.select) wait().then(() => target.select());
         }
     };
 

--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -8,9 +8,12 @@ import {XH} from '@xh/hoist/core';
 import {action} from '@xh/hoist/mobx';
 import {Exception} from '@xh/hoist/exception';
 import {castArray, isFunction, isNumber, isPlainObject} from 'lodash';
+import {apiDeprecated} from '../utils/js';
 
 /**
  * Start a new promise chain.
+ *
+ * @deprecated  Use `wait()` instead.
  *
  * This method serves as a lightweight way to start a promise chain for any code.
  * It is useful for combining promise based calls with non-promise based calls, especially when
@@ -25,6 +28,7 @@ import {castArray, isFunction, isNumber, isPlainObject} from 'lodash';
  * @returns {Promise}
  */
 export async function start(fn) {
+    apiDeprecated(true, 'start', 'Use wait() instead.');
     const promise = new Promise(resolve => setTimeout(resolve, 1));
     return fn ? promise.then(fn) : start;
 }
@@ -32,10 +36,13 @@ export async function start(fn) {
 /**
  * Return a promise that will resolve after the specified amount of time.
  *
- * @param {number} interval - milliseconds to delay.
+ * This method serves as a lightweight way to start a promise chain for any code.
+ *
+ * @param {number} [interval] - milliseconds to delay. Defaults to 0.  Note that the actual
+ *      delay will be subject to the minimum delay for setTimeout() in the browser.
  * @return {Promise}
  */
-export async function wait(interval) {
+export async function wait(interval = 0) {
     return new Promise(resolve => setTimeout(resolve, interval));
 }
 


### PR DESCRIPTION
+ deprecate start(), add default interval to wait().
+ standardize usages to wait().then()

Got tired of looking at wait(1), wait(0) and start().  Start seems especially weird, poorly named, and unecessary.
Wait does the same thing, and is more expressive.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

