### PR TITLE
Minor fixes / improvements to Grid column filter UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## v56.0.0-SNAPSHOT - under development
 
-* Coming soon....
+### 🐞 Bug Fixes
+
+* Grid column filters scroll their internal grid horizontally to avoid clipping longer values.
+* Minor improvements to the same grid filter dialog's alignment and labelling.
 
 ## v55.2.1 - 2023-02-24
 

--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -306,14 +306,6 @@
     .ag-cell {
       padding-left: var(--xh-grid-tiny-cell-lr-pad-px);
       padding-right: var(--xh-grid-tiny-cell-lr-pad-px);
-
-      .xh-check-box {
-        padding-top: 1px;
-
-        .bp4-control-indicator {
-          font-size: calc(var(--xh-grid-tiny-font-size-px) + 2px);
-        }
-      }
     }
 
     .ag-header-cell,
@@ -376,6 +368,11 @@
     .ag-overlay-no-rows-wrapper {
       color: var(--xh-grid-empty-text-color);
     }
+  }
+
+  // Set Blueprint controls - specifically checkboxes - to match grid size.
+  .bp4-control .bp4-control-indicator {
+    font-size: 1em;
   }
 }
 

--- a/desktop/cmp/grid/impl/filter/ColumnHeaderFilter.ts
+++ b/desktop/cmp/grid/impl/filter/ColumnHeaderFilter.ts
@@ -70,24 +70,27 @@ const content = hoistCmp.factory({
 const bbar = hoistCmp.factory<ColumnHeaderFilterModel>({
     render({model}) {
         const {commitOnChange} = model;
-        return toolbar(
-            filler(),
-            button({
-                icon: Icon.delete(),
-                text: 'Clear Filter',
-                intent: 'danger',
-                disabled: !model.hasFilter,
-                onClick: () => model.clear()
-            }),
-            button({
-                omit: commitOnChange,
-                icon: Icon.check(),
-                text: 'Apply Filter',
-                intent: 'success',
-                disabled: !model.hasFilter && !model.hasPendingFilter,
-                onClick: () => model.commit()
-            })
-        );
+        return toolbar({
+            compact: true,
+            items: [
+                filler(),
+                button({
+                    icon: Icon.delete(),
+                    text: 'Clear Filter',
+                    intent: 'danger',
+                    disabled: !model.hasFilter,
+                    onClick: () => model.clear()
+                }),
+                button({
+                    omit: commitOnChange,
+                    icon: Icon.check(),
+                    text: 'Apply Filter',
+                    intent: 'success',
+                    disabled: !model.hasFilter && !model.hasPendingFilter,
+                    onClick: () => model.commit()
+                })
+            ]
+        });
     }
 });
 

--- a/desktop/cmp/grid/impl/filter/values/ValuesTab.scss
+++ b/desktop/cmp/grid/impl/filter/values/ValuesTab.scss
@@ -24,4 +24,23 @@
       margin-top: var(--xh-pad-px);
     }
   }
+
+  // Fix up alignment on first checkbox column.
+  .ag-header-cell.xh-column-header-align-center {
+    padding: 0 !important;
+  }
+
+  .ag-pinned-left-header,
+  .ag-cell.ag-cell-last-left-pinned {
+    .bp4-control.bp4-inline {
+      margin-right: -8px;
+
+      input {
+        margin: 0;
+      }
+    }
+
+    // Less obvious pinning for the checkbox column.
+    border-right: none !important;
+  }
 }


### PR DESCRIPTION
+ Allow internal grid of values to autosize + scroll horizontally so long values can be viewed in full. Pin checkbox column to keep it in place.
+ Always left-align values - right align interferes with the above + looked weird with fresh eyes.
+ Use text "(Select All)"" for values col header - client request / same as Excel.
+ Fixup remaining checkbox alignment jank.
+ Remove tiny-mode specific checkbox sizing tweak, have BP controls follow grid font size instead across modes.
+ Don't collect all store values in advance when rendering checkbox col header - do so when clicked.
+ Fixes #3293

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

