### PR TITLE
Debounce Grid's data reaction + autosize improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@
 
 * FilterChooser field suggestions now search within multi-word field names
 
+### 🐞 Bug Fixes
+* Fixes several issues where Grid would display rows gaps after operating on it programmatically,
+  This problem was introduced in ag-Grid v27.
+
+### 💥 Breaking Changes
+* The data reactions between `GridModel` and the underlying ag-Grid are now debounced, to avoid
+  corrupting ag-Grid's underlying state. This should not be a problem for most applications, but
+  applications that are querying any grid state immediately after loading a grid or changing the
+  data in its store (e.g. selection, row visible/expansion state, etc.) should be tested carefully
+  and may require a call to  `whenGridReadyAsync()`.  (Note that this method is already
+  incorporated in to several public methods on `GridModel` including  `selectFirstAsync` and
+  `ensureSelectionVisibleAsync`.)
+
 [Commit Log](https://github.com/xh/hoist-react/compare/v49.2.0...develop)
 
 ## v49.2.0 - 2022-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,21 @@
 
 ### 🎁 New Features
 
-* FilterChooser field suggestions now search within multi-word field names
+* FilterChooser field suggestions now search within multi-word field names.
+* Improved autosize behavior for very large grids.
 
 ### 🐞 Bug Fixes
 * Fixes several issues where Grid would display rows gaps after operating on it programmatically,
   This problem was introduced in ag-Grid v27.
 
 ### 💥 Breaking Changes
-* The data reactions between `GridModel` and the underlying ag-Grid are now debounced, to avoid
-  corrupting ag-Grid's underlying state. This should not be a problem for most applications, but
-  applications that are querying any grid state immediately after loading a grid or changing the
-  data in its store (e.g. selection, row visible/expansion state, etc.) should be tested carefully
-  and may require a call to  `whenGridReadyAsync()`.  (Note that this method is already
-  incorporated in to several public methods on `GridModel` including  `selectFirstAsync` and
-  `ensureSelectionVisibleAsync`.)
+* The data reactions between `GridModel` and the underlying ag-Grid is now minimally debounced, to
+  avoid multiple data updates during a single event loop tick. This avoids corrupting ag-Grid's
+  underlying state. This should not be a problem for most applications, but
+  applications that are querying any grid state immediately after loading or filtering a grid
+  (e.g. selection, row visible/expansion state, etc.) should be tested carefully and may require a
+  call to  `whenGridReadyAsync()`.  (Note that this method is already incorporated in to several
+  public methods on `GridModel` including  `selectFirstAsync` and `ensureSelectionVisibleAsync`.)
 
 [Commit Log](https://github.com/xh/hoist-react/compare/v49.2.0...develop)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### 🎁 New Features
 
 * FilterChooser field suggestions now search within multi-word field names.
-* Improved autosize behavior for very large grids.
+* Improved autosize performance for very large grids: Asynchronous loops are now used to avoid
+  locking-up entire app during autosize.
 
 ### 🐞 Bug Fixes
 * Fixes several issues where Grid would display rows gaps after operating on it programmatically,

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -384,7 +384,8 @@ class GridLocalModel extends HoistModel {
             track: () => [model.isReady, store._filtered, model.showSummary, store.summaryRecord],
             run: () => {
                 if (model.isReady) this.syncData();
-            }
+            },
+            debounce: 0
         };
     }
 
