### PR TITLE
Fix warning from ColumnWidthCalculator

### DIFF
--- a/cmp/grid/impl/ColumnWidthCalculator.js
+++ b/cmp/grid/impl/ColumnWidthCalculator.js
@@ -229,14 +229,12 @@ export class ColumnWidthCalculator {
 
     setClassNames(sizingMode, rowClass, cellClass) {
         this.resetClassNames();
-        this.getRowEl().classList.add(
-            !isEmpty(rowClass) ? rowClass : null
-        );
         this.getCellEl().classList.add(
             'xh-grid-autosize-cell--active',
-            `xh-grid-autosize-cell--${sizingMode}`,
-            !isEmpty(cellClass) ? cellClass : null
+            `xh-grid-autosize-cell--${sizingMode}`
         );
+        if (!isEmpty(rowClass)) this.getRowEl().classList.add(...rowClass.split(' '));
+        if (!isEmpty(cellClass)) this.getCellEl().classList.add(...cellClass.split(' '));
     }
 
     getCellEl() {


### PR DESCRIPTION
The output from cellClassRules, rowClassRules, etc can sometimes be several CSS classnames joined as single space-delimited string. `Element.classList.add()` requires each class to be its own argument, and will emit a warning when providing a token with a space. This change rectifies by splitting and spreading any provided custom class names.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

