### PR TITLE
Stop click events from emanating from certain popovers.

### DIFF
--- a/desktop/cmp/button/ColChooserButton.js
+++ b/desktop/cmp/button/ColChooserButton.js
@@ -10,7 +10,7 @@ import {hoistCmp, useContextModel} from '@xh/hoist/core';
 import {colChooser} from '@xh/hoist/desktop/cmp/grid/impl/colchooser/ColChooser';
 import {Icon} from '@xh/hoist/icon';
 import {popover} from '@xh/hoist/kit/blueprint';
-import {withDefault} from '@xh/hoist/utils/js';
+import {withDefault, stopPropagation} from '@xh/hoist/utils/js';
 import PT from 'prop-types';
 import {button, Button} from './Button';
 
@@ -51,16 +51,14 @@ export const [ColChooserButton, colChooserButton] = hoistCmp.withFactory({
                 ...rest
             }),
             disabled,
-            content: vbox(
-                div({
-                    ref,
-                    className: 'xh-popup__title',
-                    item: 'Choose Columns'
-                }),
-                colChooser({
-                    model: colChooserModel
-                })
-            ),
+            content: vbox({
+                onClick: stopPropagation,
+                onDoubleClick: stopPropagation,
+                items: [
+                    div({ref, className: 'xh-popup__title', item: 'Choose Columns'}),
+                    colChooser({model: colChooserModel})
+                ]
+            }),
             onInteraction: (willOpen) => {
                 if (willOpen) {
                     colChooserModel.openPopover();

--- a/desktop/cmp/grid/impl/filter/ColumnHeaderFilter.js
+++ b/desktop/cmp/grid/impl/filter/ColumnHeaderFilter.js
@@ -13,6 +13,7 @@ import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {buttonGroup, button} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {FieldType} from '@xh/hoist/data';
+import {stopPropagation} from '@xh/hoist/utils/js';
 
 import './ColumnHeaderFilter.scss';
 import {ColumnHeaderFilterModel} from './ColumnHeaderFilterModel';
@@ -53,12 +54,13 @@ export const columnHeaderFilter = hoistCmp.factory({
 });
 
 const content = hoistCmp.factory({
-    render({model}) {
+    render() {
         return panel({
             title: `Filter`,
             className: 'xh-column-header-filter',
             compactHeader: true,
-            onClick: (e) => e.stopPropagation(),
+            onClick: stopPropagation,
+            onDoubleClick: stopPropagation,
             headerItems: [switcher()],
             item: tabContainer(),
             bbar: bbar()

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -15,7 +15,7 @@ import {datePicker as bpDatePicker, popover} from '@xh/hoist/kit/blueprint';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 import {isLocalDate, LocalDate} from '@xh/hoist/utils/datetime';
-import {warnIf, withDefault} from '@xh/hoist/utils/js';
+import {warnIf, withDefault, consumeEvent} from '@xh/hoist/utils/js';
 import {getLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {assign, castArray, clone, trim} from 'lodash';
@@ -241,12 +241,12 @@ class Model extends HoistInputModel {
     onClearBtnClick = (ev) => {
         this.noteValueChange(null);
         this.doCommit();
-        this.consumeEvent(ev);
+        consumeEvent(ev);
     };
 
     onOpenPopoverClick = (ev) => {
         this.setPopoverOpen(!this.popoverOpen);
-        this.consumeEvent(ev);
+        consumeEvent(ev);
     };
 
     onKeyDown = (ev) => {
@@ -254,10 +254,10 @@ class Model extends HoistInputModel {
             this.doCommit();
         } else if (this.popoverOpen && ev.key === 'Escape') {
             this.setPopoverOpen(false);
-            this.consumeEvent(ev);
+            consumeEvent(ev);
         } else if (!this.popoverOpen && ['ArrowUp', 'ArrowDown'].includes(ev.key)) {
             this.setPopoverOpen(true);
-            this.consumeEvent(ev);
+            consumeEvent(ev);
         }
     };
 
@@ -358,11 +358,6 @@ class Model extends HoistInputModel {
     parseDate(dateString, strictInputParsing = this.strictInputParsing) {
         const parsedMoment = moment(dateString, this.getParseStrings(), strictInputParsing);
         return parsedMoment.isValid() ? parsedMoment.toDate() : null;
-    }
-
-    consumeEvent(e) {
-        e.preventDefault();
-        e.stopPropagation();
     }
 }
 

--- a/mobile/cmp/navigator/impl/swipe/Swiper.js
+++ b/mobile/cmp/navigator/impl/swipe/Swiper.js
@@ -3,6 +3,7 @@ import {computed, observable, action, makeObservable} from '@xh/hoist/mobx';
 import {frame} from '@xh/hoist/cmp/layout';
 import {gestureDetector} from '@xh/hoist/kit/onsen';
 import {isFinite} from 'lodash';
+import {consumeEvent} from '@xh/hoist/utils/js';
 
 import './Swiper.scss';
 import {NavigatorModel} from '../../NavigatorModel';
@@ -71,7 +72,7 @@ class LocalModel extends HoistModel {
             !this.isDraggingChild(e, 'right')
         ) {
             this.backStart();
-            this.consumeEvent(e);
+            consumeEvent(e);
             return;
         }
 
@@ -82,7 +83,7 @@ class LocalModel extends HoistModel {
             !this.isDraggingChild(e, 'down')
         ) {
             this.refreshStart();
-            this.consumeEvent(e);
+            consumeEvent(e);
             return;
         }
     }
@@ -100,7 +101,7 @@ class LocalModel extends HoistModel {
                 return;
             }
             this.backProgress = Math.clamp(deltaX / 150, 0, 1);
-            this.consumeEvent(e);
+            consumeEvent(e);
             return;
         }
 
@@ -111,7 +112,7 @@ class LocalModel extends HoistModel {
                 return;
             }
             this.refreshProgress = Math.clamp(deltaY / 150, 0, 1);
-            this.consumeEvent(e);
+            consumeEvent(e);
             return;
         }
     }
@@ -122,20 +123,15 @@ class LocalModel extends HoistModel {
         if (this.backStarted) {
             if (this.backCompleted) XH.popRoute();
             this.backEnd();
-            this.consumeEvent(e);
+            consumeEvent(e);
         }
 
         // Refresh
         if (this.refreshStarted) {
             if (this.refreshCompleted) XH.refreshAppAsync();
             this.refreshEnd();
-            this.consumeEvent(e);
+            consumeEvent(e);
         }
-    }
-
-    consumeEvent(e) {
-        e.preventDefault();
-        e.stopPropagation();
     }
 
     isDraggingChild(e, dir) {

--- a/utils/js/DomUtils.js
+++ b/utils/js/DomUtils.js
@@ -86,3 +86,23 @@ export function observeVisibleChange(fn, node) {
     ret.observe(node);
     return ret;
 }
+
+/**
+ * A convenience handler that will call 'stopPropagation'
+ * and 'preventDefault' on an event.
+ *
+ * @param {Event} e
+ */
+export function consumeEvent(e) {
+    e.stopPropagation();
+    e.preventDefault();
+}
+
+/**
+ * A convenience handler that will 'stopPropagation' on an event.
+ *
+ * @param {Event} e
+ */
+export function stopPropagation(e) {
+    e.stopPropagation();
+}


### PR DESCRIPTION
+ Stop click events from emanating from certain popovers.
+ New utility handlers for handling events.

I spent way too much time on this, working on a more general solution to wrap all of our popovers.  I think the risk and churn for that is not a good idea, given that we will be upgrading to popover 2 in a future release and changing a number of things with our usage of popovers then.  I will comment that ticket and link it to the tickets related to this pr.

I think this more minimal patch moves us in the right direction and allows us to close these tickets.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

