### PR TITLE
Support rowClassRules/cellClassRules configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### 🎁 New Features
 
+* New `GridModel.rowClassRules` and `Column.cellClassRules` configs added. Previously apps needed to
+  use `agOptions` to dynamically apply and remove CSS classes using either of these options - now
+  they are fully supported by Hoist.
+  * ⚠ Note that, to avoid conflicts with internal usages of these configs, Hoist will check and
+    throw if either is passed via `agOptions`. Apps only need to move their configs to the new
+    location - the shape of the rules object does *not* need to change.
 * New `GridAutosizeOptions.includeCollapsedChildren` config controls whether values from collapsed
   (i.e. hidden) child records should be measured when computing column sizes. Default of `false`
   improves autosize performance for large tree grids and should generally match user expectations

--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -5,8 +5,8 @@
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
 import {HoistModel} from '@xh/hoist/core';
-import {action, bindable, observable, makeObservable, computed} from '@xh/hoist/mobx';
-import {throwIf, apiDeprecated} from '@xh/hoist/utils/js';
+import {action, bindable, computed, makeObservable, observable} from '@xh/hoist/mobx';
+import {throwIf} from '@xh/hoist/utils/js';
 import {
     cloneDeep,
     concat,
@@ -14,11 +14,11 @@ import {
     has,
     isArray,
     isEmpty,
+    isEqual,
     isNil,
     partition,
     set,
-    startCase,
-    isEqual
+    startCase
 } from 'lodash';
 
 /**
@@ -72,13 +72,10 @@ export class AgGridModel extends HoistModel {
         cellBorders = false,
         stripeRows = true,
         showCellFocus = false,
-        hideHeaders = false,
-        compact
+        hideHeaders = false
     } = {}) {
         super();
         makeObservable(this);
-        apiDeprecated(compact, 'compact', "Use 'sizingMode' instead");
-        if (compact) sizingMode = 'compact';
 
         this.sizingMode = sizingMode;
         this.showHover = showHover;

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -67,6 +67,7 @@ export const [Grid, grid] = hoistCmp.withFactory({
         apiRemoved(props.onRowDoubleClicked, 'onRowDoubleClicked', 'Specify onRowDoubleClicked on the GridModel instead.');
         apiRemoved(props.onCellClicked, 'onCellClicked', 'Specify onCellClicked on the GridModel instead.');
         apiRemoved(props.onCellDoubleClicked, 'onCellDoubleClicked', 'Specify onCellDoubleClicked on the GridModel instead.');
+        apiRemoved(props.agOptions?.rowClassRules, 'agOptions.rowClassRules', 'Specify rowClassRules on the GridModel instead.');
 
         const impl = useLocalModel(() => new GridLocalModel(model, props)),
             platformColChooser = XH.isMobileApp ? mobileColChooser : desktopColChooser;
@@ -197,6 +198,7 @@ class GridLocalModel extends HoistModel {
             tooltipShowDelay: 0,
             getRowHeight: ({node}) => this.getRowHeight(node),
             getRowClass: ({data}) => model.rowClassFn ? model.rowClassFn(data) : null,
+            rowClassRules: model.rowClassRules,
             noRowsOverlayComponentFramework: observer(() => div(this.emptyText)),
             onCellClicked: model.onCellClicked,
             onCellDoubleClicked: model.onCellDoubleClicked,

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -87,6 +87,8 @@ export class GridModel extends HoistModel {
     colChooserModel;
     /** @member {function} */
     rowClassFn;
+    /** @member {Object.<string, RowClassRuleFn>} */
+    rowClassRules;
     /** @member {(Array|function)} */
     contextMenu;
     /** @member {number} */
@@ -215,6 +217,11 @@ export class GridModel extends HoistModel {
      *      install default context menu items.
      * @param {ExportOptions} [c.exportOptions] - default export options.
      * @param {RowClassFn} [c.rowClassFn] - closure to generate CSS class names for a row.
+     *      NOTE that, once added, classes will *not* be removed if the data changes.
+     *      Use `rowClassRules` instead if Record data can change across refreshes.
+     * @param {Object.<string, RowClassRuleFn>} [c.rowClassRules] - object keying CSS
+     *      class names to functions determining if they should be added or removed from the row.
+     *      See Ag-Grid docs on "row styles" for details.
      * @param {number} [c.groupRowHeight] - Height (in px) of a group row. Note that this will
      *      override `sizingMode` for group rows.
      * @param {Grid~groupRowRendererFn} [c.groupRowRenderer] - function returning a string used to
@@ -281,18 +288,18 @@ export class GridModel extends HoistModel {
         sizingMode = 'standard',
         showHover = false,
         rowBorders = false,
+        rowClassFn = null,
+        rowClassRules = {},
         cellBorders = false,
         treeStyle = TreeStyle.HIGHLIGHTS,
         stripeRows = (!treeMode || treeStyle === TreeStyle.NONE),
         showCellFocus = false,
         hideHeaders = false,
-        compact,
 
         lockColumnGroups = true,
         enableColumnPinning = true,
         enableExport = false,
         exportOptions = {},
-        rowClassFn = null,
 
         groupRowHeight,
         groupRowRenderer,
@@ -325,6 +332,7 @@ export class GridModel extends HoistModel {
         this.emptyText = emptyText;
         this.hideEmptyTextBeforeLoad = hideEmptyTextBeforeLoad;
         this.rowClassFn = rowClassFn;
+        this.rowClassRules = rowClassRules;
         this.groupRowHeight = groupRowHeight;
         this.groupRowRenderer = groupRowRenderer;
         this.groupRowElementRenderer = groupRowElementRenderer;
@@ -369,7 +377,6 @@ export class GridModel extends HoistModel {
 
         this.agGridModel = new AgGridModel({
             sizingMode,
-            compact,
             showHover,
             rowBorders,
             stripeRows,
@@ -1466,6 +1473,15 @@ export class GridModel extends HoistModel {
  * @callback RowClassFn - closure to generate CSS class names for a row.
  * @param {Object} data - the inner data object from the Record associated with the rendered row.
  * @returns {(String|String[])} - CSS class(es) to apply to the row level.
+ */
+
+/**
+ * @callback RowClassRuleFn - function to determine if a particular CSS class should be
+ *      added/removed from a row, via rowClassRules config.
+ * @param {RowClassParams} agParams - as provided by AG-Grid.
+ * @param {?Record} agParams.data - the backing Hoist record, if any.
+ * @return {boolean} - true if the class to which this function is keyed should be added, false if
+ *      it should be removed.
  */
 
 /**


### PR DESCRIPTION
+ Add as top-level configs to GridModel and Column, respectively.
+ Throw if detected within agOptions to ensure migration.
+ Remove obsolete `GridModel.compact` config - deprecated in v29.
+ Fixes #1331 

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

