### PR TITLE
Form supports setting readonlyRenderer in fieldDefaults prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Toasts may now be dismissed programmatically - use the new `ToastModel` returned by the
   `XH.toast()` API and its variants.
 * `Form` supports setting readonlyRenderer in `fieldDefaults` prop.
+* new utility hook `useCachedValue`
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Toasts may now be dismissed programmatically - use the new `ToastModel` returned by the
   `XH.toast()` API and its variants.
 * `Form` supports setting readonlyRenderer in `fieldDefaults` prop.
-* new utility hook `useCachedValue`
+* New utility hook `useCachedValue` provides a more flexible variant of `React.useCallback`.
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 * Timeouts are now configurable on grid exports via a new `exportOptions.timeout` config.
 * Toasts may now be dismissed programmatically - use the new `ToastModel` returned by the
   `XH.toast()` API and its variants.
-* Timeouts are now configurable on grid exports via property `exportOptions.timeout`.
 * `Form` supports setting readonlyRenderer in `fieldDefaults` prop.
 
 ### 🐞 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Toasts may now be dismissed programmatically - use the new `ToastModel` returned by the
   `XH.toast()` API and its variants.
 * Timeouts are now configurable on grid exports via property `exportOptions.timeout`.
+* `Form` supports setting readonlyRenderer in `fieldDefaults` prop.
 
 ### 🐞 Bug Fixes
 

--- a/admin/tabs/activity/clienterrors/ClientErrorDetail.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorDetail.js
@@ -108,5 +108,5 @@ export const clientErrorDetail = hoistCmp.factory(
     }
 );
 
-const valOrNa = v => v != null ? v : naSpan();
+const valOrNa = v => v != null ? v.toString() : naSpan();
 const naSpan = () => span({item: 'N/A', className: 'xh-text-color-muted'});

