### PR TITLE
applyColumnStateChanges only if not equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ## v43.0.0-SNAPSHOT - unreleased
 
 * Added support for `queryFn` to mobile Select input.
-* `Grid`: applyColumnStateChanges` only applies changes if a diff exists, 
-  so unnecessary mobx reactions are not triggered.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v42.2.0...develop)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v43.0.0-SNAPSHOT - unreleased
 
 * Added support for `queryFn` to mobile Select input.
+* `Grid`: applyColumnStateChanges` only applies changes if a diff exists, 
+  so unnecessary mobx reactions are not triggered.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v42.2.0...develop)
 

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -848,7 +848,9 @@ export class GridModel extends HoistModel {
             columnState = this.sortColumns(columnState);
         }
 
-        this.columnState = columnState;
+        if (!equal(this.columnState, columnState)) {
+            this.columnState = columnState;
+        }
     }
 
     /**

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -806,8 +806,9 @@ export class GridModel extends HoistModel {
     }
 
     /**
-     * This method will update the current column definition. Throws an exception if any of the
-     * columns provided in colStateChanges are not present in the current column list.
+     * This method will update the current column definition if it has changed. 
+     * Throws an exception if any of the columns provided in colStateChanges are not 
+     * present in the current column list.
      *
      * Note: Column ordering is determined by the individual (leaf-level) columns in state.
      * This means that if a column has been redefined to a new column group, that entire group may


### PR DESCRIPTION
This change is an alternative solution to the solutions one would likely consider for this _sortOrder issue: 
https://github.com/xh/hoist-react/issues/2631

The reason the _sortOrder setting was picked up in a client app is because the first change to trigger a diff check in the viewManager was a "non-change" of setting a column's hidden key to true when it is already true.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry.
- [x] Reviewed for breaking changes: no breaking changes.
- [x] Updated doc comments.
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

