### PR TITLE
Fix bug where SplitTreeMapModel.showSplitter property wasn't being set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix bug where `Panel` would throw when `headerItems = null`
 * Fix column values filtering on `tags` fields if another filter is already present.
 * Fix bug where `SwitchInput` `labelSide` would render inappropriately if within `compact` `toolbar`
+* Fix bug where `SplitTreeMapModel.showSplitter` property wasn't being set in constructor
 
 ### 📚 Libraries
 

--- a/desktop/cmp/treemap/SplitTreeMapModel.js
+++ b/desktop/cmp/treemap/SplitTreeMapModel.js
@@ -30,6 +30,8 @@ export class SplitTreeMapModel extends HoistModel {
     mapFilter;
     /** @member {function} */
     mapTitleFn;
+    /** @member {boolean} */
+    showSplitter;
 
     /** @member {TreeMapModel} */
     @managed primaryMapModel;
@@ -65,6 +67,7 @@ export class SplitTreeMapModel extends HoistModel {
         makeObservable(this);
         this.mapFilter = withDefault(mapFilter, this.defaultMapFilter);
         this.mapTitleFn = mapTitleFn;
+        this.showSplitter = showSplitter;
 
         throwIf(!['vertical', 'horizontal'].includes(orientation), `Orientation "${orientation}" not recognised.`);
         this.orientation = orientation;


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

