### PR TITLE
Enforce importing platform specific components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### 🎁 New Features
 
+* Hoist now enforces platform-specific component imports. Importing components from the `desktop`
+  or `mobile` packages into apps for the opposing platform (determined via `AppSpec.isMobileApp`)
+  will cause the app to throw.
 * New `PanelModel.modalSupport` option allows the user to expand a panel into a configurable modal
   dialog - without developers needing to write custom dialog implementations and without triggering
   a remount/rerender of the panel's contents.

--- a/core/XH.js
+++ b/core/XH.js
@@ -36,7 +36,7 @@ import {
     throwIf,
     withDebug
 } from '@xh/hoist/utils/js';
-import {camelCase, compact, flatten, isBoolean, isString, uniqueId} from 'lodash';
+import {camelCase, compact, flatten, isBoolean, isEmpty, isString, uniqueId} from 'lodash';
 import {reaction as mobxReaction} from '@xh/hoist/mobx';
 import ReactDOM from 'react-dom';
 import parser from 'ua-parser-js';
@@ -236,7 +236,18 @@ class XHClass {
         const spinner = document.getElementById('xh-preload-spinner');
         if (spinner) spinner.style.display = 'none';
 
+        // 1) Create AppSpec
         this.appSpec = appSpec instanceof AppSpec ? appSpec : new AppSpec(appSpec);
+
+        // 2) Enforce platform specific components
+        const cmps = window.xhComponents;
+        if (this.isMobileApp && !isEmpty(cmps.desktop)) {
+            throw XH.exception(`Desktop components imported into mobile app: [${cmps.desktop.join(', ')}]`);
+        } else if (!this.isMobileApp && !isEmpty(cmps.mobile)) {
+            throw XH.exception(`Mobile components imported into desktop app: [${cmps.mobile.join(', ')}]`);
+        }
+
+        // 3) Render app to root
         const rootView = elem(appSpec.containerClass, {model: this.appContainerModel});
         ReactDOM.render(rootView, document.getElementById('xh-root'));
     }

