### PR TITLE
TreeMap minor basket node

### DIFF
--- a/desktop/cmp/treemap/SplitTreeMap.js
+++ b/desktop/cmp/treemap/SplitTreeMap.js
@@ -4,7 +4,7 @@
  *
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
-import {placeholder, fragment, hframe, vframe, hbox, vbox, box, div, p} from '@xh/hoist/cmp/layout';
+import {placeholder, fragment, hframe, vframe, hbox, vbox, box, div} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
 import {errorMessage} from '@xh/hoist/desktop/cmp/error';
 import {mask} from '@xh/hoist/desktop/cmp/mask';
@@ -33,7 +33,7 @@ export const [SplitTreeMap, splitTreeMap]  = hoistCmp.withFactory({
         return container({
             ref,
             className,
-            items: errors.length ? errorPanel({errors}) : childMaps(),
+            items: errors.length ? errorMessage({error: errors[0]}) : childMaps(),
             ...props
         });
     }
@@ -108,8 +108,4 @@ const mapTitle = hoistCmp.factory(
             })
         });
     }
-);
-
-const errorPanel = hoistCmp.factory(
-    ({errors}) => errorMessage({message: fragment(errors.map(e => p(e)))})
 );

--- a/desktop/cmp/treemap/SplitTreeMapModel.js
+++ b/desktop/cmp/treemap/SplitTreeMapModel.js
@@ -106,6 +106,12 @@ export class SplitTreeMapModel extends HoistModel {
     get theme()             {return this.primaryMapModel.theme}
 
     @action
+    setError(...args) {
+        this.primaryMapModel.setHighchartsConfig(...args);
+        this.secondaryMapModel.setHighchartsConfig(...args);
+    }
+
+    @action
     setHighchartsConfig(...args) {
         this.primaryMapModel.setHighchartsConfig(...args);
         this.secondaryMapModel.setHighchartsConfig(...args);

--- a/desktop/cmp/treemap/TreeMap.js
+++ b/desktop/cmp/treemap/TreeMap.js
@@ -286,7 +286,7 @@ class LocalModel extends HoistModel {
     }
 
     getModelConfig() {
-        const {data, algorithm, tooltip, maxNodes, highchartsConfig} = this.model,
+        const {data, algorithm, tooltip, highchartsConfig} = this.model,
             {defaultTooltip} = this;
 
         return merge({
@@ -299,14 +299,13 @@ class LocalModel extends HoistModel {
                 outside: true,
                 pointFormatter: function() {
                     if (!tooltip) return;
-                    const {record} = this;
-                    return isFunction(tooltip) ? tooltip(record) : defaultTooltip(record);
+                    const {record, raw} = this;
+                    return isFunction(tooltip) ? tooltip({record, raw}) : defaultTooltip({record, raw});
                 }
             },
             plotOptions: {
                 treemap: {
                     layoutAlgorithm: algorithm,
-                    turboThreshold: maxNodes,
                     animation: false,
                     borderWidth: 0,
                     events: {click: this.onClick},
@@ -409,13 +408,11 @@ class LocalModel extends HoistModel {
     //----------------------
     // Tooltip
     //----------------------
-    defaultTooltip = (record) => {
+    defaultTooltip = ({raw}) => {
         const {model} = this,
-            {labelField, valueField, heatField, valueFieldLabel, heatFieldLabel, valueRenderer, heatRenderer} = model,
-            name = record.get(labelField),
-            value = record.get(valueField),
-            heat = record.get(heatField),
-            labelDiv = `<div class='xh-treemap-tooltip__label'>${name}</div>`;
+            {label, value, heat} = raw,
+            {valueField, heatField, valueFieldLabel, heatFieldLabel, valueRenderer, heatRenderer} = model,
+            labelDiv = `<div class='xh-treemap-tooltip__label'>${label}</div>`;
 
         let valueDiv = '';
         if (model.valueIsValid(value)) {


### PR DESCRIPTION
+ TreeMap nodes that exceed the maxNodes config are collapsed into a "Minor Basket" node.
+ TreeMap's default tooltip works without a backing Store record.
+ TreeMapModel.error is bindable, allowing applications to display their own errors in the built in errorMessage cmp.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [ ] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [ ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

