### PR TITLE
Add support for filtering on committed data, current data, or both

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v49.0.0-SNAPSHOT - unreleased
+
+### 🎁 New Features
+
+* Added `Store.filterValueMode`, allowing apps more control over how values are retrieved from
+  records when filtering on record fields.
+
 ## v48.0.1 - 2022-04-22
 
 ### 🐞 Bug Fixes

--- a/data/Store.js
+++ b/data/Store.js
@@ -979,7 +979,7 @@ export const FilterValueMode = Object.freeze({
 
     /**
      * Both the committed and current values are used to test the filter and the record passes if
-     * either value passes.
+     * either value passes. This is the recommended mode for inline-editing enabled Grids.
      */
     ANY: 'any'
 });

--- a/data/Store.js
+++ b/data/Store.js
@@ -114,7 +114,7 @@ export class Store extends HoistBase {
      * @param {boolean} [c.filterIncludesChildren] - true if all children of a passing record should
      *      also be considered passing (default false).
      * @param {FilterValueMode} [c.filterValueMode] - determines how record field values are
-     *      considered when processing filters. Default behavior is to only consider 'committed'
+     *      considered when processing `FieldFilter`s. Default behavior is to only consider 'committed'
      *      values.
      * @param {boolean} [c.loadTreeData] - true (default) to load hierarchical/tree data, if any.
      * @param {string} [c.loadTreeDataFrom] - the property on each raw data object that holds its
@@ -966,7 +966,7 @@ function forIn(obj, fn) {
 }
 
 /**
- * Modes for how record field values should be considered when filtering.
+ * Determines which Record field values should be used for matching against a `FieldFilter`.
  * @readonly
  * @enum {string}
  */

--- a/data/Store.js
+++ b/data/Store.js
@@ -46,6 +46,9 @@ export class Store extends HoistBase {
     /** @member {boolean} */
     @observable filterIncludesChildren;
 
+    /** @member {FilterValueMode} */
+    @observable filterValueMode;
+
     /** @member {boolean} */
     loadTreeData;
 
@@ -110,6 +113,9 @@ export class Store extends HoistBase {
      *      array, a single 'AND' filter will be created.
      * @param {boolean} [c.filterIncludesChildren] - true if all children of a passing record should
      *      also be considered passing (default false).
+     * @param {FilterValueMode} [c.filterValueMode] - determines how record field values are
+     *      considered when processing filters. Default behavior is to only consider 'committed'
+     *      values.
      * @param {boolean} [c.loadTreeData] - true (default) to load hierarchical/tree data, if any.
      * @param {string} [c.loadTreeDataFrom] - the property on each raw data object that holds its
      *      (raw) child objects, if any. Default 'children', no effect if `loadTreeData: false`.
@@ -138,6 +144,7 @@ export class Store extends HoistBase {
         processRawData = null,
         filter = null,
         filterIncludesChildren = false,
+        filterValueMode = FilterValueMode.COMMITTED,
         loadTreeData = true,
         loadTreeDataFrom = 'children',
         loadRootAsSummary = false,
@@ -155,6 +162,7 @@ export class Store extends HoistBase {
         this.processRawData = processRawData;
         this.filter = parseFilter(filter);
         this.filterIncludesChildren = filterIncludesChildren;
+        this.filterValueMode = filterValueMode;
         this.loadTreeData = loadTreeData;
         this.loadTreeDataFrom = loadTreeDataFrom;
         this.loadRootAsSummary = loadRootAsSummary;
@@ -618,6 +626,16 @@ export class Store extends HoistBase {
         this.rebuildFiltered();
     }
 
+    /**
+     * Sets the filter value mode on this store and rebuilds the filtered data.
+     * @param {FilterValueMode} mode
+     */
+    @action
+    setFilterValueMode(mode) {
+        this.filterValueMode = mode;
+        this.rebuildFiltered();
+    }
+
     /** Convenience method to clear the Filter applied to this store. */
     clearFilter() {
         this.setFilter(null);
@@ -946,6 +964,25 @@ function forIn(obj, fn) {
         fn(obj[key], key);
     }
 }
+
+/**
+ * Modes for how record field values should be considered when filtering.
+ * @readonly
+ * @enum {string}
+ */
+export const FilterValueMode = Object.freeze({
+    /** The committed value is used to test the filter. */
+    COMMITTED: 'committed',
+
+    /** The current value is used to test the filter. */
+    CURRENT: 'current',
+
+    /**
+     * Both the committed and current values are used to test the filter and the record passes if
+     * either value passes.
+     */
+    ANY: 'any'
+});
 
 /**
  * @typedef {Object} StoreTransaction - object representing data changes to perform on a Store's

--- a/data/StoreRecord.js
+++ b/data/StoreRecord.js
@@ -5,7 +5,7 @@
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
 import {throwIf} from '@xh/hoist/utils/js';
-import {get, isNil} from 'lodash';
+import {isNil} from 'lodash';
 import {ValidationState} from './validation/ValidationState';
 
 /**
@@ -107,7 +107,7 @@ export class StoreRecord {
      * @returns {*} - the committed value of a field.
      */
     getCommitted(fieldName) {
-        return get(this.committedData, fieldName);
+        return this.committedData ? this.committedData[fieldName] : undefined;
     }
 
     /** @returns {StoreRecord[]} - children of this record, respecting any filter (if applied). */

--- a/data/StoreRecord.js
+++ b/data/StoreRecord.js
@@ -5,7 +5,7 @@
  * Copyright © 2021 Extremely Heavy Industries Inc.
  */
 import {throwIf} from '@xh/hoist/utils/js';
-import {isNil} from 'lodash';
+import {get, isNil} from 'lodash';
 import {ValidationState} from './validation/ValidationState';
 
 /**
@@ -100,6 +100,14 @@ export class StoreRecord {
      */
     get(fieldName) {
         return this.data[fieldName];
+    }
+
+    /**
+     * @param {string} fieldName
+     * @returns {*} - the committed value of a field.
+     */
+    getCommitted(fieldName) {
+        return get(this.committedData, fieldName);
     }
 
     /** @returns {StoreRecord[]} - children of this record, respecting any filter (if applied). */


### PR DESCRIPTION
When working on this it seemed to me that for an inline editable grid, you probably would want to consider both committed and current values when filtering, so I ended up adding a new `FilterValueMode` enumeration which you can set on `Store`, and will be respected by `FilterField` when building the test function. 

Let me know if this seems over-engineered, could be simplified into a boolean probably. 

Also note that this config is only respected in FilterField. Was not sure if we wanted to handle this elsewhere also (such as in StoreFilterField) 

Toolbox branch with control for testing different modes: https://github.com/xh/toolbox/tree/storeFilterValueMode

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

