### PR TITLE
Viewport orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Changes to App Options are now tracked in the admin activity tab.
 * New Server > Environment tab added to Admin Console to display UI server environment variables and
   JVM system properties. (Requires `hoist-core >= 10.1` to enable this optional feature.)
+* Provided observable getters `XH.viewportSize`, `XH.isPortrait` and `XH.isLandscape` to allow apps
+  to react to changes in viewport size and orientation.
 
 ### 🐞 Bug Fixes
 

--- a/appcontainer/AppContainerModel.js
+++ b/appcontainer/AppContainerModel.js
@@ -15,6 +15,7 @@ import {ImpersonationBarModel} from './ImpersonationBarModel';
 import {MessageSourceModel} from './MessageSourceModel';
 import {OptionsDialogModel} from './OptionsDialogModel';
 import {SizingModeModel} from './SizingModeModel';
+import {ViewportSizeModel} from './ViewportSizeModel';
 import {ThemeModel} from './ThemeModel';
 import {ToastSourceModel} from './ToastSourceModel';
 
@@ -42,6 +43,7 @@ export class AppContainerModel extends HoistModel {
 
     @managed refreshContextModel = new RootRefreshContextModel();
     @managed sizingModeModel = new SizingModeModel();
+    @managed viewportSizeModel = new ViewportSizeModel();
     @managed themeModel = new ThemeModel();
 
     init() {
@@ -58,6 +60,7 @@ export class AppContainerModel extends HoistModel {
             this.toastSourceModel,
             this.refreshContextModel,
             this.sizingModeModel,
+            this.viewportSizeModel,
             this.themeModel
         ];
         models.forEach(it => {

--- a/appcontainer/ViewportSizeModel.js
+++ b/appcontainer/ViewportSizeModel.js
@@ -1,0 +1,62 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2021 Extremely Heavy Industries Inc.
+ */
+import {HoistModel} from '@xh/hoist/core';
+import {action, computed, observable, makeObservable} from '@xh/hoist/mobx';
+import {debounced} from '@xh/hoist/utils/js';
+
+/**
+ * Track observable width / height of the browser viewport, and provide observable
+ * access to device orientation
+ *
+ * @private
+ */
+export class ViewportSizeModel extends HoistModel {
+
+    /** @member {Number} */
+    @observable width;
+
+    /** @member {Number} */
+    @observable height;
+
+    /** @returns {Object} */
+    @computed.struct
+    get size() {
+        const {width, height} = this;
+        return {width, height};
+    }
+
+    /** @returns {boolean} */
+    @computed
+    get isPortrait() {
+        return this.width < this.height;
+    }
+
+    /** @returns {boolean} */
+    get isLandscape() {
+        return !this.isPortrait;
+    }
+
+    constructor() {
+        super();
+        makeObservable(this);
+        window.addEventListener('resize', () => this.setViewportSize());
+    }
+
+    init() {
+        this.setViewportSize();
+    }
+
+    //---------------------
+    // Implementation
+    //---------------------
+    @debounced(500)
+    @action
+    setViewportSize() {
+        this.width = window.innerWidth;
+        this.height = window.innerHeight;
+    }
+}

--- a/appcontainer/ViewportSizeModel.js
+++ b/appcontainer/ViewportSizeModel.js
@@ -6,7 +6,6 @@
  */
 import {HoistModel} from '@xh/hoist/core';
 import {action, computed, observable, makeObservable} from '@xh/hoist/mobx';
-import {debounced} from '@xh/hoist/utils/js';
 
 /**
  * Track observable width / height of the browser viewport, and provide observable
@@ -53,7 +52,6 @@ export class ViewportSizeModel extends HoistModel {
     //---------------------
     // Implementation
     //---------------------
-    @debounced(500)
     @action
     setViewportSize() {
         this.width = window.innerWidth;

--- a/appcontainer/ViewportSizeModel.js
+++ b/appcontainer/ViewportSizeModel.js
@@ -21,7 +21,7 @@ export class ViewportSizeModel extends HoistModel {
     /** @returns {boolean} */
     @computed
     get isPortrait() {
-        return this.width < this.height;
+        return this.size.width < this.size.height;
     }
 
     /** @returns {boolean} */

--- a/appcontainer/ViewportSizeModel.js
+++ b/appcontainer/ViewportSizeModel.js
@@ -15,18 +15,8 @@ import {action, computed, observable, makeObservable} from '@xh/hoist/mobx';
  */
 export class ViewportSizeModel extends HoistModel {
 
-    /** @member {Number} */
-    @observable width;
-
-    /** @member {Number} */
-    @observable height;
-
-    /** @returns {Object} */
-    @computed.struct
-    get size() {
-        const {width, height} = this;
-        return {width, height};
-    }
+    /** @member {Object} - contains `width` and `height` in pixels */
+    @observable.ref size;
 
     /** @returns {boolean} */
     @computed
@@ -43,9 +33,6 @@ export class ViewportSizeModel extends HoistModel {
         super();
         makeObservable(this);
         window.addEventListener('resize', () => this.setViewportSize());
-    }
-
-    init() {
         this.setViewportSize();
     }
 
@@ -54,7 +41,9 @@ export class ViewportSizeModel extends HoistModel {
     //---------------------
     @action
     setViewportSize() {
-        this.width = window.innerWidth;
-        this.height = window.innerHeight;
+        this.size = {
+            width: window.innerWidth,
+            height: window.innerHeight
+        };
     }
 }

--- a/core/XH.js
+++ b/core/XH.js
@@ -348,17 +348,17 @@ class XHClass extends HoistBase {
     //------------------------
     // Viewport Size
     //------------------------
-    /** @return {Object} - current viewport width / height. */
+    /** @return {Object} - current viewport width / height. (observable) */
     get viewportSize() {
         return this.acm.viewportSizeModel.size;
     }
 
-    /** @return {boolean} - is the viewport in portrait orientation. */
+    /** @return {boolean} - is the viewport in portrait orientation? (observable) */
     get isPortrait() {
         return this.acm.viewportSizeModel.isPortrait;
     }
 
-    /** @return {boolean} - is the viewport in landscape orientation. */
+    /** @return {boolean} - is the viewport in landscape orientation? (observable) */
     get isLandscape() {
         return this.acm.viewportSizeModel.isLandscape;
     }

--- a/core/XH.js
+++ b/core/XH.js
@@ -345,6 +345,24 @@ class XHClass extends HoistBase {
         return this.acm.sizingModeModel.sizingMode;
     }
 
+    //------------------------
+    // Viewport Size
+    //------------------------
+    /** @return {Object} - current viewport width / height. */
+    get viewportSize() {
+        return this.acm.viewportSizeModel.size;
+    }
+
+    /** @return {boolean} - is the viewport in portrait orientation. */
+    get isPortrait() {
+        return this.acm.viewportSizeModel.isPortrait;
+    }
+
+    /** @return {boolean} - is the viewport in landscape orientation. */
+    get isLandscape() {
+        return this.acm.viewportSizeModel.isLandscape;
+    }
+
     //-------------------------
     // Routing support
     //-------------------------


### PR DESCRIPTION
Add observable viewport size and orientation getters. Primary motivation is allow an easier way for mobile / tablet apps to react to orientation changes.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

