### PR TITLE
Adjustments to default mask styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   the `--xh-grid-tree-group-color-level-*` CSS vars to customize colors as needed.
 * `TreeStyle.HIGHLIGHTS` and `TreeStyle.HIGHLIGHTS_AND_BORDERS` now highlight row nodes on a
   gradient according to their depth.
+* Default colors for masks and dialog backdrops have been adjusted, with less obtrusive colors used
+  for masks via `--xh-mask-bg` and a darker `--xh-backdrop-bg` var now used behind dialogs.
 * Mobile-specific styles and CSS vars for panel and dialog title background have been tweaked to use
   desktop defaults, and mobile dialogs now respect `--xh-popup-*` vars as expected.
 

--- a/desktop/appcontainer/IdlePanel.scss
+++ b/desktop/appcontainer/IdlePanel.scss
@@ -20,6 +20,6 @@
 }
 
 .xh-viewport.xh-idle-viewport {
-  background-color: var(--xh-mask-bg);
+  background-color: var(--xh-bg);
   background-image: none;
 }

--- a/desktop/cmp/mask/Mask.scss
+++ b/desktop/cmp/mask/Mask.scss
@@ -1,7 +1,7 @@
 .xh-mask {
+  align-items: center;
   display: flex !important;
   flex-direction: column;
-  align-items: center;
   justify-content: center;
 
   .bp3-overlay-backdrop {
@@ -13,12 +13,13 @@
     justify-content: center;
 
     .xh-mask-text {
-      max-width: 200px;
-      text-align: center;
-      border-radius: var(--xh-border-radius-px);
-      padding: var(--xh-pad-half-px);
       background-color: var(--xh-mask-text-bg);
+      border: var(--xh-mask-text-border);
+      border-radius: var(--xh-border-radius-px);
       color: var(--xh-mask-text-color);
+      max-width: 200px;
+      padding: var(--xh-pad-half-px);
+      text-align: center;
     }
   }
 }

--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -48,8 +48,10 @@
   }
 }
 
