### PR TITLE
Fix autosize tree column indentation calculation

### DIFF
--- a/cmp/grid/impl/ColumnWidthCalculator.js
+++ b/cmp/grid/impl/ColumnWidthCalculator.js
@@ -304,9 +304,9 @@ export class ColumnWidthCalculator {
     //-----------------
     getIndentation(depth) {
         const cellEl = this.getCellEl(),
-            indentation = parseInt(window.getComputedStyle(cellEl).getPropertyValue('left'));
+            indentation = parseFloat(window.getComputedStyle(cellEl).getPropertyValue('left'));
         depth = parseInt(depth) + 1; // Add 1 to account for expand / collapse arrow.
-        return indentation * depth;
+        return Math.ceil(indentation * depth);
     }
 
     //------------------


### PR DESCRIPTION
Indentation was previously being rounded down if fractional (due to `em` value), resulting in too-small-by-1-px tree columns
See issue: https://github.com/xh/hoist-react/issues/2725

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

