### PR TITLE
Autosize aims to respect class names applied to the row and cell

### DIFF
--- a/cmp/grid/impl/ColumnWidthCalculator.js
+++ b/cmp/grid/impl/ColumnWidthCalculator.js
@@ -119,23 +119,17 @@ export class ColumnWidthCalculator {
 
         // 4) Get longest values, with unique combinations of row and cell classes applied to them
         const samples = longestValues.map(value => {
-            // Early out if we know there won't be row or cell classes.
-            if (
-                isNil(rowClassFn) &&
-                isNil(cellClassFn) &&
-                isEmpty(rowClassRules) &&
-                isEmpty(cellClassRules)
-            ) {
-                return {value, classNames: ['|']};
-            }
-
             const classNames = new Set();
-            recsByValue.get(value).forEach(record => {
-                const rawValue = getValueFn({record, field, column, gridModel, store}),
-                    rowClass = this.getRowClass(gridModel, record),
-                    cellClass = this.getCellClass(gridModel, column, record, rawValue);
-                classNames.add(rowClass + '|' + cellClass);
-            });
+            if (rowClassFn || cellClassFn || !isEmpty(rowClassRules) || !isEmpty(cellClassRules)) {
+                recsByValue.get(value).forEach(record => {
+                    const rawValue = getValueFn({record, field, column, gridModel, store}),
+                        rowClass = this.getRowClass(gridModel, record),
+                        cellClass = this.getCellClass(gridModel, column, record, rawValue);
+                    classNames.add(rowClass + '|' + cellClass);
+                });
+            } else {
+                classNames.add('|');
+            }
             return {value, classNames};
         });
 
@@ -272,7 +266,7 @@ export class ColumnWidthCalculator {
             });
         }
 
-        return !isEmpty(ret) ? ret.join(' ') : null;
+        return ret.join(' ');
     }
 
     //------------------
@@ -304,7 +298,7 @@ export class ColumnWidthCalculator {
             });
         }
 
-        return !isEmpty(ret) ? ret.join(' ') : null;
+        return ret.join(' ');
     }
 
     //-----------------

--- a/cmp/grid/impl/ColumnWidthCalculator.js
+++ b/cmp/grid/impl/ColumnWidthCalculator.js
@@ -54,13 +54,11 @@ export class ColumnWidthCalculator {
         if (!autosizeIncludeHeader) return null;
 
         try {
-            this.setHeaderElActive(true);
-            this.setHeaderElSizingMode(gridModel.sizingMode);
             return this.getHeaderWidth(gridModel, column, autosizeIncludeHeaderIcons, bufferPx);
         } catch (e) {
             console.warn(`Error calculating max header width for column "${column.colId}".`, e);
         } finally {
-            this.setHeaderElActive(false);
+            this.resetHeaderClassNames();
         }
     }
 
@@ -147,45 +145,32 @@ export class ColumnWidthCalculator {
     //------------------
     getHeaderWidth(gridModel, column, includeHeaderIcons, bufferPx) {
         const {colId, headerName, agOptions, sortable, filterable} = column,
+            {sizingMode} = gridModel,
             headerHtml = isFunction(headerName) ? headerName({column, gridModel}) : headerName,
             showSort = sortable && (includeHeaderIcons || gridModel.sortBy.find(sorter => sorter.colId === colId)),
             showMenu = (agOptions?.suppressMenu === false || filterable) && includeHeaderIcons;
 
         // Render to a hidden header cell to calculate the max displayed width
         const headerEl = this.getHeaderEl();
-        this.setHeaderElSortAndMenu(showSort, showMenu);
+        this.setHeaderClassNames(sizingMode, showSort, showMenu);
         headerEl.firstChild.innerHTML = headerHtml;
         return Math.ceil(headerEl.clientWidth) + bufferPx;
     }
 
-    setHeaderElActive(active) {
+    resetHeaderClassNames() {
         const headerEl = this.getHeaderEl();
-        if (active) {
-            headerEl.classList.add('xh-grid-autosize-header--active');
-        } else {
-            headerEl.classList.remove('xh-grid-autosize-header--active');
-        }
+        headerEl.classList.remove(...headerEl.classList);
+        headerEl.classList.add('xh-grid-autosize-header');
     }
 
-    setHeaderElSizingMode(sizingMode) {
-        const headerEl = this.getHeaderEl();
-        headerEl.classList.remove(
-            'xh-grid-autosize-header--large',
-            'xh-grid-autosize-header--standard',
-            'xh-grid-autosize-header--compact',
-            'xh-grid-autosize-header--tiny'
+    setHeaderClassNames(sizingMode, showSort, showMenu) {
+        this.resetHeaderClassNames();
+        this.getHeaderEl().classList.add(
+            'xh-grid-autosize-header--active',
+            `xh-grid-autosize-header--${sizingMode}`,
+            showSort ? 'xh-grid-autosize-header--sort' : null,
+            showMenu ? 'xh-grid-autosize-header--menu' : null
         );
-        headerEl.classList.add(`xh-grid-autosize-header--${sizingMode}`);
-    }
-
-    setHeaderElSortAndMenu(sort, menu) {
-        const headerEl = this.getHeaderEl();
-        headerEl.classList.remove(
-            'xh-grid-autosize-header--sort',
-            'xh-grid-autosize-header--menu'
-        );
-        if (sort) headerEl.classList.add('xh-grid-autosize-header--sort');
-        if (menu) headerEl.classList.add('xh-grid-autosize-header--menu');
     }
 
     getHeaderEl() {


### PR DESCRIPTION
CSS class names applied to grid cells can interfere with column autosizing. This was seen in a client app where row classes were used to bold the cells, making them wider.

This PR incorporates `GridModel.rowClassFn`, `GridModel.rowClassRules`, `Column.cellClassFn` and `Column.cellClassRules` into the autosizing calculations. Please note due to the (necessary) optimisation to only sample a subset of values, there are still some cases that may slip through the gaps (e.g. conditionally applying a cell class to make an otherwise narrow cell much wider). However, for simpler cases such as bold fonts and added padding this should prove sufficient.

See Toolbox branch which replicates the issue seen in the app: https://github.com/xh/toolbox/tree/autosizeClassNames

See issue: https://github.com/xh/hoist-react/issues/2667

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

