### PR TITLE
Remove _sortId artifact on grid column state

### DIFF
--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -46,8 +46,7 @@ import {
     max,
     min,
     omit,
-    pull,
-    sortBy
+    pull
 } from 'lodash';
 import {GridPersistenceModel} from './impl/GridPersistenceModel';
 import {GridSorter} from './impl/GridSorter';
@@ -806,8 +805,8 @@ export class GridModel extends HoistModel {
     }
 
     /**
-     * This method will update the current column definition if it has changed. 
-     * Throws an exception if any of the columns provided in colStateChanges are not 
+     * This method will update the current column definition if it has changed.
+     * Throws an exception if any of the columns provided in colStateChanges are not
      * present in the current column list.
      *
      * Note: Column ordering is determined by the individual (leaf-level) columns in state.
@@ -836,17 +835,8 @@ export class GridModel extends HoistModel {
         });
 
         // 2) If the changes provided is a full list of leaf columns, synchronize the sort order
-        const leafCols = this.getLeafColumns();
-        if (colStateChanges.length === leafCols.length) {
-            // 2.a) Mark (potentially changed) sort order
-            colStateChanges.forEach((change, index) => {
-                const col = this.findColumn(columnState, change.colId);
-                col._sortOrder = index;
-            });
-
-            // 2.b) Install implied group sort orders and sort
-            columnState.forEach(it => this.markGroupSortOrder(it));
-            columnState = this.sortColumns(columnState);
+        if (colStateChanges.length === this.getLeafColumns().length) {
+            columnState = colStateChanges.map(c => this.findColumn(columnState, c.colId));
         }
 
         if (!equal(this.columnState, columnState)) {
@@ -1183,23 +1173,6 @@ export class GridModel extends HoistModel {
         });
 
         return leaves;
-    }
-
-    markGroupSortOrder(col) {
-        if (col.groupId) {
-            col.children.forEach(child => this.markGroupSortOrder(child));
-            col._sortOrder = col.children[0]._sortOrder;
-        }
-    }
-
-    sortColumns(columns) {
-        columns.forEach(col => {
-            if (col.children) {
-                col.children = this.sortColumns(col.children);
-            }
-        });
-
-        return sortBy(columns, [it => it._sortOrder]);
     }
 
     collectIds(cols, ids = []) {


### PR DESCRIPTION
Normally would avoid this kind of fiddly cleanup change, but `_sortId` it is a rather ugly artifact in a very core piece of configuration data for us.  Also, gets us a nice cleanup.

Main point is that our column state is always only leaves at this point, and we should not need this exotic sorting.  

Will be sure to have Don take a look -- have already run it by Tom and John Haynes

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [xX] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

