### PR TITLE
AppMenuButton fixes

### DIFF
--- a/desktop/cmp/button/AppMenuButton.ts
+++ b/desktop/cmp/button/AppMenuButton.ts
@@ -105,7 +105,7 @@ function buildMenuItems(props: AppMenuButtonProps) {
     hideLogoutItem = withDefault(hideLogoutItem, XH.appSpec.isSSO);
     hideOptionsItem = hideOptionsItem || !XH.appContainerModel.optionsDialogModel.hasOptions;
 
-    const defaultItems = [
+    const defaultItems: MenuItemLike[] = [
         {
             omit: hideOptionsItem,
             text: 'Options',
@@ -158,7 +158,7 @@ function buildMenuItems(props: AppMenuButtonProps) {
             intent: 'danger',
             actionFn: () => XH.identityService.logoutAsync()
         }
-    ] as MenuItemLike[];
+    ];
 
     return parseMenuItems([
         ...extraItems,
@@ -169,7 +169,7 @@ function buildMenuItems(props: AppMenuButtonProps) {
 
 function parseMenuItems(items: MenuItemLike[]): ReactNode[] {
     items = items.map(item => {
-        if (!isMenuItemCfg(item)) return item;
+        if (!isMenuItem(item)) return item;
 
         item = clone(item);
         item.items = clone(item.items);
@@ -178,16 +178,14 @@ function parseMenuItems(items: MenuItemLike[]): ReactNode[] {
     });
 
     return items
-        .filter(it => !isMenuItemCfg(it) || (!it.hidden && !it.omit))
+        .filter(it => !isMenuItem(it) || (!it.hidden && !it.omit))
         .filter(filterConsecutiveMenuSeparators())
         .map(item => {
             if (item === '-') return menuDivider();
-            if (!isMenuItemCfg(item)) return item;
+            if (!isMenuItem(item)) return item;
 
-            const onClick = (item as any).onClick;
-            if (onClick) {
-                apiDeprecated('AppMenuButton.extraItems.onClick', {msg: 'Use `actionFn` instead', v: 'v54'});
-            }
+            const onClick = item['onClick'];
+            apiDeprecated('AppMenuButton.extraItems.onClick', {test: onClick, msg: 'Use `actionFn` instead', v: 'v56'});
             const actionFn = item.actionFn ?? onClick;
 
             // Create menuItem from config
@@ -195,7 +193,7 @@ function parseMenuItems(items: MenuItemLike[]): ReactNode[] {
                 text: item.text,
                 icon: item.icon,
                 intent: item.intent,
-                onClick: actionFn ? () => wait().then(actionFn) : null,
+                onClick: actionFn ? () => wait().then(actionFn) : null, // do async to allow menu to close
                 disabled: item.disabled
             } as PlainObject;
 
@@ -209,6 +207,6 @@ function parseMenuItems(items: MenuItemLike[]): ReactNode[] {
         });
 }
 
-function isMenuItemCfg(item: MenuItemLike): item is MenuItem {
+function isMenuItem(item: MenuItemLike): item is MenuItem {
     return !isString(item) && !isValidElement(item);
 }

--- a/desktop/cmp/button/AppMenuButton.ts
+++ b/desktop/cmp/button/AppMenuButton.ts
@@ -4,15 +4,16 @@
  *
  * Copyright © 2022 Extremely Heavy Industries Inc.
  */
-import {hoistCmp, MenuItemLike, XH} from '@xh/hoist/core';
+import {hoistCmp, MenuItemLike, MenuItem, PlainObject, XH} from '@xh/hoist/core';
 import {ButtonProps, button} from '@xh/hoist/desktop/cmp/button';
 import '@xh/hoist/desktop/register';
 import {Icon} from '@xh/hoist/icon';
-import {menu, menuDivider, MenuDivider, MenuItem, menuItem, popover} from '@xh/hoist/kit/blueprint';
+import {menu, menuDivider, menuItem, popover} from '@xh/hoist/kit/blueprint';
+import {wait} from '@xh/hoist/promise';
 import {filterConsecutiveMenuSeparators} from '@xh/hoist/utils/impl';
-import {withDefault} from '@xh/hoist/utils/js';
-import {isEmpty} from 'lodash';
-import {isValidElement} from 'react';
+import {apiDeprecated, withDefault} from '@xh/hoist/utils/js';
+import {clone, isEmpty, isString} from 'lodash';
+import {isValidElement, ReactNode} from 'react';
 
 
 export interface AppMenuButtonProps extends ButtonProps {
@@ -109,45 +110,45 @@ function buildMenuItems(props: AppMenuButtonProps) {
             omit: hideOptionsItem,
             text: 'Options',
             icon: Icon.options(),
-            onClick: () => XH.showOptionsDialog()
+            actionFn: () => XH.showOptionsDialog()
         },
         {
             omit: hideFeedbackItem,
             text: 'Feedback',
             icon: Icon.comment({className: 'fa-flip-horizontal'}),
-            onClick: () => XH.showFeedbackDialog()
+            actionFn: () => XH.showFeedbackDialog()
         },
         {
             omit: hideThemeItem,
             text: XH.darkTheme ? 'Light Theme' : 'Dark Theme',
             icon: XH.darkTheme ? Icon.sun({prefix: 'fas'}) : Icon.moon(),
-            onClick: () => XH.toggleTheme()
+            actionFn: () => XH.toggleTheme()
         },
         '-',
         {
             omit: hideAdminItem,
             text: 'Admin',
             icon: Icon.wrench(),
-            onClick: () => window.open('/admin')
+            actionFn: () => window.open('/admin')
         },
         {
             omit: hideImpersonateItem,
             text: 'Impersonate',
             icon: Icon.impersonate(),
-            onClick: () => XH.showImpersonationBar()
+            actionFn: () => XH.showImpersonationBar()
         },
         '-',
         {
             omit: hideChangelogItem,
             text: 'Release Notes',
             icon: Icon.gift(),
-            onClick: () => XH.showChangelog()
+            actionFn: () => XH.showChangelog()
         },
         {
             omit: hideAboutItem,
             text: `About ${XH.clientAppName}`,
             icon: Icon.info(),
-            onClick: () => XH.showAboutDialog()
+            actionFn: () => XH.showAboutDialog()
         },
         '-',
         {
@@ -155,9 +156,9 @@ function buildMenuItems(props: AppMenuButtonProps) {
             text: 'Logout',
             icon: Icon.logout(),
             intent: 'danger',
-            onClick: () => XH.identityService.logoutAsync()
+            actionFn: () => XH.identityService.logoutAsync()
         }
-    ];
+    ] as MenuItemLike[];
 
     return parseMenuItems([
         ...extraItems,
@@ -166,22 +167,48 @@ function buildMenuItems(props: AppMenuButtonProps) {
     ]);
 }
 
-function parseMenuItems(items: any) {
-    return items.filter(it => !it.omit)
-        .filter(filterConsecutiveMenuSeparators())
-        .map(it => {
-            if (it === '-') return menuDivider();
-            if (isValidElement(it)) {
-                if (it instanceof MenuItem || it instanceof MenuDivider) return it;
-                return menuItem({text: it});
-            }
+function parseMenuItems(items: MenuItemLike[]): ReactNode[] {
+    items = items.map(item => {
+        if (!isMenuItemCfg(item)) return item;
 
-            // Create menuItem from config, recursively parsing any submenus
-            const cfg = {...it};
-            if (!isEmpty(cfg.items)) {
-                cfg.items = parseMenuItems(cfg.items);
+        item = clone(item);
+        item.items = clone(item.items);
+        item.prepareFn?.(item);
+        return item;
+    });
+
+    return items
+        .filter(it => !isMenuItemCfg(it) || (!it.hidden && !it.omit))
+        .filter(filterConsecutiveMenuSeparators())
+        .map(item => {
+            if (item === '-') return menuDivider();
+            if (!isMenuItemCfg(item)) return item;
+
+            const onClick = (item as any).onClick;
+            if (onClick) {
+                apiDeprecated('AppMenuButton.extraItems.onClick', {msg: 'Use `actionFn` instead', v: 'v54'});
+            }
+            const actionFn = item.actionFn ?? onClick;
+
+            // Create menuItem from config
+            const cfg = {
+                text: item.text,
+                icon: item.icon,
+                intent: item.intent,
+                onClick: actionFn ? () => wait().then(actionFn) : null,
+                disabled: item.disabled
+            } as PlainObject;
+
+            // Recursively parse any submenus
+            if (!isEmpty(item.items)) {
+                cfg.items = parseMenuItems(item.items);
                 cfg.popoverProps = {openOnTargetFocus: false};
             }
+
             return menuItem(cfg);
         });
+}
+
+function isMenuItemCfg(item: MenuItemLike): item is MenuItem {
+    return !isString(item) && !isValidElement(item);
 }

--- a/desktop/cmp/contextmenu/ContextMenu.ts
+++ b/desktop/cmp/contextmenu/ContextMenu.ts
@@ -46,7 +46,7 @@ export const [ContextMenu, contextMenu] = hoistCmp.withFactory<ContextMenuProps>
 //---------------------------
 function parseItems(items: MenuItemLike[]): ReactNode[] {
     items = items.map(item => {
-        if (!isMenuItem(item)) return item;
+        if (!isMenuItemCfg(item)) return item;
 
         item = clone(item);
         item.items = clone(item.items);
@@ -55,12 +55,12 @@ function parseItems(items: MenuItemLike[]): ReactNode[] {
     });
 
     return items
-        .filter(it => isMenuItem(it) && !it.hidden && !it.omit)
+        .filter(it => !isMenuItemCfg(it) || (!it.hidden && !it.omit))
         .filter(filterConsecutiveMenuSeparators())
         .map(item => {
             // Process dividers
             if (item === '-') return menuDivider();
-            if (!isMenuItem(item)) return item;
+            if (!isMenuItemCfg(item)) return item;
 
             // Process items
             const items = item.items ? parseItems(item.items) : null;
@@ -76,6 +76,6 @@ function parseItems(items: MenuItemLike[]): ReactNode[] {
 }
 
 
-function isMenuItem(item: MenuItemLike): item is MenuItem {
+function isMenuItemCfg(item: MenuItemLike): item is MenuItem {
     return !isString(item) && !isValidElement(item);
 }

--- a/desktop/cmp/contextmenu/ContextMenu.ts
+++ b/desktop/cmp/contextmenu/ContextMenu.ts
@@ -46,7 +46,7 @@ export const [ContextMenu, contextMenu] = hoistCmp.withFactory<ContextMenuProps>
 //---------------------------
 function parseItems(items: MenuItemLike[]): ReactNode[] {
     items = items.map(item => {
-        if (!isMenuItemCfg(item)) return item;
+        if (!isMenuItem(item)) return item;
 
         item = clone(item);
         item.items = clone(item.items);
@@ -55,12 +55,12 @@ function parseItems(items: MenuItemLike[]): ReactNode[] {
     });
 
     return items
-        .filter(it => !isMenuItemCfg(it) || (!it.hidden && !it.omit))
+        .filter(it => !isMenuItem(it) || (!it.hidden && !it.omit))
         .filter(filterConsecutiveMenuSeparators())
         .map(item => {
             // Process dividers
             if (item === '-') return menuDivider();
-            if (!isMenuItemCfg(item)) return item;
+            if (!isMenuItem(item)) return item;
 
             // Process items
             const items = item.items ? parseItems(item.items) : null;
@@ -76,6 +76,6 @@ function parseItems(items: MenuItemLike[]): ReactNode[] {
 }
 
 
-function isMenuItemCfg(item: MenuItemLike): item is MenuItem {
+function isMenuItem(item: MenuItemLike): item is MenuItem {
     return !isString(item) && !isValidElement(item);
 }

--- a/mobile/cmp/menu/impl/Menu.ts
+++ b/mobile/cmp/menu/impl/Menu.ts
@@ -68,7 +68,7 @@ class LocalMenuModel extends HoistModel {
         const {pressedIdx} = this;
 
         items = items.map(item => {
-            if (!isMenuItem(item)) return item;
+            if (!isMenuItemCfg(item)) return item;
 
             item = clone(item);
             item.prepareFn?.(item);
@@ -76,11 +76,11 @@ class LocalMenuModel extends HoistModel {
         });
 
         return items
-            .filter(it => isMenuItem(it) && !it.omit && !it.hidden)
+            .filter(it => !isMenuItemCfg(it) || (!it.hidden && !it.omit))
             .filter(filterConsecutiveMenuSeparators())
             .map((item, idx) => {
                 // Process dividers
-                if (!isMenuItem(item)) return item;
+                if (!isMenuItemCfg(item)) return item;
 
                 // Process items
                 const {text, icon, actionFn, hidden} = item,
@@ -107,6 +107,6 @@ class LocalMenuModel extends HoistModel {
     }
 }
 
-function isMenuItem(item: MenuItemLike): item is MenuItem {
+function isMenuItemCfg(item: MenuItemLike): item is MenuItem {
     return !isString(item) && !isValidElement(item);
 }

--- a/mobile/cmp/menu/impl/Menu.ts
+++ b/mobile/cmp/menu/impl/Menu.ts
@@ -68,7 +68,7 @@ class LocalMenuModel extends HoistModel {
         const {pressedIdx} = this;
 
         items = items.map(item => {
-            if (!isMenuItemCfg(item)) return item;
+            if (!isMenuItem(item)) return item;
 
             item = clone(item);
             item.prepareFn?.(item);
@@ -76,11 +76,11 @@ class LocalMenuModel extends HoistModel {
         });
 
         return items
-            .filter(it => !isMenuItemCfg(it) || (!it.hidden && !it.omit))
+            .filter(it => !isMenuItem(it) || (!it.hidden && !it.omit))
             .filter(filterConsecutiveMenuSeparators())
             .map((item, idx) => {
                 // Process dividers
-                if (!isMenuItemCfg(item)) return item;
+                if (!isMenuItem(item)) return item;
 
                 // Process items
                 const {text, icon, actionFn, hidden} = item,
@@ -107,6 +107,6 @@ class LocalMenuModel extends HoistModel {
     }
 }
 
-function isMenuItemCfg(item: MenuItemLike): item is MenuItem {
+function isMenuItem(item: MenuItemLike): item is MenuItem {
     return !isString(item) && !isValidElement(item);
 }


### PR DESCRIPTION
+ Desktop AppMenuButton now implements the advertised MenuItemLike interface, including actionFn, prepareFn and hidden.
+ Fixed a bug where ContextMenu and mobile Menu would strip out Elements and Strings.

See issue: https://github.com/xh/hoist-react/issues/3222

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [ ] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [ ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

