### PR TITLE
Fix exception when noting manually sized columns

### DIFF
--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -712,8 +712,9 @@ class GridLocalModel extends HoistModel {
     onColumnResized = (ev) => {
         if (!isDisplayed(this.viewRef.current) || !ev.finished) return;
         if (ev.source === 'uiColumnDragged') {
-            const width = ev.columnApi.getColumnState().find(it => it.colId === ev.column.colId)?.width;
-            this.model.noteColumnManuallySized(ev.column.colId, width);
+            const colId = ev.columns[0].colId,
+                width = ev.columnApi.getColumnState().find(it => it.colId === colId)?.width;
+            this.model.noteColumnManuallySized(colId, width);
         } else if (ev.source === 'autosizeColumns') {
             this.model.noteAgColumnStateChanged(ev.columnApi.getColumnState());
         }


### PR DESCRIPTION
Noticed an issue where if manually changing a column's size affects another column's size (i.e. there is a flex grid that can change within its min / max width constraints), `ev.column` is null. Can be seen by resizing columns in the admin Config panel.

This change accesses the more reliable `ev.columns[0]` instead. Since flex column adjustments happen left-to-right, the first entry is always the column the user interacted with.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

