### PR TITLE
Edit alert banners without reshowing

### DIFF
--- a/svc/AlertBannerService.js
+++ b/svc/AlertBannerService.js
@@ -31,8 +31,8 @@ export class AlertBannerService extends HoistService {
         return this.interval > 0;
     }
 
-    get lastDismissedId() {
-        return XH.localStorageService.get('xhAlertBanner.lastDismissedId');
+    get lastDismissed() {
+        return XH.localStorageService.get('xhAlertBanner.lastDismissed');
     }
 
     async initAsync() {
@@ -45,25 +45,24 @@ export class AlertBannerService extends HoistService {
     async checkForBannerAsync() {
         if (!this.enabled) return;
 
-        const category = 'xhAlertBanner',
-            results = await XH.jsonBlobService.listAsync({
-                type: 'xhAlertBanner',
-                includeValue: true
-            });
+        const results = await XH.jsonBlobService.listAsync({
+            type: 'xhAlertBanner',
+            includeValue: true
+        });
 
         if (isEmpty(results)) {
-            XH.hideBanner(category);
+            XH.hideBanner('xhAlertBanner');
             return;
         }
 
-        const {id, active, message, intent, iconName, enableClose, expires} = results[0].value,
-            {lastDismissedId} = this;
+        const {active, message, intent, iconName, enableClose, publishDate, expires} = results[0].value,
+            {lastDismissed, onClose} = this;
 
         if (!active || !message || (expires && expires < Date.now())) {
-            XH.hideBanner(category);
-        } else if (!lastDismissedId || lastDismissedId < id) {
+            XH.hideBanner('xhAlertBanner');
+        } else if (!lastDismissed || lastDismissed < publishDate) {
             const conf = this.genBannerConfig({message, intent, iconName, enableClose});
-            XH.showBanner({...conf, onClose: () => this.onClose(id)});
+            XH.showBanner({...conf, onClose});
         }
     }
 
@@ -74,7 +73,7 @@ export class AlertBannerService extends HoistService {
             showFullAlert = () => XH.alert({
                 title: 'Alert',
                 icon,
-                message: div(msgLines.map(it => p(it)))
+                message: div(msgLines.map(p))
             });
 
         let actionButtonProps, onClick;
@@ -98,7 +97,7 @@ export class AlertBannerService extends HoistService {
         };
     }
 
-    onClose = (id) => {
-        XH.localStorageService.set('xhAlertBanner.lastDismissedId', id);
+    onClose = () => {
+        XH.localStorageService.set('xhAlertBanner.lastDismissed', Date.now());
     }
 }


### PR DESCRIPTION
Allow editing an active alert banner without reshowing it to users who have already dismissed it

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

