### PR TITLE
Fix mobile navigator animation bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,9 @@ to use TypeScript for its own app-level code.
 
 ### 🐞 Bug Fixes
 * Fix bug where dragging on any panel header which is a descendant of a `DashCanvasView` would move
-  the `DashCanvasView`
-* Fix bug where `GridModel.ensureRecordsVisibleAsync` could fail to make collapsed nodes visible
+  the `DashCanvasView`.
+* Fix bug where `GridModel.ensureRecordsVisibleAsync` could fail to make collapsed nodes visible.
+* Fix animation bug when popping pages in the mobile navigator.
 
 ### ✅ Testing Scope
 

--- a/mobile/cmp/navigator/impl/Page.scss
+++ b/mobile/cmp/navigator/impl/Page.scss
@@ -1,7 +1,13 @@
-.xh-page .page__content {
-  display: flex;
-  align-items: stretch;
-  flex-direction: column;
-  transform: translateX(0);
-  font-family: var(--xh-font-family);
+.xh-page {
+  &--force-hidden {
+    display: none !important;
+  }
+
+  .page__content {
+    display: flex;
+    align-items: stretch;
+    flex-direction: column;
+    transform: translateX(0);
+    font-family: var(--xh-font-family);
+  }
 }


### PR DESCRIPTION
This was a tricky one to track down and figure out!

We already had code to prevent flashing pages following a transition, but it was no longer working. It's not clear **why** it stopped working, possibly a difference in the browsers CSS transition API or a change to make promises wait a frame before resolving.

The solution was to move that code to trigger on the `transitionend` event, which triggers the on the correct frame. As part of this, it was necessary to force hiding the page with a CSS class (rather than an inline style) since the inline style would be cleared as part of finishing the transition.

See issue: https://github.com/xh/hoist-react/issues/3226

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

