### PR TITLE
Fix fmtNumber's support for large ints and floats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### ⚙️ Technical
 
-* The `formatConfig` property of the fmtConfig methods's config argument has been deprecated.
+* The `formatConfig` property of the `fmtConfig` method's `config` argument has been deprecated.
 
 ## v44.1.0 - 2021-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 * `DashContainerModel` now supports an observable `showMenuButton` config which will display a
   button in the stack header for showing the context menu
 
+### 🐞 Bug Fixes
+
+* `fmtNumber` now correctly rounds and zero pads very large floats.
+
+### ⚙️ Technical
+
+* The `formatConfig` property of the fmtConfig methods's config argument has been deprecated.
+
 ## v44.1.0 - 2021-11-08
 
 ### 🎁 New Features

--- a/admin/columns/Tracking.js
+++ b/admin/columns/Tracking.js
@@ -86,7 +86,8 @@ export const elapsed = {
     renderer: numberRenderer({
         label: 'ms',
         nullDisplay: '-',
-        formatConfig: {thousandSeparated: false, mantissa: 0}
+        withCommas: false,
+        precision: 0
     })
 };
 

--- a/admin/tabs/activity/tracking/ActivityTrackingModel.js
+++ b/admin/tabs/activity/tracking/ActivityTrackingModel.js
@@ -119,7 +119,8 @@ export class ActivityTrackingModel extends HoistModel {
                     valueRenderer: (v) => {
                         return fmtNumber(v, {
                             label: 'ms',
-                            formatConfig: {thousandSeparated: false, mantissa: 0}
+                            withCommas: false,
+                            precision: 0
                         });
                     }
                 },

