### PR TITLE
GridModel should not mutate ctor config objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@
 * Log Viewer now supports downloading log files.
   * Note apps must update their server-side to `hoist-core v10.0` or greater to download log files
     (although this is _not_ a general or hard requirement for taking this version of hoist-react).
+* The `field` key in the constructor for `Column` will now accept an Object with field defaults, as
+  an alternative to the field name. This form allows the auto-construction of fully-defined `Field`
+  objects from the column specification.
 
-* The `field` key in the constructor for `Column` will now accept an Object with field defaults,
-  as an alternative to the field name.  This form allows the auto-construction of fully-defined
- `Field` objects from the column specification.
+### 🐞 Bug Fixes
+
+* `GridModel` no longer mutates any `selModel` or `colChooser` config objects provided to its
+  constructor, resolving an edge-case bug where re-using the same object for either of these configs
+  across multiple GridModel instances (e.g. as a shared set of defaults) would wire those supporting
+  models to the first grid that received them.
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v43.0.2...develop)
 
@@ -41,8 +47,8 @@
 * In the `@xh/hoist/desktop/grid` package, `CheckboxEditor` has been renamed `BooleanEditor`. This
   new component supports a `quickToggle` prop which allows for more streamlined inline editing of
   boolean values.
-* `LoadSpec` now supports a new `meta` property.  Use this property to pass app-specific metadata
-   through the `LoadSupport` loading and refresh lifecycle.
+* `LoadSpec` now supports a new `meta` property. Use this property to pass app-specific metadata
+  through the `LoadSupport` loading and refresh lifecycle.
 * A spinner is now shown while the app downloads and parses its javascript - most noticeable when
   loading a new (uncached) version, especially on a slower mobile connection. (Requires
   `@xh/hoist-dev-utils` v5.11 or greater to enable.)


### PR DESCRIPTION
+ Avoid mutating `selModel` and `chooserModel` configs in their plain object form - these could be shared defaults provided to multiple GridModels.
+ For those two configs, always ensure the current GridModel/Store are used to create the supporting model.
+ Similar changes to use of defaults in two other cases within GridModel - mostly for consistency in those cases.
+ Auto-formatting comment/CL tweaks

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

