### PR TITLE
Ensure mouse events are captured over iframes

### DIFF
--- a/desktop/cmp/panel/impl/dragger/DraggerModel.js
+++ b/desktop/cmp/panel/impl/dragger/DraggerModel.js
@@ -224,7 +224,6 @@ export class DraggerModel extends HoistModel {
     /**
      * @param {('none'|'auto')} v - Workaround to allow dragging over iframe, which is its own
      *  separate document and cannot listen for events from main document.
-     *  {@see onDragStart|onDragEnd}
      */
     setIframePointerEvents(v) {
         for (const el of document.getElementsByTagName('iframe')) {

--- a/desktop/cmp/panel/impl/dragger/DraggerModel.js
+++ b/desktop/cmp/panel/impl/dragger/DraggerModel.js
@@ -8,6 +8,7 @@ import {XH, HoistModel} from '@xh/hoist/core';
 import {throwIf} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
 import {clamp, throttle} from 'lodash';
+import $ from 'jquery';
 
 export class DraggerModel extends HoistModel {
 
@@ -53,6 +54,8 @@ export class DraggerModel extends HoistModel {
         const dragger = e.target;
         this.panelEl = dragger.parentElement;
         const {panelEl: panel, panelModel} = this;
+
+        $('iframe').css('pointer-events', 'none');
 
         throwIf(
             !panel.nextElementSibling && !panel.previousElementSibling,
@@ -113,6 +116,8 @@ export class DraggerModel extends HoistModel {
     };
 
     onDragEnd = () => {
+        $('iframe').css('pointer-events', 'auto');
+
         const {panelModel} = this;
         if (!panelModel.isResizing) return;
 

--- a/desktop/cmp/panel/impl/dragger/DraggerModel.js
+++ b/desktop/cmp/panel/impl/dragger/DraggerModel.js
@@ -54,16 +54,12 @@ export class DraggerModel extends HoistModel {
         this.panelEl = dragger.parentElement;
         const {panelEl: panel, panelModel} = this;
 
-        /** Workaround to allow dragging over iframe, which is its own separate document and cannot
-         listen for events from main document. {@see onDragEnd} */
-        if (XH.isDesktop) {
-            document.getElementById('xh-root').classList.add('xh-disable-iframe-pointer-events');
-        }
-
         throwIf(
             !panel.nextElementSibling && !panel.previousElementSibling,
             'Resizable panel has no sibling panel against which to resize.'
         );
+
+        if (XH.isDesktop) this.setIframePointerEvents('none');
 
         e.stopPropagation();
 
@@ -119,10 +115,7 @@ export class DraggerModel extends HoistModel {
     };
 
     onDragEnd = () => {
-        /** Remove class name added as workaround for dragging over iframe {@see onDragStart} */
-        if (XH.isDesktop) {
-            document.getElementById('xh-root').classList.remove('xh-disable-iframe-pointer-events');
-        }
+        if (XH.isDesktop) this.setIframePointerEvents('auto');
 
         const {panelModel} = this;
         if (!panelModel.isResizing) return;
@@ -226,5 +219,16 @@ export class DraggerModel extends HoistModel {
 
     isValidTouchEvent(e) {
         return e.touches && e.touches.length > 0;
+    }
+
+    /**
+     * @param {('none'|'auto')} v - Workaround to allow dragging over iframe, which is its own
+     *  separate document and cannot listen for events from main document.
+     *  {@see onDragStart|onDragEnd}
+     */
+    setIframePointerEvents(v) {
+        for (const el of document.getElementsByTagName('iframe')) {
+            el.style['pointer-events'] = v;
+        }
     }
 }

--- a/desktop/cmp/panel/impl/dragger/DraggerModel.js
+++ b/desktop/cmp/panel/impl/dragger/DraggerModel.js
@@ -8,7 +8,6 @@ import {XH, HoistModel} from '@xh/hoist/core';
 import {throwIf} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
 import {clamp, throttle} from 'lodash';
-import $ from 'jquery';
 
 export class DraggerModel extends HoistModel {
 
@@ -55,8 +54,10 @@ export class DraggerModel extends HoistModel {
         this.panelEl = dragger.parentElement;
         const {panelEl: panel, panelModel} = this;
 
+        /** Workaround to allow dragging over iframe, which is its own separate document and cannot
+         listen for events from main document. {@see onDragEnd} */
         if (XH.isDesktop) {
-            $('iframe').css('pointer-events', 'none');
+            document.getElementById('xh-root').classList.add('xh-disable-iframe-pointer-events');
         }
 
         throwIf(
@@ -118,8 +119,9 @@ export class DraggerModel extends HoistModel {
     };
 
     onDragEnd = () => {
+        /** Remove class name added as workaround for dragging over iframe {@see onDragStart} */
         if (XH.isDesktop) {
-            $('iframe').css('pointer-events', 'auto');
+            document.getElementById('xh-root').classList.remove('xh-disable-iframe-pointer-events');
         }
 
         const {panelModel} = this;

--- a/desktop/cmp/panel/impl/dragger/DraggerModel.js
+++ b/desktop/cmp/panel/impl/dragger/DraggerModel.js
@@ -55,7 +55,9 @@ export class DraggerModel extends HoistModel {
         this.panelEl = dragger.parentElement;
         const {panelEl: panel, panelModel} = this;
 
-        $('iframe').css('pointer-events', 'none');
+        if (XH.isDesktop) {
+            $('iframe').css('pointer-events', 'none');
+        }
 
         throwIf(
             !panel.nextElementSibling && !panel.previousElementSibling,
@@ -116,7 +118,9 @@ export class DraggerModel extends HoistModel {
     };
 
     onDragEnd = () => {
-        $('iframe').css('pointer-events', 'auto');
+        if (XH.isDesktop) {
+            $('iframe').css('pointer-events', 'auto');
+        }
 
         const {panelModel} = this;
         if (!panelModel.isResizing) return;

--- a/styles/XH.scss
+++ b/styles/XH.scss
@@ -63,13 +63,6 @@ body.xh-app {
     cursor: pointer;
   }
 
-  // Workaround to enable panel resizing/splitter dragging over iframes
-  .xh-disable-iframe-pointer-events {
-    iframe {
-      pointer-events: none;
-    }
-  }
-
   // Avoid default select / magnify behaviors on touch-screens
   &.xh-mobile,
   &.xh-tablet {

--- a/styles/XH.scss
+++ b/styles/XH.scss
@@ -63,6 +63,13 @@ body.xh-app {
     cursor: pointer;
   }
 
+  // Workaround to enable panel resizing/splitter dragging over iframes
+  .xh-disable-iframe-pointer-events {
+    iframe {
+      pointer-events: none;
+    }
+  }
+
   // Avoid default select / magnify behaviors on touch-screens
   &.xh-mobile,
   &.xh-tablet {


### PR DESCRIPTION
May resolve #2457 

Temporarily set `pointer-events: none` on iframe elements to capture drag events correctly for panel resizing.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [N/A] Added CHANGELOG entry, or determined not required.
- [N/A] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [N/A] Updated doc comments / prop-types, or determined not required.
- [N/A] Reviewed and tested on Mobile, or determined not required.
- [N/A] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

