### PR TITLE
Support "long press" to open DashContainer ContextMenu on Tablet

### DIFF
--- a/kit/golden-layout/index.js
+++ b/kit/golden-layout/index.js
@@ -59,9 +59,9 @@ GoldenLayout['__lm'].utils.ReactComponentHandler = ReactComponentHandlerPatched;
 const DragListener = GoldenLayout['__lm'].utils.DragListener;
 class DragListenerPatched extends DragListener {
     onMouseDown(oEvent) {
-        oEvent.preventDefault();
-
         // PATCH BEGINS
+        if (oEvent.cancelable) oEvent.preventDefault();
+
         if (oEvent.type === 'touchstart') {
             this._touchTarget = oEvent.target;
 
@@ -87,7 +87,14 @@ class DragListenerPatched extends DragListener {
             this._oDocument.on('mousemove touchmove', this._fMove);
             this._oDocument.one('mouseup touchend', this._fUp);
 
-            this._timeout = setTimeout(GoldenLayout['__lm'].utils.fnBind(this._startDrag, this), this._nDelay);
+            // PATCH BEGINS
+            // Extend time held to begin drag for stationary touch events. Note that this should be
+            // quite long to allow for showing the context menu on a shorter hold. The user can
+            // initiate a drag at any time in the interim by moving their touch.
+            const ms = oEvent.type === 'touchstart' ? 3000 : this._nDelay;
+            this._touchStart = Date.now();
+            this._timeout = setTimeout(GoldenLayout['__lm'].utils.fnBind(this._startDrag, this), ms);
+            // PATCH ENDS
         }
     }
 
@@ -110,7 +117,14 @@ class DragListenerPatched extends DragListener {
             if (this._bDragging === true) {
                 this._bDragging = false;
                 this.emit('dragStop', oEvent, this._nOriginalX + this._nX);
+            // PATCH BEGINS
+            // If the touch is released *before* dragging has started, trigger the context menu
+            // event. We still require a minimum about of time to pass, to differentiate from
+            // taps to change the selected tab.
+            } else if (oEvent.type === 'touchend' && Date.now() - this._touchStart > 800) {
+                this._eElement.trigger('contextmenu');
             }
+            // PATCH ENDS
         }
     }
 }


### PR DESCRIPTION
Adds support for opening the DashContainer ContextMenu via long press on dash view header in Tablet.

Note that this PR categorizes touches as one of 3:

1) Tap, to change the selected tab
2) Long-press, to open the context menu
3) Very long-press, to initiate dragging the dash view. This state can be entered earlier by moving the finger during the long-press.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

