### PR TITLE
Do not save SNAPSHOT versions to xhLastReadChangelog preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,15 +25,14 @@
 * Mobile-specific styles and CSS vars for panel and dialog title background have been tweaked to use
   desktop defaults, and mobile dialogs now respect `--xh-popup-*` vars as expected.
 
-### ⚙️ Technical
-
-* The `xhLastReadChangelog` preference will not save SNAPSHOT versions to ensure the user continues
-  to see the 'What's New?' notification for non-SNAPSHOT releases.
-
 ### 🎁 Breaking Changes
 
 * In the `@xh/hoist/desktop/grid` package, `CheckboxEditor` has been renamed `BooleanEditor`.
 
+### ⚙️ Technical
+
+* The `xhLastReadChangelog` preference will not save SNAPSHOT versions to ensure the user continues
+  to see the 'What's New?' notification for non-SNAPSHOT releases.
 
 ### 📚 Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
 * Mobile-specific styles and CSS vars for panel and dialog title background have been tweaked to use
   desktop defaults, and mobile dialogs now respect `--xh-popup-*` vars as expected.
 
+### ⚙️ Technical
+
+* The `xhLastReadChangelog` preference will not save SNAPSHOT versions to ensure the user continues
+  to see the 'What's New?' notification for non-SNAPSHOT releases.
+
 ### 🎁 Breaking Changes
 
 * In the `@xh/hoist/desktop/grid` package, `CheckboxEditor` has been renamed `BooleanEditor`.

--- a/svc/ChangelogService.js
+++ b/svc/ChangelogService.js
@@ -61,7 +61,7 @@ export class ChangelogService extends HoistService {
 
     /** @return {?string} */
     get latestAvailableVersion() {
-        if (!this.enabled || includes(this.versions[0].version, 'SNAPSHOT')) return null;
+        if (!this.enabled) return null;
         return this.versions[0].version;
     }
 
@@ -88,8 +88,13 @@ export class ChangelogService extends HoistService {
     markLatestAsRead() {
         const {latestAvailableVersion, LAST_READ_PREF_KEY} = this;
 
+        if (includes(latestAvailableVersion, 'SNAPSHOT')) {
+            console.warn('Unable to mark changelog as read when latest version is SNAPSHOT.');
+            return;
+        }
+
         if (!latestAvailableVersion || !XH.prefService.hasKey(LAST_READ_PREF_KEY)) {
-            console.warn(`Unable to mark changelog as read - latest version or required pref not found.`);
+            console.warn('Unable to mark changelog as read - latest version or required pref not found.');
             return;
         }
 

--- a/svc/ChangelogService.js
+++ b/svc/ChangelogService.js
@@ -8,7 +8,7 @@ import {HoistService, XH} from '@xh/hoist/core';
 import jsonFromMarkdown from '@xh/app-changelog.json';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {checkMinVersion} from '@xh/hoist/utils/js';
-import {isEmpty, forOwn} from 'lodash';
+import {isEmpty, forOwn, includes} from 'lodash';
 
 /**
  * Service to display an application changelog (aka release notes) to end users, if so configured.
@@ -61,7 +61,7 @@ export class ChangelogService extends HoistService {
 
     /** @return {?string} */
     get latestAvailableVersion() {
-        if (!this.enabled) return null;
+        if (!this.enabled || includes(this.versions[0].version, 'SNAPSHOT')) return null;
         return this.versions[0].version;
     }
 


### PR DESCRIPTION
Closes #2695 

Console warns 'Unable to mark changelog as read - latest version or required pref not found.'

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

