### PR TITLE
Add new `enableTooltipsOnTags` prop to `Select`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Added new `GroupingChooserModel.commitOnChange` config - enable to update the observable grouping
   value as the user adjusts their choices within the control.
 * Enabled user-driven sorting for the list of available values within Grid column filters.
+* `Select` has a new prop `enableTooltipsOnTags` which can be used to show tooltips on tags selected
+   in a multi-select (`enableMulti` === true).  Set `enableTooltipsOnTags` to true if you
+   know some tag labels will be too long, and therefore elided when selected, and could use a
+   tooltip to help identify them.
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Added new `GroupingChooserModel.commitOnChange` config - enable to update the observable grouping
   value as the user adjusts their choices within the control. Default behavior is unchanged,
   requiring user to dismiss the popover to commit the new value.
-* Added new `Select.enableTooltipsOnTags` prop - enable for multi-value inputs where the text of a
+* Added new `Select.enableTooltips` prop - enable for select inputs where the text of a
   selected value might be elided due to space constraints. The tooltip will display the full text.
 * Enabled user-driven sorting for the list of available values within Grid column filters.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,11 @@
 ### 🎁 New Features
 
 * Added new `GroupingChooserModel.commitOnChange` config - enable to update the observable grouping
-  value as the user adjusts their choices within the control.
+  value as the user adjusts their choices within the control. Default behavior is unchanged,
+  requiring user to dismiss the popover to commit the new value.
+* Added new `Select.enableTooltipsOnTags` prop - enable for multi-value inputs where the text of a
+  selected value might be elided due to space constraints. The tooltip will display the full text.
 * Enabled user-driven sorting for the list of available values within Grid column filters.
-* `Select` has a new prop `enableTooltipsOnTags` which can be used to show tooltips on tags selected
-   in a multi-select (`enableMulti` === true).  Set `enableTooltipsOnTags` to true if you
-   know some tag labels will be too long, and therefore elided when selected, and could use a
-   tooltip to help identify them.
 
 ### ⚙️ Technical
 

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -93,14 +93,6 @@
 
       &__label {
         color: var(--xh-text-color);
-
-        &__tooltip {
-          &__target {
-            // Required to override tooltip styling applied by Blueprint, which was breaking the
-            // react-select styles that elide overly-long values.
-            display: inherit;
-          }
-        }
       }
 
       &__remove {
@@ -110,6 +102,19 @@
       &--is-disabled {
         .xh-select__multi-value__label {
           color: var(--xh-input-disabled-text-color);
+        }
+      }
+    }
+
+    &__single-value,
+    &__multi-value {
+      &__label {
+        &__tooltip {
+          &__target {
+            // Required to override tooltip styling applied by Blueprint, which was breaking the
+            // react-select styles that elide overly-long values.
+            display: inherit;
+          }
         }
       }
     }

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -96,8 +96,8 @@
 
         &__tooltip {
           &__target {
-            // This is needed to overide BP styling
-            // which was breaking react-select's ellipsis styling
+            // Required to override tooltip styling applied by Blueprint, which was breaking the
+            // react-select styles that elide overly-long values.
             display: inherit;
           }
         }

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -93,6 +93,12 @@
 
       &__label {
         color: var(--xh-text-color);
+
+        &__tooltip {
+          &__target {
+            display: inherit;
+          }
+        }
       }
 
       &__remove {

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -96,6 +96,8 @@
 
         &__tooltip {
           &__target {
+            // This is needed to overide BP styling
+            // which was breaking react-select's ellipsis styling
             display: inherit;
           }
         }

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -106,16 +106,11 @@
       }
     }
 
