### PR TITLE
Fixes Issue #3241: Grid Cell Date Picker is not positioned correctly …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🐞 Bug Fixes
 
 * Fixed: grid cell editors would drop a single character edit.
-* Fixed: grid date input editors did not position correctly in a grid with pinned columns.
+* Fixed: grid date input editor's popup did not position correctly in a grid with pinned columns.
 * Fixed issue with `DashContainer` flashing its "empty" text briefly before loading.
 * Several Hoist TypeScript types, interfaces, and signatures have been improved or corrected (typing
   changes only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### 🐞 Bug Fixes
 
-* Fixed a bug in which grid cell editors would drop a single character edit.
+* Fixed: grid cell editors would drop a single character edit.
+* Fixed: grid date input editors did not position correctly in a grid with pinned columns.
 * Fixed issue with `DashContainer` flashing its "empty" text briefly before loading.
 * Several Hoist TypeScript types, interfaces, and signatures have been improved or corrected (typing
   changes only).

--- a/desktop/cmp/grid/editors/DateEditor.ts
+++ b/desktop/cmp/grid/editors/DateEditor.ts
@@ -96,11 +96,18 @@ function computeStyleInAgGrid(data: Popper.Data, options: PlainObject, portalCon
         return data;
     }
 
-    // recalc reference offsets with the dateEditor cell's column's ag-grid container of all rows
+    // Recalc reference offsets with the dateEditor cell's ag-grid row container
     data.offsets.reference = getOffsetRectRelativeToArbitraryNode(inputEl, rowContainer, false);
+    // 1. Handle case where dateInput is in a column that is pinned right.
     if (rightContainer) {
         data.offsets.reference.left += rightContainer.offsetLeft;
         data.offsets.reference.right += rightContainer.offsetLeft;
+    }
+
+    // 2. Handle case where dateInput is in centerContainer
+    // but other columns are pinned left.
+    if (centerContainer) {
+        data.offsets.reference.left += centerContainer.offsetLeft;
     }
 
     const scrollLeft = rowContainer.parentNode.scrollLeft,


### PR DESCRIPTION
…when grid has pinned columns.


NOT A BREAKING CHANGE.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry.
- [x] Reviewed for breaking changes: NOT A BREAKING CHANGE.
- [x] Updated doc comments / prop-types:  not required.
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: can be validated with with these toolbox branches: 

1. https://github.com/xh/toolbox/tree/gridEditorDateInputPinnedRight
2. https://github.com/xh/toolbox/tree/gridEditorDateInputLeftPinned
3. https://github.com/xh/toolbox/tree/gridEditorDateInputInCenterWithLeftPinnedColumns

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

