### PR TITLE
RelativeTimestamp should not require a model

### DIFF
--- a/cmp/relativetimestamp/RelativeTimestamp.ts
+++ b/cmp/relativetimestamp/RelativeTimestamp.ts
@@ -5,7 +5,7 @@
  * Copyright © 2022 Extremely Heavy Industries Inc.
  */
 import {box, span} from '@xh/hoist/cmp/layout';
-import {hoistCmp, HoistModel, managed, useLocalModel, XH, lookup, BoxProps, HoistProps} from '@xh/hoist/core';
+import {hoistCmp, HoistModel, managed, useLocalModel, XH, BoxProps, HoistProps} from '@xh/hoist/core';
 import {fmtCompactDate, fmtDateTime} from '@xh/hoist/format';
 import {action, observable, makeObservable, computed} from '@xh/hoist/mobx';
 import {Timer} from '@xh/hoist/utils/async';
@@ -90,7 +90,7 @@ class RelativeTimestampLocalModel extends HoistModel {
     xhImpl = true;
 
     @observable display = '';
-    @lookup('*') model;
+    model: HoistModel;
 
     @managed
     timer = Timer.create({
@@ -100,7 +100,7 @@ class RelativeTimestampLocalModel extends HoistModel {
 
     get timestamp() {
         const {model} = this,
-            {bind, timestamp} = this.componentProps;
+            {timestamp, bind} = this.componentProps;
         return withDefault(timestamp, (model && bind ? model[bind] : null));
     }
 
@@ -117,6 +117,10 @@ class RelativeTimestampLocalModel extends HoistModel {
             track: () => [this.timestamp, this.options],
             run: () => this.refreshDisplay()
         });
+    }
+
+    override onLinked() {
+        this.model = this.lookupModel('*');
     }
 
     @action


### PR DESCRIPTION
This fixes the bug in question.

There may be a separate issue regarding whether an element rendered in a grid cell *should* always have a context model (the grid perhaps?).  I think it should.  I will look into that and file it separately, if needed.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

