### PR TITLE
Add ability to show a menu button in dash container stack header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v45.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* `DashContainerModel` now supports an observable `showMenuButton` config which will display a
+  button in the stack header for showing the context menu
 
 ## v44.1.0 - 2021-11-08
 

--- a/desktop/cmp/dash/DashContainer.scss
+++ b/desktop/cmp/dash/DashContainer.scss
@@ -10,3 +10,12 @@
     }
   }
 }
+
+.xh-dash-container-menu-btn {
+  margin: 2px 0;
+  padding: 0 !important;
+  height: 22px;
+  width: 22px;
+  min-height: 22px;
+  min-width: 22px;
+}

--- a/desktop/cmp/dash/DashContainerModel.js
+++ b/desktop/cmp/dash/DashContainerModel.js
@@ -4,6 +4,7 @@
  *
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
+import ReactDOM from 'react-dom';
 import {HoistModel, managed, RefreshMode, RenderMode, XH, PersistenceProvider, TaskObserver} from '@xh/hoist/core';
 import {convertIconToHtml, deserializeIcon} from '@xh/hoist/icon';
 import {ContextMenu} from '@xh/hoist/kit/blueprint';
@@ -15,6 +16,7 @@ import {createObservableRef} from '@xh/hoist/utils/react';
 import {cloneDeep, defaultsDeep, find, isFinite, reject} from 'lodash';
 import {DashViewModel} from './DashViewModel';
 import {DashViewSpec} from './DashViewSpec';
+import {dashContainerMenuButton} from './impl/DashContainerMenuButton';
 import {dashContainerContextMenu} from './impl/DashContainerContextMenu';
 import {convertGLToState, convertStateToGL, getViewModelId} from './impl/DashContainerUtils';
 import {dashView} from './impl/DashView';
@@ -96,6 +98,8 @@ export class DashContainerModel extends HoistModel {
     @bindable contentLocked;
     /** @member {boolean} */
     @bindable renameLocked;
+    /** @member {boolean} */
+    @bindable showMenuButton;
 
     //------------------------
     // Immutable public properties
@@ -131,6 +135,8 @@ export class DashContainerModel extends HoistModel {
      * @param {boolean} [c.layoutLocked] - prevent re-arranging views by dragging and dropping.
      * @param {boolean} [c.contentLocked] - prevent adding and removing views.
      * @param {boolean} [c.renameLocked] - prevent renaming views.
+     * @param {boolean} [c.showMenuButton] - true to include a button in each stack header showing
+     *      the dash context menu.
      * @param {Object} [c.goldenLayoutSettings] - custom settings to be passed to the GoldenLayout instance.
      *      @see http://golden-layout.com/docs/Config.html
      * @param {PersistOptions} [c.persistWith] - options governing persistence
@@ -149,6 +155,7 @@ export class DashContainerModel extends HoistModel {
         layoutLocked = false,
         contentLocked = false,
         renameLocked = false,
+        showMenuButton = false,
         goldenLayoutSettings,
         persistWith = null,
         emptyText = 'No views have been added to the container.',
@@ -169,6 +176,7 @@ export class DashContainerModel extends HoistModel {
         this.layoutLocked = layoutLocked;
         this.contentLocked = contentLocked;
         this.renameLocked = renameLocked;
+        this.showMenuButton = showMenuButton;
         this.goldenLayoutSettings = goldenLayoutSettings;
         this.emptyText = emptyText;
         this.addViewButtonText = addViewButtonText;
@@ -379,6 +387,10 @@ export class DashContainerModel extends HoistModel {
     onStackCreated(stack) {
         // Listen to active item change to support RenderMode
         stack.on('activeContentItemChanged', () => this.onStackActiveItemChange(stack));
+
+        // Add menu button to stack header
+        const containerEl = stack.header.controlsContainer[0];
+        ReactDOM.render(dashContainerMenuButton({dashContainerModel: this, stack}), containerEl);
 
         // Add context menu listener for adding components
         const $el = stack.header.element;

--- a/desktop/cmp/dash/impl/DashContainerContextMenu.js
+++ b/desktop/cmp/dash/impl/DashContainerContextMenu.js
@@ -19,7 +19,7 @@ import {isEmpty} from 'lodash';
  * @private
  */
 export const dashContainerContextMenu = hoistCmp.factory({
-    model: null, observable: null,
+    model: null, observer: null,
     render(props) {
         const menuItems = createMenuItems(props);
         return contextMenu({menuItems});

--- a/desktop/cmp/dash/impl/DashContainerMenuButton.js
+++ b/desktop/cmp/dash/impl/DashContainerMenuButton.js
@@ -1,0 +1,34 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2021 Extremely Heavy Industries Inc.
+ */
+import {hoistCmp} from '@xh/hoist/core';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {Icon} from '@xh/hoist/icon';
+import {popover, Position} from '@xh/hoist/kit/blueprint';
+import {dashContainerContextMenu} from './DashContainerContextMenu';
+
+/**
+ * Button and popover for displaying the context menu. Apps can control whether this button is
+ * displayed via DashContainerModel's `showMenuButton` config.
+ *
+ * @see DashContainerModel
+ * @private
+ */
+export const dashContainerMenuButton = hoistCmp.factory({
+    model: null,
+    render({stack, dashContainerModel}) {
+        if (dashContainerModel.contentLocked || !dashContainerModel.showMenuButton) return null;
+
+        return popover({
+            position: Position.BOTTOM,
+            target: button({
+                icon: Icon.ellipsisVertical(),
+                className: 'xh-dash-container-menu-btn'
+            }),
+            content: dashContainerContextMenu({stack, dashContainerModel})
+        });
+    }
+});


### PR DESCRIPTION
Decided to not make this button specific to the add menu, but to just show the context menu in case there are extra menu items added by the app. I think this makes sense and provides the most flexibility.

Toolbox branch: https://github.com/xh/toolbox/tree/dashContainerAddButton

Fixes #2768 

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

