### PR TITLE
Setup grid cell sizes for groupUseEntireRow = false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🐞 Bug Fixes
 
 * Better coverage of Fetch abort error.
+* Grid SizingMode styles fixed to support agGrid `groupUseEntireRow = false`
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v42.4.0..develop)
 

--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -243,9 +243,15 @@
       font-size: var(--xh-grid-large-header-font-size-px);
     }
 
+    .ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {
+      height: var(--xh-grid-large-cell-height-px);
+    }
+
+    .ag-full-width-row .ag-cell-wrapper.ag-row-group,
     .ag-cell {
       padding-left: var(--xh-grid-large-cell-lr-pad-px);
       padding-right: var(--xh-grid-large-cell-lr-pad-px);
+      line-height: var(--xh-grid-large-cell-height-px);
     }
 
     .ag-header-cell,
@@ -265,9 +271,15 @@
       font-size: var(--xh-grid-compact-header-font-size-px);
     }
 
+    .ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {
+      height: var(--xh-grid-compact-cell-height-px);
+    }
+
+    .ag-full-width-row .ag-cell-wrapper.ag-row-group,
     .ag-cell {
       padding-left: var(--xh-grid-compact-cell-lr-pad-px);
       padding-right: var(--xh-grid-compact-cell-lr-pad-px);
+      line-height: var(--xh-grid-compact-cell-height-px);
     }
 
     .ag-header-cell,
@@ -287,9 +299,15 @@
       font-size: var(--xh-grid-tiny-header-font-size-px);
     }
 
+    .ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {
+      height: var(--xh-grid-tiny-cell-height-px);
+    }
+
+    .ag-full-width-row .ag-cell-wrapper.ag-row-group,
     .ag-cell {
       padding-left: var(--xh-grid-tiny-cell-lr-pad-px);
       padding-right: var(--xh-grid-tiny-cell-lr-pad-px);
+      line-height: var(--xh-grid-tiny-cell-height-px);
 
       .xh-check-box {
         padding-top: 1px;

--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -194,6 +194,9 @@
       text-overflow: ellipsis;
       min-width: 0;
     }
+    .ag-row-group {
+      align-items: center;
+    }
   }
 
   // Cell borders
@@ -243,15 +246,9 @@
       font-size: var(--xh-grid-large-header-font-size-px);
     }
 
-    .ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {
-      height: var(--xh-grid-large-cell-height-px);
-    }
-
-    .ag-full-width-row .ag-cell-wrapper.ag-row-group,
     .ag-cell {
       padding-left: var(--xh-grid-large-cell-lr-pad-px);
       padding-right: var(--xh-grid-large-cell-lr-pad-px);
-      line-height: var(--xh-grid-large-cell-height-px);
     }
 
     .ag-header-cell,
@@ -271,15 +268,9 @@
       font-size: var(--xh-grid-compact-header-font-size-px);
     }
 
-    .ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {
-      height: var(--xh-grid-compact-cell-height-px);
-    }
-
-    .ag-full-width-row .ag-cell-wrapper.ag-row-group,
     .ag-cell {
       padding-left: var(--xh-grid-compact-cell-lr-pad-px);
       padding-right: var(--xh-grid-compact-cell-lr-pad-px);
-      line-height: var(--xh-grid-compact-cell-height-px);
     }
 
     .ag-header-cell,
@@ -299,15 +290,9 @@
       font-size: var(--xh-grid-tiny-header-font-size-px);
     }
 
