### PR TITLE
OR CompoundFilter fixes

### DIFF
--- a/cmp/grid/filter/GridFilterModel.js
+++ b/cmp/grid/filter/GridFilterModel.js
@@ -71,7 +71,14 @@ export class GridFilterModel extends HoistModel {
      */
     @action
     setColumnFilters(field, filter) {
-        const ret = withFilterByField(this.filter, filter, field);
+        // If current bound filter is an 'OR' CompoundFilter, wrap it in an 'AND'
+        // CompoundFilter so new columns get 'ANDed' alongside it.
+        let currFilter = this.filter;
+        if (currFilter?.isCompoundFilter && currFilter.op === 'OR') {
+            currFilter = {filters: [currFilter], op: 'AND'};
+        }
+
+        const ret = withFilterByField(currFilter, filter, field);
         this.setFilter(ret);
     }
 

--- a/cmp/store/impl/StoreFilterFieldImplModel.js
+++ b/cmp/store/impl/StoreFilterFieldImplModel.js
@@ -127,7 +127,14 @@ export class StoreFilterFieldImplModel extends HoistModel {
             testFn = this.filter,
             filter = testFn ? {key, testFn} : null;
 
-        const ret = withFilterByKey(store.filter, filter, key);
+        // If current Store filter is an 'OR' CompoundFilter, wrap it in an 'AND'
+        // CompoundFilter so this FunctionFilter gets 'ANDed' alongside it.
+        let currFilter = store.filter;
+        if (currFilter?.isCompoundFilter && currFilter.op === 'OR') {
+            currFilter = {filters: [currFilter], op: 'AND'};
+        }
+
+        const ret = withFilterByKey(currFilter, filter, key);
         store.setFilter(ret);
     }
 

--- a/data/filter/Utils.js
+++ b/data/filter/Utils.js
@@ -60,11 +60,14 @@ export function parseFilter(spec) {
  * @return {Filter} - the new Filter
  */
 export function withFilterByField(filter, newFilter, field) {
-    const currFilters = filter?.isCompoundFilter ? filter.filters : [filter],
+    const isCompoundFilter = filter?.filters,
+        currFilters = isCompoundFilter ? filter.filters : [filter],
         ret = currFilters.filter(it => it && it.field !== field);
 
     ret.push(...castArray(newFilter));
-    return parseFilter(ret);
+    return isCompoundFilter ?
+        parseFilter({filters: ret, op: filter.op}) :
+        parseFilter(ret);
 }
 
 /**
@@ -75,11 +78,14 @@ export function withFilterByField(filter, newFilter, field) {
  * @return {Filter} - the new Filter
  */
 export function withFilterByKey(filter, newFilter, key) {
-    const currFilters = filter?.isCompoundFilter ? filter.filters : [filter],
+    const isCompoundFilter = filter?.isCompoundFilter,
+        currFilters = isCompoundFilter ? filter.filters : [filter],
         ret = currFilters.filter(it => it && it.key !== key);
 
     ret.push(...castArray(newFilter));
-    return parseFilter(ret);
+    return isCompoundFilter ?
+        parseFilter({filters: ret, op: filter.op}) :
+        parseFilter(ret);
 }
 
 /**
@@ -90,7 +96,8 @@ export function withFilterByKey(filter, newFilter, key) {
  * @return {Filter} - the new Filter
  */
 export function withFilterByTypes(filter, newFilter, types) {
-    const currFilters = filter?.isCompoundFilter ? filter.filters : [filter];
+    const isCompoundFilter = filter?.isCompoundFilter,
+        currFilters = isCompoundFilter ? filter.filters : [filter];
 
     const ret = currFilters.filter(it => {
         for (const type of castArray(types)) {
@@ -102,7 +109,9 @@ export function withFilterByTypes(filter, newFilter, types) {
     });
 
     ret.push(...castArray(newFilter));
-    return parseFilter(ret);
+    return isCompoundFilter ?
+        parseFilter({filters: ret, op: filter.op}) :
+        parseFilter(ret);
 }
 
 /**


### PR DESCRIPTION
The first part of this PR addresses https://github.com/xh/hoist-react/issues/2640. This is fixed by updating the `withFilterByXXX` util methods respect the original `AND|OR` operator when modifying a CompoundFilter. Previously they would only create `AND` CompoundFilters.

Fixing this revealed a further issue. If your root-level filter was an `OR` CompoundFilter, adding new filters with the `GridFilterModel` or `StoreFilterField` would add these to the `OR` filter, resulting in undesirable behaviour. This PR also addresses that, by wrapping in an `AND` before modifying. This is safe to do, since if no new filters are added or just the original filter is replaced, the single child `AND` filter is discarded by `parseFilter()`.

Note: To test creating a root-level OR filter, use the Custom Filter tab on one column and add a `begins` filter and an `ends` filter.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

