### PR TITLE
Fix autosize resetting column order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v47.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+* Fixed an issue where column autosize can reset column order under certain circumstances.
 
 ## v46.1.1 - 2022-02-15
 

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -652,10 +652,9 @@ class GridLocalModel extends HoistModel {
                 model.autosizeAsync();
             } else {
                 // ...otherwise, only autosize columns that are not manually sized
-                const columns = model.getLeafColumnIds().filter(colId => {
-                    const state = model.findColumn(model.columnState, colId);
-                    return state && !state.manuallySized;
-                });
+                const columns = model.columnState
+                    .filter(it => !it.manuallySized)
+                    .map(it => it.colId);
                 model.autosizeAsync({columns});
             }
         }

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -1078,9 +1078,9 @@ export class GridModel extends HoistModel {
         let colIds, includeColFn = () => true;
         if (isFunction(columns)) {
             includeColFn = columns;
-            colIds = this.getLeafColumnIds();
+            colIds = this.columnState.map(it => it.colId);
         } else {
-            colIds = columns ?? this.getLeafColumnIds();
+            colIds = columns ?? this.columnState.map(it => it.colId);
         }
 
         colIds = castArray(colIds).filter(id => {


### PR DESCRIPTION
If every column in a grid is autosizable (visible, resizable, non-flex and non elementRenderer), autosize will reset the column order.

This is because after an autosize completes, column state is updated for each autosized column with `manuallySized: false` - and if ***all*** columns are included in a column state change, the system takes that as a sign that we should update the column order.

The problem arose because autosize takes it's column ids from the 'code order' specified in `gridModel.columns` rather the  'state order' from `gridModel.columnState`. The solution is to ensure that columns are autosized in their 'state order' rather than their 'code order'.

See Toolbox branch which can be used to reproduce the issue: https://github.com/xh/toolbox/tree/autosizeColumnOrder

Note that issue is present even if the GridModel does not need use GridAutosizeMode.MANAGED (although that of course exacerbates it) 

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

