### PR TITLE
Fix sizing of GridFindField in compact toolbars

### DIFF
--- a/desktop/cmp/grid/find/GridFindField.scss
+++ b/desktop/cmp/grid/find/GridFindField.scss
@@ -13,8 +13,8 @@
     border-radius: 0 3px 3px 0;
 
     .xh-button {
-      max-height: calc(var(--xh-tbar-compact-item-height-px) * 0.5);
-      min-height: calc(var(--xh-tbar-compact-item-height-px) * 0.5);
+      max-height: calc(var(--xh-tbar-compact-item-height-px) * 0.5) !important;
+      min-height: calc(var(--xh-tbar-compact-item-height-px) * 0.5) !important;
       min-width: var(--xh-tbar-compact-item-height-px);
       max-width: var(--xh-tbar-compact-item-height-px);
       margin: 0 !important;
@@ -30,4 +30,8 @@
     min-width: 30px;
     text-align: right;
   }
+}
+
+.xh-toolbar--compact .xh-grid-find-field__controls {
+  border: none;
 }


### PR DESCRIPTION
The height of the up / down buttons messes with vertical alignment in compact toolbars:

<img width="401" alt="Screenshot 2022-06-09 at 09 03 28" src="https://user-images.githubusercontent.com/3017757/172801046-91f1e325-8593-4bc4-80a3-e2433af1873e.png">

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

