### PR TITLE
Fix bug where Grid ColumnHeaders could throw when `groupDisplayType` …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
  This will maximize chances that records under edit will not disappear from user view due to
  active filters.
 
+### 🐞 Bug Fixes
+
+* Fix bug where Grid ColumnHeaders could throw when `groupDisplayType` was set to `singleColumn`.
+
 ### ⚙️ Typescript API Adjustments
 
 * Improved return types for `FetchService` methods and corrected `FetchOptions` interface.

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -197,8 +197,8 @@ class GridLocalModel extends HoistModel {
                 clipboardCopy: Icon.copy({asHtml: true})
             },
             components: {
-                agColumnHeader: props => columnHeader(props),
-                agColumnGroupHeader: props => columnGroupHeader(props)
+                agColumnHeader: props => columnHeader({...props, gridModel: model}),
+                agColumnGroupHeader: props => columnGroupHeader({...props, gridModel: model})
             },
             rowSelection: selModel.mode == 'disabled' ? undefined : selModel.mode,
             suppressRowClickSelection: !selModel.isEnabled,

--- a/cmp/grid/columns/Column.ts
+++ b/cmp/grid/columns/Column.ts
@@ -703,7 +703,7 @@ export class Column {
                 lockPinned: !gridModel.enableColumnPinning || XH.isMobileApp,
                 pinned: this.pinned,
                 lockVisible: !this.hideable || !gridModel.colChooserModel || XH.isMobileApp,
-                headerComponentParams: {gridModel, xhColumn: this},
+                headerComponentParams: {xhColumn: this},
                 suppressColumnsToolPanel: this.excludeFromChooser,
                 suppressFiltersToolPanel: this.excludeFromChooser,
                 enableCellChangeFlash: this.highlightOnChange,


### PR DESCRIPTION
…was set to `singleColumn`.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

