### PR TITLE
FilterChooser autocomplete fix

### DIFF
--- a/cmp/filter/FilterChooserModel.js
+++ b/cmp/filter/FilterChooserModel.js
@@ -12,6 +12,7 @@ import {throwIf, apiRemoved} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
 import {
     compact,
+    cloneDeep,
     flatten,
     groupBy,
     isEmpty,
@@ -317,6 +318,12 @@ export class FilterChooserModel extends HoistModel {
         wait().then(() => {
             rsSelectCmp.focus();
             rsSelectCmp.handleInputChange(inputValue);
+        }).thenAction(() => {
+            // Setting the Select's `inputValue` state above has the side-effect of modifying
+            // it's internal `value`. Force synchronise its `value` to our bound `selectValue`
+            // to get it back inline. Note we're intentionally not using `setSelectValue()`,
+            // which returns early if the actual filter value hasn't changed.
+            this.selectValue = cloneDeep(this.selectValue);
         });
     }
 


### PR DESCRIPTION
Force the FilterChooser's Select's input value to our bound value following an autocomplete. Fixes https://github.com/xh/hoist-react/issues/2732

This is a regression caused by this change: https://github.com/xh/hoist-react/commit/bfaeac4cb81bd4aa69f40e1b666aa9dd338f3843

We were previously setting the `selectValue` to match the displayFilters after an auto complete via `setValue()`. However, now we early out of `setValue` if the actual parsed filter value hasn't changed. This PR ensures the `selectValue` remains correctly displayed within the Select after an auto-complete.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

