### PR TITLE
Thinner TreeMap borders

### DIFF
--- a/desktop/cmp/treemap/TreeMap.scss
+++ b/desktop/cmp/treemap/TreeMap.scss
@@ -20,14 +20,15 @@
   }
 
   rect.highcharts-point {
-    outline-style: solid;
-    outline-width: 1px;
-    outline-offset: -1px;
-    // Using transparent borders means they 'double' up, leading to
-    // slightly more pronounced borders around parent groups.
-    outline-color: rgba(0, 0, 0, 0.15);
+    stroke: rgba(0, 0, 0, 0.2);
+    stroke-width: 1px;
 
     &.highcharts-point-select {
+      // We need to *remove* the stroke in order for the inset outline to work
+      stroke: none;
+      outline-style: solid;
+      outline-width: 1px;
+      outline-offset: -1px;
       outline-color: var(--xh-blue-light);
     }
   }
@@ -41,7 +42,7 @@
 
   // Use white borders in dark theme
   &--dark rect.highcharts-point {
-    outline-color: rgba(255, 255, 255, 0.2);
+    stroke: rgba(255, 255, 255, 0.2);
   }
 }
 


### PR DESCRIPTION
Use `stroke` rather than `outline` to prevent TreeMap borders from doubling up

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

