### PR TITLE
FilterChooser tweaks

### DIFF
--- a/cmp/filter/FilterChooserModel.js
+++ b/cmp/filter/FilterChooserModel.js
@@ -52,6 +52,9 @@ export class FilterChooserModel extends HoistModel {
     /** @member {boolean} */
     suggestFieldsWhenEmpty;
 
+    /** @member {boolean} */
+    sortFieldSuggestions;
+
     /** @member {number} */
     maxTags;
 
@@ -99,6 +102,8 @@ export class FilterChooserModel extends HoistModel {
      *      configurations, or a function to produce such an array.
      * @param {boolean} [c.suggestFieldsWhenEmpty] - true to offer all field suggestions when the
      *      control is focussed with an empty query, to aid discoverability.
+     * @param {boolean} [c.sortFieldSuggestions] - true (default) to sort field suggestions by
+     *      displayed label. Set to false to preserve the order provided to `fieldSpecs`.
      * @param {number} [c.maxTags] - maximum number of filter tags to render before disabling the
      *      control. Limits the performance impact of rendering large filters.
      * @param {number} [c.maxResults] - maximum number of dropdown options to show before
@@ -113,6 +118,7 @@ export class FilterChooserModel extends HoistModel {
         initialValue = null,
         initialFavorites = [],
         suggestFieldsWhenEmpty = true,
+        sortFieldSuggestions = true,
         maxTags = 100,
         maxResults = 50,
         persistWith,
@@ -125,6 +131,7 @@ export class FilterChooserModel extends HoistModel {
         this.valueSource = valueSource;
         this.fieldSpecs = this.parseFieldSpecs(fieldSpecs, fieldSpecDefaults);
         this.suggestFieldsWhenEmpty = !!suggestFieldsWhenEmpty;
+        this.sortFieldSuggestions = sortFieldSuggestions;
         this.maxTags = maxTags;
         this.maxResults = maxResults;
         this.queryEngine = new QueryEngine(this);

--- a/cmp/filter/impl/Option.js
+++ b/cmp/filter/impl/Option.js
@@ -16,7 +16,7 @@ import {isNil} from 'lodash';
  * Create an option representing a field suggestion
  * @return {FilterChooserOption}
  */
-export function fieldOption({fieldSpec, isExact = false}) {
+export function fieldOption({fieldSpec, isExact = false, inclPrefix = true}) {
     const {displayName} = fieldSpec;
     return {
         type: 'field',
@@ -24,6 +24,7 @@ export function fieldOption({fieldSpec, isExact = false}) {
         label: displayName,
         isExact,
 
+        inclPrefix,
         fieldSpec
     };
 }
@@ -89,7 +90,7 @@ export function msgOption(msg) {
  * @property {string} type - one of ['filter'|'field'|'msg'] - indicates if option allows user to
  *      select a fully-formed filter or a field to use for filtering, or if option is an
  *      unselectable informational message.
- * @property {string} value  - unique value for the underlying Select.
+ * @property {string} value - unique value for the underlying Select.
  * @property {string} label - unique display for the underlying Select.
  * @property {boolean} isExact - if based on a matching process, was this an exact match?
  */

--- a/desktop/cmp/filter/FilterChooser.js
+++ b/desktop/cmp/filter/FilterChooser.js
@@ -125,12 +125,12 @@ function optionRenderer(opt) {
 
 const fieldOption = hoistCmp.factory({
     model: false, observer: false, memo: false,
-    render({fieldSpec}) {
+    render({fieldSpec, inclPrefix}) {
         const {displayName, ops, example} = fieldSpec;
         return hframe({
             className: 'xh-filter-chooser-option__field',
             items: [
-                div('e.g.'),
+                div({className: 'prefix', item: 'e.g.', omit: !inclPrefix}),
                 div({className: 'name', item: displayName}),
                 div({className: 'operators', item: '[ ' + ops.join(', ') + ' ]'}),
                 div({className: 'example', item: example})

--- a/desktop/cmp/filter/FilterChooser.scss
+++ b/desktop/cmp/filter/FilterChooser.scss
@@ -54,6 +54,10 @@
   }
 
   &__field {
+    .prefix {
+      color: var(--xh-text-color-muted);
+    }
+
     .name {
       margin-left: var(--xh-pad-half-px);
       color: var(--xh-intent-primary);


### PR DESCRIPTION
Implement feedback added to https://github.com/xh/hoist-react/pull/2829:

+ Add option to sort field suggestions
+ Omit 'e.g.' prefix from field suggestions when in discover mode
+ Mute styling of 'e.g.' prefix

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