--- a/desktop/cmp/appbar/AppBar.js
+++ b/desktop/cmp/appbar/AppBar.js
@@ -25,8 +25,9 @@ import './AppBar.scss';
  */
 export const [AppBar, appBar] = hoistCmp.withFactory({
     displayName: 'AppBar',
-    model: false,
     className: 'xh-appbar',
+    model: false,
+    desktop: true,
 
     render(props) {
         const {

--- a/desktop/cmp/appbar/AppBarSeparator.js
+++ b/desktop/cmp/appbar/AppBarSeparator.js
@@ -12,6 +12,7 @@ import {navbarDivider} from '@xh/hoist/kit/blueprint';
  */
 export const [AppBarSeparator, appBarSeparator] = hoistCmp.withFactory({
     displayName: 'AppBarSeparator',
+    desktop: true,
 
     render() {
         return navbarDivider();

--- a/desktop/cmp/button/AppMenuButton.js
+++ b/desktop/cmp/button/AppMenuButton.js
@@ -16,8 +16,9 @@ import {isValidElement} from 'react';
 
 export const [AppMenuButton, appMenuButton] = hoistCmp.withFactory({
     displayName: 'AppMenuButton',
-    model: false,
     className: 'xh-app-menu',
+    model: false,
+    desktop: true,
 
     render(props) {
         const {

--- a/desktop/cmp/button/Button.js
+++ b/desktop/cmp/button/Button.js
@@ -21,8 +21,9 @@ import './Button.scss';
  */
 export const [Button, button] = hoistCmp.withFactory({
     displayName: 'Button',
-    model: false,
     className: 'xh-button',
+    model: false,
+    desktop: true,
 
     render(props, ref) {
         const [layoutProps, nonLayoutProps] = splitLayoutProps(props),

--- a/desktop/cmp/button/ButtonGroup.js
+++ b/desktop/cmp/button/ButtonGroup.js
@@ -15,6 +15,7 @@ import PT from 'prop-types';
 export const [ButtonGroup, buttonGroup] = hoistCmp.withFactory({
     displayName: 'ButtonGroup',
     model: false,
+    desktop: true,
     className: 'xh-button-group',
 
     render(props, ref) {

--- a/desktop/cmp/button/ColAutosizeButton.js
+++ b/desktop/cmp/button/ColAutosizeButton.js
@@ -17,6 +17,7 @@ import {button, Button} from './Button';
 export const [ColAutosizeButton, colAutosizeButton] = hoistCmp.withFactory({
     displayName: 'ColAutosizeButton',
     model: false,
+    desktop: true,
 
     render({icon, title, onClick, gridModel, disabled, autosizeOptions = {}, ...rest}, ref) {
         gridModel = withDefault(gridModel, useContextModel(GridModel));

--- a/desktop/cmp/button/ColChooserButton.js
+++ b/desktop/cmp/button/ColChooserButton.js
@@ -24,6 +24,7 @@ import {button, Button} from './Button';
 export const [ColChooserButton, colChooserButton] = hoistCmp.withFactory({
     displayName: 'ColChooserButton',
     model: false,
+    desktop: true,
 
     render({icon, title, gridModel, popoverPosition, disabled, ...rest}, ref) {
         gridModel = withDefault(gridModel, useContextModel(GridModel));

--- a/desktop/cmp/button/ExportButton.js
+++ b/desktop/cmp/button/ExportButton.js
@@ -26,6 +26,7 @@ import {button, Button} from './Button';
 export const [ExportButton, exportButton] = hoistCmp.withFactory({
     displayName: 'ExportButton',
     model: false,
+    desktop: true,
 
     render({icon, title, onClick, gridModel, exportOptions = {}, disabled, ...rest}, ref) {
 

--- a/desktop/cmp/button/FeedbackButton.js
+++ b/desktop/cmp/button/FeedbackButton.js
@@ -15,6 +15,7 @@ import {button, Button} from './Button';
 export const [FeedbackButton, feedbackButton] = hoistCmp.withFactory({
     displayName: 'FeedbackButton',
     model: false,
+    desktop: true,
 
     render(props, ref) {
         return button({

--- a/desktop/cmp/button/LaunchAdminButton.js
+++ b/desktop/cmp/button/LaunchAdminButton.js
@@ -15,6 +15,7 @@ import {Icon} from '@xh/hoist/icon';
 export const [LaunchAdminButton, launchAdminButton] = hoistCmp.withFactory({
     displayName: 'LaunchAdminButton',
     model: false,
+    desktop: true,
 
     render(props, ref) {
         if (!XH.getUser().isHoistAdmin) return null;

--- a/desktop/cmp/button/LogoutButton.js
+++ b/desktop/cmp/button/LogoutButton.js
@@ -17,6 +17,7 @@ import {button, Button} from './Button';
 export const [LogoutButton, logoutButton] = hoistCmp.withFactory({
     displayName: 'LogoutButton',
     model: false,
+    desktop: true,
 
     render(props, ref)  {
         if (XH.appSpec.isSSO) return null;

--- a/desktop/cmp/button/ModalToggleButton.js
+++ b/desktop/cmp/button/ModalToggleButton.js
@@ -16,6 +16,7 @@ import {errorIf, withDefault} from '@xh/hoist/utils/js';
 export const [ModalToggleButton, modalToggleButton] = hoistCmp.withFactory({
     displayName: 'ModalToggleButton',
     model: false,
+    desktop: true,
 
     render({panelModel, ...rest}, ref) {
         panelModel = withDefault(panelModel, useContextModel(PanelModel));

--- a/desktop/cmp/button/OptionsButton.js
+++ b/desktop/cmp/button/OptionsButton.js
@@ -16,6 +16,7 @@ import {button, Button} from './Button';
 export const [OptionsButton, optionsButton] = hoistCmp.withFactory({
     displayName: 'OptionsButton',
     model: false,
+    desktop: true,
 
     render(props, ref) {
         return button({

--- a/desktop/cmp/button/RefreshButton.js
+++ b/desktop/cmp/button/RefreshButton.js
@@ -20,6 +20,7 @@ import {Button, button} from './Button';
 export const [RefreshButton, refreshButton] = hoistCmp.withFactory({
     displayName: 'RefreshButton',
     model: false,  // For consistency with all other buttons -- the model prop here could be replaced by 'target'
+    desktop: true,
 
     render({model, onClick, ...props}, ref) {
         const refreshContextModel = useContextModel(RefreshContextModel);

--- a/desktop/cmp/button/RestoreDefaultsButton.js
+++ b/desktop/cmp/button/RestoreDefaultsButton.js
@@ -19,6 +19,7 @@ import {button, Button} from './Button';
 export const [RestoreDefaultsButton, restoreDefaultsButton] = hoistCmp.withFactory({
     displayName: 'RestoreDefaultsButton',
     model: false,
+    desktop: true,
 
     render({
         warningTitle = 'Please Confirm',

--- a/desktop/cmp/button/ThemeToggleButton.js
+++ b/desktop/cmp/button/ThemeToggleButton.js
@@ -14,6 +14,7 @@ import {button, Button} from './Button';
 export const [ThemeToggleButton, themeToggleButton] = hoistCmp.withFactory({
     displayName: 'ThemeToggleButton',
     model: false,
+    desktop: true,
 
     render(props, ref) {
         return button({

--- a/desktop/cmp/button/WhatsNewButton.js
+++ b/desktop/cmp/button/WhatsNewButton.js
@@ -17,6 +17,7 @@ import {Icon} from '@xh/hoist/icon';
 export const [WhatsNewButton, whatsNewButton] = hoistCmp.withFactory({
     displayName: 'WhatsNewButton',
     model: false,
+    desktop: true,
 
     render(props) {
         if (!XH.changelogService.currentVersionIsUnread) return null;

--- a/desktop/cmp/clipboard/ClipboardButton.js
+++ b/desktop/cmp/clipboard/ClipboardButton.js
@@ -17,6 +17,7 @@ import PT from 'prop-types';
 export const [ClipboardButton, clipboardButton] = hoistCmp.withFactory({
     displayName: 'ClipboardButton',
     model: false,
+    desktop: true,
 
     render(props) {
         let {icon, onClick, text, getCopyText, successMessage, ...rest} = props;

--- a/desktop/cmp/clipboard/ClipboardMenuItem.js
+++ b/desktop/cmp/clipboard/ClipboardMenuItem.js
@@ -16,6 +16,7 @@ import {clipboardButton} from './ClipboardButton';
 export const [ClipboardMenuItem, clipboardMenuItem] = hoistCmp.withFactory({
     displayName: 'ClipboardMenuItem',
     model: false,
+    desktop: true,
     observer: false,
 
     render(props) {

--- a/desktop/cmp/contextmenu/ContextMenu.js
+++ b/desktop/cmp/contextmenu/ContextMenu.js
@@ -25,6 +25,7 @@ import {isEmpty} from 'lodash';
 export const [ContextMenu, contextMenu] = hoistCmp.withFactory({
     displayName: 'ContextMenu',
     memo: false, model: false, observer: false,
+    desktop: true,
 
     render({menuItems}) {
         menuItems = parseMenuItems(menuItems);

--- a/desktop/cmp/dash/canvas/DashCanvas.js
+++ b/desktop/cmp/dash/canvas/DashCanvas.js
@@ -35,6 +35,8 @@ export const [DashCanvas, dashCanvas] = hoistCmp.withFactory({
     displayName: 'DashCanvas',
     className: 'xh-dash-canvas',
     model: uses(DashCanvasModel),
+    desktop: true,
+
     render({className, model}) {
         const isDraggable = !model.layoutLocked,
             isResizable = !model.layoutLocked;

--- a/desktop/cmp/dash/container/DashContainer.js
+++ b/desktop/cmp/dash/container/DashContainer.js
@@ -28,6 +28,7 @@ export const [DashContainer, dashContainer] = hoistCmp.withFactory({
     displayName: 'DashContainer',
     model: uses(DashContainerModel),
     className: 'xh-dash-container',
+    desktop: true,
 
     render({model, className}, ref) {
         // Store current ModelLookupContext in model, to be applied in views later

--- a/desktop/cmp/error/ErrorMessage.js
+++ b/desktop/cmp/error/ErrorMessage.js
@@ -18,6 +18,7 @@ import './ErrorMessage.scss';
  */
 export const [ErrorMessage, errorMessage] = hoistCmp.withFactory({
     className: 'xh-error-message',
+    desktop: true,
     render({
         className,
         model,

--- a/desktop/cmp/filechooser/FileChooser.js
+++ b/desktop/cmp/filechooser/FileChooser.js
@@ -32,6 +32,7 @@ export const [FileChooser, fileChooser] = hoistCmp.withFactory({
     displayName: 'FileChooser',
     model: uses(FileChooserModel),
     className: 'xh-file-chooser',
+    desktop: true,
 
     render({
         model,

--- a/desktop/cmp/filter/FilterChooser.js
+++ b/desktop/cmp/filter/FilterChooser.js
@@ -26,6 +26,7 @@ import './FilterChooser.scss';
 export const [FilterChooser, filterChooser] = hoistCmp.withFactory({
     model: uses(FilterChooserModel),
     className: 'xh-filter-chooser',
+    desktop: true,
     render({model, className, ...props}, ref) {
         const [layoutProps, chooserProps] = splitLayoutProps(props),
             {inputRef, suggestFieldsWhenEmpty, selectOptions, unsupportedFilter, favoritesIsOpen} = model,

--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -47,6 +47,7 @@ export const [FormField, formField] = hoistCmp.withFactory({
         publishMode: ModelPublishMode.NONE,
         optional: true
     }),
+    desktop: true,
 
     render({model, className, field, children, info, ...props}, ref) {
         // Resolve FieldModel

--- a/desktop/cmp/grid/editors/BooleanEditor.js
+++ b/desktop/cmp/grid/editors/BooleanEditor.js
@@ -18,6 +18,7 @@ export const [BooleanEditor, booleanEditor] = hoistCmp.withFactory({
     className: 'xh-boolean-editor',
     memo: false,
     observer: false,
+    desktop: true,
     render({
         quickToggle,
         ...props

--- a/desktop/cmp/grid/editors/DateEditor.js
+++ b/desktop/cmp/grid/editors/DateEditor.js
@@ -17,6 +17,7 @@ export const [DateEditor, dateEditor] = hoistCmp.withFactory({
     className: 'xh-date-editor',
     memo: false,
     observer: false,
+    desktop: true,
     render(props, ref) {
         // We need to render the day picker popover inside the grid viewport in order for
         // `stopEditingWhenCellsLoseFocus` to work properly - otherwise the day picker becomes

--- a/desktop/cmp/grid/editors/NumberEditor.js
+++ b/desktop/cmp/grid/editors/NumberEditor.js
@@ -15,6 +15,7 @@ export const [NumberEditor, numberEditor] = hoistCmp.withFactory({
     className: 'xh-number-editor',
     memo: false,
     observer: false,
+    desktop: true,
     render(props, ref) {
         return useInlineEditorModel(numberInput, props, ref);
     }

--- a/desktop/cmp/grid/editors/SelectEditor.js
+++ b/desktop/cmp/grid/editors/SelectEditor.js
@@ -15,6 +15,7 @@ export const [SelectEditor, selectEditor] = hoistCmp.withFactory({
     className: 'xh-select-editor',
     memo: false,
     observer: false,
+    desktop: true,
     render(props, ref) {
         props = {
             ...props,

--- a/desktop/cmp/grid/editors/TextAreaEditor.js
+++ b/desktop/cmp/grid/editors/TextAreaEditor.js
@@ -15,6 +15,7 @@ export const [TextAreaEditor, textAreaEditor] = hoistCmp.withFactory({
     className: 'xh-textarea-editor',
     memo: false,
     observer: false,
+    desktop: true,
     render(props, ref) {
         props = {
             ...props,

--- a/desktop/cmp/grid/editors/TextEditor.js
+++ b/desktop/cmp/grid/editors/TextEditor.js
@@ -15,6 +15,7 @@ export const [TextEditor, textEditor] = hoistCmp.withFactory({
     className: 'xh-text-editor',
     memo: false,
     observer: false,
+    desktop: true,
     render(props, ref) {
         return useInlineEditorModel(textInput, props, ref);
     }

--- a/desktop/cmp/grid/find/GridFindField.js
+++ b/desktop/cmp/grid/find/GridFindField.js
@@ -35,6 +35,7 @@ import {GridFindFieldImplModel} from './impl/GridFindFieldImplModel';
 export const [GridFindField, gridFindField] = hoistCmp.withFactory({
     displayName: 'GridFindField',
     className: 'xh-grid-find-field',
+    desktop: true,
     render({className, model, ...props}) {
         let [layoutProps, restProps] = splitLayoutProps(props);
         const impl = useLocalModel(GridFindFieldImplModel);

--- a/desktop/cmp/grid/impl/colchooser/ColChooser.js
+++ b/desktop/cmp/grid/impl/colchooser/ColChooser.js
@@ -27,6 +27,7 @@ import {Icon} from '@xh/hoist/icon';
  */
 export const colChooser = hoistCmp.factory({
     className: 'xh-col-chooser',
+    desktop: true,
 
     render({model, className}) {
         const {commitOnChange, showRestoreDefaults, width, height} = model;

--- a/desktop/cmp/grid/impl/colchooser/ColChooserDialog.js
+++ b/desktop/cmp/grid/impl/colchooser/ColChooserDialog.js
@@ -13,6 +13,7 @@ import {ColChooserModel} from './ColChooserModel';
 export const colChooserDialog = hoistCmp.factory({
     model: uses(ColChooserModel),
     className: 'xh-col-chooser-dialog',
+    desktop: true,
 
     render({model, className}) {
 

--- a/desktop/cmp/grouping/GroupingChooser.js
+++ b/desktop/cmp/grouping/GroupingChooser.js
@@ -28,6 +28,7 @@ import './GroupingChooser.scss';
 export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
     model: uses(GroupingChooserModel),
     className: 'xh-grouping-chooser',
+    desktop: true,
     render({
         model,
         className,

--- a/desktop/cmp/input/ButtonGroupInput.js
+++ b/desktop/cmp/input/ButtonGroupInput.js
@@ -23,6 +23,7 @@ import {cloneElement, Children} from 'react';
 export const [ButtonGroupInput, buttonGroupInput] = hoistCmp.withFactory({
     displayName: 'ButtonGroupInput',
     className: 'xh-button-group-input',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/desktop/cmp/input/Checkbox.js
+++ b/desktop/cmp/input/Checkbox.js
@@ -18,6 +18,7 @@ import {isNil} from 'lodash';
 export const [Checkbox, checkbox] = hoistCmp.withFactory({
     displayName: 'Checkbox',
     className: 'xh-check-box',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref);
     }

--- a/desktop/cmp/input/CodeInput.js
+++ b/desktop/cmp/input/CodeInput.js
@@ -50,6 +50,7 @@ import './CodeInput.scss';
 export const [CodeInput, codeInput] = hoistCmp.withFactory({
     displayName: 'CodeInput',
     className: 'xh-code-input',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -35,6 +35,7 @@ import './DateInput.scss';
 export const [DateInput, dateInput] = hoistCmp.withFactory({
     displayName: 'DateInput',
     className: 'xh-date-input',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/desktop/cmp/input/JsonInput.js
+++ b/desktop/cmp/input/JsonInput.js
@@ -16,6 +16,7 @@ import {jsonlint} from './impl/jsonlint';
 export const [JsonInput, jsonInput] = hoistCmp.withFactory({
     displayName: 'JsonInput',
     className: 'xh-json-input',
+    desktop: true,
     render(props, ref) {
         return codeInput({
             linter,

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -34,6 +34,7 @@ import PT from 'prop-types';
 export const [NumberInput, numberInput] = hoistCmp.withFactory({
     displayName: 'NumberInput',
     className: 'xh-number-input',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/desktop/cmp/input/RadioInput.js
+++ b/desktop/cmp/input/RadioInput.js
@@ -19,6 +19,7 @@ import './RadioInput.scss';
 export const [RadioInput, radioInput] = hoistCmp.withFactory({
     displayName: 'RadioInput',
     className: 'xh-radio-input',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -51,6 +51,7 @@ import './Select.scss';
 export const [Select, select] = hoistCmp.withFactory({
     displayName: 'Select',
     className: 'xh-select',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/desktop/cmp/input/Slider.js
+++ b/desktop/cmp/input/Slider.js
@@ -20,6 +20,7 @@ import './Slider.scss';
 export const [Slider, slider] = hoistCmp.withFactory({
     displayName: 'Slider',
     className: 'xh-slider',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/desktop/cmp/input/SwitchInput.js
+++ b/desktop/cmp/input/SwitchInput.js
@@ -17,6 +17,7 @@ import './SwitchInput.scss';
 export const [SwitchInput, switchInput] = hoistCmp.withFactory({
     displayName: 'SwitchInput',
     className: 'xh-switch-input',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref);
     }

--- a/desktop/cmp/input/TextArea.js
+++ b/desktop/cmp/input/TextArea.js
@@ -19,6 +19,7 @@ import './TextArea.scss';
 export const [TextArea, textArea] = hoistCmp.withFactory({
     displayName: 'TextArea',
     className: 'xh-text-area',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -22,6 +22,7 @@ import PT from 'prop-types';
 export const [TextInput, textInput] = hoistCmp.withFactory({
     displayName: 'TextInput',
     className: 'xh-text-input',
+    desktop: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/desktop/cmp/leftrightchooser/LeftRightChooser.js
+++ b/desktop/cmp/leftrightchooser/LeftRightChooser.js
@@ -24,6 +24,7 @@ export const [LeftRightChooser, leftRightChooser] = hoistCmp.withFactory({
     displayName: 'LeftRightChooser',
     model: uses(LeftRightChooserModel),
     className: 'xh-lr-chooser',
+    desktop: true,
 
     render({model, ...props}, ref) {
         const {leftModel, rightModel, leftGroupingExpanded, rightGroupingExpanded} = model,

--- a/desktop/cmp/leftrightchooser/LeftRightChooserFilter.js
+++ b/desktop/cmp/leftrightchooser/LeftRightChooserFilter.js
@@ -19,6 +19,7 @@ import {LeftRightChooserModel} from './LeftRightChooserModel';
 export const [LeftRightChooserFilter, leftRightChooserFilter] = hoistCmp.withFactory({
     displayName: 'LeftRightChooserFilter',
     model: uses(LeftRightChooserModel),
+    desktop: true,
 
     render() {
         const impl = useLocalModel(LocalModel);

--- a/desktop/cmp/loadingindicator/LoadingIndicator.js
+++ b/desktop/cmp/loadingindicator/LoadingIndicator.js
@@ -25,6 +25,7 @@ import {withDefault} from '@xh/hoist/utils/js';
 export const [LoadingIndicator, loadingIndicator] = hoistCmp.withFactory({
     displayName: 'LoadingIndicator',
     className: 'xh-loading-indicator',
+    desktop: true,
 
     render({
         isDisplayed,

--- a/desktop/cmp/mask/Mask.js
+++ b/desktop/cmp/mask/Mask.js
@@ -24,6 +24,7 @@ import './Mask.scss';
 export const [Mask, mask] = hoistCmp.withFactory({
     displayName: 'Mask',
     className: 'xh-mask',
+    desktop: true,
 
     render({
         isDisplayed,

--- a/desktop/cmp/panel/Panel.js
+++ b/desktop/cmp/panel/Panel.js
@@ -47,6 +47,7 @@ export const [Panel, panel] = hoistCmp.withFactory({
         createDefault: () => new PanelModel({collapsible: false, resizable: false})
     }),
     className: 'xh-panel',
+    desktop: true,
 
     render({model, className,  ...props}, ref) {
 

--- a/desktop/cmp/record/RecordActionBar.js
+++ b/desktop/cmp/record/RecordActionBar.js
@@ -26,6 +26,7 @@ import {recordActionButton} from './impl/RecordActionButton';
 export const [RecordActionBar, recordActionBar] = hoistCmp.withFactory({
     displayName: 'RecordActionBar',
     className: 'xh-record-action-bar',
+    desktop: true,
 
     render(props) {
         const {actions, record, selModel, gridModel, column, buttonProps, vertical, ...rest} = props;

--- a/desktop/cmp/rest/RestGrid.js
+++ b/desktop/cmp/rest/RestGrid.js
@@ -20,6 +20,7 @@ export const [RestGrid, restGrid] = hoistCmp.withFactory({
     displayName: 'RestGrid',
     model: uses(RestGridModel, {publishMode: ModelPublishMode.LIMITED}),
     className: 'xh-rest-grid',
+    desktop: true,
 
     render({
         model,

--- a/desktop/cmp/tab/TabSwitcher.js
+++ b/desktop/cmp/tab/TabSwitcher.js
@@ -49,6 +49,7 @@ export const [TabSwitcher, tabSwitcher] = hoistCmp.withFactory({
     displayName: 'TabSwitcher',
     model: uses(TabContainerModel),
     className: 'xh-tab-switcher',
+    desktop: true,
 
     render({
         model,

--- a/desktop/cmp/toolbar/Toolbar.js
+++ b/desktop/cmp/toolbar/Toolbar.js
@@ -26,6 +26,7 @@ export const [Toolbar, toolbar] = hoistCmp.withFactory({
     displayName: 'Toolbar',
     model: false, memo: false, observer: false,
     className: 'xh-toolbar',
+    desktop: true,
 
     render({
         children,

--- a/desktop/cmp/toolbar/ToolbarSep.js
+++ b/desktop/cmp/toolbar/ToolbarSep.js
@@ -14,6 +14,7 @@ import './Toolbar.scss';
 export const [ToolbarSeparator, toolbarSeparator] = hoistCmp.withFactory({
     displayName: 'ToolbarSeparator',
     model: false, observer: false,
+    desktop: true,
     className: 'xh-toolbar__separator',
 
     render(props) {

--- a/desktop/cmp/treemap/SplitTreeMap.js
+++ b/desktop/cmp/treemap/SplitTreeMap.js
@@ -27,6 +27,7 @@ export const [SplitTreeMap, splitTreeMap]  = hoistCmp.withFactory({
     displayName: 'SplitTreeMap',
     model: uses(SplitTreeMapModel),
     className: 'xh-split-treemap',
+    desktop: true,
 
     render({model, className, ...props}, ref) {
         const {primaryMapModel, secondaryMapModel, orientation} = model,

--- a/desktop/cmp/treemap/TreeMap.js
+++ b/desktop/cmp/treemap/TreeMap.js
@@ -33,6 +33,7 @@ export const [TreeMap, treeMap] = hoistCmp.withFactory({
     displayName: 'TreeMap',
     model: uses(TreeMapModel),
     className: 'xh-treemap',
+    desktop: true,
 
     render({model, className, ...props}, ref) {
         if (!Highcharts) {

--- a/mobile/cmp/button/Button.js
+++ b/mobile/cmp/button/Button.js
@@ -19,8 +19,9 @@ import './Button.scss';
  */
 export const [Button, button] = hoistCmp.withFactory({
     displayName: 'Button',
-    model: false,
     className: 'xh-button',
+    model: false,
+    mobile: true,
 
     render(props, ref) {
         const [layoutProps, nonLayoutProps] = splitLayoutProps(props),

--- a/mobile/cmp/button/ButtonGroup.js
+++ b/mobile/cmp/button/ButtonGroup.js
@@ -18,6 +18,7 @@ export const [ButtonGroup, buttonGroup] = hoistCmp.withFactory({
     displayName: 'ButtonGroup',
     className: 'xh-button-group',
     model: false,
+    mobile: true,
 
     render(props, ref) {
         const {children, className, intent, minimal, outlined, ...rest} = props;

--- a/mobile/cmp/button/ColAutosizeButton.js
+++ b/mobile/cmp/button/ColAutosizeButton.js
@@ -17,6 +17,7 @@ import PT from 'prop-types';
 export const [ColAutosizeButton, colAutosizeButton] = hoistCmp.withFactory({
     displayName: 'ColAutosizeButton',
     model: false,
+    mobile: true,
 
     render({
         gridModel,

--- a/mobile/cmp/button/ColChooserButton.js
+++ b/mobile/cmp/button/ColChooserButton.js
@@ -20,6 +20,7 @@ import PT from 'prop-types';
 export const [ColChooserButton, colChooserButton] = hoistCmp.withFactory({
     displayName: 'ColChooserButton',
     model: false,
+    mobile: true,
 
     render({
         gridModel,

--- a/mobile/cmp/button/ExpandCollapseButton.js
+++ b/mobile/cmp/button/ExpandCollapseButton.js
@@ -18,6 +18,8 @@ import PT from 'prop-types';
 export const [ExpandCollapseButton, expandCollapseButton] = hoistCmp.withFactory({
     displayName: 'ExpandCollapseButton',
     model: false,
+    mobile: true,
+
     render({
         gridModel,
         onClick,

--- a/mobile/cmp/button/FeedbackButton.js
+++ b/mobile/cmp/button/FeedbackButton.js
@@ -15,6 +15,7 @@ import {button, Button} from '@xh/hoist/mobile/cmp/button';
 export const [FeedbackButton, feedbackButton] = hoistCmp.withFactory({
     displayName: 'FeedbackButton',
     model: false,
+    mobile: true,
 
     render({
         icon = Icon.comment({className: 'fa-flip-horizontal'}),

--- a/mobile/cmp/button/LogoutButton.js
+++ b/mobile/cmp/button/LogoutButton.js
@@ -17,6 +17,7 @@ import {button, Button} from '@xh/hoist/mobile/cmp/button';
 export const [LogoutButton, logoutButton] = hoistCmp.withFactory({
     displayName: 'LogoutButton',
     model: false,
+    mobile: true,
 
     render({
         icon = Icon.logout(),

--- a/mobile/cmp/button/NavigatorBackButton.js
+++ b/mobile/cmp/button/NavigatorBackButton.js
@@ -15,6 +15,7 @@ import {NavigatorModel} from '@xh/hoist/mobile/cmp/navigator';
 export const [NavigatorBackButton, navigatorBackButton] = hoistCmp.withFactory({
     displayName: 'NavigatorBackButton',
     model: false,
+    mobile: true,
 
     render({
         icon = Icon.chevronLeft(),

--- a/mobile/cmp/button/OptionsButton.js
+++ b/mobile/cmp/button/OptionsButton.js
@@ -16,6 +16,7 @@ import {button, Button} from '@xh/hoist/mobile/cmp/button';
 export const [OptionsButton, optionsButton] = hoistCmp.withFactory({
     displayName: 'OptionsButton',
     model: false,
+    mobile: true,
 
     render({
         icon = Icon.gear(),

--- a/mobile/cmp/button/RefreshButton.js
+++ b/mobile/cmp/button/RefreshButton.js
@@ -20,6 +20,7 @@ import PT from 'prop-types';
 export const [RefreshButton, refreshButton] = hoistCmp.withFactory({
     displayName: 'RefreshButton',
     model: false,  // For consistency with all other buttons -- the model prop here could be replaced by 'target'
+    mobile: true,
 
     render({model, icon = Icon.sync(), onClick, ...props}) {
         const refreshContextModel = useContextModel(RefreshContextModel);

--- a/mobile/cmp/button/RestoreDefaultsButton.js
+++ b/mobile/cmp/button/RestoreDefaultsButton.js
@@ -18,6 +18,8 @@ import PT from 'prop-types';
 export const [RestoreDefaultsButton, restoreDefaultsButton] = hoistCmp.withFactory({
     displayName: 'RestoreDefaultsButton',
     model: false,
+    mobile: true,
+
     render({
         warningTitle = 'Please Confirm',
         warningMessage = 'All app options (including grid customizations) will be restored to their default settings, and the app will be reloaded.',

--- a/mobile/cmp/button/ThemeToggleButton.js
+++ b/mobile/cmp/button/ThemeToggleButton.js
@@ -14,6 +14,7 @@ import {button, Button} from '@xh/hoist/mobile/cmp/button';
 export const [ThemeToggleButton, themeToggleButton] = hoistCmp.withFactory({
     displayName: 'ThemeToggleButton',
     model: false,
+    mobile: true,
 
     render({
         icon = XH.darkTheme ? Icon.sun({prefix: 'fas'}) : Icon.moon(),

--- a/mobile/cmp/dialog/Dialog.js
+++ b/mobile/cmp/dialog/Dialog.js
@@ -16,6 +16,7 @@ export const [Dialog, dialog] = hoistCmp.withFactory({
     displayName: 'Dialog',
     className: 'xh-dialog',
     model: false,
+    mobile: true,
 
     render({className, isOpen, onCancel, icon, title, content, buttons = []}) {
         const contextModel = useContextModel('*');

--- a/mobile/cmp/error/ErrorMessage.js
+++ b/mobile/cmp/error/ErrorMessage.js
@@ -18,6 +18,8 @@ import './ErrorMessage.scss';
  */
 export const [ErrorMessage, errorMessage] = hoistCmp.withFactory({
     className: 'xh-error-message',
+    mobile: true,
+
     render({
         className,
         model,

--- a/mobile/cmp/form/FormField.js
+++ b/mobile/cmp/form/FormField.js
@@ -46,6 +46,7 @@ export const [FormField, formField] = hoistCmp.withFactory({
         publishMode: ModelPublishMode.NONE,
         optional: true
     }),
+    mobile: true,
 
     render({model, className, field, children, info, ...props}, ref) {
 

--- a/mobile/cmp/grid/impl/ColChooser.js
+++ b/mobile/cmp/grid/impl/ColChooser.js
@@ -34,6 +34,7 @@ export const [ColChooser, colChooser] = hoistCmp.withFactory({
     displayName: 'ColChooser',
     model: uses(ColChooserModel),
     className: 'xh-col-chooser',
+    mobile: true,
 
     render({model, className}) {
         const {isOpen, gridModel, pinnedColumn, visibleColumns, hiddenColumns, showRestoreDefaults} = model,

--- a/mobile/cmp/grouping/GroupingChooser.js
+++ b/mobile/cmp/grouping/GroupingChooser.js
@@ -27,6 +27,7 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory({
     displayName: 'GroupingChooser',
     model: uses(GroupingChooserModel),
     className: 'xh-grouping-chooser',
+    mobile: true,
 
     render({
         model,

--- a/mobile/cmp/header/AppBar.js
+++ b/mobile/cmp/header/AppBar.js
@@ -26,6 +26,7 @@ export const [AppBar, appBar] = hoistCmp.withFactory({
     displayName: 'AppBar',
     className: 'xh-appbar',
     model: false,
+    mobile: true,
 
     render({
         className,

--- a/mobile/cmp/header/AppMenuButton.js
+++ b/mobile/cmp/header/AppMenuButton.js
@@ -20,8 +20,9 @@ import PT from 'prop-types';
  */
 export const [AppMenuButton, appMenuButton] = hoistCmp.withFactory({
     displayName: 'AppMenuButton',
-    model: false,
     className: 'xh-app-menu-button',
+    model: false,
+    mobile: true,
 
     render(props) {
         const {className, extraItems, hideImpersonateItem, hideFeedbackItem, hideLogoutItem, hideOptionsItem, hideThemeItem, hideAboutItem, ...rest} = props;

--- a/mobile/cmp/input/ButtonGroupInput.js
+++ b/mobile/cmp/input/ButtonGroupInput.js
@@ -23,6 +23,7 @@ import './ButtonGroupInput.scss';
 export const [ButtonGroupInput, buttonGroupInput] = hoistCmp.withFactory({
     displayName: 'ButtonGroupInput',
     className: 'xh-button-group-input',
+    mobile: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/mobile/cmp/input/Checkbox.js
+++ b/mobile/cmp/input/Checkbox.js
@@ -16,6 +16,7 @@ import './Checkbox.scss';
 export const [Checkbox, checkbox] = hoistCmp.withFactory({
     displayName: 'Checkbox',
     className: 'xh-check-box',
+    mobile: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref);
     }

--- a/mobile/cmp/input/DateInput.js
+++ b/mobile/cmp/input/DateInput.js
@@ -24,6 +24,7 @@ import './DateInput.scss';
 export const [DateInput, dateInput] = hoistCmp.withFactory({
     displayName: 'DateInput',
     className: 'xh-date-input',
+    mobile: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/mobile/cmp/input/Label.js
+++ b/mobile/cmp/input/Label.js
@@ -16,6 +16,7 @@ import './Label.scss';
 export const [Label, label] = hoistCmp.withFactory({
     displayName: 'Label',
     className: 'xh-input-label',
+    mobile: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref);
     }

--- a/mobile/cmp/input/NumberInput.js
+++ b/mobile/cmp/input/NumberInput.js
@@ -21,6 +21,7 @@ import './NumberInput.scss';
 export const [NumberInput, numberInput] = hoistCmp.withFactory({
     displayName: 'NumberInput',
     className: 'xh-number-input',
+    mobile: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/mobile/cmp/input/SearchInput.js
+++ b/mobile/cmp/input/SearchInput.js
@@ -18,6 +18,7 @@ import './SearchInput.scss';
 export const [SearchInput, searchInput] = hoistCmp.withFactory({
     displayName: 'SearchInput',
     className: 'xh-search-input',
+    mobile: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/mobile/cmp/input/Select.js
+++ b/mobile/cmp/input/Select.js
@@ -51,6 +51,7 @@ import './Select.scss';
 export const [Select, select] = hoistCmp.withFactory({
     displayName: 'Select',
     className: 'xh-select',
+    mobile: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/mobile/cmp/input/SwitchInput.js
+++ b/mobile/cmp/input/SwitchInput.js
@@ -16,6 +16,7 @@ import './SwitchInput.scss';
 export const [SwitchInput, switchInput] = hoistCmp.withFactory({
     displayName: 'SwitchInput',
     className: 'xh-switch-input',
+    mobile: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref);
     }

--- a/mobile/cmp/input/TextArea.js
+++ b/mobile/cmp/input/TextArea.js
@@ -18,6 +18,7 @@ import './TextArea.scss';
 export const [TextArea, textArea] = hoistCmp.withFactory({
     displayName: 'TextArea',
     className: 'xh-textarea',
+    mobile: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/mobile/cmp/input/TextInput.js
+++ b/mobile/cmp/input/TextInput.js
@@ -22,6 +22,7 @@ import './TextInput.scss';
 export const [TextInput, textInput] = hoistCmp.withFactory({
     displayName: 'TextInput',
     className: 'xh-text-input',
+    mobile: true,
     render(props, ref) {
         return useHoistInputModel(cmp, props, ref, Model);
     }

--- a/mobile/cmp/loadingindicator/LoadingIndicator.js
+++ b/mobile/cmp/loadingindicator/LoadingIndicator.js
@@ -25,6 +25,7 @@ import './LoadingIndicator.scss';
 export const [LoadingIndicator, loadingIndicator] = hoistCmp.withFactory({
     displayName: 'LoadingIndicator',
     className: 'xh-loading-indicator',
+    mobile: true,
 
     render({
         isDisplayed,

--- a/mobile/cmp/mask/Mask.js
+++ b/mobile/cmp/mask/Mask.js
@@ -22,6 +22,7 @@ import './Mask.scss';
 export const [Mask, mask] = hoistCmp.withFactory({
     displayName: 'Mask',
     className: 'xh-mask',
+    mobile: true,
 
     render({
         isDisplayed,

--- a/mobile/cmp/menu/MenuButton.js
+++ b/mobile/cmp/menu/MenuButton.js
@@ -20,6 +20,7 @@ import {menu} from './impl/Menu';
 export const [MenuButton, menuButton] = hoistCmp.withFactory({
     displayName: 'MenuButton',
     className: 'xh-menu-button',
+    mobile: true,
 
     render({
         menuItems,

--- a/mobile/cmp/navigator/Navigator.js
+++ b/mobile/cmp/navigator/Navigator.js
@@ -16,8 +16,9 @@ import {NavigatorModel} from './NavigatorModel';
  */
 export const [Navigator, navigator] = hoistCmp.withFactory({
     displayName: 'Navigator',
-    model: uses(NavigatorModel),
     className: 'xh-navigator',
+    model: uses(NavigatorModel),
+    mobile: true,
 
     render({model, className, animation = 'slide'}) {
         return swiper(

--- a/mobile/cmp/panel/DialogPanel.js
+++ b/mobile/cmp/panel/DialogPanel.js
@@ -20,6 +20,7 @@ export const [DialogPanel, dialogPanel] = hoistCmp.withFactory({
     displayName: 'DialogPanel',
     className: 'xh-dialog xh-dialog-panel',
     memo: false, model: false, observer: false,
+    mobile: true,
 
     render({className, isOpen, children, ...rest}) {
 

--- a/mobile/cmp/panel/Panel.js
+++ b/mobile/cmp/panel/Panel.js
@@ -25,6 +25,7 @@ export const [Panel, panel] = hoistCmp.withFactory({
     displayName: 'Panel',
     className: 'xh-panel',
     model: false,
+    mobile: true,
 
     render(props, ref) {
         const contextModel = useContextModel('*');

--- a/mobile/cmp/popover/Popover.js
+++ b/mobile/cmp/popover/Popover.js
@@ -27,6 +27,7 @@ import './Popover.scss';
 export const [Popover, popover] = hoistCmp.withFactory({
     displayName: 'Popover',
     className: 'xh-popover',
+    mobile: true,
 
     render({
         className,

--- a/mobile/cmp/toolbar/Toolbar.js
+++ b/mobile/cmp/toolbar/Toolbar.js
@@ -17,6 +17,7 @@ export const [Toolbar, toolbar] = hoistCmp.withFactory({
     displayName: 'Toolbar',
     className: 'xh-toolbar',
     model: false, memo: false, observer: false,
+    mobile: true,
 
     render({className, vertical, ...rest}, ref) {
         return (vertical ? vbox : hbox)({

--- a/mobile/cmp/toolbar/ToolbarSeparator.js
+++ b/mobile/cmp/toolbar/ToolbarSeparator.js
@@ -15,7 +15,7 @@ export const [ToolbarSeparator, toolbarSeparator] = hoistCmp.withFactory({
     displayName: 'ToolbarSeparator',
     className: 'xh-toolbar__separator',
     model: false, memo: false, observer: false,
-
+    mobile: true,
 
     render({className, ...props}) {
         return span({className, ...props});


### PR DESCRIPTION
See issue: https://github.com/xh/hoist-react/issues/3074

HoistComponents can be optionally tagged as being intended for use with either `desktop` or `mobile` toolkits by setting a flag in `hoistComponent`, e.g.
```
export const [Button, button] = hoistCmp.withFactory({
    displayName: 'Button',
    desktop: true,
   ...
});
```
If these components are imported into an app using the wrong platform, `XH.renderApp()` will throw. Note that the component only has to be imported, not necessarily rendered.

Also note that this change has surfaced an import issue, that should be resolved before this is merged: https://github.com/xh/hoist-react/issues/3075

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

