### PR TITLE
Support for readonly form fields without children.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@
 * Admins can now force suspension of individual client apps from the Server > WebSockets tab.
   Intended to e.g. force an app to stop refreshing an expensive query or polling an endpoint removed
   in a new release. Requires websockets to be enabled on both server and client.
-* `FormField` no longer need to specify a child input, and will simply render their readonly version
+* `FormField`s no longer need to specify a child input, and will simply render their readonly version
    if no child is specified.  This simplifies the common use-case of fields/forms that are always
    readonly.
+
+### 🐞 Bug Fixes
+* `FormField` would previously throw if given a child that did not have `propTypes`.  This has
+   been fixed.
 
 ## v46.0.0 - 2022-01-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Admins can now force suspension of individual client apps from the Server > WebSockets tab.
   Intended to e.g. force an app to stop refreshing an expensive query or polling an endpoint removed
   in a new release. Requires websockets to be enabled on both server and client.
+* `FormField` no longer need to specify a child input, and will simply render their readonly version
+   if no child is specified.  This simplifies the common use-case of fields/forms that are always
+   readonly.
 
 ## v46.0.0 - 2022-01-25
 

--- a/admin/tabs/activity/clienterrors/ClientErrorDetail.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorDetail.js
@@ -8,7 +8,7 @@ import {form} from '@xh/hoist/cmp/form';
 import {a, div, h3, hframe, span, vbox} from '@xh/hoist/cmp/layout';
 import {hoistCmp} from '@xh/hoist/core';
 import {formField} from '@xh/hoist/desktop/cmp/form';
