### PR TITLE
New `Store.loadTreeDataFrom` config

### DIFF
--- a/data/Store.js
+++ b/data/Store.js
@@ -860,7 +860,7 @@ export class Store extends HoistBase {
 
             recordMap.set(id, rec);
 
-            if (loadTreeData && loadTreeDataFrom && raw[loadTreeDataFrom]) {
+            if (loadTreeData && raw[loadTreeDataFrom]) {
                 this.createRecords(raw[loadTreeDataFrom], rec, recordMap);
             }
         });

--- a/data/Store.js
+++ b/data/Store.js
@@ -49,6 +49,9 @@ export class Store extends HoistBase {
     /** @member {boolean} */
     loadTreeData;
 
+    /** @member {string} */
+    loadTreeDataFrom;
+
     /** @member {boolean} */
     loadRootAsSummary;
 
@@ -102,13 +105,13 @@ export class Store extends HoistBase {
      * @param {function} [c.processRawData] - function to run on each individual data object
      *      presented to loadData() prior to creating a StoreRecord from that object. This function
      *      must return an object, cloning the original object if edits are necessary.
-     * @param {(Filter|*|*[])} [c.filter] - one or more filters or configs to create one.  If an
+     * @param {(Filter|*|*[])} [c.filter] - one or more filters or configs to create one. If an
      *      array, a single 'AND' filter will be created.
      * @param {boolean} [c.filterIncludesChildren] - true if all children of a passing record should
      *      also be considered passing (default false).
-     * @param {boolean} [c.loadTreeData] - true to load hierarchical/tree data. When this flag is
-     *      true, the children property on raw data objects will be used to load child records.
-     *      (default true).
+     * @param {boolean} [c.loadTreeData] - true (default) to load hierarchical/tree data, if any.
+     * @param {string} [c.loadTreeDataFrom] - the property on each raw data object that holds its
+     *      (raw) child objects, if any. Default 'children', no effect if `loadTreeData: false`.
      * @param {boolean} [c.loadRootAsSummary] - true to treat the root node in hierarchical data as
      *      the summary record (default false).
      * @param {boolean} [c.freezeData] - true to freeze the internal data object of the record.
@@ -135,6 +138,7 @@ export class Store extends HoistBase {
         filter = null,
         filterIncludesChildren = false,
         loadTreeData = true,
+        loadTreeDataFrom = 'children',
         loadRootAsSummary = false,
         freezeData = true,
         idEncodesTreePath = false,
@@ -151,6 +155,7 @@ export class Store extends HoistBase {
         this.filter = parseFilter(filter);
         this.filterIncludesChildren = filterIncludesChildren;
         this.loadTreeData = loadTreeData;
+        this.loadTreeDataFrom = loadTreeDataFrom;
         this.loadRootAsSummary = loadRootAsSummary;
         this.freezeData = freezeData;
         this.idEncodesTreePath = idEncodesTreePath;
@@ -843,7 +848,7 @@ export class Store extends HoistBase {
     }
 
     createRecords(rawData, parent, recordMap = new Map()) {
-        const {loadTreeData} = this;
+        const {loadTreeData, loadTreeDataFrom} = this;
         rawData.forEach(raw => {
             const rec = this.createRecord(raw, parent),
                 {id} = rec;
@@ -855,8 +860,8 @@ export class Store extends HoistBase {
 
             recordMap.set(id, rec);
 
-            if (loadTreeData && raw.children) {
-                this.createRecords(raw.children, rec, recordMap);
+            if (loadTreeData && loadTreeDataFrom && raw[loadTreeDataFrom]) {
+                this.createRecords(raw[loadTreeDataFrom], rec, recordMap);
             }
         });
         return recordMap;


### PR DESCRIPTION
+ Allow developer to override path to children on raw data objects.
+ No change to `StoreRecord.children` (post-processing), defaults remain the same.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

