### PR TITLE
TreeMaps use a light border in dark theme to improve legibility

### DIFF
--- a/desktop/cmp/treemap/TreeMap.js
+++ b/desktop/cmp/treemap/TreeMap.js
@@ -13,6 +13,7 @@ import {wait} from '@xh/hoist/promise';
 import {logWithDebug, withDebug} from '@xh/hoist/utils/js';
 import {createObservableRef, getLayoutProps, useOnResize, useOnVisibleChange} from '@xh/hoist/utils/react';
 import {assign, cloneDeep, debounce, isFunction, merge, omit} from 'lodash';
+import classNames from 'classnames';
 import composeRefs from '@seznam/compose-react-refs';
 import equal from 'fast-deep-equal';
 import PT from 'prop-types';
@@ -80,7 +81,10 @@ export const [TreeMap, treeMap] = hoistCmp.withFactory({
 
         return box({
             ...layoutProps,
-            className,
+            className: classNames(
+                className,
+                `xh-treemap--${impl.theme}`
+            ),
             ref,
             items
         });
@@ -101,6 +105,11 @@ class LocalModel extends HoistModel {
     chart = null;
     clickCount = 0;
 
+    get theme() {
+        if (this.model.theme) return this.model.theme;
+        return XH.darkTheme ? 'dark' : 'light';
+    }
+
     constructor(model) {
         super();
         this.model = model;
@@ -115,8 +124,7 @@ class LocalModel extends HoistModel {
             model.highchartsConfig,
             model.algorithm,
             model.data,
-            model.theme,
-            XH.darkTheme
+            this.theme
         ]);
 
         this.addReaction({
@@ -261,8 +269,7 @@ class LocalModel extends HoistModel {
     }
 
     getColorConfig() {
-        const {theme} = this.model,
-            darkTheme = theme ? theme === 'dark' : XH.darkTheme;
+        const darkTheme = this.theme === 'dark';
         return {
             colorAxis: {
                 min: 0,

--- a/desktop/cmp/treemap/TreeMap.scss
+++ b/desktop/cmp/treemap/TreeMap.scss
@@ -40,6 +40,11 @@
     font-size: var(--xh-font-size-small-px) !important;
     font-weight: normal !important;
   }
+
+  // Use white borders in dark theme
+  &--dark rect.highcharts-point {
+    outline-color: rgba(255, 255, 255, 0.2);
+  }
 }
 
 .xh-treemap-tooltip {


### PR DESCRIPTION
+ TreeMaps apply their own theme CSS class, since their theme can be decoupled from the global theme
Fixes: https://github.com/xh/hoist-react/issues/2644

<img width="2049" alt="Screenshot 2021-09-03 at 10 31 50" src="https://user-images.githubusercontent.com/3017757/131984003-71f8c88f-2127-4441-bfda-40ee8bbde104.png">

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

