### PR TITLE
Dock Container fixes

### DIFF
--- a/desktop/cmp/dock/DockViewModel.js
+++ b/desktop/cmp/dock/DockViewModel.js
@@ -111,7 +111,10 @@ export class DockViewModel extends HoistModel {
         this.refreshContextModel = new ManagedRefreshContextModel(this);
 
         this.modalSupportModel = new ModalSupportModel({
-            width: width ?? null, height: height ?? null, canOutsideClickClose: false
+            width: width ?? null,
+            height: height ?? null,
+            startModal: !docked,
+            canOutsideClickClose: false
         });
     }
 

--- a/desktop/cmp/dock/DockViewModel.js
+++ b/desktop/cmp/dock/DockViewModel.js
@@ -113,7 +113,7 @@ export class DockViewModel extends HoistModel {
         this.modalSupportModel = new ModalSupportModel({
             width: width ?? null,
             height: height ?? null,
-            startModal: !docked,
+            defaultModal: !docked,
             canOutsideClickClose: false
         });
     }

--- a/desktop/cmp/dock/impl/Dock.scss
+++ b/desktop/cmp/dock/impl/Dock.scss
@@ -30,6 +30,14 @@
       margin-right: var(--xh-pad-px);
     }
   }
+
+  .xh-modal-support__inline {
+    // Don't flex-shrink docked dock views, allowing them to clip the container.
+    flex: none;
+    // Workaround for this class getting `width: 100%` for 1 frame while waiting for
+    // an observable ref. See ModalSupport.js.
+    width: auto !important;
+  }
 }
 
 .xh-dock-view {

--- a/desktop/cmp/modalsupport/ModalSupport.js
+++ b/desktop/cmp/modalsupport/ModalSupport.js
@@ -11,6 +11,7 @@ import '@xh/hoist/desktop/register';
 import {dialog} from '@xh/hoist/kit/blueprint';
 import {Children} from 'react';
 import {createPortal} from 'react-dom';
+import './ModalSupport.scss';
 import {ModalSupportModel} from './ModalSupportModel';
 
 /**

--- a/desktop/cmp/modalsupport/ModalSupport.scss
+++ b/desktop/cmp/modalsupport/ModalSupport.scss
@@ -1,0 +1,7 @@
+.xh-modal-support {
+  // Unwind the (surprising) 500px default dialog width coming from Blueprint.
+  // If the user has configured their ModalSupportOptions with null width, this should be respected.
+  &__modal {
+    width: auto;
+  }
+}

--- a/desktop/cmp/modalsupport/ModalSupportModel.js
+++ b/desktop/cmp/modalsupport/ModalSupportModel.js
@@ -35,7 +35,7 @@ export class ModalSupportModel extends HoistModel {
         this.hostNode = this.createHostNode();
 
         this.options = opts instanceof ModalSupportOptions ? opts : new ModalSupportOptions(opts);
-        this.isModal = this.options.startModal;
+        this.isModal = this.options.defaultModal;
 
         const {inlineRef, modalRef, hostNode} = this;
         this.addReaction({

--- a/desktop/cmp/modalsupport/ModalSupportModel.js
+++ b/desktop/cmp/modalsupport/ModalSupportModel.js
@@ -35,6 +35,7 @@ export class ModalSupportModel extends HoistModel {
         this.hostNode = this.createHostNode();
 
         this.options = opts instanceof ModalSupportOptions ? opts : new ModalSupportOptions(opts);
+        this.isModal = this.options.startModal;
 
         const {inlineRef, modalRef, hostNode} = this;
         this.addReaction({

--- a/desktop/cmp/modalsupport/ModalSupportOptions.js
+++ b/desktop/cmp/modalsupport/ModalSupportOptions.js
@@ -14,7 +14,7 @@ export class ModalSupportOptions {
     /** @member {?String|number} */
     height;
     /** @member {boolean} */
-    startModal;
+    defaultModal;
     /** @member boolean */
     canOutsideClickClose;
     /**
@@ -22,18 +22,18 @@ export class ModalSupportOptions {
      * @param {Object} opts
      * @param {String|number} [width] - css width
      * @param {String|number} [height] - css height
-     * @param {boolean} [startModal] - begin in modal mode?
+     * @param {boolean} [defaultModal] - begin in modal mode?
      * @param {boolean} [canOutsideClickClose]
      */
     constructor({
         width = '90vw',
         height = '90vh',
-        startModal = false,
+        defaultModal = false,
         canOutsideClickClose = true
     } = {}) {
         this.width = width;
         this.height = height;
-        this.startModal = startModal;
+        this.defaultModal = defaultModal;
         this.canOutsideClickClose = canOutsideClickClose;
     }
 }

--- a/desktop/cmp/modalsupport/ModalSupportOptions.js
+++ b/desktop/cmp/modalsupport/ModalSupportOptions.js
@@ -13,6 +13,8 @@ export class ModalSupportOptions {
     width;
     /** @member {?String|number} */
     height;
+    /** @member {boolean} */
+    startModal;
     /** @member boolean */
     canOutsideClickClose;
     /**
@@ -20,11 +22,18 @@ export class ModalSupportOptions {
      * @param {Object} opts
      * @param {String|number} [width] - css width
      * @param {String|number} [height] - css height
+     * @param {boolean} [startModal] - begin in modal mode?
      * @param {boolean} [canOutsideClickClose]
      */
-    constructor({width = '90vw', height = '90vh', canOutsideClickClose = true} = {}) {
+    constructor({
+        width = '90vw',
+        height = '90vh',
+        startModal = false,
+        canOutsideClickClose = true
+    } = {}) {
         this.width = width;
         this.height = height;
+        this.startModal = startModal;
         this.canOutsideClickClose = canOutsideClickClose;
     }
 }


### PR DESCRIPTION
+ Fix docked views appearing on the left due to 1 frame with `width: 100%` due to waiting for observable ref. See https://github.com/xh/hoist-react/blob/develop/desktop/cmp/modalsupport/ModalSupport.js#L59-L60
+ Don't flex-shrink docked views.
+ Remove unwanted default `500px` width for modal support dialogs. Width should either be configured, default to `90vw`, or be explicitly unset.
+ Add support for starting modal support in modal mode. Used to fix `DockView.docked = false`.

See issue: https://github.com/xh/hoist-react/issues/3148

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

