### PR TITLE
Fix filter context menu

### DIFF
--- a/desktop/cmp/contextmenu/StoreContextMenu.js
+++ b/desktop/cmp/contextmenu/StoreContextMenu.js
@@ -82,7 +82,7 @@ export class StoreContextMenu {
                     const {field} = column,
                         fieldSpec = filterModel.getFieldSpec(field);
 
-                    if (!fieldSpec.supportsOperator(op)) return {hidden: true};
+                    if (!fieldSpec?.supportsOperator(op)) return {hidden: true};
 
                     const values = getValues(selectedRecords, field);
                     if (values.length > 1) return {text: `${values.length} values`};
@@ -98,7 +98,13 @@ export class StoreContextMenu {
                     text: 'Filter',
                     icon: Icon.filter(),
                     displayFn: ({column}) => {
-                        return {hidden: !filterModel || !filterModel.bind.isStore || !column?.filterable};
+                        return {
+                            hidden: (
+                                !filterModel?.bind.isStore ||
+                                !filterModel.getFieldSpec(column?.field) ||
+                                !column?.filterable
+                            )
+                        };
                     },
                     items: [
                         {


### PR DESCRIPTION
Require both `Column.filterable` and a corresponding `GridFilterModel.fieldSpec` to show the filter context menu.

See issue: https://github.com/xh/hoist-react/issues/2724

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

