### PR TITLE
Fix to gaps between select inputs and their dropdown menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,23 @@
 
 ### 🐞 Bug Fixes
 
-* Fix bug where constructing a `PanelModel` with `ModalSupport` could cause unexpected layout issues
-  with other top-level DOM elements.
-
+* Fixed layout issues caused by top-level DOM elements created by `ModalSupport`
+  and `ColumnWidthCalculator` (grid auto-sizing). Resolved occasional gaps between select inputs and
+  their drop-down menus.
 
 ## v53.0.0 - 2022-10-19
 
 ### 🎁 New Features
 
-* New application permission role: `HOIST_ADMIN_READER`.
-* All Hoist Framework Admin tabs are now readable (read only) by users who have this new role: `HOIST_ADMIN_READER`.
-* Actions (edit, delete, etc) in the Hoist Framework Admin tabs are available only to users who have the `HOIST_ADMIN` role.
-* The `HOIST_ADMIN` role inherits the new `HOIST_ADMIN_READER` role.
-* The `HOIST_ADMIN_READER` role can be assigned to users in the `roles` soft-config.
+* The Hoist Admin Console is now accessible in a read-only capacity to users assigned the
+  new `HOIST_ADMIN_READER` role.
+* The pre-existing `HOIST_ADMIN` role inherits this new role, and is still required to take any
+  actions that modify data.
 
 ### 💥 Breaking Changes
-* Upgrading to Hoist-React v53+ requires an upgrade of Hoist-Core to v14.4.0+
-  to take advantage of the new `HOIST_ADMIN_READER` role.
+
+* Requires `hoist-core >= 14.4` to support the new `HOIST_ADMIN_READER` role described above. (Core
+  upgrade _not_ required otherwise.)
 
 ## v52.0.2 - 2022-10-13
 

--- a/cmp/grid/impl/ColumnWidthCalculator.js
+++ b/cmp/grid/impl/ColumnWidthCalculator.js
@@ -82,7 +82,7 @@ export class ColumnWidthCalculator {
                     levelMaxes = await Promise.all(levelTasks);
                 return max(levelMaxes);
             } else {
-                return this.calcLevelWidthAsync(gridModel, records, column, options);
+                return await this.calcLevelWidthAsync(gridModel, records, column, options);
             }
         } catch (e) {
             console.warn(`Error calculating max data width for column "${column.colId}".`, e);


### PR DESCRIPTION
+ Caused by grid autosizing - `ColumnWidthCalculator` is supposed to clean up the classes on its top-level DOM elements after sizing. Change back in #3057 to make these methods async defeated the cleanup in the `finally` clause.
+ A rare example where `return await` is required, and not an anti-pattern!

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