-    &__single-value,
-    &__multi-value {
-      &__label {
-        &__tooltip {
-          &__target {
-            // Required to override tooltip styling applied by Blueprint, which was breaking the
-            // react-select styles that elide overly-long values.
-            display: inherit;
-          }
-        }
+    &__tooltip {
+      &__target {
+        // Required to override tooltip styling applied by Blueprint, which was breaking the
+        // react-select styles that elide overly-long values.
+        display: inherit;
       }
     }
   }

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -81,7 +81,7 @@ export interface SelectProps extends HoistProps, HoistInputProps, LayoutProps {
      * available to the select component might not support showing the full text of each tag's
      * value. Ignored when `enableMulti: false`.
      */
-    enableTooltipsOnTags?: boolean;
+    enableTooltipsOnMulti?: boolean;
 
     /**
      * True to use react-windowed-select for improved performance on large option lists.
@@ -269,8 +269,8 @@ class SelectInputModel extends HoistInputModel {
         return this.componentProps.hideSelectedOptionCheck || this.hideSelectedOptions;
     }
 
-    get showTooltipsOnTags(): boolean {
-        return this.componentProps.enableMulti && this.componentProps.enableTooltipsOnTags;
+    get showTooltipsOnMulti(): boolean {
+        return this.componentProps.enableMulti && this.componentProps.enableTooltipsOnMulti;
     }
 
     // Managed value for underlying text input under certain conditions
@@ -622,7 +622,7 @@ class SelectInputModel extends HoistInputModel {
     }
 
     getMultiValueLabelCmp() {
-        return this.showTooltipsOnTags
+        return this.showTooltipsOnMulti
             ? props => {
                   props = {
                       ...props,

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -369,7 +369,7 @@ class SelectInputModel extends HoistInputModel {
         super.noteFocused();
     }
 
-    selectText() {
+    private selectText() {
         const {reactSelect} = this;
         if (!reactSelect) return;
 
@@ -437,7 +437,7 @@ class SelectInputModel extends HoistInputModel {
         return this.findOption(external, !isNil(external));
     }
 
-    findOption(value, createIfNotFound, options = this.internalOptions) {
+    private findOption(value, createIfNotFound, options = this.internalOptions) {
         // Do a depth-first search of options
         for (const option of options) {
             if (option.options) {
@@ -462,7 +462,7 @@ class SelectInputModel extends HoistInputModel {
         return internal.value;
     }
 
-    normalizeOptions(options, depth = 0) {
+    private normalizeOptions(options, depth = 0) {
         throwIf(depth > 1, 'Grouped select options support only one-deep nesting.');
 
         options = options || [];
@@ -472,11 +472,11 @@ class SelectInputModel extends HoistInputModel {
     // Normalize / clone a single source value into a normalized option object. Supports Strings
     // and Objects. Objects are validated/defaulted to ensure a label+value or label+options sublist,
     // with other fields brought along to support Selects emitting value objects with ad hoc properties.
-    toOption(src, depth) {
+    private toOption(src, depth) {
         return isPlainObject(src) ? this.objectToOption(src, depth) : this.valueToOption(src);
     }
 
-    objectToOption(src, depth) {
+    private objectToOption(src, depth) {
         const {componentProps} = this,
             labelField = withDefault(componentProps.labelField, 'label'),
             valueField = withDefault(componentProps.valueField, 'value');
@@ -499,7 +499,7 @@ class SelectInputModel extends HoistInputModel {
               };
     }
 
-    valueToOption(src) {
+    private valueToOption(src) {
         return {label: src != null ? src.toString() : '-null-', value: src};
     }
 
@@ -549,7 +549,7 @@ class SelectInputModel extends HoistInputModel {
         return optionRenderer(opt);
     };
 
-    optionRenderer = opt => {
+    private optionRenderer = opt => {
         if (this.hideSelectedOptionCheck) {
             return div(opt.label);
         }

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -76,10 +76,10 @@ export interface SelectProps extends HoistProps, HoistInputProps, LayoutProps {
     /** True to allow entry/selection of multiple values - "tag picker" style. */
     enableMulti?: boolean;
 
-    /** True to show tooltips on all selected tags when enableMulti is true.  Set to true if you
-     * know some tag labels will be too long, and therefore elided when selected, and could use a
-     * tooltip to help identify them.  Defaults to false.
-     * Ignored if enableMulti is false.
+    /**
+     * True to enable tooltips on selected tags when `enableMulti: true`. Enable when the space
+     * available to the select component might not support showing the full text of each tag's
+     * value. Ignored when `enableMulti: false`.
      */
     enableTooltipsOnTags?: boolean;
 

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -43,9 +43,8 @@ import {
     merge
 } from 'lodash';
 import {ReactElement, ReactNode} from 'react';
-import {components, MultiValueProps} from 'react-select';
+import {components} from 'react-select';
 import './Select.scss';
-import {SingleValueProps} from 'react-select/src/components/SingleValue';
 
 export const MENU_PORTAL_ID = 'xh-select-input-portal';
 
@@ -620,7 +619,7 @@ class SelectInputModel extends HoistInputModel {
     getMultiValueLabelCmp() {
         return this.componentProps.enableTooltips
             ? props => {
-                  props = this.addTooltip(props, 'xh-select__multi-value__label__tooltip__target');
+                  props = this.withTooltip(props, 'xh-select__tooltip__target');
                   return createElement(components.MultiValueLabel, props);
               }
             : components.MultiValueLabel;
@@ -629,7 +628,7 @@ class SelectInputModel extends HoistInputModel {
     getSingleValueCmp() {
         return this.componentProps.enableTooltips
             ? props => {
-                  props = this.addTooltip(props, 'xh-select__single-value__label__tooltip__target');
+                  props = this.withTooltip(props, 'xh-select__tooltip__target');
                   return createElement(components.SingleValue, props);
               }
             : components.SingleValue;
@@ -662,10 +661,7 @@ class SelectInputModel extends HoistInputModel {
         return portal;
     }
 
-    private addTooltip(
-        props: SingleValueProps<any, any> | MultiValueProps<any, any>,
-        targetClassName: string
-    ): SingleValueProps<any, any> | MultiValueProps<any, any> {
+    private withTooltip(props: PlainObject, targetClassName: string): PlainObject {
         return {
             ...props,
             children: tooltip({


### PR DESCRIPTION
…Multi is true.

There is a corresponding Toolbox
PR: https://github.com/xh/toolbox/pull/649
and branch: https://github.com/xh/toolbox/tree/selectTagToolTips

which demo this new prop `enableTooltipsOnTags`.



Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry.
- [x] Reviewed for breaking changes: no breaking changes.
- [x] Updated doc comments: done
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: https://github.com/xh/toolbox/tree/selectTagToolTips

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

