### PR TITLE
Apply CSS class to inline-editable grid cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ these requests.
 * New/renamed CSS vars `--xh-grid-selected-row-bg` and `--xh-grid-selected-row-text-color` now used
   to style selected grid rows.
   * ⚠ Note the `--xh-grid-bg-highlight` CSS var has been removed.
+* New `.xh-cell--editable` CSS class applied to cells with inline editing enabled.
+  * ⚠ Grid CSS class `.xh-invalid-cell` has been renamed to `.xh-cell--invalid` for consistency -
+    any app style overrides should update to this new classname.
 
 ### 🐞 Bug Fixes
 

--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -130,7 +130,7 @@
   }
 
   // Render badge on invalid cells
-  .ag-cell.xh-invalid-cell {
+  .ag-cell.xh-cell--invalid {
     &::before {
       content: '';
       position: absolute;
@@ -152,25 +152,25 @@
 
   .xh-ag-grid {
     &--tiny {
-      .ag-cell.xh-invalid-cell::before {
+      .ag-cell.xh-cell--invalid::before {
         border-width: 3px;
       }
     }
 
     &--compact {
-      .ag-cell.xh-invalid-cell::before {
+      .ag-cell.xh-cell--invalid::before {
         border-width: 4px;
       }
     }
 
     &--standard {
-      .ag-cell.xh-invalid-cell::before {
+      .ag-cell.xh-cell--invalid::before {
         border-width: 5px;
       }
     }
 
     &--large {
-      .ag-cell.xh-invalid-cell::before {
+      .ag-cell.xh-cell--invalid::before {
         border-width: 6px;
       }
     }

--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -438,7 +438,7 @@ export class Column {
         }
 
         // Tooltip Handling
-        const {tooltip, tooltipElement, editor} = this,
+        const {tooltip, tooltipElement, editable, editor} = this,
             tooltipSpec = tooltipElement ?? tooltip;
 
         if (tooltipSpec || editor) {
@@ -610,7 +610,16 @@ export class Column {
                 throw XH.exception('Column editor must be a HoistComponent or a render function');
             });
             ret.cellClassRules = {
-                'xh-invalid-cell': ({data: record}) => record && !isEmpty(record.errors[field])
+                'xh-cell--invalid': (agParams) => {
+                    const record = agParams.data;
+                    return record && !isEmpty(record.errors[field]);
+                },
+                'xh-cell--editable': (agParams) => {
+                    const record = agParams.data;
+                    return isFunction(editable) ?
+                        editable({record, store: record.store, gridModel, column: this, agParams}) :
+                        editable;
+                }
             };
         }
 


### PR DESCRIPTION
+ New `.xh-cell--editable` applied, but with no default styling provided by Hoist.
+ Changed previous `.xh-invalid-cell` to `.xh-cell--invalid` for consistency.
+ Fixes #2553

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

