### PR TITLE
Safer TrackLog creation/querying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,28 @@
 
 ### 🎁 New Features
 
+* `PanelModel` now supports a `defaultSize` property specified in percentage as well as pixels
+  (e.g. `defaultSize: '20%'` as well as `defaultSize: 200`).
 * `DashCanvas` views can now be programmatically added with specified width and height dimensions.
 * New `FetchService.abort()` API allows manually aborting a pending fetch request.
 * Hoist exceptions have been enhanced and standardized, including new TypeScript types. The
   `Error.cause` property is now populated for wrapping exceptions.
-* `PanelModel` now supports a `defaultSize` property specified in percentage as well as pixels
-  (e.g. `defaultSize: '20%'` as well as `defaultSize: 200`).
 
 ### 💥 Breaking Changes
 
-* Hoist now requires AG Grid v29.0.0 or higher - update your AG Grid dependency in your app's
-  `package.json` file. See the [AG Grid Changelog](https://www.ag-grid.com/changelog) for details.
+* Requires Hoist Core v16 or higher.
+* Requires AG Grid v29.0.0 or higher - update your AG Grid dependency in your app's `package.json`
+  file. See the [AG Grid Changelog](https://www.ag-grid.com/changelog) for details.
+* New `xhActivityTrackingConfig` soft-configuration entry places new limits on the size of
+  any `data` objects passed to `XH.track()` calls.
+    * Any track requests with data objects exceeding this length will be persisted, but without the
+      requested data.
+    * Activity tracking can also be disabled (completely) via this same config.
 * "Local" preferences are no longer supported. Application should use `LocalStorageService` instead.
   With v56, the `local` flag on any preferences will be ignored, and all preferences will be saved
   on the server instead.
     * Note that Hoist will execute a one-time migration of any existing local preference values
       from the user's browser to the server on app load.
-    * This change necessitates an update to `hoist-core v16.0.0`.
 * Removed `Column.tooltipElement`. Use `tooltip` instead.
 * Removed `fill` prop on `TextArea` and `NumberInput` component. Use `flex` instead.
 * Removed previously deprecated `Button.modifier.outline` and `Button.modifier.quiet` (mobile only).
@@ -34,6 +39,8 @@
 ### ⚙️ Technical
 
 * Hoist source code has been reformatted with Prettier.
+* Admin Console modules that have been disabled via config are no longer hidden completely, but
+  instead will render a placeholder pointing to the relevant config name.
 
 ### 📚 Libraries
 

--- a/admin/AppModel.ts
+++ b/admin/AppModel.ts
@@ -129,8 +129,7 @@ export class AppModel extends HoistAppModel {
             {
                 id: 'monitor',
                 icon: Icon.shieldCheck(),
-                content: monitorTab,
-                omit: !XH.getConf('xhEnableMonitoring', true)
+                content: monitorTab
             },
             {
                 id: 'userData',

--- a/admin/tabs/activity/tracking/ActivityTrackingPanel.ts
+++ b/admin/tabs/activity/tracking/ActivityTrackingPanel.ts
@@ -9,6 +9,7 @@ import {grid} from '@xh/hoist/cmp/grid';
 import {div, hframe} from '@xh/hoist/cmp/layout';
 import {creates, hoistCmp} from '@xh/hoist/core';
 import {button, buttonGroup, colChooserButton, exportButton} from '@xh/hoist/desktop/cmp/button';
+import {errorMessage} from '@xh/hoist/desktop/cmp/error';
 import {filterChooser} from '@xh/hoist/desktop/cmp/filter';
 import {formField} from '@xh/hoist/desktop/cmp/form';
 import {groupingChooser} from '@xh/hoist/desktop/cmp/grouping';
@@ -24,7 +25,13 @@ import {activityDetailView} from './detail/ActivityDetailView';
 export const activityTrackingPanel = hoistCmp.factory({
     model: creates(ActivityTrackingModel),
 
-    render() {
+    render({model}) {
+        if (!model.enabled) {
+            return errorMessage({
+                error: 'Activity tracking disabled via xhActivityTrackingConfig.'
+            });
+        }
+
         return panel({
             className: 'xh-admin-activity-panel',
             tbar: tbar(),
@@ -96,12 +103,7 @@ const tbar = hoistCmp.factory<ActivityTrackingModel>(({model}) => {
                     item: select({
                         enableFilter: false,
                         hideDropdownIndicator: true,
-                        options: [
-                            {label: '5k', value: 5000},
-                            {label: '25k', value: 25000},
-                            {label: '50k', value: 50000},
-                            {label: '100k', value: 100000}
-                        ]
+                        options: model.maxRowOptions
                     })
                 }),
                 toolbarSep(),

--- a/admin/tabs/monitor/MonitorTab.ts
+++ b/admin/tabs/monitor/MonitorTab.ts
@@ -5,20 +5,24 @@
  * Copyright © 2022 Extremely Heavy Industries Inc.
  */
 import {tabContainer} from '@xh/hoist/cmp/tab';
-import {hoistCmp} from '@xh/hoist/core';
+import {hoistCmp, XH} from '@xh/hoist/core';
+import {errorMessage} from '@xh/hoist/desktop/cmp/error';
 import {Icon} from '@xh/hoist/icon';
 import {monitorEditorPanel} from './MonitorEditorPanel';
 import {monitorResultsPanel} from './MonitorResultsPanel';
 
 export const monitorTab = hoistCmp.factory(() => {
-    return tabContainer({
-        modelConfig: {
-            route: 'default.monitor',
-            switcher: {orientation: 'left'},
-            tabs: [
-                {id: 'status', icon: Icon.shieldCheck(), content: monitorResultsPanel},
-                {id: 'config', icon: Icon.settings(), content: monitorEditorPanel}
-            ]
-        }
-    });
+    const enabled = XH.getConf('xhEnableMonitoring', true);
+    return enabled
+        ? tabContainer({
+              modelConfig: {
+                  route: 'default.monitor',
+                  switcher: {orientation: 'left'},
+                  tabs: [
+                      {id: 'status', icon: Icon.shieldCheck(), content: monitorResultsPanel},
+                      {id: 'config', icon: Icon.settings(), content: monitorEditorPanel}
+                  ]
+              }
+          })
+        : errorMessage({error: 'Monitoring disabled via xhEnableMonitor config.'});
 });

--- a/admin/tabs/server/ServerTab.ts
+++ b/admin/tabs/server/ServerTab.ts
@@ -6,7 +6,7 @@
  */
 import {serverEnvPanel} from '@xh/hoist/admin/tabs/server/environment/ServerEnvPanel';
 import {tabContainer} from '@xh/hoist/cmp/tab';
-import {hoistCmp, XH} from '@xh/hoist/core';
+import {hoistCmp} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {ehCachePanel} from './ehcache/EhCachePanel';
 import {logLevelPanel} from './logLevel/LogLevelPanel';
@@ -21,12 +21,7 @@ export const serverTab = hoistCmp.factory(() =>
             route: 'default.server',
             switcher: {orientation: 'left'},
             tabs: [
-                {
-                    id: 'logViewer',
-                    icon: Icon.fileText(),
-                    content: logViewer,
-                    omit: !XH.getConf('xhEnableLogViewer', true)
-                },
+                {id: 'logViewer', icon: Icon.fileText(), content: logViewer},
                 {id: 'logLevels', icon: Icon.settings(), content: logLevelPanel},
                 {
                     id: 'memory',

--- a/admin/tabs/server/logViewer/LogViewer.ts
+++ b/admin/tabs/server/logViewer/LogViewer.ts
@@ -8,6 +8,7 @@ import {grid} from '@xh/hoist/cmp/grid';
 import {hframe} from '@xh/hoist/cmp/layout';
 import {storeFilterField} from '@xh/hoist/cmp/store';
 import {creates, hoistCmp} from '@xh/hoist/core';
+import {errorMessage} from '@xh/hoist/desktop/cmp/error';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {recordActionBar} from '@xh/hoist/desktop/cmp/record';
 import {Icon} from '@xh/hoist/icon';
@@ -19,8 +20,11 @@ export const logViewer = hoistCmp.factory({
     model: creates(LogViewerModel),
 
     render({model}) {
-        const {filesGridModel} = model;
+        if (!model.enabled) {
+            return errorMessage({error: 'Log viewer disabled via xhEnableLogViewer config.'});
+        }
 
+        const {filesGridModel} = model;
         return hframe({
             className: 'xh-log-viewer',
             ref: model.viewRef,

--- a/admin/tabs/server/logViewer/LogViewerModel.ts
+++ b/admin/tabs/server/logViewer/LogViewerModel.ts
@@ -20,7 +20,6 @@ import {AppModel} from '@xh/hoist/admin/AppModel';
  * @internal
  */
 export class LogViewerModel extends HoistModel {
-    // Overall State
     @observable file: string = null;
 
     viewRef = createRef<HTMLElement>();
@@ -30,6 +29,10 @@ export class LogViewerModel extends HoistModel {
 
     @managed
     filesGridModel: GridModel;
+
+    get enabled(): boolean {
+        return XH.getConf('xhEnableLogViewer', true);
+    }
 
     get selectedRecord() {
         return this.filesGridModel.selectedRecord;
@@ -67,8 +70,12 @@ export class LogViewerModel extends HoistModel {
     }
 
     override async doLoadAsync(loadSpec: LoadSpec) {
-        const store = this.filesGridModel.store as UrlStore,
-            selModel = this.filesGridModel.selModel;
+        const {enabled, filesGridModel} = this;
+        if (!enabled) return;
+
+        const store = filesGridModel.store as UrlStore,
+            selModel = filesGridModel.selModel;
+
         try {
             await store.loadAsync(loadSpec);
             if (selModel.isEmpty) {

--- a/core/XH.ts
+++ b/core/XH.ts
@@ -709,7 +709,6 @@ export class XHApi {
 
         try {
             await this.installServicesAsync(FetchService);
-            await this.installServicesAsync(TrackService);
 
             // pre-flight allows clean recognition when we have no server.
             try {
@@ -774,13 +773,9 @@ export class XHApi {
 
             // Complete initialization process
             this.setAppState('INITIALIZING');
-            await this.installServicesAsync(LocalStorageService);
-            await this.installServicesAsync(
-                EnvironmentService,
-                PrefService,
-                ConfigService,
-                JsonBlobService
-            );
+            await this.installServicesAsync(ConfigService, LocalStorageService);
+            await this.installServicesAsync(TrackService);
+            await this.installServicesAsync(EnvironmentService, PrefService, JsonBlobService);
 
             // Confirm hoist-core version after environment service loaded
             const hcVersion = XH.environmentService.get('hoistCoreVersion');


### PR DESCRIPTION
New `xhActivityTrackingConfig` w/constraints for safer TrackLog creation/querying

+ New config limits maximum size of tracked data and provides configurable (and lowered) constraints on admin client querying.
+ Intended for use with corresponding hoist-core v16 updates to respect the same config on the server.
+ Admin modules disabled via config are now rendered, but as an errorMessage indicating which config has turned them off.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

