### PR TITLE
Need to parse values in FieldFilter before comparing to existing values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * Hoist exceptions have been enhanced and standardized, including new TypeScript types.  The
  `Error.cause` property is now populated for wrapping exceptions.
 
+### 🐞 Bug Fixes
+* Fix grid bug whereby LocalDate filter entered via FilterChooser was causing column filtering
+to fail.
+
 ### 💥 Breaking Changes
 * "Local" Preference support in PreferenceService is no longer supported.  Application should use
   `LocalStorageService` instead. With v56, the `local` flag on any preferences will be ignored, and

--- a/cmp/filter/FilterChooserModel.ts
+++ b/cmp/filter/FilterChooserModel.ts
@@ -88,7 +88,7 @@ export interface FilterChooserConfig {
     initialFavorites?: FilterChooserFilterLike[] | (() => FilterChooserFilterLike[]);
 
     /**
-     * true to offer all field suggestions when the control is focussed with an empty query,
+     * true to offer all field suggestions when the control is focused with an empty query,
      * to aid discoverability.
      */
     suggestFieldsWhenEmpty?: boolean;

--- a/cmp/grid/filter/GridFilterFieldSpec.ts
+++ b/cmp/grid/filter/GridFilterFieldSpec.ts
@@ -65,7 +65,7 @@ export class GridFilterFieldSpec extends BaseFilterFieldSpec {
     // Implementation
     //------------------------
     loadValuesFromSource() {
-        const {filterModel, field, source} = this,
+        const {filterModel, field, source, sourceField} = this,
             columnFilters = filterModel.getColumnFilters(field),
             sourceStore = source instanceof View ? source.cube.store : source,
             allRecords = sourceStore.allRecords;
@@ -82,9 +82,10 @@ export class GridFilterFieldSpec extends BaseFilterFieldSpec {
         // Get values from current column filter
         const filterValues = [];
         columnFilters.forEach(filter => {
-            const newValues = castArray(filter.value).map(value =>
-                filterModel.toDisplayValue(value)
-            );
+            const newValues = castArray(filter.value).map(value => {
+                value = sourceField.parseVal(value);
+                return filterModel.toDisplayValue(value);
+            });
             filterValues.push(...newValues);
         });
 

--- a/desktop/cmp/grid/impl/filter/values/ValuesTabModel.ts
+++ b/desktop/cmp/grid/impl/filter/values/ValuesTabModel.ts
@@ -144,7 +144,7 @@ export class ValuesTabModel extends HoistModel {
 
     @action
     private doSyncWithFilter() {
-        const {values, columnFilters, gridFilterModel} = this,
+        const {values, columnFilters, gridFilterModel, fieldSpec} = this,
             {fieldType} = this.headerFilterModel;
 
         if (isEmpty(columnFilters)) {
@@ -162,9 +162,10 @@ export class ValuesTabModel extends HoistModel {
             filterValues = [];
 
         arr.forEach(filter => {
-            const newValues = castArray(filter.value).map(value =>
-                gridFilterModel.toDisplayValue(value)
-            );
+            const newValues = castArray(filter.value).map(value => {
+                value = fieldSpec.sourceField.parseVal(value);
+                return gridFilterModel.toDisplayValue(value);
+            });
             filterValues.push(...newValues); // Todo: Is this safe?
         });
 


### PR DESCRIPTION
So FieldFilters have "unparsed" values that can evaluated at the time of filtering/evaluations.  Its a bit surprising, but there are good reason for it.  

But it can trip us up, as there are a number of places we need to remember to do that before using the value.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

