### PR TITLE
Change LocalDate's default output fmt to yyyy-mm-dd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 ### 💥 Breaking Changes
 
-* `LocalDate.toString()`, `LocalDate.toJSON()` and `LocalDate.valueOf()` all return a string with dashes: `YYYY-MM-DD`.  
-  Prior versions returned the string without dashes: `YYYYMMDD`.
+* `LocalDate` methods `toString()`, `toJSON()`, `valueOf()`, and `isoString()` now all return the
+standard ISO format: `YYYY-MM-DD`. (Prior versions returned`YYYYMMDD`).
+This is consistent with the built-in javascript `Date.toISOString()`
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### 💥 Breaking Changes
 
 * `LocalDate.toString()`, `LocalDate.toJSON()` and `LocalDate.valueOf()` all return a string with dashes: `YYYY-MM-DD`.  
-  Prior versions returned the string without dashes: `YYYYMMDD`.  Requires Hoist-Core v13.0.5 or later.
+  Prior versions returned the string without dashes: `YYYYMMDD`.
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,19 @@
 
 ## v46.0.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes
+
+* `LocalDate` methods `toString()`, `toJSON()`, `valueOf()`, and `isoString()` now all return the
+  standard ISO format: `YYYY-MM-DD`. (Prior versions returned`YYYYMMDD`).
+  This is consistent with the built-in javascript `Date.toISOString()`
+
+
 ## v45.0.2 - 2022-01-13
 
 ### 🎁 New Features
 
 * `FilterChooser` has new `menuWidth` prop, allowing you to specify as width for the dropdown
   menu that is different from the control.
-
-### 💥 Breaking Changes
-
-* `LocalDate` methods `toString()`, `toJSON()`, `valueOf()`, and `isoString()` now all return the
-standard ISO format: `YYYY-MM-DD`. (Prior versions returned`YYYYMMDD`).
-This is consistent with the built-in javascript `Date.toISOString()`
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 💥 Breaking Changes
 
-* `LocalDate.toString()`, `LocalDate.toJSON()` and `LocalDate.valueOf()` all return a string with dashes: `YYYY-MM-DD`.  Prior versions returned the string without dashes: `YYYYMMDD`.
+* `LocalDate.toString()`, `LocalDate.toJSON()` and `LocalDate.valueOf()` all return a string with dashes: `YYYY-MM-DD`.  Prior versions returned the string without dashes: `YYYYMMDD`.  This changes requires use of Hoist-Core v11.0.4 or later.
 
 ### 🐞 Bug Fixes
 * Fixed cache clearing method on Admin Console's Server > Services tab.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### 💥 Breaking Changes
 
-* `LocalDate.toString()`, `LocalDate.toJSON()` and `LocalDate.valueOf()` all return a string with dashes: `YYYY-MM-DD`.  Prior versions returned the string without dashes: `YYYYMMDD`.  This changes requires use of Hoist-Core v11.0.4 or later.
+* `LocalDate.toString()`, `LocalDate.toJSON()` and `LocalDate.valueOf()` all return a string with dashes: `YYYY-MM-DD`.  
+  Prior versions returned the string without dashes: `YYYYMMDD`.  Requires Hoist-Core v13.0.5 or later.
 
 ### 🐞 Bug Fixes
 * Fixed cache clearing method on Admin Console's Server > Services tab.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## v46.0.0-SNAPSHOT - unreleased
+
+### 💥 Breaking Changes
+
+* `LocalDate.toString()`, `LocalDate.toJSON()` and `LocalDate.valueOf()` all return a string with dashes: `YYYY-MM-DD`.  Prior versions returned the string without dashes: `YYYYMMDD`.
+
 ### 🐞 Bug Fixes
 * Fixed cache clearing method on Admin Console's Server > Services tab.
 

