### PR TITLE
Call Children.toArray on all panel items to create stable keys

### DIFF
--- a/desktop/cmp/panel/Panel.js
+++ b/desktop/cmp/panel/Panel.js
@@ -19,7 +19,7 @@ import {mask} from '@xh/hoist/desktop/cmp/mask';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {useContextMenu, useHotkeys} from '@xh/hoist/desktop/hooks';
 import {splitLayoutProps} from '@xh/hoist/utils/react';
-import {omitBy} from 'lodash';
+import {castArray, omitBy} from 'lodash';
 import PT from 'prop-types';
 import {isValidElement, useRef, Children} from 'react';
 import {panelHeader} from './impl/PanelHeader';
@@ -104,11 +104,11 @@ export const [Panel, panel] = hoistCmp.withFactory({
 
             coreContents = vframe({
                 style: {display: collapsed ? 'none' : 'flex'},
-                items: [
+                items: Children.toArray([
                     parseToolbar(tbar),
-                    ...Children.toArray(children),
+                    ...castArray(children),
                     parseToolbar(bbar)
-                ]
+                ])
             });
         }
         if (!collapsed) wasDisplayed.current = true;


### PR DESCRIPTION
Example that requires this change: 
`panel({
  bbar: toolbar1()
  items: [
     grid(),
     toolbar2({omit: !showToolbar2})
  ]
})`

In the case where `showToolbar2` is observable to toggle visibility of another sibling toolbar, toolbar1 gets remounted if it does not have a key explicitly assigned to it. 

Calling Children.toArray() on all the children ensures a stable key is assigned to all items and prevents unnecessary remounting of toolbars when panel is re-rendered.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [ N/A] Added CHANGELOG entry, or determined not required.
- [ N/A] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ N/A] Updated doc comments / prop-types, or determined not required.
- [ N/A] Reviewed and tested on Mobile, or determined not required.
- [ N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

