### PR TITLE
Fix @bindable to produce enumerable properties

### DIFF
--- a/mobx/index.ts
+++ b/mobx/index.ts
@@ -6,13 +6,15 @@
  */
 import {
     action,
+    AnnotationsMap,
     autorun,
     comparer,
     computed,
     configure,
+    CreateObservableOptions,
     extendObservable,
     isObservableProp,
-    makeObservable,
+    makeObservable as mobxMakeObservable,
     observable,
     override,
     reaction,
@@ -37,9 +39,8 @@ export {
     comparer,
     computed,
     extendObservable,
-    isObservableProp,
-    makeObservable,
     observable,
+    isObservableProp,
     observer,
     override,
     reaction,
@@ -50,3 +51,21 @@ export {
     untracked,
     when
 };
+
+
+export function makeObservable(target: any, annotations?: AnnotationsMap<any, never>, options?: CreateObservableOptions) {
+
+    // Finish creating 'bindable' properties.
+    const bindables = target._xhBindableProperties ?? [];
+    bindables.forEach(name => {
+        const propName = `_${name}_bindable`;
+        Object.defineProperty(target, name, {
+            get() {return this[propName].get()},
+            set(v) {runInAction(() => this[propName].set(v))},
+            enumerable: true,
+            configurable: true
+        });
+    });
+
+    return mobxMakeObservable(target, annotations, options);
+}

--- a/mobx/index.ts
+++ b/mobx/index.ts
@@ -6,15 +6,12 @@
  */
 import {
     action,
-    AnnotationsMap,
     autorun,
     comparer,
     computed,
     configure,
-    CreateObservableOptions,
     extendObservable,
     isObservableProp,
-    makeObservable as mobxMakeObservable,
     observable,
     override,
     reaction,
@@ -25,7 +22,6 @@ import {
     when
 } from 'mobx';
 import {observer} from 'mobx-react-lite';
-import {bindable, settable} from './decorators';
 
 configure({enforceActions: 'observed'});
 
@@ -35,7 +31,6 @@ configure({enforceActions: 'observed'});
 export {
     action,
     autorun,
-    bindable,
     comparer,
     computed,
     extendObservable,
@@ -45,27 +40,11 @@ export {
     override,
     reaction,
     runInAction,
-    settable,
     toJS,
     trace,
     untracked,
     when
 };
 
-
-export function makeObservable(target: any, annotations?: AnnotationsMap<any, never>, options?: CreateObservableOptions) {
-
-    // Finish creating 'bindable' properties.
-    const bindables = target._xhBindableProperties ?? [];
-    bindables.forEach(name => {
-        const propName = `_${name}_bindable`;
-        Object.defineProperty(target, name, {
-            get() {return this[propName].get()},
-            set(v) {runInAction(() => this[propName].set(v))},
-            enumerable: true,
-            configurable: true
-        });
-    });
-
-    return mobxMakeObservable(target, annotations, options);
-}
+export * from './decorators';
+export * from './makeObservable';

--- a/mobx/makeObservable.ts
+++ b/mobx/makeObservable.ts
@@ -1,0 +1,27 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2022 Extremely Heavy Industries Inc.
+ */
+import {forEach} from 'lodash';
+import {AnnotationsMap, CreateObservableOptions, makeObservable as baseMakeObservable} from 'mobx';
+
+/**
+ * An enhanced version of the native mobx makeObservable.
+ */
+export function makeObservable(
+    target: any,
+    annotations?: AnnotationsMap<any, never>,
+    options?: CreateObservableOptions
+) {
+
+    // Finish creating 'bindable' properties for this instance.
+    // Do here to ensure it's enumerable on *instance*
+    const bindables = target._xhBindableProperties ?? {};
+    forEach(bindables, (descriptor, name) => {
+        Object.defineProperty(target, name, descriptor);
+    });
+
+    return baseMakeObservable(target, annotations, options);
+}


### PR DESCRIPTION
A little more complicated than you may have expected -- happy to go through this in more detail if you like.

A few unrelated cleanups to how the `mobx` imports are organized.

See interesting discussion I started on mobx discussion group on this topic.

https://github.com/mobxjs/mobx/discussions/3587

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [xX] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