--- a/admin/tabs/activity/clienterrors/ClientErrorsModel.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorsModel.js
@@ -204,7 +204,7 @@ export class ClientErrorsModel extends HoistModel {
     }
 
     getParams() {
-        // TODO - revert formatting when most apps have migrated to Hoist-Core 13.0.5
+        // TODO - revert formatting when most apps have migrated to Hoist-Core 13
         return {
             startDay: this.startDay.format('YYYYMMDD'),
             endDay: this.endDay.format('YYYYMMDD')

--- a/admin/tabs/activity/clienterrors/ClientErrorsModel.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorsModel.js
@@ -204,7 +204,14 @@ export class ClientErrorsModel extends HoistModel {
     }
 
     getParams() {
-        const {startDay, endDay} = this;
+        // TODO - revert this date formatting when most client apps
+        // have migrated to Hoist-Core 13.0.5 or later.
+        const BASIC_ISO_DATE_FORMAT = 'YYYYMMDD';
+
+        const startDay = this.startDay.format(BASIC_ISO_DATE_FORMAT),
+            endDay = this.endDay.format(BASIC_ISO_DATE_FORMAT);
+        // END TODO
+        
         return {startDay, endDay};
     }
 

--- a/admin/tabs/activity/clienterrors/ClientErrorsModel.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorsModel.js
@@ -204,15 +204,11 @@ export class ClientErrorsModel extends HoistModel {
     }
 
     getParams() {
-        // TODO - revert this date formatting when most client apps
-        // have migrated to Hoist-Core 13.0.5 or later.
-        const BASIC_ISO_DATE_FORMAT = 'YYYYMMDD';
-
-        const startDay = this.startDay.format(BASIC_ISO_DATE_FORMAT),
-            endDay = this.endDay.format(BASIC_ISO_DATE_FORMAT);
-        // END TODO
-        
-        return {startDay, endDay};
+        // TODO - revert formatting when most apps have migrated to Hoist-Core 13.0.5
+        return {
+            startDay: this.startDay.format('YYYYMMDD'),
+            endDay: this.endDay.format('YYYYMMDD')
+        };
     }
 
     getDefaultStartDay() {return LocalDate.currentAppDay().subtract(6)}

--- a/admin/tabs/activity/tracking/ActivityTrackingModel.js
+++ b/admin/tabs/activity/tracking/ActivityTrackingModel.js
@@ -203,10 +203,20 @@ export class ActivityTrackingModel extends HoistModel {
 
     async doLoadAsync(loadSpec) {
         const {cube, formModel} = this;
+
+        // TODO - revert this date formatting when most client apps
+        // have migrated to Hoist-Core 13.0.5 or later.
+        const params = formModel.getData(),
+            BASIC_ISO_DATE_FORMAT = 'YYYYMMDD';
+
+        params.startDay = params.startDay.format(BASIC_ISO_DATE_FORMAT);
+        params.endDay = params.endDay.format(BASIC_ISO_DATE_FORMAT);
+        // END TODO
+
         try {
             const data = await XH.fetchJson({
                 url: 'trackLogAdmin',
-                params: formModel.getData(),
+                params,
                 loadSpec
             });
 

--- a/admin/tabs/activity/tracking/ActivityTrackingModel.js
+++ b/admin/tabs/activity/tracking/ActivityTrackingModel.js
@@ -168,7 +168,6 @@ export class ActivityTrackingModel extends HoistModel {
                     flex: 1,
                     minWidth: 100,
                     isTreeColumn: true,
-                    renderer: (v, params) => params.record.raw.cubeDimension === 'day' ? fmtDate(v) : v,
                     comparator: this.cubeLabelComparator.bind(this)
                 },
                 {...Col.username, hidden},

--- a/admin/tabs/activity/tracking/ActivityTrackingModel.js
+++ b/admin/tabs/activity/tracking/ActivityTrackingModel.js
@@ -204,14 +204,11 @@ export class ActivityTrackingModel extends HoistModel {
     async doLoadAsync(loadSpec) {
         const {cube, formModel} = this;
 
-        // TODO - revert this date formatting when most client apps
-        // have migrated to Hoist-Core 13.0.5 or later.
-        const params = formModel.getData(),
-            BASIC_ISO_DATE_FORMAT = 'YYYYMMDD';
+        const params = formModel.getData();
 
-        params.startDay = params.startDay.format(BASIC_ISO_DATE_FORMAT);
-        params.endDay = params.endDay.format(BASIC_ISO_DATE_FORMAT);
-        // END TODO
+        // TODO - revert formatting when most apps have migrated to Hoist-Core 13
+        params.startDay = params.startDay.format('YYYYMMDD');
+        params.endDay = params.endDay.format('YYYYMMDD');
 
         try {
             const data = await XH.fetchJson({

--- a/utils/datetime/LocalDate.js
+++ b/utils/datetime/LocalDate.js
@@ -26,10 +26,6 @@ export class LocalDate {
     static _instances = new Map();
     static VALID_UNITS = ['year', 'quarter', 'month', 'week', 'day', 'date'];
 
-    // Regex to check if string passed to LocalDate.get() needs dashes added.
-    // Input fully validated as a date when passed to moment in constructor.
-    static noDashesRegEx = new RegExp(/^\d{8}$/);
-
     _isoString;
     _moment;
     _date;
@@ -47,9 +43,7 @@ export class LocalDate {
     static get(s) {
         if (isNil(s)) return s;
         throwIf(!isString(s), 'String required for LocalDate.get()');
-        s = LocalDate.noDashesRegEx.test(s) ? 
-            s.slice(0, 4) + '-' + s.slice(4, 6) + '-' + s.slice(6, 8) : 
-            s;
+        s = s.length == 8 ? s.slice(0, 4) + '-' + s.slice(4, 6) + '-' + s.slice(6, 8) : s;
         let {_instances} = this,
             ret = _instances.get(s);
         if (!ret) {

--- a/utils/datetime/LocalDate.js
+++ b/utils/datetime/LocalDate.js
@@ -313,7 +313,7 @@ export class LocalDate {
             !m.isValid(),
             `Invalid argument for LocalDate: ${s}.  Use 'YYYYMMDD' or 'YYYY-MM-DD' format.`
         );
-        this._isoString = s;
+        this._isoString = s.slice(0, 4) + '-' + s.slice(4, 6) + '-' + s.slice(6, 8);
         this._moment = m;
         this._date = m.toDate();
     }

--- a/utils/datetime/LocalDate.js
+++ b/utils/datetime/LocalDate.js
@@ -26,6 +26,10 @@ export class LocalDate {
     static _instances = new Map();
     static VALID_UNITS = ['year', 'quarter', 'month', 'week', 'day', 'date'];
 
+    // Regex to check if string passed to LocalDate.get() needs dashes added.
+    // Input fully validated as a date when passed to moment in constructor.
+    static noDashesRegEx = new RegExp(/^\d{8}$/);
+
     _isoString;
     _moment;
     _date;
@@ -43,7 +47,9 @@ export class LocalDate {
     static get(s) {
         if (isNil(s)) return s;
         throwIf(!isString(s), 'String required for LocalDate.get()');
-        s = s.replace('-', '').replace('-', '');   // Use replaceAll when fully supported.
+        s = LocalDate.noDashesRegEx.test(s) ? 
+            s.slice(0, 4) + '-' + s.slice(4, 6) + '-' + s.slice(6, 8) : 
+            s;
         let {_instances} = this,
             ret = _instances.get(s);
         if (!ret) {
@@ -67,7 +73,7 @@ export class LocalDate {
         if (isNil(val)) return val;
         if (val.isLocalDate) return val;
         const m = moment.isMoment(val) ? val : moment(val);
-        return this.get(m.format('YYYYMMDD'));
+        return this.get(m.format('YYYY-MM-DD'));
     }
 
     /** @returns {LocalDate} - a LocalDate representing the current day. */
@@ -308,12 +314,12 @@ export class LocalDate {
     //-------------------
     /** @private - use one of the static factory methods instead. */
     constructor(s) {
-        const m = moment(s, 'YYYYMMDD', true);
+        const m = moment(s, 'YYYY-MM-DD', true);
         throwIf(
             !m.isValid(),
             `Invalid argument for LocalDate: ${s}.  Use 'YYYYMMDD' or 'YYYY-MM-DD' format.`
         );
-        this._isoString = s.slice(0, 4) + '-' + s.slice(4, 6) + '-' + s.slice(6, 8);
+        this._isoString = s;
         this._moment = m;
         this._date = m.toDate();
     }


### PR DESCRIPTION
This is for issue #2845.
It is a breaking change.

Apps that take this change will need to use Hoist-Core v13.0.5 or later, as mentioned in the changelog entry.

Toolbox PR (with updated LocalDate tests): https://github.com/xh/toolbox/pull/546


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

