### PR TITLE
Fix issues with NumberEditor/SelectEditor

### DIFF
--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -573,8 +573,16 @@ export class Column {
                 suppressKeyboardEvent: ({editing, event}) => {
                     if (!editing) return false;
 
+                    // Avoid stomping on react-select menus in editors
+                    const {gridModel, colId} = this,
+                        editor = gridModel.agApi.getCellEditorInstances({columns: [colId]})[0],
+                        reactSelect = editor?.inputModel?.().reactSelect;
+                    if (reactSelect?.state.menuIsOpen) return true;
+
                     // Allow shift+enter to add newlines in certain editors
                     if (event.shiftKey && event.key === 'Enter') return true;
+
+                    return false;
                 }
             };
 

--- a/desktop/cmp/grid/editors/impl/InlineEditorModel.js
+++ b/desktop/cmp/grid/editors/impl/InlineEditorModel.js
@@ -32,7 +32,9 @@ export function useInlineEditorModel(component, props, ref) {
         getValue: () => impl.value,
 
         // This is called in full-row editing when the user tabs into the cell
-        focusIn: () => impl.focus()
+        focusIn: () => impl.focus(),
+
+        inputModel: () => impl.ref.current
     }));
 
     return component({

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -202,6 +202,7 @@ class Model extends HoistInputModel {
         super.noteBlurred();
         wait().then(() => {
             const input = this.inputRef.current;
+            // Force value to re-render in control to workaround issue with blueprint state caching
             if (input) input.value = this.formatRenderValue(this.renderValue);
         });
     }
@@ -227,7 +228,7 @@ const cmp = hoistCmp.factory(
                 withDefault(props.minorStepSize, round(Math.pow(10, -precision), precision)) :
                 null;
 
-        // Render BP input.  Force remount when focus changes to avoid problems with cached state.
+        // Render BP input.
         return numericInput({
             value: model.formatRenderValue(model.renderValue),
             allowNumericCharactersOnly: !props.enableShorthandUnits && !props.displayWithCommas,

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -190,15 +190,22 @@ class Model extends HoistInputModel {
         return parseFloat(value);
     }
 
-    onFocus = (ev) => {
-        this.noteFocused();
-
-        // Deferred to allow any value conversion to complete and flush into input.
+    noteFocused() {
+        super.noteFocused();
         if (this.componentProps.selectOnFocus) {
-            const target = ev.target;
-            wait().then(() => target.select());
+            // Deferred to allow any value conversion to complete and flush into input.
+            wait().then(() => this.inputRef.current?.select());
         }
     }
+
+    noteBlurred() {
+        super.noteBlurred();
+        wait().then(() => {
+            const input = this.inputRef.current;
+            if (input) input.value = this.formatRenderValue(this.renderValue);
+        });
+    }
+
 }
 
 const cmp = hoistCmp.factory(
@@ -222,7 +229,6 @@ const cmp = hoistCmp.factory(
 
         // Render BP input.  Force remount when focus changes to avoid problems with cached state.
         return numericInput({
-            key: model.xhId + model.hasFocus,
             value: model.formatRenderValue(model.renderValue),
             allowNumericCharactersOnly: !props.enableShorthandUnits && !props.displayWithCommas,
             buttonPosition: 'none',


### PR DESCRIPTION
Fix to issues with NumberEditor and SelectEditor.

+ Improve NumberInput workaround to avoid remounting
+ Adapt SelectEditor to new ag-Grid behavior

Note that SelectEditor still has some unfortunate focus behavior when using the enter key when grid editing.  This is *NOT* regression, and the focus with this PR is to allow us to move forward with the ag-Grid upgrade.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

