### PR TITLE
Fix destructuring to get StoreFilterField's includeFields and excludeFields values

### DIFF
--- a/cmp/store/impl/StoreFilterFieldImplModel.js
+++ b/cmp/store/impl/StoreFilterFieldImplModel.js
@@ -156,7 +156,8 @@ export class StoreFilterFieldImplModel extends HoistModel {
     }
 
     getActiveFields() {
-        let {gridModel, includeFields, excludeFields, store} = this;
+        const {gridModel, store, componentProps} = this,
+            {includeFields, excludeFields} = componentProps;
 
         let ret = store ? ['id', ...store.fields.map(f => f.name)] : [];
         if (includeFields) ret = store ? intersection(ret, includeFields) : includeFields;


### PR DESCRIPTION
Properties includeFields and excludeFields were previously defined on the model but are now accessible via the componentProps.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

