### PR TITLE
Remove mask override from BP context menus / popovers

### DIFF
--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -50,7 +50,7 @@
 
 // Customized here for backdrops behind dialogs.
 // Note that masks use their own CSS var, set in Mask.scss.
-.bp3-overlay-backdrop {
+.bp3-overlay-backdrop:not(.bp3-popover-backdrop) {
   background-color: var(--xh-backdrop-bg);
 }
 


### PR DESCRIPTION
Scoped use of `--xh-backdrop-bg` var to only apply to dialog backdrops, and not popover backdrops (i.e. ContextMenu.show() in DashContainer and Charts, Popovers with `hasBackdrop: true`)

Fixes https://github.com/xh/hoist-react/issues/2740

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

