### PR TITLE
fix to Desktop ButtonGroupProps

### DIFF
--- a/desktop/cmp/button/ButtonGroup.ts
+++ b/desktop/cmp/button/ButtonGroup.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2022 Extremely Heavy Industries Inc.
  */
-import {ReactNode} from 'react';
+import {SetOptional} from 'type-fest';
 import {ButtonGroupProps as BpButtonGroupProps} from '@blueprintjs/core';
 import {hoistCmp, HoistModel, HoistProps, LayoutProps, StyleProps} from '@xh/hoist/core';
 import '@xh/hoist/desktop/register';
@@ -15,7 +15,7 @@ export interface ButtonGroupProps<M extends HoistModel = null>
     extends HoistProps<M>,
         LayoutProps,
         StyleProps,
-        Omit<BpButtonGroupProps, 'children'> {
+        SetOptional<BpButtonGroupProps, 'children'> {
     /** True to have all buttons fill available width equally. */
     fill?: boolean;
 
@@ -24,9 +24,6 @@ export interface ButtonGroupProps<M extends HoistModel = null>
 
     /** True to render in a vertical orientation. */
     vertical?: boolean;
-
-    /** Override non-optional `children` from BpButtonGroupProps to support ElementFactor. */
-    children?: ReactNode | undefined;
 }
 
 /**

--- a/desktop/cmp/button/ButtonGroup.ts
+++ b/desktop/cmp/button/ButtonGroup.ts
@@ -25,6 +25,7 @@ export interface ButtonGroupProps<M extends HoistModel = null>
     /** True to render in a vertical orientation. */
     vertical?: boolean;
 
+    /** Override non-optional `children` from BpButtonGroupProps to support ElementFactor. */
     children?: ReactNode | undefined;
 }
 

--- a/desktop/cmp/button/ButtonGroup.ts
+++ b/desktop/cmp/button/ButtonGroup.ts
@@ -4,12 +4,12 @@
  *
  * Copyright © 2022 Extremely Heavy Industries Inc.
  */
+import {ReactNode} from 'react';
 import {ButtonGroupProps as BpButtonGroupProps} from '@blueprintjs/core';
 import {hoistCmp, HoistModel, HoistProps, LayoutProps, StyleProps} from '@xh/hoist/core';
 import '@xh/hoist/desktop/register';
 import {buttonGroup as bpButtonGroup} from '@xh/hoist/kit/blueprint';
 import {splitLayoutProps} from '@xh/hoist/utils/react';
-import * as React from 'react';
 
 export interface ButtonGroupProps<M extends HoistModel = null>
     extends HoistProps<M>,
@@ -25,7 +25,7 @@ export interface ButtonGroupProps<M extends HoistModel = null>
     /** True to render in a vertical orientation. */
     vertical?: boolean;
 
-    children?: React.ReactNode | undefined;
+    children?: ReactNode | undefined;
 }
 
 /**

--- a/desktop/cmp/button/ButtonGroup.ts
+++ b/desktop/cmp/button/ButtonGroup.ts
@@ -4,6 +4,7 @@
  *
  * Copyright © 2022 Extremely Heavy Industries Inc.
  */
+import {ReactNode} from 'react';
 import {ButtonGroupProps as BpButtonGroupProps} from '@blueprintjs/core';
 import {hoistCmp, HoistModel, HoistProps, LayoutProps, StyleProps} from '@xh/hoist/core';
 import '@xh/hoist/desktop/register';
@@ -14,7 +15,7 @@ export interface ButtonGroupProps<M extends HoistModel = null>
     extends HoistProps<M>,
         LayoutProps,
         StyleProps,
-        Partial<BpButtonGroupProps> {
+        Omit<BpButtonGroupProps, 'children'> {
     /** True to have all buttons fill available width equally. */
     fill?: boolean;
 
@@ -23,6 +24,9 @@ export interface ButtonGroupProps<M extends HoistModel = null>
 
     /** True to render in a vertical orientation. */
     vertical?: boolean;
+
+    /** Override non-optional `children` from BpButtonGroupProps to support ElementFactor. */
+    children?: ReactNode | undefined;
 }
 
 /**

--- a/desktop/cmp/button/ButtonGroup.ts
+++ b/desktop/cmp/button/ButtonGroup.ts
@@ -4,7 +4,6 @@
  *
  * Copyright © 2022 Extremely Heavy Industries Inc.
  */
-import {ReactNode} from 'react';
 import {ButtonGroupProps as BpButtonGroupProps} from '@blueprintjs/core';
 import {hoistCmp, HoistModel, HoistProps, LayoutProps, StyleProps} from '@xh/hoist/core';
 import '@xh/hoist/desktop/register';
@@ -15,7 +14,7 @@ export interface ButtonGroupProps<M extends HoistModel = null>
     extends HoistProps<M>,
         LayoutProps,
         StyleProps,
-        Omit<BpButtonGroupProps, 'children'> {
+        Partial<BpButtonGroupProps> {
     /** True to have all buttons fill available width equally. */
     fill?: boolean;
 
@@ -24,9 +23,6 @@ export interface ButtonGroupProps<M extends HoistModel = null>
 
     /** True to render in a vertical orientation. */
     vertical?: boolean;
-
-    /** Override non-optional `children` from BpButtonGroupProps to support ElementFactor. */
-    children?: ReactNode | undefined;
 }
 
 /**

--- a/desktop/cmp/button/ButtonGroup.ts
+++ b/desktop/cmp/button/ButtonGroup.ts
@@ -9,6 +9,7 @@ import {hoistCmp, HoistModel, HoistProps, LayoutProps, StyleProps} from '@xh/hoi
 import '@xh/hoist/desktop/register';
 import {buttonGroup as bpButtonGroup} from '@xh/hoist/kit/blueprint';
 import {splitLayoutProps} from '@xh/hoist/utils/react';
+import * as React from 'react';
 
 export interface ButtonGroupProps<M extends HoistModel = null>
     extends HoistProps<M>,
@@ -23,6 +24,8 @@ export interface ButtonGroupProps<M extends HoistModel = null>
 
     /** True to render in a vertical orientation. */
     vertical?: boolean;
+
+    children?: React.ReactNode | undefined;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
   },
   "devDependencies": {
     "@xh/hoist-dev-utils": "^6.1.1",
-    "eslint-plugin-tsdoc": "^0.2.17",
     "eslint-config-prettier": "8.x",
+    "eslint-plugin-tsdoc": "^0.2.17",
     "husky": "^8.0.2",
     "lint-staged": "^13.0.3",
     "postcss": "^8.4.19",
@@ -95,6 +95,7 @@
     "react-dom": "^18.2.0",
     "stylelint": "^14.15.0",
     "stylelint-config-standard-scss": "^6.1.0",
+    "type-fest": "^3.6.1",
     "typescript": "~4.9.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6742,6 +6742,11 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.6.1.tgz#cf8025edeebfd6cf48de73573a5e1423350b9993"
+  integrity sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"


### PR DESCRIPTION
Desktop ButtonGroupProps: Allow children (for *.tsx) but make children optional (since not needed by ElementFactory)

This fixes this TS error when using the ButtonGroup and ButtonGroupInput components in *.tsx:
"Property 'children' does not exist on type 'IntrinsicAttributes & ButtonGroupProps'."

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry: not required.
- [x] Reviewed for breaking changes: TS change
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch: I can push my toolbox tests if wanted

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

