### PR TITLE
Document rowClassRules in DataViewModel

### DIFF
--- a/cmp/dataview/DataViewModel.js
+++ b/cmp/dataview/DataViewModel.js
@@ -52,6 +52,11 @@ export class DataViewModel extends HoistModel {
      *      or token strings with which to create grid context menu items.  May also be specified
      *      as a function returning a StoreContextMenu. Desktop only.
      * @param {RowClassFn} [c.rowClassFn] - closure to generate CSS class names for a row.
+     *      NOTE that, once added, classes will *not* be removed if the data changes.
+     *      Use `rowClassRules` instead if Record data can change across refreshes.
+     * @param {Object.<string, RowClassRuleFn>} [c.rowClassRules] - object keying CSS
+     *      class names to functions determining if they should be added or removed from the row.
+     *      See Ag-Grid docs on "row styles" for details.
      * @param {function} [c.onRowClicked] - Callback when a row is clicked. Function will receive an
      *      event with a data node containing the row's data. (Note that this may be null - e.g. for
      *      clicks on group rows.)
@@ -77,6 +82,7 @@ export class DataViewModel extends HoistModel {
         stripeRows = false,
         contextMenu = null,
         rowClassFn,
+        rowClassRules,
         onRowClicked,
         onRowDoubleClicked,
         ...restArgs
@@ -119,6 +125,7 @@ export class DataViewModel extends HoistModel {
             groupRowRenderer,
             groupRowElementRenderer,
             rowClassFn,
+            rowClassRules,
             onRowClicked,
             onRowDoubleClicked,
             columns,


### PR DESCRIPTION
`rowClassRules` are usually preferred over the already documented `rowClassFn`, so seemed like a gap in the documentation

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

