### PR TITLE
Grid Header Tweaks

### DIFF
--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -33,13 +33,11 @@
     }
 
     svg {
-      margin-left: var(--xh-pad-half-px);
       color: var(--xh-grid-header-icon-color);
     }
   }
 
   .xh-grid-header {
-    margin-top: 1px;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -56,7 +54,6 @@
     .xh-grid-header-menu-icon,
     .xh-grid-header-expand-collapse-icon {
       color: var(--xh-grid-header-icon-color);
-      margin-left: var(--xh-pad-half-px);
       width: 1.5em;
     }
 
@@ -388,7 +385,6 @@
 
   .xh-grid-header-sort-icon,
   .xh-grid-header-menu-icon {
-    margin-left: var(--xh-pad-half-px);
     width: 1.5em;
     display: none;
   }

--- a/desktop/cmp/grid/impl/filter/ColumnHeaderFilter.scss
+++ b/desktop/cmp/grid/impl/filter/ColumnHeaderFilter.scss
@@ -14,10 +14,6 @@
     width: 1.5em;
     font-size: 12px;
     color: var(--xh-grid-header-icon-color);
-
-    :hover {
-      color: var(--xh-text-color-highlight);
-    }
   }
 
   &__tab-switcher {

--- a/desktop/cmp/grid/impl/filter/ColumnHeaderFilter.scss
+++ b/desktop/cmp/grid/impl/filter/ColumnHeaderFilter.scss
@@ -9,11 +9,15 @@
   height: 350px;
 
   &__icon {
-    margin: 2px 0 0 var(--xh-pad-half-px);
+    margin-top: 2px;
     flex: none !important;
     width: 1.5em;
     font-size: 12px;
     color: var(--xh-grid-header-icon-color);
+
+    :hover {
+      color: var(--xh-text-color-highlight);
+    }
   }
 
   &__tab-switcher {


### PR DESCRIPTION
Resolves #1896

Adjust grid header margin values
+ Remove extra margins from icons and svgs in header - their fixed width already creates a sufficient margin between it and the header text. This is a nice win for header names that are only Icons - they center properly now.
+ Remove margin-top from grid header (this now aligns the text and sort/menu icons much better)

Apply hover color on column header filter icon
+ In line with hover color applied to the tree expand/collapse icon
+ Chose not to hover on sort icon, since clicking into the main body of the header accomplishes sorting as well... open to feedback (could apply hover color on sort icon when hovering over entire text as well)

Left ellipsis on overflow text as is. Clipping text has the unfortunate effect of looking like typos for most header text, especially when short. Found some exciting experimental text-overflow values that we could hopefully implement in the future (specifically, the fade function) when supported in browsers: https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [N/A] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [N/A] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

