### PR TITLE
Suppress adding empty cell when pasting from Excel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
     * The `isPopup` argument to `useInlineEditorModel()` has been removed. If you want to display your
       inline editor in a popup, you must set the new flag `Column.editorIsPopup` to `true`.
 
+### 🐞 Bug Fixes
+
+* Set ag-Grid's `suppressLastEmptyLineOnPaste` to true to work around a bug with Excel (Windows)
+  that adds an empty line beneath the range pasted from the clipboard in editable grids.
+
 ### 📚 Libraries
 
 * mobx `6.3 -> 6.5`

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -246,7 +246,8 @@ class GridLocalModel extends HoistModel {
             editType: model.fullRowEditing ? 'fullRow' : undefined,
             singleClickEdit: clicksToEdit === 1,
             suppressClickEdit: clicksToEdit !== 1 && clicksToEdit !== 2,
-            stopEditingWhenCellsLoseFocus: true
+            stopEditingWhenCellsLoseFocus: true,
+            suppressLastEmptyLineOnPaste: true
         };
 
         // Platform specific defaults


### PR DESCRIPTION
Fixes user-reported bug with Excel (Windows) that adds an empty line beneath the range pasted from the clipboard in editable grids.
https://www.ag-grid.com/react-data-grid/grid-properties/

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

