### PR TITLE
#2803 - Chart does not re-render well in fullscreen mode so just close fullscreen mode if it's open.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### 🐞 Bug Fixes
 
 * Fixes issue displaying the DashContainer overflow menu when the menu button is enabled
+* A chart in fullscreen mode now gracefully exits fullscreen mode before re-rendering
 
 * [Commit Log](https://github.com/xh/hoist-react/compare/v44.3.0...develop)
 

--- a/cmp/chart/Chart.js
+++ b/cmp/chart/Chart.js
@@ -154,6 +154,12 @@ class LocalModel extends HoistModel {
     }
 
     renderHighChart() {
+        // Chart does not rerender well in fullscreen mode
+        // so just close fullscreen mode if it's open.
+        if (this.chart?.fullscreen?.isOpen) {
+            this.chart.fullscreen.close();
+        }
+
         this.destroyHighChart();
         const chartElem = this.chartRef.current;
         if (chartElem) {

--- a/cmp/chart/Chart.js
+++ b/cmp/chart/Chart.js
@@ -154,7 +154,7 @@ class LocalModel extends HoistModel {
     }
 
     renderHighChart() {
-        // Chart does not rerender well in fullscreen mode
+        // Chart does not re-render well in fullscreen mode
         // so just close fullscreen mode if it's open.
         if (this.chart?.fullscreen?.isOpen) {
             this.chart.fullscreen.close();


### PR DESCRIPTION
Simple mitigation strategy for the issue described in #2803.
If a chart in fullscreen mode re-renders for some reason, (usually because new data is loaded in to accommodate a date range change) the chart will now exit fullscreen.  Users can get back to fullscreen with the new date range if they want to.

There are other more complex solutions, such as "fade document.body opacity, exit fullscreen before re-render, then re-open fullscreen right after render, then restore document.body opacity" but this creates some UI "jank" and might add more to maintenance complexity than we'd like.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry.
- [x] Reviewed for breaking changes: no breaking changes.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

