### PR TITLE
Fix autosizing headers when `headerName` is a react element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v48.0.0-SNAPSHOT- unreleased
 
+### 🐞 Bug Fixes
+
+* Fix column auto-sizing when `headerName` is/returns an element
+
 ## v47.0.1 - 2022-03-06
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v47.0.0...v47.0.1)

--- a/cmp/grid/impl/ColumnWidthCalculator.js
+++ b/cmp/grid/impl/ColumnWidthCalculator.js
@@ -223,7 +223,7 @@ export class ColumnWidthCalculator {
         if (isNil(headerClass)) return '';
 
         if (isFunction(headerClass)) {
-            headerClass = headerClass(column, gridModel);
+            headerClass = headerClass({column, gridModel});
         }
 
         const ret = [];


### PR DESCRIPTION
This seems to work well, tested in client app where I ran into this limitation.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

