### PR TITLE
Improve duplicate column header warning when exporting

### DIFF
--- a/svc/GridExportService.js
+++ b/svc/GridExportService.js
@@ -15,15 +15,17 @@ import download from 'downloadjs';
 import {StatusCodes} from 'http-status-codes';
 import {
     castArray,
+    countBy,
     isArray,
     isEmpty,
     isFunction,
     isNil,
     isString,
+    pickBy,
     sortBy,
-    uniq,
     compact,
-    findIndex
+    findIndex,
+    keys
 } from 'lodash';
 import {span, a} from '@xh/hoist/cmp/layout';
 import {wait} from '@xh/hoist/promise';
@@ -298,8 +300,10 @@ export class GridExportService extends HoistService {
 
         // Excel does not like duplicate (case-insensitive) header names in tables and will prompt
         // the user to "repair" the file when opened if present.
-        if (type === 'excelTable' && uniq(headers.map(it => it.toLowerCase())).length !== headers.length) {
-            console.warn('Excel tables require unique headers on each column. Consider using the "exportName" property to ensure unique headers.');
+        const headerCounts = countBy(headers.map(it => it.toLowerCase())),
+            dupeHeaders = keys(pickBy(headerCounts, it => it > 1));
+        if (type === 'excelTable' && !isEmpty(dupeHeaders)) {
+            console.warn('Excel tables require unique headers on each column. Consider using the "exportName" property to ensure unique headers. Duplicate headers: ', dupeHeaders);
         }
         return {data: headers, depth: 0};
     }


### PR DESCRIPTION
We already warned when exports produce duplicate headers, but without an indication to *which* headers are duplicated, it can be hard to troubleshoot on wide grids. This small tweak to list the duplicate headers hopefully makes the warning a bit more actionable.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

