### PR TITLE
Fix FilterChooser instruction wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## v46.0.0-SNAPSHOT - unreleased
+
+### 🎁 New Features
+* `FilterChooser` has new `menuWidth` prop, allowing you to specify as width for the dropdown
+  menu that is different from the control.
+
 ### 🐞 Bug Fixes
 * Fixed cache clearing method on Admin Console's Server > Services tab.
 

--- a/desktop/cmp/filter/FilterChooser.js
+++ b/desktop/cmp/filter/FilterChooser.js
@@ -29,7 +29,7 @@ export const [FilterChooser, filterChooser] = hoistCmp.withFactory({
     render({model, className, ...props}, ref) {
         const [layoutProps, chooserProps] = splitLayoutProps(props),
             {inputRef, suggestFieldsWhenEmpty, selectOptions, unsupportedFilter, favoritesIsOpen} = model,
-            {autoFocus, enableClear, leftIcon, maxMenuHeight, menuPlacement} = chooserProps,
+            {autoFocus, enableClear, leftIcon, maxMenuHeight, menuPlacement, menuWidth} = chooserProps,
             disabled = unsupportedFilter || chooserProps.disabled,
             placeholder = unsupportedFilter ?
                 'Unsupported filter' : // Todo: How to message this better?
@@ -49,6 +49,7 @@ export const [FilterChooser, filterChooser] = hoistCmp.withFactory({
                     autoFocus,
                     disabled,
                     menuPlacement,
+                    menuWidth,
                     placeholder,
                     leftIcon: withDefault(leftIcon, Icon.filter()),
                     enableClear: withDefault(enableClear, true),
@@ -105,6 +106,9 @@ FilterChooser.propTypes = {
 
     /** Placement of the dropdown menu relative to the input control. */
     menuPlacement: PT.oneOf(['auto', 'top', 'bottom']),
+
+    /** Width in pixels for the dropdown menu - if unspecified, defaults to control width. */
+    menuWidth: PT.number,
 
     /** Text to display when control is empty. */
     placeholder: PT.string

--- a/desktop/cmp/filter/FilterChooser.scss
+++ b/desktop/cmp/filter/FilterChooser.scss
@@ -54,6 +54,10 @@
   }
 
   &__field {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
     .prefix {
       color: var(--xh-text-color-muted);
     }


### PR DESCRIPTION
+ Prevent FilterChooser instructions from wrapping.
+ Add FilterChooser.menuWidth prop

Fixes [#2857](https://github.com/xh/hoist-react/issues/2857)

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

