### PR TITLE
Support children on TSX elements

### DIFF
--- a/core/HoistComponent.ts
+++ b/core/HoistComponent.ts
@@ -43,8 +43,10 @@ import {
 } from 'react';
 
 /**
- * Configuration for creating a Component.  May be specified either as a render function,
- * or an object containing a render function and associated metadata.
+ * Type representing props passed to a HoistComponent's render function.
+ *
+ * This type removes from its base type several props that are used by HoistComponent itself and
+ * not provided to the render function.
  */
 export type RenderPropsOf<P extends HoistProps> = P & {
     /** Pre-processed by HoistComponent internals into a mounted model.  Never passed to render. */
@@ -52,15 +54,12 @@ export type RenderPropsOf<P extends HoistProps> = P & {
 
     /** Pre-processed by HoistComponent internals and attached to model.  Never passed to render. */
     modelRef: never;
-
-    /**
-     *  React Children. Populated on props by React internally, before rendering.  Applications
-     *  will typically provide children to a component via JSX or the `item(s)` property passed to
-     *  an element factory.
-     */
-    children?: ReactNode;
 };
 
+/**
+ * Configuration for creating a Component.  May be specified either as a render function,
+ * or an object containing a render function and associated metadata.
+ */
 export type ComponentConfig<P extends HoistProps> =
     | ((props: RenderPropsOf<P>, ref?: ForwardedRef<any>) => ReactNode)
     | {

--- a/core/HoistProps.ts
+++ b/core/HoistProps.ts
@@ -40,10 +40,8 @@ export interface HoistProps<M extends HoistModel = HoistModel> {
      */
     className?: string;
 
-    /**
-     * Support children on TSX elements
-     */
-    children?: ReactNode | undefined;
+    /** React children. */
+    children?: ReactNode;
 }
 
 /**

--- a/core/HoistProps.ts
+++ b/core/HoistProps.ts
@@ -5,7 +5,7 @@
  * Copyright © 2022 Extremely Heavy Industries Inc.
  */
 import {HoistModel} from '@xh/hoist/core/model';
-import {CSSProperties, HTMLAttributes, Ref} from 'react';
+import {CSSProperties, HTMLAttributes, ReactNode, Ref} from 'react';
 
 /**
  * Props interface for Hoist Components.
@@ -39,6 +39,11 @@ export interface HoistProps<M extends HoistModel = HoistModel> {
      * any base class name provided by the component definition itself.
      */
     className?: string;
+
+    /**
+     * Support children on TSX elements
+     */
+    children?: ReactNode | undefined;
 }
 
 /**


### PR DESCRIPTION
Solves this problem:
<img width="669" alt="image" src="https://user-images.githubusercontent.com/2573928/235264162-80434a54-56ef-4f39-9dd3-f4a4a7a65ba4.png">

found in app that uses TSX, not elementFactory.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