--- a/admin/tabs/activity/clienterrors/ClientErrorDetail.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorDetail.js
@@ -10,8 +10,9 @@ import {hoistCmp} from '@xh/hoist/core';
 import {formField} from '@xh/hoist/desktop/cmp/form';
 import {jsonInput, switchInput, textInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
-import {dateTimeRenderer} from '@xh/hoist/format';
+import {fmtDateTime} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
+import {isNil} from 'lodash';
 
 export const clientErrorDetail = hoistCmp.factory(
     ({model}) => {
@@ -41,7 +42,7 @@ export const clientErrorDetail = hoistCmp.factory(
                             formField({
                                 field: 'dateCreated',
                                 item: textInput(),
-                                readonlyRenderer: dateTimeRenderer({})
+                                readonlyRenderer: fmtDateTime
                             }),
                             formField({
                                 field: 'appVersion',
@@ -108,5 +109,5 @@ export const clientErrorDetail = hoistCmp.factory(
     }
 );
 
-const valOrNa = v => v != null ? v.toString() : naSpan();
+const valOrNa = v => !isNil(v) ? v.toString() : naSpan();
 const naSpan = () => span({item: 'N/A', className: 'xh-text-color-muted'});

--- a/admin/tabs/activity/clienterrors/ClientErrorDetail.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorDetail.js
@@ -27,7 +27,7 @@ export const clientErrorDetail = hoistCmp.factory(
                 defaultSize: 370
             },
             item: form({
-                fieldDefaults: {inline: true},
+                fieldDefaults: {inline: true, readonlyRenderer: valOrNa},
                 item: hframe(
                     div({
                         className: 'xh-admin-activity-detail__form',
@@ -36,8 +36,7 @@ export const clientErrorDetail = hoistCmp.factory(
                             h3(Icon.info(), 'Error Info'),
                             formField({
                                 field: 'username',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             }),
                             formField({
                                 field: 'dateCreated',
@@ -46,8 +45,7 @@ export const clientErrorDetail = hoistCmp.factory(
                             }),
                             formField({
                                 field: 'appVersion',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             }),
                             formField({
                                 field: 'userAlerted',
@@ -56,24 +54,20 @@ export const clientErrorDetail = hoistCmp.factory(
                             }),
                             formField({
                                 field: 'id',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             }),
                             h3(Icon.desktop(), 'Device / Browser'),
                             formField({
                                 field: 'device',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             }),
                             formField({
                                 field: 'browser',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             }),
                             formField({
                                 field: 'userAgent',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             })
                         ]
                     }),

--- a/admin/tabs/activity/tracking/detail/ActivityDetailView.js
+++ b/admin/tabs/activity/tracking/detail/ActivityDetailView.js
@@ -54,7 +54,7 @@ const detailRecForm = hoistCmp.factory(
                 defaultSize: 370
             },
             item: form({
-                fieldDefaults: {inline: true},
+                fieldDefaults: {inline: true, readonlyRenderer: valOrNa},
                 item: hframe(
                     div({
                         className: 'xh-admin-activity-detail__form',
@@ -73,13 +73,11 @@ const detailRecForm = hoistCmp.factory(
                             }),
                             formField({
                                 field: 'category',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             }),
                             formField({
                                 field: 'msg',
-                                item: textArea(),
-                                readonlyRenderer: valOrNa
+                                item: textArea()
                             }),
                             formField({
                                 field: 'dateCreated',
@@ -98,24 +96,20 @@ const detailRecForm = hoistCmp.factory(
                             }),
                             formField({
                                 field: 'id',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             }),
                             h3(Icon.desktop(), 'Device / Browser'),
                             formField({
                                 field: 'device',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             }),
                             formField({
                                 field: 'browser',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             }),
                             formField({
                                 field: 'userAgent',
-                                item: textInput(),
-                                readonlyRenderer: valOrNa
+                                item: textInput()
                             })
                         ]
                     }),

--- a/cmp/form/Form.js
+++ b/cmp/form/Form.js
@@ -5,9 +5,11 @@
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
 import {elemFactory, hoistCmp, ModelPublishMode, uses} from '@xh/hoist/core';
+import equal from 'fast-deep-equal';
 import PT from 'prop-types';
-import {createContext, useContext, useMemo} from 'react';
+import {createContext, useContext} from 'react';
 import {apiRemoved} from '@xh/hoist/utils/js';
+import {useCachedVal} from '@xh/hoist/utils/react';
 import {FormModel} from './FormModel';
 
 export const FormContext = createContext({});
@@ -27,8 +29,6 @@ const formContextProvider = elemFactory(FormContext.Provider);
  * @see FormField - field-level wrapper component, which labels and displays info for a...
  * @see HoistInput - superclass for the data entry components themselves.
  */
-/* eslint-disable react-hooks/exhaustive-deps */
-
 export const [Form, form] = hoistCmp.withFactory({
     displayName: 'Form',
     model: uses(FormModel, {publishMode: ModelPublishMode.NONE}),
@@ -36,19 +36,16 @@ export const [Form, form] = hoistCmp.withFactory({
     render({model, fieldDefaults, children}) {
         apiRemoved(fieldDefaults?.labelAlign, 'labelAlign', 'Use labelTextAlign instead.');
 
-        const parentContext = useContext(FormContext);
+        // gather own and inherited field defaults...
+        const parentDefaults = useContext(FormContext).fieldDefaults;
+        if (parentDefaults) fieldDefaults = {...parentDefaults, ...fieldDefaults};
 
-        fieldDefaults = {...parentContext.fieldDefaults, ...fieldDefaults};
-
-        const cachedContext = useMemo(
-            () => ({model, fieldDefaults}),
-            [model, JSON.stringify(fieldDefaults)]
+        // ...and deliver as a cached context to avoid spurious re-renders
+        const formContext = useCachedVal(
+            {model, fieldDefaults},
+            (a, b) => a.model === b.model && equal(a.fieldDefaults, b.fieldDefaults)
         );
-
-        return formContextProvider({
-            value: cachedContext,
-            items: children
-        });
+        return formContextProvider({value: formContext, items: children});
     }
 });
 

--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -90,7 +90,8 @@ export const [FormField, formField] = hoistCmp.withFactory({
             label = defaultProp('label', props, formContext, model?.displayName),
             commitOnChange = defaultProp('commitOnChange', props, formContext, undefined),
             tooltipPosition = defaultProp('tooltipPosition', props, formContext, 'right'),
-            tooltipBoundary = defaultProp('tooltipBoundary', props, formContext, 'viewport');
+            tooltipBoundary = defaultProp('tooltipBoundary', props, formContext, 'viewport'),
+            readonlyRenderer = defaultProp('readOnlyRenderer', props, formContext, defaultReadonlyRenderer);
 
         // Styles
         const classes = [childCssName];
@@ -103,7 +104,7 @@ export const [FormField, formField] = hoistCmp.withFactory({
 
 
         let childEl = readonly ?
-            readonlyChild({model, readonlyRenderer: props.readonlyRenderer}) :
+            readonlyChild({model, readonlyRenderer}) :
             editableChild({
                 model,
                 child,
@@ -222,8 +223,8 @@ FormField.propTypes = {
     minimal: PT.bool,
 
     /**
-     * Optional function for use in readonly mode. Called with the Field's current value
-     * and should return an element suitable for presentation to the end-user.
+     * Optional function for use in readonly mode. Called with the Field's current value and should
+     * return an element suitable for presentation to the end-user. Defaulted from containing Form.
      */
     readonlyRenderer: PT.func,
 
@@ -253,9 +254,8 @@ const readonlyChild = hoistCmp.factory({
     model: false,
 
     render({model, readonlyRenderer}) {
-        const value = model ? model['value'] : null,
-            renderer = withDefault(readonlyRenderer, defaultReadonlyRenderer);
-        return div({className: 'xh-form-field-readonly-display', item: renderer(value)});
+        const value = model ? model['value'] : null;
+        return div({className: 'xh-form-field-readonly-display', item: readonlyRenderer(value)});
     }
 });
 

--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -91,7 +91,7 @@ export const [FormField, formField] = hoistCmp.withFactory({
             commitOnChange = defaultProp('commitOnChange', props, formContext, undefined),
             tooltipPosition = defaultProp('tooltipPosition', props, formContext, 'right'),
             tooltipBoundary = defaultProp('tooltipBoundary', props, formContext, 'viewport'),
-            readonlyRenderer = defaultProp('readOnlyRenderer', props, formContext, defaultReadonlyRenderer);
+            readonlyRenderer = defaultProp('readonlyRenderer', props, formContext, defaultReadonlyRenderer);
 
         // Styles
         const classes = [childCssName];

--- a/mobile/cmp/form/FormField.js
+++ b/mobile/cmp/form/FormField.js
@@ -76,7 +76,8 @@ export const [FormField, formField] = hoistCmp.withFactory({
         const layoutProps =  getLayoutProps(props),
             minimal = defaultProp('minimal', props, formContext, false),
             label = defaultProp('label', props, formContext, model?.displayName),
-            commitOnChange = defaultProp('commitOnChange', props, formContext, undefined);
+            commitOnChange = defaultProp('commitOnChange', props, formContext, undefined),
+            readonlyRenderer = defaultProp('readonlyRenderer', props, formContext, defaultReadonlyRenderer);
 
         // Styles
         const classes = [];
@@ -87,7 +88,7 @@ export const [FormField, formField] = hoistCmp.withFactory({
         if (displayNotValid) classes.push('xh-form-field-invalid');
 
         let childEl = readonly ?
-            readonlyChild({model, readonlyRenderer: props.readonlyRenderer}) :
+            readonlyChild({model, readonlyRenderer}) :
             editableChild({
                 model,
                 child,
@@ -165,8 +166,8 @@ FormField.propTypes = {
     minimal: PT.bool,
 
     /**
-     * Optional function for use in readonly mode. Called with the Field's current value
-     * and should return an element suitable for presentation to the end-user.
+     * Optional function for use in readonly mode. Called with the Field's current value and should
+     * return an element suitable for presentation to the end-user. Defaulted from containing Form.
      */
     readonlyRenderer: PT.func,
 
@@ -179,9 +180,8 @@ const readonlyChild = hoistCmp.factory({
     model: false,
 
     render({model, readonlyRenderer}) {
-        const value = model ? model['value'] : null,
-            renderer = withDefault(readonlyRenderer, defaultReadonlyRenderer);
-        return div({className: 'xh-form-field-readonly-display', item: renderer(value)});
+        const value = model ? model['value'] : null;
+        return div({className: 'xh-form-field-readonly-display', item: readonlyRenderer(value)});
     }
 });
 

--- a/utils/react/Hooks.js
+++ b/utils/react/Hooks.js
@@ -79,3 +79,19 @@ export function useOnScroll(fn) {
         if (node) node.addEventListener('scroll', fn);
     }, []);
 }
+
+/**
+ * Hook to return a cached version of an object.
+ *
+ * This hook is similar useCallback() and useMemo() and
+ * useful for providing stable object references across renders.
+ *
+ * @param {*} val - to be cached and potentially returned in this and subsequent calls.
+ * @param {function} [equalsFn] - If evaluates to true, any cached value will be returned rather
+ *      that the presented val.  If null, any cached value will always be returned.
+ */
+export function useCachedVal(val, equalsFn) {
+    const cache = useRef(val);
+    if (equalsFn && !equalsFn(cache.current, val)) cache.current = val;
+    return cache.current;
+}


### PR DESCRIPTION
Closes #2444
See toolbox PR that cleans up label fieldDefault

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