--- a/admin/tabs/activity/tracking/detail/ActivityDetailView.js
+++ b/admin/tabs/activity/tracking/detail/ActivityDetailView.js
@@ -91,7 +91,8 @@ const detailRecForm = hoistCmp.factory(
                                     label: 'ms',
                                     nullDisplay: '-',
                                     asElement: true,
-                                    formatConfig: {thousandSeparated: false, mantissa: 0}
+                                    withCommas: false,
+                                    precision: 0
                                 })
                             }),
                             formField({

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -84,7 +84,7 @@ export function fmtNumber(v, {
         apiDeprecated('formatConfig', {msg: `Formatting via Numbro will soon be removed.`, v: 'v45'});
         str = numbro(v).format(formatConfig).replace('-', '');
     } else {
-        let BN = buildBNInstance(v, precision, zeroPad, withCommas, omitFourDigitComma),
+        let BN = buildBnInstance(v, precision, zeroPad, withCommas, omitFourDigitComma),
             dp = BN.config().DECIMAL_PLACES;
         BN = BN(v).abs();
         str = zeroPad ? BN.toFormat(dp) : BN.dp(dp).toFormat();
@@ -331,7 +331,7 @@ function valueColor(v, colorSpec) {
     return colorSpec.neutral;
 }
 
-function buildBNInstance(v, precision, zeroPad, withCommas, omitFourDigitComma) {
+function buildBnInstance(v, precision, zeroPad, withCommas, omitFourDigitComma) {
     const num = BigNumber(v).abs();
     let mantissa = undefined;
 

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -332,7 +332,7 @@ function valueColor(v, colorSpec) {
 }
 
 function buildBNInstance(v, precision, zeroPad, withCommas, omitFourDigitComma) {
-    const num = Math.abs(v),
+    const num = BigNumber(v).abs(),
         format = BigNumber.config().FORMAT;  // the default BigNumber format
 
     let mantissa = undefined;
@@ -341,13 +341,13 @@ function buildBNInstance(v, precision, zeroPad, withCommas, omitFourDigitComma) 
         precision = precision < MAX_NUMERIC_PRECISION ? precision : MAX_NUMERIC_PRECISION;
         mantissa = precision === 0 ? 0 : precision;
     } else {
-        if (num === 0) {
+        if (num.eq(0)) {
             mantissa = 2;
-        } else if (num < .01) {
+        } else if (num.lt(.01)) {
             mantissa = 6;
-        } else if (num < 100) {
+        } else if (num.lt(100)) {
             mantissa = 4;
-        } else if (num < 10000) {
+        } else if (num.lt(10000)) {
             mantissa = 2;
         } else {
             mantissa = 0;
@@ -355,7 +355,7 @@ function buildBNInstance(v, precision, zeroPad, withCommas, omitFourDigitComma) 
     }
 
     const useCommas = withCommas &&
-        !(omitFourDigitComma && num < 10000 && (mantissa === 0 || (!zeroPad && Number.isInteger(num))));
+        !(omitFourDigitComma && num.lt(10000) && (mantissa === 0 || (!zeroPad && num.isInteger())));
     format.groupSeparator = useCommas ? ',' : '';
 
     return BigNumber.clone({DECIMAL_PLACES: mantissa, FORMAT: format });

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -29,7 +29,7 @@ const UP_TICK = '▴',
  * @param {number} v - value to format.
  * @param {Object} [opts]
  * @param {string} [opts.nullDisplay] - display string for null values.
- * @param {Object} [opts.formatConfig] - a valid numbro format object.
+ * @param {Object} [opts.formatConfig] - @deprecated - a valid numbro format object.
  * @param {(number|'auto')} [opts.precision] - desired number of decimal places.
  * @param {boolean} [opts.zeroPad] - true to pad with trailing zeros out to given precision.
  * @param {boolean} [opts.ledger] - true to use ledger format.

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -332,9 +332,7 @@ function valueColor(v, colorSpec) {
 }
 
 function buildBNInstance(v, precision, zeroPad, withCommas, omitFourDigitComma) {
-    const num = BigNumber(v).abs(),
-        format = BigNumber.config().FORMAT;  // the default BigNumber format
-
+    const num = BigNumber(v).abs();
     let mantissa = undefined;
 
     if (precision % 1 === 0) {
@@ -355,10 +353,11 @@ function buildBNInstance(v, precision, zeroPad, withCommas, omitFourDigitComma) 
     }
 
     const useCommas = withCommas &&
-        !(omitFourDigitComma && num.lt(10000) && (mantissa === 0 || (!zeroPad && num.isInteger())));
-    format.groupSeparator = useCommas ? ',' : '';
+        !(omitFourDigitComma && num.lt(10000) && (mantissa === 0 || (!zeroPad && num.isInteger()))),
+        {FORMAT} = BigNumber.config(), // the default BigNumber format
+        groupSeparator = useCommas ? ',' : '';
 
-    return BigNumber.clone({DECIMAL_PLACES: mantissa, FORMAT: format });
+    return BigNumber.clone({DECIMAL_PLACES: mantissa, FORMAT: {...FORMAT, groupSeparator}});
 }
 
 function isInvalidInput(v) {

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -26,7 +26,7 @@ const UP_TICK = '▴',
 /**
  * Standard number formatting for Hoist
  *
- * @param {number} v - value to format.
+ * @param {(number|string|BigNumber)} v - value to format.
  * @param {Object} [opts]
  * @param {string} [opts.nullDisplay] - display string for null values.
  * @param {Object} [opts.formatConfig] - @deprecated - a valid numbro format object.
@@ -105,14 +105,14 @@ export function fmtNumber(v, {
 /**
  * Render number in thousands.
  *
- * @param {number} v - value to format.
+ * @param {(number|string|BigNumber)} v - value to format.
  * @param {Object} [opts] - @see {@link fmtNumber} method.
  */
 export function fmtThousands(v, opts)  {
     opts = {...opts};
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
-    v = v / THOUSAND;
+    v = BigNumber(v).dividedBy(THOUSAND);
     if (opts.label === true) opts.label = 'k';
     return fmtNumber(v, opts);
 }
@@ -120,7 +120,7 @@ export function fmtThousands(v, opts)  {
 /**
  * Render number in millions.
  *
- * @param {number} v - value to format.
+ * @param {(number|string|BigNumber)} v - value to format.
  * @param {Object} [opts] - @see {@link fmtNumber} method.
  */
 export function fmtMillions(v, opts)  {
@@ -128,7 +128,7 @@ export function fmtMillions(v, opts)  {
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
-    v = v / MILLION;
+    v = BigNumber(v).dividedBy(MILLION);
     if (opts.label === true) opts.label = 'm';
     return fmtNumber(v, opts);
 }
@@ -137,7 +137,7 @@ export function fmtMillions(v, opts)  {
 /**
  * Render number in billions.
  *
- * @param {number} v - value to format.
+ * @param {(number|string|BigNumber)} v - value to format.
  * @param {Object} [opts] - @see {@link fmtNumber} method.
  */
 export function fmtBillions(v, opts)  {
@@ -145,7 +145,7 @@ export function fmtBillions(v, opts)  {
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
-    v = v / BILLION;
+    v = BigNumber(v).dividedBy(BILLION);
     if (opts.label === true) opts.label = 'b';
     return fmtNumber(v, opts);
 }
@@ -153,7 +153,7 @@ export function fmtBillions(v, opts)  {
 /**
  * Render a quantity value, handling highly variable amounts by using 2dp millions for values > 1m
  *
- * @param {number} v - value to format.
+ * @param {(number|string|BigNumber)} v - value to format.
  * @param {Object} [opts] - @see {@link fmtNumber} method.
  */
 export function fmtQuantity(v, opts = {}) {
@@ -161,7 +161,8 @@ export function fmtQuantity(v, opts = {}) {
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
-    const lessThanM = Math.abs(v) < MILLION;
+    v = BigNumber(v);
+    const lessThanM = v.abs().lt(MILLION);
 
     defaults(opts, {
         ledger: true,
@@ -175,7 +176,7 @@ export function fmtQuantity(v, opts = {}) {
 /**
  * Render market price
  *
- * @param {number} v - value to format.
+ * @param {(number|string|BigNumber)} v - value to format.
  * @param {Object} [opts] - @see {@link fmtNumber} method.
  */
 export function fmtPrice(v, opts) {
@@ -183,9 +184,10 @@ export function fmtPrice(v, opts) {
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
+    v = BigNumber(v);
     if (opts.precision === undefined) {
-        const absVal = Math.abs(v);
-        opts.precision = absVal < 1000 && absVal !== 0 ? 2 : 0;
+        const absVal = v.abs();
+        opts.precision = absVal.lt(1000) && !absVal.eq(0) ? 2 : 0;
     }
 
     return fmtNumber(v, opts);
@@ -195,7 +197,7 @@ export function fmtPrice(v, opts) {
  * Render a number as a percent. Value will be multiplied by 100 to calculated the percentage.
  * This behavior purposefully matches Microsoft Excel's percentage formatting.
  *
- * @param {number} v - value to format.
+ * @param {(number|string|BigNumber)} v - value to format.
  * @param {Object} [opts] - @see {@link fmtNumber} method.
  */
 export function fmtPercent(v, opts = {}) {
@@ -204,14 +206,14 @@ export function fmtPercent(v, opts = {}) {
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
     defaults(opts, {precision: 2, label: '%', labelCls: null});
-    return fmtNumber(v * 100, opts);
+    return fmtNumber(BigNumber(v).times(100), opts);
 }
 
 /**
  * Render a minimally formatted, full precision number, suitable for use in tooltips.
  * Only ledger opt is supported.
  *
- * @param {number} v - value to format.
+ * @param {(number|string|BigNumber)} v - value to format.
  * @param {Object} [opts]
  * @param {boolean} [opts.ledger] - true to use ledger format.
  */

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -112,7 +112,7 @@ export function fmtThousands(v, opts)  {
     opts = {...opts};
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
-    v = BigNumber(v).dividedBy(THOUSAND);
+    v = new BigNumber(v).dividedBy(THOUSAND);
     if (opts.label === true) opts.label = 'k';
     return fmtNumber(v, opts);
 }
@@ -128,7 +128,7 @@ export function fmtMillions(v, opts)  {
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
-    v = BigNumber(v).dividedBy(MILLION);
+    v = new BigNumber(v).dividedBy(MILLION);
     if (opts.label === true) opts.label = 'm';
     return fmtNumber(v, opts);
 }
@@ -145,7 +145,7 @@ export function fmtBillions(v, opts)  {
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
-    v = BigNumber(v).dividedBy(BILLION);
+    v = new BigNumber(v).dividedBy(BILLION);
     if (opts.label === true) opts.label = 'b';
     return fmtNumber(v, opts);
 }
@@ -161,7 +161,7 @@ export function fmtQuantity(v, opts = {}) {
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
-    v = BigNumber(v);
+    v = new BigNumber(v);
     const lessThanM = v.abs().lt(MILLION);
 
     defaults(opts, {
@@ -184,7 +184,7 @@ export function fmtPrice(v, opts) {
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
-    v = BigNumber(v);
+    v = new BigNumber(v);
     if (opts.precision === undefined) {
         const absVal = v.abs();
         opts.precision = absVal.lt(1000) && !absVal.eq(0) ? 2 : 0;


### PR DESCRIPTION
This PR resolves this issue: https://github.com/xh/hoist-react/issues/2780

This corresponding toolbox branch https://github.com/xh/toolbox/pull/541 should also be merged, it adds a few tests that help confirm this fix is working.

Some helpful reference links:
https://mikemcl.github.io/bignumber.js/#
https://stackoverflow.com/questions/45929493/node-js-maximum-safe-floating-point-number

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile: did not yet test on mobile, not expecting any issues.  
- [x] Created Toolbox branch.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

