### PR TITLE
Enable ag-grid prop `stopEditingWhenCellsLoseFocus` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v43.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* The ag-grid grid property `stopEditingWhenCellsLoseFocus` is now enabled by default to ensure
+  values are committed to the Store if the user clicks somewhere outside the grid while editing a
+  cell.
+
 ### 📚 Libraries
 
 * @blueprintjs/core `3.49 -> 3.50`

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -257,7 +257,8 @@ class GridLocalModel extends HoistModel {
             autoSizePadding: 3, // tighten up cells for ag-Grid native autosizing.  Remove when Hoist autosizing no longer experimental,
             editType: model.fullRowEditing ? 'fullRow' : undefined,
             singleClickEdit: clicksToEdit === 1,
-            suppressClickEdit: clicksToEdit !== 1 && clicksToEdit !== 2
+            suppressClickEdit: clicksToEdit !== 1 && clicksToEdit !== 2,
+            stopEditingWhenCellsLoseFocus: true
         };
 
         // Platform specific defaults

--- a/desktop/cmp/grid/editors/DateEditor.js
+++ b/desktop/cmp/grid/editors/DateEditor.js
@@ -20,18 +20,23 @@ export const [DateEditor, dateEditor] = hoistCmp.withFactory({
     render(props, ref) {
         // We need to render the day picker popover inside the grid viewport in order for
         // `stopEditingWhenCellsLoseFocus` to work properly - otherwise the day picker becomes
-        // unusable due to the grid losing focus and stopping the editing when clicking inside the
-        // picker
+        // unusable due to the grid losing focus and stopping editing when clicking inside picker
         const portalContainer = props.gridModel.agApi.gridBodyComp?.eBodyViewport;
-        warnIf(!portalContainer, 'Could not find the grid body viewport for rendering DateEditor picker popover.');
+        warnIf(
+            !portalContainer,
+            'Could not find the grid body viewport for rendering DateEditor picker popover.'
+        );
 
         props = {
             ...props,
             inputProps: {
                 rightElement: null,
-                showPickerOnFocus: true,
-                popoverBoundary: 'scrollParent', // try to fit the picker within the grid viewport
+
+                enablePicker: !!portalContainer,
+                showPickerOnFocus: !!portalContainer,
                 portalContainer,
+                popoverBoundary: 'scrollParent',
+
                 ...props.inputProps
             }
         };

--- a/desktop/cmp/grid/editors/DateEditor.js
+++ b/desktop/cmp/grid/editors/DateEditor.js
@@ -6,6 +6,7 @@
  */
 import {hoistCmp} from '@xh/hoist/core';
 import {dateInput} from '@xh/hoist/desktop/cmp/input';
+import {warnIf} from '@xh/hoist/utils/js';
 import {useInlineEditorModel} from './impl/InlineEditorModel';
 import {EditorPropTypes} from './EditorPropTypes';
 import './Editors.scss';
@@ -21,7 +22,8 @@ export const [DateEditor, dateEditor] = hoistCmp.withFactory({
         // `stopEditingWhenCellsLoseFocus` to work properly - otherwise the day picker becomes
         // unusable due to the grid losing focus and stopping the editing when clicking inside the
         // picker
-        const portalContainer = props.gridModel.agApi.gridBodyComp.eBodyViewport;
+        const portalContainer = props.gridModel.agApi.gridBodyComp?.eBodyViewport;
+        warnIf(!portalContainer, 'Could not find the grid body viewport for rendering DateEditor picker popover.');
 
         props = {
             ...props,

--- a/desktop/cmp/grid/editors/DateEditor.js
+++ b/desktop/cmp/grid/editors/DateEditor.js
@@ -17,11 +17,19 @@ export const [DateEditor, dateEditor] = hoistCmp.withFactory({
     memo: false,
     observer: false,
     render(props, ref) {
+        // We need to render the day picker popover inside the grid viewport in order for
+        // `stopEditingWhenCellsLoseFocus` to work properly - otherwise the day picker becomes
+        // unusable due to the grid losing focus and stopping the editing when clicking inside the
+        // picker
+        const portalContainer = props.gridModel.agApi.gridBodyComp.eBodyViewport;
+
         props = {
             ...props,
             inputProps: {
                 rightElement: null,
                 showPickerOnFocus: true,
+                popoverBoundary: 'scrollParent', // try to fit the picker within the grid viewport
+                portalContainer,
                 ...props.inputProps
             }
         };

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -125,6 +125,9 @@ DateInput.propTypes = {
     /** Boundary for calendar popover, as per Blueprint docs. Defaults to viewport. */
     popoverBoundary: PT.oneOf(['scrollParent', 'viewport', 'window']),
 
+    /** Container element to render the calendar popover inside. Defaults to document body. */
+    portalContainer: PT.instanceOf(HTMLElement),
+
     /** True to select contents when control receives focus. */
     selectOnFocus: PT.bool,
 
@@ -421,6 +424,7 @@ const cmp = hoistCmp.factory(
                 enforceFocus: false,
                 position: props.popoverPosition ?? 'auto',
                 boundary: props.popoverBoundary ?? 'viewport',
+                portalContainer: props.portalContainer ?? document.body,
                 popoverRef: (v) => {model.popoverRef.current = v},  // Workaround for #2272
                 onClose: model.onPopoverClose,
                 onInteraction: (nextOpenState) => {

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -125,8 +125,8 @@ DateInput.propTypes = {
     /** Boundary for calendar popover, as per Blueprint docs. Defaults to viewport. */
     popoverBoundary: PT.oneOf(['scrollParent', 'viewport', 'window']),
 
-    /** Container element to render the calendar popover inside. Defaults to document body. */
-    portalContainer: PT.instanceOf(HTMLElement),
+    /** Container DOM element to render the calendar popover inside. Defaults to document body. */
+    portalContainer: PT.instanceOf(window.HTMLElement),
 
     /** True to select contents when control receives focus. */
     selectOnFocus: PT.bool,


### PR DESCRIPTION
Fixes #2530

This seemed like the best approach to address this. It does have the caveat that a really short or thin grid may not have enough space to render the day picker, but that seems very unlikely to be the case in an application.

Alternative solutions would be to figure out how to kill focus on the day picker popover such that it does not trigger the `focusout` event on the grid viewports, but not sure if that is easy and/or possible.

Also could convert the date editor to a popup editor and render the day picker inside of the popup editor container instead of the grid viewport, which would address the caveat above but would mean the input component would not be rendered inside the cell and be inconsistent with other non-popup editors (and the implementation would likely be more complex)

See the relevant ag-grid code for stopping editing on `focusout` here: https://github.com/ag-grid/ag-grid/blob/39aa69f4b03c4710c41844578956aad9706ecbd0/community-modules/core/src/ts/gridBodyComp/gridBodyCtrl.ts#L169

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

