### PR TITLE
Enhance NumberInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ### 🐞 New Features
 
-* Improve behavior and fix bugs related to `NumberInput.min` and `NumberInput.max` props.
-The new implementation no longer relies on the underlying props provided by Blueprint, which were
-buggy and only constrained the value during incremental stepping with keyboard or mouse.
-
+* Improve behavior of `NumberInput`:
+ ** Improvements to  `min` and `max` props.
+    The new implementation constrains the set value more fully whether changes being made by
+    keyboard or mouse. Also fixed some bugs related to Blueprint.
+ ** The `precision` prop is now respected more fully.  All values produced by editing the control
+    will respect this value.
+ ** Added debounce to make value more stable during user typing.
 
 ## v48.0.1 - 2022-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v49.0.0-SNAPSHOT - unreleased
+
+### 🐞 New Features
+
+* Improve behavior and fix bugs related to `NumberInput.min` and `NumberInput.max` props.
+The new implementation no longer relies on the underlying props provided by Blueprint, which were
+buggy and only constrained the value during incremental stepping with keyboard or mouse.
+
+
 ## v48.0.1 - 2022-04-22
 
 ### 🐞 Bug Fixes

--- a/cmp/input/HoistInputModel.js
+++ b/cmp/input/HoistInputModel.js
@@ -58,7 +58,7 @@ import ReactDOM from 'react-dom';
 export class HoistInputModel extends HoistModel {
 
     /**
-     * Does this input have the focus ?
+     * Does this input have the focus?
      * @type {boolean}
      */
     @observable hasFocus = false;
@@ -116,6 +116,7 @@ export class HoistInputModel extends HoistModel {
     @observable.ref internalValue = null;    // Cached internal value
     inputRef = createObservableRef();        // ref to internal <input> element, if any
     domRef = createObservableRef();          // ref to outermost element, or class Component.
+    isDirty = false;
 
     constructor() {
         super();
@@ -191,6 +192,7 @@ export class HoistInputModel extends HoistModel {
      * This is the primary method for HoistInput implementations to call on value change.
      */
     noteValueChange(val) {
+        this.isDirty = true;
         const {onChange} = this.componentProps,
             oldVal = this.internalValue;
 
@@ -298,6 +300,9 @@ export class HoistInputModel extends HoistModel {
     }
 
     doCommitInternal() {
+        if (!this.isDirty) return;
+        this.isDirty = false;
+
         const {onCommit, bind} = this.componentProps,
             {model} = this;
         let currentValue = this.externalValue,

--- a/cmp/input/HoistInputModel.js
+++ b/cmp/input/HoistInputModel.js
@@ -196,7 +196,7 @@ export class HoistInputModel extends HoistModel {
 
         this.setInternalValue(val);
         if (onChange) onChange(this.toExternal(val), this.toExternal(oldVal));
-        if (this.commitOnChange) this.doCommitInternal();
+        if (this.commitOnChange) this.doCommitOnChangeInternal();
     }
 
     /**
@@ -262,6 +262,10 @@ export class HoistInputModel extends HoistModel {
     //----------------------
     // Implementation
     //------------------------
+    isValid(externalValue) {
+        return true;
+    }
+
     internalFromExternal() {
         const ret = this.toInternal(this.externalValue);
 
@@ -289,13 +293,17 @@ export class HoistInputModel extends HoistModel {
         };
     }
 
+    doCommitOnChangeInternal() {
+        this.doCommitInternal();
+    }
+
     doCommitInternal() {
         const {onCommit, bind} = this.componentProps,
             {model} = this;
         let currentValue = this.externalValue,
             newValue = this.externalFromInternal();
 
-        if (isEqual(newValue, currentValue)) return;
+        if (isEqual(newValue, currentValue) || !this.isValid(newValue)) return;
 
         if (model && bind) {
             model.setBindable(bind, newValue);

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -186,8 +186,7 @@ class Model extends HoistInputModel {
         if (isNaN(val)) return false;
         if (val === null) return true;
 
-        // Enforce min/max here. This is instead of the bp props which are
-        // buggy and only limit the incremental step change in any case
+        // Enforce min/max here on commit. BP props only limit the incremental step change
         if (!isNil(min) && val < min) return false;
         if (!isNil(max) && val > max) return false;
 

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -17,7 +17,7 @@ import {isNaN, isNil, isNumber, round} from 'lodash';
 import PT from 'prop-types';
 
 /**
- * Number input, with optional support for formatted of display value, shorthand units, and more.
+ * Number input, with optional support for formatting of display value, shorthand units, and more.
  *
  * This component is built on the Blueprint NumericInput and gets default increment/decrement
  * functionality from that component, based on the three stepSize props.
@@ -63,24 +63,23 @@ NumberInput.propTypes = {
     /** Icon to display inline on the left side of the input. */
     leftIcon: PT.element,
 
-
     /**
-     * Minimum value.  Note that this will govern the smallest value that this control can produce
-     * via user input.  Smaller values passed to it via props or a bound model will still be displayed.
+     * Minimum value. Note that this will govern the smallest value that this control can produce
+     * via user input. Smaller values passed to it via props or a bound model will still be displayed.
      */
     min: PT.number,
 
-    /** Major step size for increment/decrement handling. */
-    majorStepSize: PT.number,
-
     /**
-     * Maximum value.  Note that this will govern the largest value that this control can produce
-     * via user input.  Larger values passed to it via props or a bound model will still be displayed.
+     * Maximum value. Note that this will govern the largest value that this control can produce
+     * via user input. Larger values passed to it via props or a bound model will still be displayed.
      */
     max: PT.number,
 
     /** Minor step size for increment/decrement handling. */
     minorStepSize: PT.number,
+
+    /** Major step size for increment/decrement handling. */
+    majorStepSize: PT.number,
 
     /** Callback for normalized keydown event. */
     onKeyDown: PT.func,
@@ -97,7 +96,7 @@ NumberInput.propTypes = {
     /**
      * Scale factor to apply when converting between the internal and external value. Useful for
      * cases such as handling a percentage value where the user would expect to see or input 20 but
-     * the external value the input is bound to should be 0.2.  Must be a factor of 10.
+     * the external value the input is bound to should be 0.2. Must be a factor of 10.
      * Defaults to 1 (no scaling applied).
      */
     scaleFactor: PT.number,
@@ -125,10 +124,9 @@ NumberInput.hasLayoutSupport = true;
 //-----------------------
 // Implementation
 //-----------------------
-
 class Model extends HoistInputModel {
-    static shorthandValidator = /((\.\d+)|(\d+(\.\d+)?))([kmb])\b/i;
 
+    static shorthandValidator = /((\.\d+)|(\d+(\.\d+)?))([kmb])\b/i;
 
     constructor() {
         super();
@@ -155,7 +153,6 @@ class Model extends HoistInputModel {
     doCommitOnChangeInternal() {
         super.doCommitOnChangeInternal();
     }
-
 
     toInternal(val) {
         if (isNaN(val)) return val;
@@ -192,7 +189,6 @@ class Model extends HoistInputModel {
 
         return true;
     }
-
 
     onKeyDown = (ev) => {
         if (ev.key === 'Enter') this.doCommit();
@@ -254,14 +250,12 @@ const cmp = hoistCmp.factory(
         const {width, ...layoutProps} = getLayoutProps(props),
             renderValue = model.formatRenderValue(model.renderValue);
 
-
         // BP workaround -- min, max, and stepsize can block Blueprint from rendering
         // intended value in underlying control -- ensure it is always shown.
         useLayoutEffect(() => {
             const input = model.inputRef.current;
             if (input) input.value = renderValue;
         });
-
 
         // BP bases expected precision off of dps in minorStepSize, if specified.
         // The default BP value of 0.1 for this prop emits a console warning any time the input

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -152,9 +152,10 @@ class Model extends HoistInputModel {
 
         // Enforce min/max here. This is instead of the bp props which are
         // buggy and only limit the incremental step change in any case
-        return ((!isNil(min) && val < min) || (!isNil(max) && val > max)) ?
-            this.externalValue :
-            val;
+        if (!isNil(min) && val < min) return this.externalValue;
+        if (!isNil(max) && val > max) return this.externalValue;
+
+        return val;
     }
 
     onKeyDown = (ev) => {

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -195,6 +195,7 @@ class Model extends HoistInputModel {
         if (isNil(value) || value === '') return null;
         if (isNumber(value)) return value;
 
+        value = value.toString();
         value = value.replace(/,/g, '');
 
         if (Model.shorthandValidator.test(value)) {

--- a/mobile/cmp/input/NumberInput.js
+++ b/mobile/cmp/input/NumberInput.js
@@ -67,7 +67,8 @@ NumberInput.propTypes = {
     /**
      * Scale factor to apply when converting between the internal and external value. Useful for
      * cases such as handling a percentage value where the user would expect to see or input 20 but
-     * the external value the input is bound to should be 0.2. Defaults to 1 (no scaling applied).
+     * the external value the input is bound to should be 0.2. Must be a factor of 10.
+     * Defaults to 1 (no scaling applied).
      */
     scaleFactor: PT.number,
 

--- a/mobile/cmp/input/NumberInput.js
+++ b/mobile/cmp/input/NumberInput.js
@@ -16,7 +16,7 @@ import PT from 'prop-types';
 import './NumberInput.scss';
 
 /**
- * Number Input, with optional support for formatted of display value,
+ * Number input, with optional support for formatting of display value, shorthand units, and more.
  */
 export const [NumberInput, numberInput] = hoistCmp.withFactory({
     displayName: 'NumberInput',
@@ -32,36 +32,34 @@ NumberInput.propTypes = {
     /** True to commit on every change/keystroke, default false. */
     commitOnChange: PT.bool,
 
-    /** Whether to display large values with commas */
+    /** True to insert commas in displayed value. */
     displayWithCommas: PT.bool,
 
-    /** Set to true for advanced input evaluation, defaults to false.
-     Inputs suffixed with k, m, or b will be calculated as thousands, millions, or billions respectively */
+    /** True to convert entries suffixed with k/m/b to thousands/millions/billions. */
     enableShorthandUnits: PT.bool,
 
-
     /**
-     * Minimum value.  Note that this will govern the smallest value that this control can produce
-     * via user input.  Smaller values passed to it via props or a bound model will still be displayed.
+     * Minimum value. Note that this will govern the smallest value that this control can produce
+     * via user input. Smaller values passed to it via props or a bound model will still be displayed.
      */
     min: PT.number,
 
     /**
-     * Maximum value.  Note that this will govern the largest value that this control can produce
-     * via user input.  Larger values passed to it via props or a bound model will still be displayed.
+     * Maximum value. Note that this will govern the largest value that this control can produce
+     * via user input. Larger values passed to it via props or a bound model will still be displayed.
      */
     max: PT.number,
 
-    /** Onsen modifier string */
+    /** Onsen modifier string. */
     modifier: PT.string,
 
-    /** Function which receives keydown event */
+    /** Function which receives keydown event. */
     onKeyDown: PT.func,
 
-    /** Text to display when control is empty */
+    /** Text to display when control is empty. */
     placeholder: PT.string,
 
-    /** Number of decimal places to allow on field's value, defaults to 4 */
+    /** Max decimal precision of the value, defaults to 4. */
     precision: PT.number,
 
     /**
@@ -72,7 +70,7 @@ NumberInput.propTypes = {
      */
     scaleFactor: PT.number,
 
-    /** Whether text in field is selected when field receives focus */
+    /** True to select contents when control receives focus. */
     selectOnFocus: PT.bool,
 
     /** Alignment of entry text within control, default 'right'. */
@@ -84,7 +82,7 @@ NumberInput.propTypes = {
      */
     valueLabel: PT.string,
 
-    /** Allow/automatically fill in trailing zeros in accord with precision, defaults to false */
+    /** True to pad with trailing zeros out to precision, default false. */
     zeroPad: PT.bool
 };
 NumberInput.hasLayoutSupport = true;
@@ -92,7 +90,6 @@ NumberInput.hasLayoutSupport = true;
 //-----------------------
 // Implementation
 //-----------------------
-
 class Model extends HoistInputModel {
 
     static shorthandValidator = /((\.\d+)|(\d+(\.\d+)?))([kmb])\b/i;
@@ -147,10 +144,7 @@ class Model extends HoistInputModel {
         let {precision} = this;
         if (!isNil(precision)) {
             precision = precision + Math.log10(this.scaleFactor);
-            console.log(precision);
-            console.log(val);
             val = round(val, precision);
-            console.log(val);
         }
         return val;
     }
@@ -161,14 +155,12 @@ class Model extends HoistInputModel {
         if (isNaN(val)) return false;
         if (val === null) return true;
 
-        // Enforce min/max here. This is instead of the bp props which are
-        // buggy and only limit the incremental step change in any case
+        // Enforce min/max here on commit.
         if (!isNil(min) && val < min) return false;
         if (!isNil(max) && val > max) return false;
 
         return true;
     }
-
 
     onKeyDown = (ev) => {
         if (ev.key === 'Enter') this.doCommit();

--- a/mobile/cmp/input/NumberInput.js
+++ b/mobile/cmp/input/NumberInput.js
@@ -39,15 +39,16 @@ NumberInput.propTypes = {
      Inputs suffixed with k, m, or b will be calculated as thousands, millions, or billions respectively */
     enableShorthandUnits: PT.bool,
 
+
     /**
-     * Minimum value - NOTE, as with underlying HTML input, this ONLY constrains step-wise updates
-     * made via increment/decrement handling, does NOT validate or block out-of-bounds inputs.
+     * Minimum value.  Note that this will govern the smallest value that this control can produce
+     * via user input.  Smaller values passed to it via props or a bound model will still be displayed.
      */
     min: PT.number,
 
     /**
-     * Maximum value - NOTE, as with underlying HTML input, this ONLY constrains step-wise updates
-     * made via increment/decrement handling, does NOT validate or block out-of-bounds inputs.
+     * Maximum value.  Note that this will govern the largest value that this control can produce
+     * via user input.  Larger values passed to it via props or a bound model will still be displayed.
      */
     max: PT.number,
 
@@ -120,7 +121,17 @@ class Model extends HoistInputModel {
     }
 
     toExternal(val) {
-        return isNil(val) ? null : val / this.scaleFactor;
+        const {min, max} = this.componentProps;
+        val = this.parseValue(val);
+        if (isNaN(val) || isNil(val)) return null;
+
+        val = val / this.scaleFactor;
+
+        // Enforce min/max here. This is in addition to the onsen props which
+        // only limit the incremental step change.
+        return ((!isNil(min) && val < min) || (!isNil(max) && val > max)) ?
+            this.externalValue :
+            val;
     }
 
     onKeyDown = (ev) => {

--- a/mobile/cmp/input/NumberInput.js
+++ b/mobile/cmp/input/NumberInput.js
@@ -129,9 +129,10 @@ class Model extends HoistInputModel {
 
         // Enforce min/max here. This is in addition to the onsen props which
         // only limit the incremental step change.
-        return ((!isNil(min) && val < min) || (!isNil(max) && val > max)) ?
-            this.externalValue :
-            val;
+        if (!isNil(min) && val < min) return this.externalValue;
+        if (!isNil(max) && val > max) return this.externalValue;
+
+        return val;
     }
 
     onKeyDown = (ev) => {

--- a/mobile/cmp/input/NumberInput.js
+++ b/mobile/cmp/input/NumberInput.js
@@ -11,7 +11,7 @@ import {input} from '@xh/hoist/kit/onsen';
 import {wait} from '@xh/hoist/promise';
 import {withDefault, debounced} from '@xh/hoist/utils/js';
 import {getLayoutProps} from '@xh/hoist/utils/react';
-import {isNaN, isNil} from 'lodash';
+import {isNaN, isNil, isNumber} from 'lodash';
 import PT from 'prop-types';
 import './NumberInput.scss';
 
@@ -94,7 +94,7 @@ NumberInput.hasLayoutSupport = true;
 
 class Model extends HoistInputModel {
 
-    static shorthandValidator = /((\.\d+)|(\d+(\.\d+)?))([kmb])\b/gi;
+    static shorthandValidator = /((\.\d+)|(\d+(\.\d+)?))([kmb])\b/i;
 
     @debounced(250)
     doCommitOnChangeInternal() {
@@ -115,10 +115,8 @@ class Model extends HoistInputModel {
         wait().then(() => super.select());
     }
 
-    onChange = (ev) => {
-        let value = this.parseValue(ev.target.value);
-        value = isNaN(value)  ? null : value;
-        this.noteValueChange(value);
+    onValueChange = (ev) => {
+        this.noteValueChange(ev.target.value);
     };
 
     toInternal(val) {
@@ -181,7 +179,9 @@ class Model extends HoistInputModel {
     }
 
     parseValue(value) {
-        if (!value) return value;
+        if (isNil(value) || value === '') return null;
+        if (isNumber(value)) return value;
+
         value = value.toString();
         value = value.replace(/,/g, '');
 
@@ -197,12 +197,11 @@ class Model extends HoistInputModel {
                 case 'b':
                     return num * 1000000000;
                 default:
-                    return null;
+                    return NaN;
             }
         }
 
-        value = parseFloat(value);
-        return isNaN(value) ? null : value;
+        return parseFloat(value);
     }
 }
 
@@ -235,7 +234,7 @@ const cmp = hoistCmp.factory(
             },
             spellCheck: false,
 
-            onChange: model.onChange,
+            onChange: model.onValueChange,
             onKeyDown: model.onKeyDown,
             onBlur: model.onBlur,
             onFocus: model.onFocus,


### PR DESCRIPTION
This fixes a number of issues with NumberInput. :-)

- Precision now enforced when first focused on overprecise source value.
- Precision now enforced when setting value back to source.
- Debounce provides less thrashing when user typing in numbers
- scaleFactor now clearly documented as being a factor of 10
- Max/min are enforced.  Workaround for related Blueprint errors with this prop handled more reliably 

Also provides some additional template Hooks in HoistInputModel for future use.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

