### PR TITLE
Prevent `Separators.filterConsecutiveMenuSeparators()` from removing …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 * `CodeInput` is now rendered within an additional `div` element.  Unlikely to cause issues, unless
   using targeted styling of this component.
 
+### ⚙️ Technical
+
+* Hoist-supported menus will no longer filter out a `MenuDivider` if it has a `title`.
+
 ## v50.1.1 - 2022-07-29
 
 ### 🐞 Bug Fixes

--- a/utils/impl/Separators.js
+++ b/utils/impl/Separators.js
@@ -14,7 +14,9 @@ import {filterConsecutive} from '../js';
  */
 export function filterConsecutiveMenuSeparators() {
     return filterConsecutive(it => {
-        return it === '-' || it === 'separator' || it?.type?.name === 'MenuDivider';
+        return it === '-' ||
+            it === 'separator' ||
+            (it?.type?.name === 'MenuDivider' && !it.props?.title);
     });
 }
 


### PR DESCRIPTION
…a `MenuDivider` with a `title` prop specified

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