@@ -517,12 +518,12 @@ class GridLocalModel extends HoistModel {
     }
 
     sizingModeReaction() {
-        const {model} = this,
-            {mode} = model.autosizeOptions;
+        const {model} = this;
 
         return {
             track: () => model.sizingMode,
             run: () => {
+                const {mode} = model.autosizeOptions;
                 if (mode === GridAutosizeMode.MANAGED || mode === GridAutosizeMode.ON_SIZING_MODE_CHANGE) {
                     model.autosizeAsync({showMask: true});
                 }
@@ -546,7 +547,7 @@ class GridLocalModel extends HoistModel {
                     agApi.refreshCells({columns: colIds, force: true});
                 }
             },
-            debounce: 1
+            debounce: 0
         };
     }
 

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -646,13 +646,13 @@ class GridLocalModel extends HoistModel {
         if (model.autosizeOptions.mode === GridAutosizeMode.MANAGED) {
             // If sizingMode different to autosizeState, autosize all columns...
             if (model.autosizeState.sizingMode !== model.sizingMode) {
-                wait(100).then(() => model.autosizeAsync());
+                model.autosizeAsync();
             } else {
                 // ...otherwise, only autosize columns that are not manually sized
                 const columns = model.columnState
                     .filter(it => !it.manuallySized)
                     .map(it => it.colId);
-                wait(100).then(() => model.autosizeAsync({columns}));
+                model.autosizeAsync({columns});
             }
         }
 

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -384,8 +384,7 @@ class GridLocalModel extends HoistModel {
             track: () => [model.isReady, store._filtered, model.showSummary, store.summaryRecord],
             run: () => {
                 if (model.isReady) this.syncData();
-            },
-            debounce: 0
+            }
         };
     }
 
@@ -518,12 +517,12 @@ class GridLocalModel extends HoistModel {
     }
 
     sizingModeReaction() {
-        const {model} = this;
+        const {model} = this,
+            {mode} = model.autosizeOptions;
 
         return {
             track: () => model.sizingMode,
             run: () => {
-                const {mode} = model.autosizeOptions;
                 if (mode === GridAutosizeMode.MANAGED || mode === GridAutosizeMode.ON_SIZING_MODE_CHANGE) {
                     model.autosizeAsync({showMask: true});
                 }
@@ -547,7 +546,7 @@ class GridLocalModel extends HoistModel {
                     agApi.refreshCells({columns: colIds, force: true});
                 }
             },
-            debounce: 0
+            debounce: 1
         };
     }
 

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -1223,9 +1223,8 @@ export class GridModel extends HoistModel {
             agApi.showLoadingOverlay();
         }
 
