### PR TITLE
Fix DashCanvas rendering exception

### DIFF
--- a/desktop/cmp/dash/canvas/DashCanvasModel.js
+++ b/desktop/cmp/dash/canvas/DashCanvasModel.js
@@ -290,7 +290,6 @@ export class DashCanvasModel extends HoistModel {
         }
     }
 
-
     @action
     addViewInternal(specId, {layout, title, state, previousViewId}) {
         const viewSpec = this.getSpec(specId),
@@ -325,7 +324,6 @@ export class DashCanvasModel extends HoistModel {
         return model;
     }
 
-
     @action
     setLayout(layout) {
         // strip extra properties from react-grid
@@ -334,8 +332,9 @@ export class DashCanvasModel extends HoistModel {
             this.layout = layout;
 
             // Check if scrollbar visibility has changed, and force resize event if so
-            const {current: node} = this.ref,
-                scrollbarVisible = node.offsetWidth > node.clientWidth;
+            const node = this.ref.current;
+            if (!node) return;
+            const scrollbarVisible = node.offsetWidth > node.clientWidth;
             if (scrollbarVisible !== this.scrollbarVisible) {
                 window.dispatchEvent(new Event('resize'));
                 this.scrollbarVisible = scrollbarVisible;


### PR DESCRIPTION
DashCanvas's `setLayout()` can throw in a nasty way, bringing down the whole app with a `An error occurred while rendering this Component.` message. Seen in a client app. 

If you have saved state that references a non-existent or omitted DashCanvasViewSpec, the `setLayout()` callback gets called before the component has rendered. The check for scrollbar visibility then throws because the ref has not yet been set.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

