### PR TITLE
Initialize `state` member after loading initial state

### DIFF
--- a/desktop/cmp/dash/canvas/DashCanvasModel.js
+++ b/desktop/cmp/dash/canvas/DashCanvasModel.js
@@ -160,7 +160,10 @@ export class DashCanvasModel extends HoistModel {
                 this.provider = null;
             }
         }
+
         this.loadState(persistState?.state ?? initialState);
+        this.state = this.buildState();
+
         this.addReaction({
             track: () => [this.viewState, this.layout],
             run: () => this.publishState()


### PR DESCRIPTION
Could have sworn we made this change with previous enhancements, but apparently we did not ... this should get the `state` member initialized to the initial state in the constructor, without publishing it to the provider until it changes again (triggering the publish reaction)

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

