### PR TITLE
Mobile TabContainer orientation change fix

### DIFF
--- a/mobile/cmp/tab/impl/TabContainer.js
+++ b/mobile/cmp/tab/impl/TabContainer.js
@@ -4,24 +4,24 @@
  *
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
+import {HoistModel, useLocalModel, XH} from '@xh/hoist/core';
 import {div, frame} from '@xh/hoist/cmp/layout';
-import {tab as onsenTab, tabbar} from '@xh/hoist/kit/onsen';
+import {tab as onsenTab, tabbar as onsenTabbar, page} from '@xh/hoist/kit/onsen';
 import {throwIf} from '@xh/hoist/utils/js';
-import classNames from 'classnames';
-import {tab} from './Tab';
 import {isEmpty} from 'lodash';
-import {page} from '@xh/hoist/kit/onsen';
-
+import classNames from 'classnames';
 import './Tabs.scss';
+import {tab} from './Tab';
 
 /**
  * Mobile Implementation of TabContainer.
  *
  * @private
  */
-export function tabContainerImpl({model, className, ...props}) {
+export function tabContainerImpl({model, className}) {
     const {activeTab, switcher} = model,
-        tabs = model.tabs.filter(it => !it.excludeFromSwitcher);
+        tabs = model.tabs.filter(it => !it.excludeFromSwitcher),
+        impl = useLocalModel(LocalModel);
 
     throwIf(
         switcher && !['top', 'bottom'].includes(switcher?.orientation),
@@ -38,11 +38,15 @@ export function tabContainerImpl({model, className, ...props}) {
             })
         });
     }
-    return tabbar({
+
+    return onsenTabbar({
         className: classNames(className, `xh-tab-container--${switcher?.orientation}`),
         position: switcher?.orientation,
         index: activeTab ? tabs.indexOf(activeTab) : 0,
-        renderTabs: () => tabs.map(renderTabModel),
+        renderTabs: (idx, tabbar) => {
+            impl.setSwiper(tabbar?._tabbar?._swiper);
+            return tabs.map(renderTabModel);
+        },
         onPreChange: (e) => model.activateTab(tabs[e.index].id),
         visible: !!switcher,
         ...switcher
@@ -63,4 +67,22 @@ function renderTabModel(tabModel) {
             ]
         })
     };
+}
+
+class LocalModel extends HoistModel {
+
+    swiper;
+
+    setSwiper(swiper) {
+        if (this.swiper) return;
+        this.swiper = swiper;
+    }
+
+    constructor() {
+        super();
+        this.addReaction({
+            track: () => XH.isPortrait,
+            run: () => this.swiper?.onResize()
+        });
+    }
 }

--- a/mobile/cmp/tab/impl/TabContainer.js
+++ b/mobile/cmp/tab/impl/TabContainer.js
@@ -73,15 +73,7 @@ class LocalModel extends HoistModel {
 
     swiper;
 
-    // Capture a reference to the underlying Onsen Swiper from the Tabbar ref.
-    // Note that we must debounce as the first time this method is called the
-    // Tabbar's constructor has not completed and it does not yet have a Swiper.
-    @debounced(1)
-    setSwiper(ref) {
-        if (this.swiper) return;
-        this.swiper = ref?._tabbar?._swiper;
-    }
-
+    // Due to currently unknown reasons, this event handler sometimes gets removed. See: #2842
     constructor() {
         super();
         this.addReaction({
@@ -89,4 +81,14 @@ class LocalModel extends HoistModel {
             run: () => this.swiper?.onResize()
         });
     }
+
+
+    // Capture a reference to the underlying Onsen Swiper from the Tabbar ref.
+    // We must debounce as the first time this method is called the Tabbar's constructor has not completed.
+    @debounced(1)
+    setSwiper(ref) {
+        if (this.swiper) return;
+        this.swiper = ref?._tabbar?._swiper;
+    }
+
 }

--- a/mobile/cmp/tab/impl/TabContainer.js
+++ b/mobile/cmp/tab/impl/TabContainer.js
@@ -7,7 +7,7 @@
 import {HoistModel, useLocalModel, XH} from '@xh/hoist/core';
 import {div, frame} from '@xh/hoist/cmp/layout';
 import {tab as onsenTab, tabbar as onsenTabbar, page} from '@xh/hoist/kit/onsen';
-import {throwIf} from '@xh/hoist/utils/js';
+import {throwIf, debounced} from '@xh/hoist/utils/js';
 import {isEmpty} from 'lodash';
 import classNames from 'classnames';
 import './Tabs.scss';
@@ -43,8 +43,8 @@ export function tabContainerImpl({model, className}) {
         className: classNames(className, `xh-tab-container--${switcher?.orientation}`),
         position: switcher?.orientation,
         index: activeTab ? tabs.indexOf(activeTab) : 0,
-        renderTabs: (idx, tabbar) => {
-            impl.setSwiper(tabbar?._tabbar?._swiper);
+        renderTabs: (idx, ref) => {
+            impl.setSwiper(ref);
             return tabs.map(renderTabModel);
         },
         onPreChange: (e) => model.activateTab(tabs[e.index].id),
@@ -73,9 +73,13 @@ class LocalModel extends HoistModel {
 
     swiper;
 
-    setSwiper(swiper) {
+    // Capture a reference to the underlying Onsen Swiper from the Tabbar ref.
+    // Note that we must debounce as the first time this method is called the
+    // Tabbar's constructor has not completed and it does not yet have a Swiper.
+    @debounced(1)
+    setSwiper(ref) {
         if (this.swiper) return;
-        this.swiper = swiper;
+        this.swiper = ref?._tabbar?._swiper;
     }
 
     constructor() {


### PR DESCRIPTION
This PR is a workaround for inconsistent behaviour resizing a mobile tab container seen in a client app.

Onsen's 'Tabbar' uses a 'Swiper' to manage its page transitions. It sets up a resize event handler, which tells it to recalculate the size of it's pages on window resize: https://github.com/OnsenUI/OnsenUI/blob/05c8ef93b55cf4c21f31d6d614153a21cd51a2f5/core/src/ons/internal/swiper.js#L180

Due to currently unknown reasons, this event handler sometimes gets removed. I haven't yet been able to understand the cause. It happens in the client app but not in Toolbox. For the client app, it happens consistently on device, and very rarely (but it *does* occur) in the emulator. I suspect it may be due to some hard to track down race condition, but this is merely a hunch.

The workaround in this PR uses our own orientation observable to force trigger the Swiper's onResize event. I've tested it on device in the client app and it resolves the issue.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

