### PR TITLE
Use stable 'default' key for StoreFilterField.

### DIFF
--- a/cmp/store/impl/StoreFilterFieldImplModel.js
+++ b/cmp/store/impl/StoreFilterFieldImplModel.js
@@ -123,7 +123,7 @@ export class StoreFilterFieldImplModel extends HoistModel {
         const {store} = this;
         if (!store) return;
 
-        const key = this.xhId,
+        const key = 'default',
             testFn = this.filter,
             filter = testFn ? {key, testFn} : null;
 


### PR DESCRIPTION
StoreFilterField uses a LocalModel, meaning it's `xhId` is not stable if it is removed from the DOM and then re-added (as happens in the column filters popover). Use the stable 'default' key instead.

If devs want to combine other FunctionFilters with a StoreFilterField, they must either give the other FunctionFilters keys or use the existing `StoreFilterField.autoApply: false`  

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