-.bp3-dialog-container {
-  background-color: var(--xh-mask-bg);
+// Customized here for backdrops behind dialogs.
+// Note that masks use their own CSS var, set in Mask.scss.
+.bp3-overlay-backdrop {
+  background-color: var(--xh-backdrop-bg);
 }
 
 // Squelch popover scale transition - unlike Dialog with its `transitionName` prop, Popover

--- a/kit/onsen/styles.scss
+++ b/kit/onsen/styles.scss
@@ -36,19 +36,3 @@
 .xh-grid .ag-body-viewport::-webkit-scrollbar {
   display: none;
 }
-
-//--------------------
-// Onsen Overrides
-//--------------------
-.bottom-bar > .button {
-  margin: 6px 4px;
-  line-height: 26px;
-}
-
-.dialog {
-  box-shadow: 0 2px 20px rgba(0, 0, 0, 0.1);
-}
-
-.dialog-mask {
-  background-color: var(--xh-mask-bg);
-}

--- a/kit/onsen/theme.scss
+++ b/kit/onsen/theme.scss
@@ -55,6 +55,11 @@ body.xh-app.xh-mobile {
     border-color: var(--xh-border-color);
   }
 
+  .bottom-bar > .button {
+    margin: 6px 4px;
+    line-height: 26px;
+  }
+
   // Grids
   .list {
     border-top: var(--xh-border-solid);

--- a/mobile/cmp/dialog/Dialog.scss
+++ b/mobile/cmp/dialog/Dialog.scss
@@ -1,6 +1,10 @@
 .xh-dialog {
   position: fixed;
 
+  & > .dialog-mask {
+    background-color: var(--xh-backdrop-bg);
+  }
+
   & > .dialog {
     max-width: calc(100% - var(--xh-pad-double-px));
 

--- a/mobile/cmp/input/DateInput.scss
+++ b/mobile/cmp/input/DateInput.scss
@@ -37,7 +37,7 @@
 
 // Popover and mask
 .SingleDatePicker_picker__portal {
-  background-color: var(--xh-mask-bg);
+  background-color: var(--xh-backdrop-bg);
 
   .DayPicker {
     background-color: var(--xh-bg);

--- a/mobile/cmp/popover/Popover.scss
+++ b/mobile/cmp/popover/Popover.scss
@@ -21,7 +21,7 @@
     background-color: transparent;
 
     &--backdrop {
-      background-color: var(--xh-backdrop-bg);
+      background-color: var(--xh-popover-backdrop-bg);
     }
   }
 }

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -200,6 +200,47 @@ body {
   --xh-intent-danger-trans2: hsla(var(--xh-intent-danger-h), var(--xh-intent-danger-s), var(--xh-intent-danger-l3), var(--xh-intent-a2));
 
 
+  //---------
+  // AppBar
+  //---------
+  --xh-appbar-bg: var(--appbar-bg, var(--xh-bg-alt));
+  --xh-appbar-border-color: var(--appbar-border-color, transparent);
+  --xh-appbar-color: var(--appbar-color, var(--xh-text-color));
+  --xh-appbar-height: var(--appbar-height, 42);
+  --xh-appbar-height-px: calc(var(--xh-appbar-height) * 1px);
+  --xh-appbar-title-color: var(--appbar-title-color, #{mc('blue-grey', '700')});
+  --xh-appbar-title-font-size: var(--appbar-title-font-size, calc(var(--xh-font-size) * 1.9));
+  --xh-appbar-title-font-size-px: calc(var(--xh-appbar-title-font-size) * 1px);
+
+  &.xh-dark {
+    --xh-appbar-border-color: var(--appbar-border-color, #{mc('blue-grey', '700')});
+    --xh-appbar-title-color: var(--appbar-title-color, #{mc('blue-grey', '50')});
+  }
+
+  &.xh-mobile {
+    --xh-appbar-bg: var(--appbar-bg, #{mc('blue-grey', '600')});
+    --xh-appbar-color: var(--appbar-color, #{mc('blue-grey', '50')});
+    --xh-appbar-title-color: var(--appbar-title-color, var(--xh-appbar-color));
+    --xh-appbar-title-font-size: var(--appbar-title-font-size, 19);
+
+    &.xh-dark {
+      --xh-appbar-bg: var(--appbar-bg, #{mc('blue-grey', '700')});
+    }
+  }
+
+
+  //---------------------------------------------------
+  // Backdrop mask - overlay shown behind modal dialogs
+  //---------------------------------------------------
+  // Light mode uses neutral gray + higher opacity for stronger masking relative to `--xh-mask-bg`.
+  --xh-backdrop-bg: var(--backdrop-bg, rgb(128, 128, 128, 0.6));
+
+  &.xh-dark {
+    // Dark mode applies higher opacity only.
+    --xh-backdrop-bg: var(--backdrop-bg, rgb(0, 0, 0, 0.6));
+  }
+
+
   //-----------------------------------------
   // Background (app / components in general)
   //-----------------------------------------
@@ -474,72 +515,35 @@ body {
     --xh-input-disabled-text-color: var(--form-field-disabled-text-color, rgba(191, 204, 214, 0.5));
   }
 
-
   //------------------------
   // Mask + LoadingIndicator
   //------------------------
-  --xh-mask-bg: var(--mask-bg, #{mc-trans('blue-grey', '300', 0.3)});
-  --xh-mask-text-bg: var(--mask-text-bg, #{mc('blue-grey', '100')});
+  --xh-mask-bg: var(--mask-bg, rgba(255, 255, 255, 0.4));
+  --xh-mask-text-bg: var(--mask-text-bg, var(--xh-bg-alt));
+  --xh-mask-text-border: var(--mask-text-border, var(--xh-border-solid));
   --xh-mask-text-color: var(--mask-text-color, var(--xh-text-color));
   --xh-loading-indicator-bg: var(--loading-indicator-bg, #{mc('blue-grey', '100')});
   --xh-loading-indicator-border-color: var(--loading-indicator-border-color, var(--xh-border-color));
   --xh-loading-indicator-color: var(--loading-indicator-color, #{mc('blue-grey', '600')});
 
   &.xh-dark {
-    --xh-mask-bg: var(--mask-bg, #{mc-trans('blue-grey', '900', 0.2)});
-    --xh-mask-text-bg: var(--mask-text-bg, #{mc-trans('grey', '900', 0.1)});
-    --xh-mask-text-color: var(--mask-text-color, var(--xh-text-color));
+    --xh-mask-bg: var(--mask-bg, rgba(0, 0, 0, 0.4));
     --xh-loading-indicator-bg: var(--loading-indicator-bg, #{mc('blue-grey', '700')});
     --xh-loading-indicator-color: var(--loading-indicator-color, #{mc('blue-grey', '200')});
   }
 
+
+  //---------------------------------------
+  // Popovers - e.g. mobile app menu.
+  // Applicable to mobile only at this time
+  //---------------------------------------
   &.xh-mobile {
-    --xh-mask-bg: var(--mask-bg, rgba(0, 0, 0, 0.4));
+    --xh-popover-backdrop-bg: var(--popover-backdrop, rgb(128, 128, 128, 0.2));
+    --xh-popover-box-shadow: var(--popover-shadow, #{0 0 20px rgba(0, 0, 0, 0.4)});
 
     &.xh-dark {
-      --xh-mask-bg: var(--mask-bg, rgba(0, 0, 0, 0.6));
-    }
-  }
-
-  //------------------------
-  // Popovers
-  //------------------------
-  --xh-popover-box-shadow: var(--popover-shadow, #{0 0 20px rgba(0, 0, 0, 0.4)});
-  --xh-backdrop-bg: var(--backdrop-bg, #{mc-trans('blue-grey', '300', 0.2)});
-
-  &.xh-dark {
-    --xh-popover-box-shadow: var(--popover-shadow, #{0 0 20px rgba(0, 0, 0, 0.7)});
-  }
-
-  &.xh-mobile {
-    --xh-backdrop-bg: var(--backdrop-bg, rgba(0, 0, 0, 0.4));
-  }
-
-  //---------
-  // AppBar
-  //---------
-  --xh-appbar-bg: var(--appbar-bg, var(--xh-bg-alt));
-  --xh-appbar-border-color: var(--appbar-border-color, transparent);
-  --xh-appbar-color: var(--appbar-color, var(--xh-text-color));
-  --xh-appbar-height: var(--appbar-height, 42);
-  --xh-appbar-height-px: calc(var(--xh-appbar-height) * 1px);
-  --xh-appbar-title-color: var(--appbar-title-color, #{mc('blue-grey', '700')});
-  --xh-appbar-title-font-size: var(--appbar-title-font-size, calc(var(--xh-font-size) * 1.9));
-  --xh-appbar-title-font-size-px: calc(var(--xh-appbar-title-font-size) * 1px);
-
-  &.xh-dark {
-    --xh-appbar-border-color: var(--appbar-border-color, #{mc('blue-grey', '700')});
-    --xh-appbar-title-color: var(--appbar-title-color, #{mc('blue-grey', '50')});
-  }
-
-  &.xh-mobile {
-    --xh-appbar-bg: var(--appbar-bg, #{mc('blue-grey', '600')});
-    --xh-appbar-color: var(--appbar-color, #{mc('blue-grey', '50')});
-    --xh-appbar-title-color: var(--appbar-title-color, var(--xh-appbar-color));
-    --xh-appbar-title-font-size: var(--appbar-title-font-size, 19);
-
-    &.xh-dark {
-      --xh-appbar-bg: var(--appbar-bg, #{mc('blue-grey', '700')});
+      --xh-popover-backdrop-bg: var(--popover-backdrop, rgb(0, 0, 0, 0.2));
+      --xh-popover-box-shadow: var(--popover-shadow, #{0 0 20px rgba(0, 0, 0, 0.7)});
     }
   }
 


### PR DESCRIPTION
+ Break apart vars for `--xh-mask-bg` (load masks) and `--xh-backdrop-bg` (modal dialogs).
+ Mask defaults now less obtrusive (less opaque and closer to app bg, based on theme), with style tweaks to ensure any text remains legible.
+ Backdrop now better controlled via CSS var, instead of unintentional double-masking we had previously due to leaking blueprint styles.
+ Popover CSS vars more clearly scoped to mobile, the only place they are applied.
+ Fixes #2690

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