-    .ag-cell-wrapper > *:not(.ag-cell-value):not(.ag-group-value) {
-      height: var(--xh-grid-tiny-cell-height-px);
-    }
-
-    .ag-full-width-row .ag-cell-wrapper.ag-row-group,
     .ag-cell {
       padding-left: var(--xh-grid-tiny-cell-lr-pad-px);
       padding-right: var(--xh-grid-tiny-cell-lr-pad-px);
-      line-height: var(--xh-grid-tiny-cell-height-px);
 
       .xh-check-box {
         padding-top: 1px;

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -387,8 +387,6 @@ body {
   --xh-grid-large-cell-lr-pad-px: calc(var(--xh-grid-large-cell-lr-pad) * 1px);
   --xh-grid-large-font-size: var(--grid-large-font-size, 14);
   --xh-grid-large-font-size-px: calc(var(--xh-grid-large-font-size) * 1px);
-  --xh-grid-large-cell-height: var(--grid-large-cell-height, 30);
-  --xh-grid-large-cell-height-px: calc(var(--xh-grid-large-cell-height) * 1px);
   --xh-grid-large-header-font-size: var(--grid-large-header-font-size, var(--xh-grid-large-font-size));
   --xh-grid-large-header-font-size-px: calc(var(--xh-grid-large-header-font-size) * 1px);
   --xh-grid-large-header-lr-pad: var(--grid-large-header-lr-pad, 12);
@@ -399,8 +397,6 @@ body {
   --xh-grid-compact-cell-lr-pad-px: calc(var(--xh-grid-compact-cell-lr-pad) * 1px);
   --xh-grid-compact-font-size: var(--grid-compact-font-size, 12);
   --xh-grid-compact-font-size-px: calc(var(--xh-grid-compact-font-size) * 1px);
-  --xh-grid-compact-cell-height: var(--grid-compact-cell-height, 21);
-  --xh-grid-compact-cell-height-px: calc(var(--xh-grid-compact-cell-height) * 1px);
   --xh-grid-compact-header-font-size: var(--grid-compact-header-font-size, var(--xh-grid-compact-font-size));
   --xh-grid-compact-header-font-size-px: calc(var(--xh-grid-compact-header-font-size) * 1px);
   --xh-grid-compact-header-lr-pad: var(--grid-compact-header-lr-pad, 6);
@@ -411,8 +407,6 @@ body {
   --xh-grid-tiny-cell-lr-pad-px: calc(var(--xh-grid-tiny-cell-lr-pad) * 1px);
   --xh-grid-tiny-font-size: var(--grid-tiny-font-size, 11);
   --xh-grid-tiny-font-size-px: calc(var(--xh-grid-tiny-font-size) * 1px);
-  --xh-grid-tiny-cell-height: var(--grid-tiny-cell-height, 16);
-  --xh-grid-tiny-cell-height-px: calc(var(--xh-grid-tiny-cell-height) * 1px);
   --xh-grid-tiny-header-font-size: var(--grid-tiny-header-font-size, var(--xh-grid-tiny-font-size));
   --xh-grid-tiny-header-font-size-px: calc(var(--xh-grid-tiny-header-font-size) * 1px);
   --xh-grid-tiny-header-lr-pad: var(--grid-tiny-header-lr-pad, 4);

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -387,6 +387,8 @@ body {
   --xh-grid-large-cell-lr-pad-px: calc(var(--xh-grid-large-cell-lr-pad) * 1px);
   --xh-grid-large-font-size: var(--grid-large-font-size, 14);
   --xh-grid-large-font-size-px: calc(var(--xh-grid-large-font-size) * 1px);
+  --xh-grid-large-cell-height: var(--grid-large-cell-height, 30);
+  --xh-grid-large-cell-height-px: calc(var(--xh-grid-large-cell-height) * 1px);
   --xh-grid-large-header-font-size: var(--grid-large-header-font-size, var(--xh-grid-large-font-size));
   --xh-grid-large-header-font-size-px: calc(var(--xh-grid-large-header-font-size) * 1px);
   --xh-grid-large-header-lr-pad: var(--grid-large-header-lr-pad, 12);
@@ -397,6 +399,8 @@ body {
   --xh-grid-compact-cell-lr-pad-px: calc(var(--xh-grid-compact-cell-lr-pad) * 1px);
   --xh-grid-compact-font-size: var(--grid-compact-font-size, 12);
   --xh-grid-compact-font-size-px: calc(var(--xh-grid-compact-font-size) * 1px);
+  --xh-grid-compact-cell-height: var(--grid-compact-cell-height, 21);
+  --xh-grid-compact-cell-height-px: calc(var(--xh-grid-compact-cell-height) * 1px);
   --xh-grid-compact-header-font-size: var(--grid-compact-header-font-size, var(--xh-grid-compact-font-size));
   --xh-grid-compact-header-font-size-px: calc(var(--xh-grid-compact-header-font-size) * 1px);
   --xh-grid-compact-header-lr-pad: var(--grid-compact-header-lr-pad, 6);
@@ -407,6 +411,8 @@ body {
   --xh-grid-tiny-cell-lr-pad-px: calc(var(--xh-grid-tiny-cell-lr-pad) * 1px);
   --xh-grid-tiny-font-size: var(--grid-tiny-font-size, 11);
   --xh-grid-tiny-font-size-px: calc(var(--xh-grid-tiny-font-size) * 1px);
+  --xh-grid-tiny-cell-height: var(--grid-tiny-cell-height, 16);
+  --xh-grid-tiny-cell-height-px: calc(var(--xh-grid-tiny-cell-height) * 1px);
   --xh-grid-tiny-header-font-size: var(--grid-tiny-header-font-size, var(--xh-grid-tiny-font-size));
   --xh-grid-tiny-header-font-size-px: calc(var(--xh-grid-tiny-header-font-size) * 1px);
   --xh-grid-tiny-header-lr-pad: var(--grid-tiny-header-lr-pad, 4);


### PR DESCRIPTION
I was enthusiastically adding the app-wide Grid Sizing options in the Navbar App Menu for a client app, when I discovered that the Tiny, Compact, and Large sizes did not produce good group row sizes when the grid is using:

```
                    agOptions: {
                        groupUseEntireRow: false,
                        groupSuppressAutoColumn: true
                    }
```

which this client app uses A LOT.

This issue is reproducible in Toolbox in this branch: https://github.com/xh/toolbox/tree/groupUseEntireRow_false on the "Grouped Columns Grid", where I have set this agOptions config.

Here is a screenshot of the issue in toolbox:
<img width="659" alt="gridCssError" src="https://user-images.githubusercontent.com/2573928/132545053-580af087-d8f6-44e5-b983-eacf82a6e6d2.png">


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry.
- [x] Reviewed for breaking changes: no breaking changes.
- [x] Updated doc comments: not required.
- [x] Reviewed and tested on Mobile.
- [x] Created Toolbox branch: https://github.com/xh/toolbox/tree/groupUseEntireRow_false
**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

