### PR TITLE
Simplify grouping chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * `Icon` factories now support `intent`.
 * `TreeMapModel` and `SplitTreeMapModel` now supports a `theme` config, accepting the strings
   'light' or 'dark'. Leave it undefined to use the global theme.
+* Various usability improvements and simplifications to `GroupingChooser`.
 ### 🐞 Bug Fixes
 * Fixed an issue preventing `FormField` labels from rendering if `fieldDefaults` was undefined.
 

--- a/desktop/cmp/grouping/GroupingChooser.js
+++ b/desktop/cmp/grouping/GroupingChooser.js
@@ -10,7 +10,6 @@ import {hoistCmp, uses} from '@xh/hoist/core';
 import {button, Button} from '@xh/hoist/desktop/cmp/button';
 import {select, Select} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
-import {toolbar, toolbarSep} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
 import {menu, menuDivider, menuItem, popover} from '@xh/hoist/kit/blueprint';
 import {dragDropContext, draggable, droppable} from '@xh/hoist/kit/react-beautiful-dnd';
@@ -40,9 +39,9 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
         styleButtonAsInput = true,
         ...rest
     }, ref) {
-        const {editorIsOpen, favoritesIsOpen, persistFavorites, value} = model,
+        const {editorIsOpen, favoritesIsOpen, persistFavorites, value, allowEmpty} = model,
             isOpen = editorIsOpen || favoritesIsOpen,
-            label = isEmpty(value) ? emptyText : model.getValueLabel(value),
+            label = isEmpty(value) && allowEmpty ? emptyText : model.getValueLabel(value),
             [layoutProps, buttonProps] = splitLayoutProps(rest);
 
         return box({
@@ -59,6 +58,7 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
                     button({
                         text: label,
                         title: label,
+                        tabIndex: -1,
                         className: classNames(
                             'xh-grouping-chooser-button',
                             styleButtonAsInput ? 'xh-grouping-chooser-button--as-input' : null,
@@ -122,28 +122,29 @@ GroupingChooser.propTypes = {
 // Editor
 //------------------
 const editor = hoistCmp.factory({
-    render({model, popoverWidth, popoverMinHeight, popoverTitle, emptyText}) {
+    render({popoverWidth, popoverMinHeight, popoverTitle, emptyText}) {
         return panel({
             width: popoverWidth,
             minHeight: popoverMinHeight,
             items: [
                 div({className: 'xh-popup__title', item: popoverTitle}),
                 dimensionList({emptyText}),
-                addDimensionControl({omit: !model.addControlShown}),
+                addDimensionControl(),
                 filler()
-            ],
-            bbar: bbar()
+            ]
         });
     }
 });
 
 const dimensionList = hoistCmp.factory({
     render({model, emptyText}) {
-        if (!model.addControlShown && isEmpty(model.pendingValue)) {
-            return hbox({
-                className: 'xh-grouping-chooser__row',
-                items: [filler(), emptyText, filler()]
-            });
+        if (isEmpty(model.pendingValue)) {
+            return model.allowEmpty ?
+                hbox({
+                    className: 'xh-grouping-chooser__row',
+                    items: [filler(), emptyText, filler()]
+                }) :
+                null;
         }
 
         return dragDropContext({
@@ -207,7 +208,8 @@ const dimensionRow = hoistCmp.factory({
                         div({
                             className: 'xh-grouping-chooser__row__grabber',
                             item: Icon.grip({prefix: 'fal'}),
-                            ...dndProps.dragHandleProps
+                            ...dndProps.dragHandleProps,
+                            tabIndex: -1
                         }),
                         div({
                             className: 'xh-grouping-chooser__row__select',
@@ -223,6 +225,7 @@ const dimensionRow = hoistCmp.factory({
                         button({
                             icon: Icon.delete(),
                             intent: 'danger',
+                            tabIndex: -1,
                             className: 'xh-grouping-chooser__row__remove-btn',
                             onClick: () => model.removePendingDimAtIdx(idx)
                         })
@@ -241,6 +244,7 @@ const dimensionRow = hoistCmp.factory({
 
 const addDimensionControl = hoistCmp.factory({
     render({model}) {
+        if (!model.isAddEnabled) return null;
         const options = getDimOptions(model.availableDims, model);
         return div({
             className: 'xh-grouping-chooser__add-control',
@@ -257,47 +261,9 @@ const addDimensionControl = hoistCmp.factory({
                     placeholder: 'Add...',
                     flex: 1,
                     width: null,
-                    autoFocus: true,
-                    openMenuOnFocus: true,
                     hideDropdownIndicator: true,
                     hideSelectedOptionCheck: true,
                     onChange: (newDim) => model.addPendingDim(newDim)
-                })
-            ]
-        });
-    }
-});
-
-const bbar = hoistCmp.factory({
-    render({model}) {
-        const {isAddMode, addDisabledMsg, isValid} = model;
-
-        return toolbar({
-            className: 'xh-grouping-chooser__btn-row',
-            items: [
-                button({
-                    icon: Icon.add(),
-                    text: 'Add',
-                    intent: 'success',
-                    omit: isAddMode,
-                    disabled: !!addDisabledMsg,
-                    title: addDisabledMsg,
-                    onClick: () => model.addLevel()
-                }),
-                filler(),
-                button({
-                    icon: Icon.close(),
-                    title: 'Cancel',
-                    intent: 'danger',
-                    onClick: () => model.closePopover()
-                }),
-                toolbarSep(),
-                button({
-                    icon: Icon.check(),
-                    text: 'Apply',
-                    intent: 'success',
-                    disabled: !isValid,
-                    onClick: () => model.commitPendingValueAndClose()
                 })
             ]
         });

--- a/desktop/cmp/grouping/GroupingChooser.js
+++ b/desktop/cmp/grouping/GroupingChooser.js
@@ -33,7 +33,7 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
         className,
         emptyText = 'Ungrouped',
         popoverWidth = 250,
-        popoverMinHeight = 120,
+        popoverMinHeight,
         popoverTitle = 'Group By',
         popoverPosition = 'bottom',
         styleButtonAsInput = true,

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -37,8 +37,8 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
         popoverTitle = 'Group By',
         ...rest
     }, ref) {
-        const {value} = model,
-            label = isEmpty(value) ? emptyText : model.getValueLabel(value),
+        const {value, allowEmpty} = model,
+            label = isEmpty(value) && allowEmpty ? emptyText : model.getValueLabel(value),
             [layoutProps, buttonProps] = splitLayoutProps(rest);
 
         return box({
@@ -83,7 +83,7 @@ GroupingChooser.propTypes = {
 //---------------------------
 const popoverCmp = hoistCmp.factory(
     ({model, popoverTitle, popoverWidth, popoverMinHeight, emptyText}) => {
-        const {editorIsOpen, favoritesIsOpen, isAddMode, addDisabledMsg, isValid, value} = model,
+        const {editorIsOpen, favoritesIsOpen, value} = model,
             isOpen = editorIsOpen || favoritesIsOpen,
             addFavoriteDisabled = isEmpty(value) || !!model.isFavorite(value);
 
@@ -109,27 +109,7 @@ const popoverCmp = hoistCmp.factory(
                         onClick: () => model.addFavorite(model.value)
                     })
                 ] :
-                [
-                    button({
-                        icon: Icon.add(),
-                        text: 'Add',
-                        disabled: !!addDisabledMsg,
-                        omit: isAddMode,
-                        onClick: () => model.addLevel()
-                    }),
-                    filler(),
-                    button({
-                        icon: Icon.close(),
-                        modifier: 'quiet',
-                        onClick: () => model.closePopover()
-                    }),
-                    button({
-                        icon: Icon.check(),
-                        text: 'Apply',
-                        disabled: !isValid,
-                        onClick: () => model.commitPendingValueAndClose()
-                    })
-                ]
+                []
         });
     }
 );
@@ -138,21 +118,23 @@ const popoverCmp = hoistCmp.factory(
 // Editor
 //------------------
 const editor = hoistCmp.factory({
-    render({model, emptyText}) {
+    render({emptyText}) {
         return vbox(
             dimensionList({emptyText}),
-            addDimensionControl({omit: !model.addControlShown})
+            addDimensionControl()
         );
     }
 });
 
 const dimensionList = hoistCmp.factory({
     render({model, emptyText}) {
-        if (!model.addControlShown && isEmpty(model.pendingValue)) {
-            return hbox({
-                className: 'xh-grouping-chooser__row',
-                items: [filler(), emptyText, filler()]
-            });
+        if (isEmpty(model.pendingValue)) {
+            return model.allowEmpty ?
+                hbox({
+                    className: 'xh-grouping-chooser__row',
+                    items: [filler(), emptyText, filler()]
+                }) :
+                null;
         }
 
         return dragDropContext({
@@ -222,6 +204,7 @@ const dimensionRow = hoistCmp.factory({
 
 const addDimensionControl = hoistCmp.factory({
     render({model}) {
+        if (!model.isAddEnabled) return null;
         const options = getDimOptions(model.availableDims, model);
         return div({
             className: 'xh-grouping-chooser__add-control',
@@ -234,7 +217,6 @@ const addDimensionControl = hoistCmp.factory({
                     placeholder: 'Add...',
                     flex: 1,
                     width: null,
-                    autoFocus: true,
                     hideDropdownIndicator: true,
                     hideSelectedOptionCheck: true,
                     onChange: (newDim) => model.addPendingDim(newDim)

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -83,7 +83,7 @@ GroupingChooser.propTypes = {
 //---------------------------
 const popoverCmp = hoistCmp.factory(
     ({model, popoverTitle, popoverWidth, popoverMinHeight, emptyText}) => {
-        const {editorIsOpen, favoritesIsOpen, value} = model,
+        const {editorIsOpen, favoritesIsOpen, isValid, value} = model,
             isOpen = editorIsOpen || favoritesIsOpen,
             addFavoriteDisabled = isEmpty(value) || !!model.isFavorite(value);
 
@@ -98,7 +98,7 @@ const popoverCmp = hoistCmp.factory(
                 minHeight: popoverMinHeight,
                 item: favoritesIsOpen ? favoritesMenu() : editor({emptyText})
             }),
-            onCancel: () => model.commitPendingValueAndClose(),
+            onCancel: () => model.closePopover(),
             buttons: favoritesIsOpen ?
                 [
                     button({
@@ -109,7 +109,20 @@ const popoverCmp = hoistCmp.factory(
                         onClick: () => model.addFavorite(model.value)
                     })
                 ] :
-                []
+                [
+                    filler(),
+                    button({
+                        text: 'Cancel',
+                        modifier: 'quiet',
+                        onClick: () => model.closePopover()
+                    }),
+                    button({
+                        icon: Icon.check(),
+                        text: 'Apply',
+                        disabled: !isValid,
+                        onClick: () => model.commitPendingValueAndClose()
+                    })
+                ]
         });
     }
 );

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -33,7 +33,7 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
         className,
         emptyText = 'Ungrouped',
         popoverWidth = 270,
-        popoverMinHeight = 120,
+        popoverMinHeight,
         popoverTitle = 'Group By',
         ...rest
     }, ref) {


### PR DESCRIPTION
Based on a discussion with ATM, decided to take a crack at this simplification we have been talking about for a while.   

I was originally the one against always showing the "Add..." control, but I actually think this is much better and has far fewer UI elements/state.  Sorry!

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

