### PR TITLE
Form field dirty checking now uses lodash `isEqual`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v53.0.0-SNAPSHOT
+
+### 🐞 Bug Fixes
+
+* Form field dirty checking now uses lodash `isEqual` to compare initial and current values,
+  avoiding false positives with Array values.
+
 ## v52.0.1 - 2022-10-10
 
 ### 🎁 New Features

--- a/cmp/form/field/BaseFieldModel.js
+++ b/cmp/form/field/BaseFieldModel.js
@@ -4,13 +4,13 @@
  *
  * Copyright © 2022 Extremely Heavy Industries Inc.
  */
-import {managed, HoistModel, TaskObserver} from '@xh/hoist/core';
-import {Rule, ValidationState, genDisplayName, required} from '@xh/hoist/data';
-import {action, computed, observable, runInAction, makeObservable} from '@xh/hoist/mobx';
+import {HoistModel, managed, TaskObserver} from '@xh/hoist/core';
+import {genDisplayName, required, Rule, ValidationState} from '@xh/hoist/data';
+import {action, computed, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
-import {withDefault, executeIfFunction} from '@xh/hoist/utils/js';
-import {compact, flatten, isEmpty, isFunction, isNil} from 'lodash';
+import {executeIfFunction, withDefault} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
+import {compact, flatten, isEmpty, isEqual, isFunction, isNil} from 'lodash';
 
 /**
  * Abstract Base class for FieldModels.
@@ -210,7 +210,7 @@ export class BaseFieldModel extends HoistModel {
 
     /** @member {boolean} - true if value has been changed since last reset/init. */
     get isDirty() {
-        return this.value !== this.initialValue;
+        return !isEqual(this.value, this.initialValue);
     }
 
     //-------------------------


### PR DESCRIPTION
+ Avoid false positive when comparing array values - e.g. those emitted by multi-select inputs.
+ Fixes #3160

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

