### PR TITLE
Only redraw rows when absSort on a column has changed

### DIFF
--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -411,6 +411,7 @@ export class AgGridModel extends HoistModel {
 
         if (togglingAbsSort) {
             agApi.redrawRows(); // Workaround needed for ag v27.
+            togglingAbsSort = false;
         }
 
         this._prevSortBy = sortBy;

--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -409,9 +409,10 @@ export class AgGridModel extends HoistModel {
             defaultState: {sort: null, sortIndex: null}
         });
 
+        // Workaround needed for ag v27.
+        // https://github.com/xh/hoist-react/issues/2997
         if (togglingAbsSort) {
-            agApi.redrawRows(); // Workaround needed for ag v27.
-            togglingAbsSort = false;
+            agApi.redrawRows();
         }
 
         this._prevSortBy = sortBy;

--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -383,13 +383,15 @@ export class AgGridModel extends HoistModel {
         this.throwIfNotReady();
         const {agColumnApi, agApi} = this,
             prevSortBy = this._prevSortBy;
+        let togglingAbsSort = false;
 
         if (isEqual(prevSortBy, sortBy)) return;
 
         // Preclear if only toggling abs for any sort. Ag-Grid doesn't handle abs and would skip
         if (sortBy.some(curr =>
-            prevSortBy?.some(prev => curr.sort === prev.sort && curr.abs != prev.abs)
+            prevSortBy?.some(prev => curr.sort === prev.sort && curr.colId === prev.colId && curr.abs != prev.abs)
         )) {
+            togglingAbsSort = true;
             agColumnApi.applyColumnState({defaultState: {sort: null, sortIndex: null}});
         }
 
@@ -406,7 +408,10 @@ export class AgGridModel extends HoistModel {
             state: newState,
             defaultState: {sort: null, sortIndex: null}
         });
-        agApi.redrawRows(); // Workaround needed for ag v27.
+
+        if (togglingAbsSort) {
+            agApi.redrawRows();
+        }
 
         this._prevSortBy = sortBy;
     }

--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -410,7 +410,7 @@ export class AgGridModel extends HoistModel {
         });
 
         if (togglingAbsSort) {
-            agApi.redrawRows();
+            agApi.redrawRows(); // Workaround needed for ag v27.
         }
 
         this._prevSortBy = sortBy;


### PR DESCRIPTION
Only redraw rows when necessary - when only the absSort on a column has changed.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

