### PR TITLE
Per column MANAGED autosize mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Desktop inline grid editor `Select` now commits the value immediately on selection.
 * `DashContainerModel` now supports an observable `showMenuButton` config which will display a
   button in the stack header for showing the context menu
+* Added `GridAutosizeMode.MANAGED` to autosize Grid columns on data or `sizingMode` changes, unless
+  the user has manually modified their column widths. It is now the default `GridAutosizeOptions.mode`.
 
 ## v44.1.0 - 2021-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * `DashContainerModel` now supports an observable `showMenuButton` config which will display a
   button in the stack header for showing the context menu
 * Added `GridAutosizeMode.MANAGED` to autosize Grid columns on data or `sizingMode` changes, unless
-  the user has manually modified their column widths. It is now the default `GridAutosizeOptions.mode`.
+  the user has manually modified their column widths.
 
 ## v44.1.0 - 2021-11-08
 

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -530,12 +530,15 @@ class GridLocalModel extends HoistModel {
     }
 
     sizingModeReaction() {
-        const {model} = this;
+        const {model} = this,
+            {mode} = model.autosizeOptions;
+
         return {
             track: () => model.sizingMode,
             run: () => {
-                if (model.autosizeOptions.mode !== GridAutosizeMode.ON_SIZING_MODE_CHANGE) return;
-                model.autosizeAsync({showMask: true});
+                if (mode === GridAutosizeMode.MANAGED || mode === GridAutosizeMode.ON_SIZING_MODE_CHANGE) {
+                    model.autosizeAsync({showMask: true});
+                }
             }
         };
     }
@@ -657,6 +660,11 @@ class GridLocalModel extends HoistModel {
             wait().then(() => this.syncSelection());
         }
 
+        if (model.autosizeOptions.mode === GridAutosizeMode.MANAGED) {
+            const columns = model.getManagedAutosizeColumns();
+            model.autosizeAsync({columns});
+        }
+
         model.noteAgExpandStateChange();
 
         this._prevRs = newRs;
@@ -700,7 +708,10 @@ class GridLocalModel extends HoistModel {
 
     // Catches column resizing on call to autoSize API.
     onColumnResized = (ev) => {
-        if (isDisplayed(this.viewRef.current) && ev.finished && ev.source === 'autosizeColumns') {
+        if (!isDisplayed(this.viewRef.current) || !ev.finished) return;
+        if (ev.source === 'uiColumnDragged') {
+            this.model.noteColumnManuallySized(ev.column.colId);
+        } else if (ev.source === 'autosizeColumns') {
             this.model.noteAgColumnStateChanged(ev.columnApi.getColumnState());
         }
         ev.api.resetRowHeights();

--- a/cmp/grid/GridAutosizeMode.js
+++ b/cmp/grid/GridAutosizeMode.js
@@ -21,16 +21,16 @@ export const GridAutosizeMode = Object.freeze({
     ON_DEMAND: 'onDemand',
 
     /**
-     * In addition to the affordances provided by ON_DEMAND, Grid will autosize columns when
-     * the GridModel's sizingMode changes.
+     * Grid will autosize columns when the GridModel's sizingMode changes.
+     * Also offers the affordances provided by ON_DEMAND.
      */
-    ON_SIZING_MODE_CHANGE: 'onSizingModeChange'
+    ON_SIZING_MODE_CHANGE: 'onSizingModeChange',
 
-    // COMING SOON
-    // /**
-    //  *  Grid will autosize columns when data is *first* loaded into a grid.   Persisted grids
-    //  * will only resize again if GridModel's sizingMode subsequently changes.
-    //  */
-    // ON_FIRST_LOAD: 'onFirstLoad'
+    /**
+     * Grid will autosize columns when the GridModel's sizingMode changes or data is loaded,
+     * unless the user has manually modified their column widths.
+     * Also offers the affordances provided by ON_DEMAND.
+     */
+    MANAGED: 'managed'
 
 });

--- a/cmp/grid/impl/GridPersistenceModel.js
+++ b/cmp/grid/impl/GridPersistenceModel.js
@@ -89,27 +89,28 @@ export class GridPersistenceModel extends HoistModel {
     columnReaction() {
         const {gridModel} = this;
         return {
-            track: () => gridModel.columnState,
-            run: (columnState) => {
-                this.patchState({columns: gridModel.removeTransientWidths(columnState)});
+            track: () => [gridModel.columnState, gridModel.autosizeState],
+            run: ([columnState, autosizeState]) => {
+                this.patchState({
+                    columns: gridModel.removeTransientWidths(columnState),
+                    autosize: autosizeState
+                });
             }
         };
     }
 
     updateGridColumns() {
-        const {gridModel, state} = this;
-        if (!state.columns) return;
-
-        gridModel.setColumnState(state.columns);
+        const {columns, autosize} = this.state;
+        if (!isUndefined(columns)) this.gridModel.setColumnState(columns);
+        if (!isUndefined(autosize)) this.gridModel.setAutosizeState(autosize);
     }
 
     //--------------------------
     // Sort
     //--------------------------
     sortReaction() {
-        const {gridModel} = this;
         return {
-            track: () => gridModel.sortBy,
+            track: () => this.gridModel.sortBy,
             run: (sortBy) => {
                 this.patchState({sortBy: sortBy.map(it => it.toString())});
             }


### PR DESCRIPTION
An alternative PR to: https://github.com/xh/hoist-react/pull/2774

Implement MANAGED autosize mode, tracking which columns have been customized on a per column basis. It is more complex the previous PR, but I feel the complexity is worth it.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