-import {jsonInput, switchInput, textInput} from '@xh/hoist/desktop/cmp/input';
+import {jsonInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {fmtDateTimeSec} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
@@ -35,46 +35,25 @@ export const clientErrorDetail = hoistCmp.factory(
                         style: {width: '400px'},
                         items: [
                             h3(Icon.info(), 'Error Info'),
-                            formField({
-                                field: 'username',
-                                item: textInput()
-                            }),
+                            formField({field: 'username'}),
                             formField({
                                 field: 'dateCreated',
-                                item: textInput(),
                                 readonlyRenderer: fmtDateTimeSec
                             }),
-                            formField({
-                                field: 'appVersion',
-                                item: textInput()
-                            }),
+                            formField({field: 'appVersion'}),
                             formField({
                                 field: 'userAlerted',
-                                label: 'User Alerted?',
-                                item: switchInput()
+                                label: 'User Alerted?'
                             }),
-                            formField({
-                                field: 'id',
-                                item: textInput()
-                            }),
+                            formField({field: 'id'}),
                             formField({
                                 field: 'url',
-                                item: textInput(),
                                 readonlyRenderer: hyperlinkVal
                             }),
                             h3(Icon.desktop(), 'Device / Browser'),
-                            formField({
-                                field: 'device',
-                                item: textInput()
-                            }),
-                            formField({
-                                field: 'browser',
-                                item: textInput()
-                            }),
-                            formField({
-                                field: 'userAgent',
-                                item: textInput()
-                            })
+                            formField({field: 'device'}),
+                            formField({field: 'browser'}),
+                            formField({field: 'userAgent'})
                         ]
                     }),
                     vbox({

--- a/admin/tabs/activity/tracking/detail/ActivityDetailView.js
+++ b/admin/tabs/activity/tracking/detail/ActivityDetailView.js
@@ -5,7 +5,7 @@ import {storeFilterField} from '@xh/hoist/cmp/store';
 import {hoistCmp, uses} from '@xh/hoist/core';
 import {colChooserButton, exportButton} from '@xh/hoist/desktop/cmp/button';
 import {formField} from '@xh/hoist/desktop/cmp/form';
-import {jsonInput, textArea, textInput} from '@xh/hoist/desktop/cmp/input';
+import {jsonInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {dateTimeSecRenderer, numberRenderer} from '@xh/hoist/format';
@@ -63,7 +63,6 @@ const detailRecForm = hoistCmp.factory(
                             h3(Icon.info(), 'Activity'),
                             formField({
                                 field: 'username',
-                                item: textInput(),
                                 readonlyRenderer: (username) => {
                                     if (!username) return naSpan();
                                     const {impersonating} = formModel.values,
@@ -71,22 +70,14 @@ const detailRecForm = hoistCmp.factory(
                                     return span(username, impSpan);
                                 }
                             }),
-                            formField({
-                                field: 'category',
-                                item: textInput()
-                            }),
-                            formField({
-                                field: 'msg',
-                                item: textArea()
-                            }),
+                            formField({field: 'category'}),
+                            formField({field: 'msg'}),
                             formField({
                                 field: 'dateCreated',
-                                item: textInput(),
                                 readonlyRenderer: dateTimeSecRenderer({})
                             }),
                             formField({
                                 field: 'elapsed',
-                                item: textInput(),
                                 readonlyRenderer: numberRenderer({
                                     label: 'ms',
                                     nullDisplay: '-',
@@ -94,23 +85,11 @@ const detailRecForm = hoistCmp.factory(
                                     formatConfig: {thousandSeparated: false, mantissa: 0}
                                 })
                             }),
-                            formField({
-                                field: 'id',
-                                item: textInput()
-                            }),
+                            formField({field: 'id'}),
                             h3(Icon.desktop(), 'Device / Browser'),
-                            formField({
-                                field: 'device',
-                                item: textInput()
-                            }),
-                            formField({
-                                field: 'browser',
-                                item: textInput()
-                            }),
-                            formField({
-                                field: 'userAgent',
-                                item: textInput()
-                            })
+                            formField({field: 'device'}),
+                            formField({field: 'browser'}),
+                            formField({field: 'userAgent'})
                         ]
                     }),
                     panel({

--- a/admin/tabs/general/alertBanner/AlertBannerPanel.js
+++ b/admin/tabs/general/alertBanner/AlertBannerPanel.js
@@ -15,8 +15,7 @@ import {
     buttonGroupInput,
     dateInput,
     switchInput,
-    textArea,
-    textInput
+    textArea
 } from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {dateTimeRenderer} from '@xh/hoist/format';
@@ -137,14 +136,12 @@ const formPanel = hoistCmp.factory(
                                 omit: !formModel.values.updated,
                                 field: 'updated',
                                 className: 'xh-alert-banner-panel__form-panel__fields--ro',
-                                item: textInput(),
                                 readonlyRenderer: dateTimeRenderer({})
                             }),
                             formField({
                                 omit: !formModel.values.updatedBy,
                                 field: 'updatedBy',
-                                className: 'xh-alert-banner-panel__form-panel__fields--ro',
-                                item: textInput()
+                                className: 'xh-alert-banner-panel__form-panel__fields--ro'
                             })
                         ]
                     })

--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -291,11 +291,11 @@ const editableChild = hoistCmp.factory({
             }
         }
 
-        if (displayNotValid && propTypes.leftIcon && leftErrorIcon) {
+        if (displayNotValid && propTypes?.leftIcon && leftErrorIcon) {
             overrides.leftIcon = Icon.warningCircle();
         }
 
-        if (propTypes.commitOnChange && !isUndefined(commitOnChange)) {
+        if (propTypes?.commitOnChange && !isUndefined(commitOnChange)) {
             overrides.commitOnChange = commitOnChange;
         }
         return cloneElement(child, overrides);

--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -315,7 +315,9 @@ function getValidChild(children) {
     const count = Children.count(children);
     if (count === 0) return null;
     if (count > 1) {
-        throw XH.exception('Add a single HoistInput child to FormField, or no children and a readonlyRenderer.');
+        throw XH.exception(
+            'Add a single HoistInput child to FormField, or zero children if always readonly.'
+        );
     }
 
     const child = Children.only(children);

--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -21,19 +21,23 @@ import composeRefs from '@seznam/compose-react-refs/composeRefs';
 import './FormField.scss';
 
 /**
- * Standardised wrapper around a HoistInput Component. FormField provides consistent layout,
- * labelling, and optional display of validation messages for the input component.
+ * Standardised wrapper around a HoistInput component for use in a form. FormField provides
+ * consistent layout, labelling, and optional display of validation messages for the field.
+ * FormField also supports an alternative read-only display of the bound data.
  *
  * This component is intended to be used within a `Form` component and bound to a 'FieldModel'
- * within that Form's backing `FormModel`.  This binding, can happen explicitly, or by name.
+ * within that Form's backing `FormModel`. FormField will set up the binding between its input and the
+ * FieldModel instance and can display validation messages, switch between read-only and disabled
+ * variants of its child, and source default props via the parent Form's `fieldDefaults` prop.
  *
- * FormField will setup the binding between its child HoistInput and the FieldModel instance and
- * can display validation messages, switch between read-only and disabled variants of its child,
- * and source default props via the parent Form's `fieldDefaults` prop.
+ * This component is designed to work with an instance of `HoistInput` as its input, and makes use
+ * of many of HoistInput's props. For best results with a customized input, consider wrapping a
+ * HoistInput and passing all props along to it.   At the very least, all custom inputs
+ * must accept 'model' and 'bind' props in order to show and edit data.
  *
  * FormFields can be sized and otherwise customized via standard layout props. They will
- * adjust their child Inputs to fill their available space (if appropriate given the input type),
- * so the recommended approach is to specify any sizing on the FormField (as opposed to the Input).
+ * adjust their child inputs to fill their available space (if appropriate given the input type),
+ * so the recommended approach is to specify any sizing on the FormField (as opposed to the input).
  */
 export const [FormField, formField] = hoistCmp.withFactory({
     displayName: 'FormField',

--- a/mobile/cmp/form/FormField.js
+++ b/mobile/cmp/form/FormField.js
@@ -215,7 +215,7 @@ const editableChild = hoistCmp.factory({
             }
         }
 
-        if (propTypes.commitOnChange && !isUndefined(commitOnChange)) {
+        if (propTypes?.commitOnChange && !isUndefined(commitOnChange)) {
             overrides.commitOnChange = commitOnChange;
         }
 

--- a/mobile/cmp/form/FormField.js
+++ b/mobile/cmp/form/FormField.js
@@ -234,7 +234,9 @@ function getValidChild(children) {
     const count = Children.count(children);
     if (count === 0) return null;
     if (count > 1) {
-        throw XH.exception('Add a single HoistInput child to FormField, or no children and a readonlyRenderer.');
+        throw XH.exception(
+            'Add a single HoistInput child to FormField, or zero children if always readonly.'
+        );
     }
 
     const child = Children.only(children);

--- a/mobile/cmp/form/FormField.js
+++ b/mobile/cmp/form/FormField.js
@@ -20,19 +20,23 @@ import composeRefs from '@seznam/compose-react-refs/composeRefs';
 import './FormField.scss';
 
 /**
- * Standardised wrapper around a HoistInput Component. FormField provides consistent layout,
- * labelling, and optional display of validation messages for the input component.
+ * Standardised wrapper around a HoistInput component for use in a form. FormField provides
+ * consistent layout, labelling, and optional display of validation messages for the field.
+ * FormField also supports an alternative read-only display of the bound data.
  *
  * This component is intended to be used within a `Form` component and bound to a 'FieldModel'
- * within that Form's backing `FormModel`.  This binding, can happen explicitly, or by name.
-
- * FormField will setup the binding between its child HoistInput and the FieldModel instance
- * and can display validation messages, switch between read-only and disabled variants of its
- * child, and source default props via the parent Form's `fieldDefaults` prop.
+ * within that Form's backing `FormModel`. FormField will set up the binding between its input and the
+ * FieldModel instance and can display validation messages, switch between read-only and disabled
+ * variants of its child, and source default props via the parent Form's `fieldDefaults` prop.
+ *
+ * This component is designed to work with an instance of `HoistInput` as its input, and makes use
+ * of many of HoistInput's props. For best results with a customized input, consider wrapping a
+ * HoistInput and passing all props along to it.   At the very least, all custom inputs
+ * must accept 'model' and 'bind' props in order to show and edit data.
  *
  * FormFields can be sized and otherwise customized via standard layout props. They will
- * adjust their child Inputs to fill their available space (if appropriate given the input type),
- * so the recommended approach is to specify any sizing on the FormField (as opposed to the Input).
+ * adjust their child inputs to fill their available space (if appropriate given the input type),
+ * so the recommended approach is to specify any sizing on the FormField (as opposed to the input).
  */
 export const [FormField, formField] = hoistCmp.withFactory({
     displayName: 'FormField',

--- a/mobile/cmp/form/FormField.js
+++ b/mobile/cmp/form/FormField.js
@@ -6,7 +6,7 @@
  */
 import {FieldModel, FormContext} from '@xh/hoist/cmp/form';
 import {box, div, span} from '@xh/hoist/cmp/layout';
-import {hoistCmp, ModelPublishMode, uses} from '@xh/hoist/core';
+import {hoistCmp, ModelPublishMode, uses, XH} from '@xh/hoist/core';
 import {fmtDate, fmtDateTime, fmtNumber} from '@xh/hoist/format';
 import {label as labelCmp} from '@xh/hoist/mobile/cmp/input';
 import {isLocalDate} from '@xh/hoist/utils/datetime';
@@ -68,9 +68,9 @@ export const [FormField, formField] = hoistCmp.withFactory({
                 }) : null,
             isPending = model && model.isValidationPending;
 
-        // Child related props
+        // Get spec'ed child -- may be null for fields that are always read-only
         const child = getValidChild(children),
-            childIsSizeable = child.type?.hasLayoutSupport || false;
+            childIsSizeable = child?.type?.hasLayoutSupport ?? false;
 
         // Display related props
         const layoutProps =  getLayoutProps(props),
@@ -87,7 +87,7 @@ export const [FormField, formField] = hoistCmp.withFactory({
         if (disabled) classes.push('xh-form-field-disabled');
         if (displayNotValid) classes.push('xh-form-field-invalid');
 
-        let childEl = readonly ?
+        let childEl = readonly || !child ?
             readonlyChild({model, readonlyRenderer}) :
             editableChild({
                 model,
@@ -227,9 +227,19 @@ const editableChild = hoistCmp.factory({
 // Helper Functions
 //---------------------------------
 function getValidChild(children) {
+    const count = Children.count(children);
+    if (count === 0) return null;
+    if (count > 1) {
+        throw XH.exception('Add a single HoistInput child to FormField, or no children and a readonlyRenderer.');
+    }
+
     const child = Children.only(children);
-    throwIf(!child, 'FormField child must be a single component.');
-    throwIf(child.props.bind || child.props.model, 'HoistInputs should not specify "bind" or "model" props when used with FormField');
+    throwIf(
+        child.props.bind || child.props.model,
+        'Child of FormField should not specify "bind" or "model" props. These props will ' +
+        'will be set by the FormField to bind it appropriately.'
+    );
+
     return child;
 }
 


### PR DESCRIPTION
Hope this moves the ball forward for Forms, and gets us beyond the silliness, providing a good readonly story, with minimal disruption to existing apps.

Agree with Tom -- a general binding label/value mechanism could be useful as a future iteration.
  
Also agree with Anselm that a readOnlyField() might be useful for the developer.  If we felt that we wanted that, could just be 
syntactic sugar on what we have.  Would like to avoid adding extra components in this space, if possible, as the relationship between the input/FormField/FormModel/FieldModel/Form is already incredibly intricate and somewhat duplicated between mobile and desktop. Again, could do in a future iteration. 

Also fixed an annoying issue preventing us from wrapping HoistInputs.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

