### PR TITLE
Column filtering fixes

### DIFF
--- a/desktop/cmp/grid/impl/filter/values/ValuesTabModel.js
+++ b/desktop/cmp/grid/impl/filter/values/ValuesTabModel.js
@@ -166,18 +166,16 @@ export class ValuesTabModel extends HoistModel {
             filterValues.push(...newValues);
         });
 
-        // Combine unique values from record sets and column filters. [blank] is always included.
+        // Combine unique values from record sets and column filters.
         const allValues = uniqBy([
             ...allRecords.map(rec => this.valueFromRecord(rec)),
-            ...filterValues,
-            BLANK_STR
+            ...filterValues
         ], this.getUniqueValue);
         let values;
         if (cleanedFilter) {
             values = uniqBy([
                 ...filteredRecords.map(rec => this.valueFromRecord(rec)),
-                ...filterValues,
-                BLANK_STR
+                ...filterValues
             ], this.getUniqueValue);
         } else {
             values = allValues;
@@ -217,7 +215,7 @@ export class ValuesTabModel extends HoistModel {
 
     valueFromRecord(record) {
         const ret = record.get(this.field);
-        return isNil(ret) ? this.BLANK_STR : ret;
+        return isNil(ret) || ret === '' ? this.BLANK_STR : ret;
     }
 
     getUniqueValue(value) {
@@ -258,7 +256,7 @@ export class ValuesTabModel extends HoistModel {
 
         return new GridModel({
             store: {
-                idSpec: (raw) => raw.value.toString(),
+                idSpec: (raw) => this.getUniqueValue(raw.value).toString(),
                 fields: [
                     {name: 'value'},
                     {name: 'isChecked', type: 'bool'}


### PR DESCRIPTION
A number of small but important column filtering fixes, worked out on a call with @pauldelano:

+ Ensure date > ms (and any future uniquification measures) are used for the grid idSpec in Values Tab
+ Use `[blank]` for both nil and empty string values, the same as the actual filter testFn
+ Only include `[blank]` if it's in the dataset

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

