### PR TITLE
Fix React error when rendering ButtonGroupInput within a FormField with commitOnChange: true

### DIFF
--- a/desktop/cmp/input/ButtonGroupInput.ts
+++ b/desktop/cmp/input/ButtonGroupInput.ts
@@ -103,13 +103,15 @@ class ButtonGroupInputModel extends HoistInputModel {
 const cmp = hoistCmp.factory<ButtonGroupInputModel>(({model, className, ...props}, ref) => {
     const {
         children,
-        //  HoistInput Props
+        // HoistInput Props
         bind,
         disabled,
         onChange,
         onCommit,
         tabIndex,
         value,
+        // FormField Props
+        commitOnChange,
         // ButtonGroupInput Props
         enableClear,
         enableMulti,


### PR DESCRIPTION
I checked all other FormField props - `commitOnChange` is the only one that leaks through to the underlying component, because FormField passes it on to all HoistInput children.

See issue: https://github.com/xh/hoist-react/issues/3323

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

