### PR TITLE
Fix to NumberInput issue with `min/max` and `displayWithCommas` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 * Set ag-Grid's `suppressLastEmptyLineOnPaste` to true to work around a bug with Excel (Windows)
   that adds an empty line beneath the range pasted from the clipboard in editable grids.
+* Fixes an issue where NumberInput would initially render blank values when `max` and `min` were set.
 
 ### 📚 Libraries
 

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -205,28 +205,35 @@ const cmp = hoistCmp.factory(
     ({model, className, ...props}, ref) => {
         const {width, ...layoutProps} = getLayoutProps(props);
 
-        // BP NumberInput bases expected precision off of dps in minorStepSize, if specified.
+        // BP's min/max can cause problems when controlled value is formatted string so only set
+        // when focused and rendered value is number.  min/max only constrains step editing anyway
+        const min = model.hasFocus ? props.min : undefined,
+            max = model.hasFocus ? props.max : undefined;
+
+        // BP bases expected precision off of dps in minorStepSize, if specified.
         // The default BP value of 0.1 for this prop emits a console warning any time the input
         // value extends beyond 1 dp. Re-default here to sync with our `precision` prop.
         // See https://blueprintjs.com/docs/#core/components/numeric-input.numeric-precision
         const precision = withDefault(props.precision, 4),
+            majorStepSize = props.majorStepSize,
             minorStepSize = precision ?
                 withDefault(props.minorStepSize, round(Math.pow(10, -precision), precision)) :
                 null;
 
+        // Render BP input.  Force remount when focus changes to avoid problems with cached state.
         return numericInput({
+            key: model.xhId + model.hasFocus,
             value: model.formatRenderValue(model.renderValue),
-
-            allowNumericCharactersOnly: !props.enableShorthandUnits,
+            allowNumericCharactersOnly: !props.enableShorthandUnits && !props.displayWithCommas,
             buttonPosition: 'none',
             disabled: props.disabled,
             fill: props.fill,
             inputRef: composeRefs(model.inputRef, props.inputRef),
             leftIcon: props.leftIcon,
-            max: props.max,
-            majorStepSize: props.majorStepSize,
-            min: props.min,
+            min,
+            max,
             minorStepSize,
+            majorStepSize,
             placeholder: props.placeholder,
             rightElement: props.rightElement,
             stepSize: props.stepSize,


### PR DESCRIPTION
As part of this fix, am also allowing the user to type in commas, the way the can currently type in the shorthand units

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

