### PR TITLE
Stop editing immediately after selecting a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v45.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* Desktop inline grid editor `Select` now commits the value immediately on selection.
 
 ## v44.1.0 - 2021-11-08
 

--- a/desktop/cmp/grid/editors/SelectEditor.js
+++ b/desktop/cmp/grid/editors/SelectEditor.js
@@ -23,6 +23,13 @@ export const [SelectEditor, selectEditor] = hoistCmp.withFactory({
                 hideDropdownIndicator: true,
                 hideSelectedOptionCheck: true,
                 selectOnFocus: false,
+                onCommit: () => {
+                    // When not full-row editing we end the editing after commit to avoid the need
+                    // for the user to click somewhere outside the cell before the record would be
+                    // updated
+                    const {gridModel} = props;
+                    if (!gridModel.fullRowEditing) gridModel.endEditAsync();
+                },
                 rsOptions: {
                     styles: {
                         menu: styles => ({

--- a/desktop/cmp/grid/editors/SelectEditor.js
+++ b/desktop/cmp/grid/editors/SelectEditor.js
@@ -24,9 +24,7 @@ export const [SelectEditor, selectEditor] = hoistCmp.withFactory({
                 hideSelectedOptionCheck: true,
                 selectOnFocus: false,
                 onCommit: () => {
-                    // When not full-row editing we end the editing after commit to avoid the need
-                    // for the user to click somewhere outside the cell before the record would be
-                    // updated
+                    // When not full-row editing we end editing after commit to avoid extra clicks
                     const {gridModel} = props;
                     if (!gridModel.fullRowEditing) gridModel.endEditAsync();
                 },


### PR DESCRIPTION
Spent a while also trying to get `openMenuOnFocus` to work properly - but it introduces potential issues with tabbing through cells due to some react-select bugs re: setting focus correctly in the menu to the selected option. Decided that shouldn't block getting this simple and nice enhancement in.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