-        // Always wait a tick to ensure `GridLocalModel.syncData()` reaction has run and ag-Grid
-        // has been asked to render the current recordset into visible rows for measuring. Also
-        // ensures that the mask overlay is rendered (if requested).
+        // Always wait a tick to ensure data reaction has had a chance to sync for this tick.
+        // Also ensures that any mask overlay is rendered
         await wait();
 
         try {

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -1216,16 +1216,15 @@ export class GridModel extends HoistModel {
     // Implementation
     //-----------------------
     async autosizeColsInternalAsync(colIds, options) {
-        const {agApi, empty} = this;
-        const showMask = options.showMask && agApi;
+        await this.whenReadyAsync();
+        if (!this.isReady) return;
+
+        const {agApi, empty} = this,
+            {showMask} = options;
 
         if (showMask) {
             agApi.showLoadingOverlay();
         }
-
-        // Always wait a tick to ensure data reaction has had a chance to sync for this tick.
-        // Also ensures that any mask overlay is rendered
-        await wait();
 
         try {
             await XH.gridAutosizeService.autosizeAsync(this, colIds, options);

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -1193,16 +1193,10 @@ export class GridModel extends HoistModel {
      * TODO - see https://github.com/xh/hoist-react/issues/2551 and note that calls to this method
      *   within this class re-check `isReady` directly. We have observed this method returning
      *   to its caller as true when the ag-grid/API has in fact dismounted and is no longer ready.
-     *
-     * This method will introduce a minimal delay for all calls.  This is useful to ensure
-     * that the grid has had the opportunity to process any pending data updates, which are also
-     * subject to a minimal async debounce.
-     *
      * @param {number} [timeout] - timeout in ms
      * @return {Promise<boolean>} - latest ready state of grid
      */
     async whenReadyAsync(timeout = 3 * SECONDS) {
-        await wait();
         try {
             await when(() => this.isReady, {timeout});
         } catch (ignored) {

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -1193,10 +1193,16 @@ export class GridModel extends HoistModel {
      * TODO - see https://github.com/xh/hoist-react/issues/2551 and note that calls to this method
      *   within this class re-check `isReady` directly. We have observed this method returning
      *   to its caller as true when the ag-grid/API has in fact dismounted and is no longer ready.
+     *
+     * This method will introduce a minimal delay for all calls.  This is useful to ensure
+     * that the grid has had the opportunity to process any pending data updates, which are also
+     * subject to a minimal async debounce.
+     *
      * @param {number} [timeout] - timeout in ms
      * @return {Promise<boolean>} - latest ready state of grid
      */
     async whenReadyAsync(timeout = 3 * SECONDS) {
+        await wait();
         try {
             await when(() => this.isReady, {timeout});
         } catch (ignored) {

--- a/cmp/grid/impl/ColumnWidthCalculator.js
+++ b/cmp/grid/impl/ColumnWidthCalculator.js
@@ -75,11 +75,11 @@ export class ColumnWidthCalculator {
             if (treeMode && column.isTreeColumn && store.allRootCount !== store.allCount) {
                 // For tree columns, we need to account for the indentation at the different depths.
                 // Here we group the records by tree depth and determine the max width at each depth.
-                const recordsByDepth = groupBy(records, record => record.ancestors.length),
-                    levelMaxes = map(recordsByDepth, async (records, depth) => {
-                        return await this.calcLevelWidthAsync(gridModel, records, column, options, this.getIndentation(depth));
-                    });
-
+                let recordsByDepth = groupBy(records, record => record.ancestors.length),
+                    levelTasks = map(recordsByDepth, (records, depth) => {
+                        return this.calcLevelWidthAsync(gridModel, records, column, options, this.getIndentation(depth));
+                    }),
+                    levelMaxes = await Promise.all(levelTasks);
                 return max(levelMaxes);
             } else {
                 return this.calcLevelWidthAsync(gridModel, records, column, options);

--- a/cmp/grid/impl/ColumnWidthCalculator.js
+++ b/cmp/grid/impl/ColumnWidthCalculator.js
@@ -75,7 +75,7 @@ export class ColumnWidthCalculator {
             if (treeMode && column.isTreeColumn && store.allRootCount !== store.allCount) {
                 // For tree columns, we need to account for the indentation at the different depths.
                 // Here we group the records by tree depth and determine the max width at each depth.
-                let recordsByDepth = groupBy(records, record => record.ancestors.length),
+                const recordsByDepth = groupBy(records, record => record.ancestors.length),
                     levelTasks = map(recordsByDepth, (records, depth) => {
                         return this.calcLevelWidthAsync(gridModel, records, column, options, this.getIndentation(depth));
                     }),

--- a/cmp/grid/impl/ColumnWidthCalculator.js
+++ b/cmp/grid/impl/ColumnWidthCalculator.js
@@ -7,9 +7,10 @@
 
 import {XH} from '@xh/hoist/core';
 import {stripTags} from '@xh/hoist/utils/js';
-import {forOwn, groupBy, isEmpty, isArray, isFunction, isNil, isString, map, max, min, sortBy, shuffle} from 'lodash';
+import {forOwn, groupBy, isEmpty, isArray, isFunction, isNil, isString, map, max, min, sortBy, takeRight} from 'lodash';
 import {isValidElement} from 'react';
 import {renderToStaticMarkup} from 'react-dom/server';
+import {forEachAsync} from '@xh/hoist/utils/async';
 
 /**
  * Calculates the column width required to display column.  Used by GridAutoSizeService.
@@ -37,13 +38,13 @@ export class ColumnWidthCalculator {
      * @param {GridAutosizeOptions} options
      * @returns {*}
      */
-    calcWidth(gridModel, records, colId, options) {
+    async calcWidthAsync(gridModel, records, colId, options) {
         const column = gridModel.findColumn(gridModel.columns, colId),
             {autosizeMinWidth, autosizeMaxWidth} = column;
 
         let result = max([
             this.calcHeaderWidth(gridModel, column, options),
-            this.calcDataWidth(gridModel, shuffle(records), column, options)
+            await this.calcDataWidthAsync(gridModel, records, column, options)
         ]);
 
         result = max([result, autosizeMinWidth]);
@@ -66,7 +67,7 @@ export class ColumnWidthCalculator {
         }
     }
 
-    calcDataWidth(gridModel, records, column, options) {
+    async calcDataWidthAsync(gridModel, records, column, options) {
         if (isEmpty(records)) return null;
 
         try {
@@ -75,13 +76,13 @@ export class ColumnWidthCalculator {
                 // For tree columns, we need to account for the indentation at the different depths.
                 // Here we group the records by tree depth and determine the max width at each depth.
                 const recordsByDepth = groupBy(records, record => record.ancestors.length),
-                    levelMaxes = map(recordsByDepth, (records, depth) => {
-                        return this.calcLevelWidth(gridModel, records, column, options, this.getIndentation(depth));
+                    levelMaxes = map(recordsByDepth, async (records, depth) => {
+                        return await this.calcLevelWidthAsync(gridModel, records, column, options, this.getIndentation(depth));
                     });
 
                 return max(levelMaxes);
             } else {
-                return this.calcLevelWidth(gridModel, records, column, options);
+                return this.calcLevelWidthAsync(gridModel, records, column, options);
             }
         } catch (e) {
             console.warn(`Error calculating max data width for column "${column.colId}".`, e);
@@ -90,59 +91,65 @@ export class ColumnWidthCalculator {
         }
     }
 
-    calcLevelWidth(gridModel, records, column, options, indentationPx = 0) {
-        const {field, getValueFn, renderer, rendererIsComplex, cellClassFn, cellClassRules} = column,
+    async calcLevelWidthAsync(gridModel, records, column, options, indentationPx = 0) {
+        const {
+                field,
+                getValueFn,
+                renderer,
+                rendererIsComplex,
+                cellClassFn,
+                cellClassRules
+            } = column,
             {store, sizingMode, rowClassFn, rowClassRules} = gridModel,
             bufferPx = column.autosizeBufferPx ?? options.bufferPx;
 
-        // 1) Get Map of rendered values to List of records that contain them
-        const recsByValue = new Map(),
-            renderedValues = new Map();
+        // 1) Get map of rendered values to data about it
+        const estimatesByValue = new Map(),
+            renderMemo = renderer && !rendererIsComplex ? (new Map()) : null;
 
-        records.forEach(record => {
+        await forEachAsync(records, record => {
             if (!record) return;
 
             const ctx = {record, field, column, gridModel, store},
                 rawValue = getValueFn(ctx);
 
-            let value;
-            if (!renderer) {
-                // The simplest case is a column that does not use a renderer
-                value = rawValue;
-                renderedValues.set(rawValue, value);
-            } else if (!rendererIsComplex && renderedValues.get(rawValue)) {
-                // If the column does not use a complex renderer, we can reuse the rendered value.
-                value = renderedValues.get(rawValue);
-            } else {
-                // Otherwise, render and memoize the raw value.
-                value = renderer(rawValue, ctx);
-                if (isValidElement(value)) value = renderToStaticMarkup(value);
-                renderedValues.set(rawValue, value);
+            // 1a) Get rendered markup value from raw.  Use memoization if appropriate
+            let value = rawValue;
+            if (renderer) {
+                if (renderMemo?.has(rawValue)) {
+                    value = renderMemo.get(rawValue);
+                } else {
+                    value = renderer(rawValue, ctx);
+                    if (isValidElement(value)) value = renderToStaticMarkup(value);
+                    renderMemo?.set(rawValue, value);
+                }
             }
 
-            const recs = recsByValue.get(value);
-            if (!recs) {
-                recsByValue.set(value, [record]);
+            // 1b) Use a canvas to estimate pixel width of new markup.
+            // Strip html tags but include parentheses / units etc. for renderers that may return elements.
+            const est = estimatesByValue.get(value);
+            if (!est) {
+                estimatesByValue.set(value, {
+                    value,
+                    width: isNil(value) ? 0 : this.getStringWidth(stripTags(value.toString())) + indentationPx,
+                    records: [record]
+                });
             } else {
-                recs.push(record);
+                est.records.push(record);
             }
         });
 
-        // 2) Use a canvas to estimate and sort by the pixel width of the string value.
-        // Strip html tags but include parentheses / units etc. for renderers that may return elements.
-        const sortedValues = sortBy(Array.from(recsByValue.keys()), value => {
-            const width = isNil(value) ? 0 : this.getStringWidth(stripTags(value.toString()));
-            return width + indentationPx;
-        });
+        // 2) Extract the sample set of widest estimate values for rendering and sizing
+        let sample = Array.from(estimatesByValue.values());
+        sample = takeRight(sortBy(sample, 'width'), this.SIZE_CALC_SAMPLES);
 
-        // 3) Extract the sample set of longest values for rendering and sizing
-        const longestValues = sortedValues.slice(Math.max(sortedValues.length - this.SIZE_CALC_SAMPLES, 0));
-
-        // 4) Get longest values, with unique combinations of row and cell classes applied to them
-        const samples = longestValues.map(value => {
+        // 3) Get widest values, after actually rendering all css combinations for all records
+        let ret = 0;
+        await forEachAsync(sample, ({value, records}) => {
+            // Get unique combinations of row and cell classes applied
             const classNames = new Set();
             if (rowClassFn || cellClassFn || !isEmpty(rowClassRules) || !isEmpty(cellClassRules)) {
-                recsByValue.get(value).forEach(record => {
+                records.forEach(record => {
                     const rawValue = getValueFn({record, field, column, gridModel, store}),
                         rowClass = this.getRowClass(gridModel, record),
                         cellClass = this.getCellClass(gridModel, column, record, rawValue);
@@ -151,13 +158,9 @@ export class ColumnWidthCalculator {
             } else {
                 classNames.add('|');
             }
-            return {value, classNames};
-        });
 
-        // 5) Render to a hidden cell to calculate the max displayed width. Loop through all
-        // combinations of cell and row classes applied to this value, and return the largest.
-        let ret = 0;
-        samples.forEach(({value, classNames}) => {
+            // 5) Render to a hidden cell to calculate the max displayed width. Loop through all
+            // combinations of cell and row classes applied to this value, and return the largest.
             classNames.forEach(it => {
                 const [rowClass, cellClass] = it.split('|');
                 this.setClassNames(sizingMode, rowClass, cellClass);

--- a/svc/GridAutosizeService.js
+++ b/svc/GridAutosizeService.js
@@ -34,6 +34,9 @@ export class GridAutosizeService extends HoistService {
      * @param {GridAutosizeOptions} options - options to use for this autosize.
      */
     async autosizeAsync(gridModel, colIds, options) {
+        await gridModel.whenReadyAsync();
+        if (!gridModel.isReady) return;
+
         // 1) Check columns exist
         colIds = colIds.filter(id => gridModel.getColumn(id));
         if (isEmpty(colIds)) return;
@@ -103,18 +106,18 @@ export class GridAutosizeService extends HoistService {
             ret = [];
 
         if (renderedRowsOnly) {
-            agApi?.getRenderedNodes().forEach(node => {
+            agApi.getRenderedNodes().forEach(node => {
                 const record = store.getById(node.data?.id);
                 if (record) ret.push(record);
             });
-        } else if (agApi && !includeCollapsedChildren && (treeMode || groupBy)) {
+        } else if (!includeCollapsedChildren && (treeMode || groupBy)) {
             // In tree/grouped grids, included expanded rows only by default.
             for (let idx = 0; idx < agApi.getDisplayedRowCount(); idx++) {
                 const node = agApi.getDisplayedRowAtIndex(idx),
                     record = store.getById(node.data?.id);
                 if (record) ret.push(record);
             }
-        } else if (agApi?.isAnyFilterPresent()) {
+        } else if (agApi.isAnyFilterPresent()) {
             // Respect "native" ag-Grid filtering, if in use.
             agApi.forEachNodeAfterFilter(node => {
                 const record = store.getById(node.data?.id);


### PR DESCRIPTION
+ Solves a critical row-gap rendering problem jbar found in client app, which is reproduced in a toolbox branch with same name.
+ Improves autosizing to use asynchronous loops, throw away obsolete results, and start right away in managed mode.
+ I like the debounce change, because even if there is some fix to ag-Grid that would handle the "multiple data updates in single tick" we would not want to thrash in that way -- could be problematic in a number of ways for large data sets.
+ I like the async loop change because, it allows grid sizing to degrade better as grids get too large.  We should aim to never write code that can lock up browser.
+ One major client flagship app testing fine.  Want to test a bit more on a few more in-the-wild apps, and see if it (hopefully) solves other related row-gap rendering problems.  But think this can be merged now.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

