### PR TITLE
Fix broken `CodeInput` copy-to-clipboard feature + enable by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,13 @@
 
 * Added `regexOption` and `caseSensitive` props to the `LogDisplayModel`. (Case-sensitive search
   requires `hoist-core >= v16.2.0`).
-
-### 🎁 New Features
-
 * Added new `GroupingChooserModel.commitOnChange` config - enable to update the observable grouping
   value as the user adjusts their choices within the control. Default behavior is unchanged,
   requiring user to dismiss the popover to commit the new value.
 * Added new `Select.enableTooltips` prop - enable for select inputs where the text of a
   selected value might be elided due to space constraints. The tooltip will display the full text.
 * Enabled user-driven sorting for the list of available values within Grid column filters.
+* Enabled copy-to-clipboard button in JSON inputs by default.
 
 ### ⚙️ Technical
 
@@ -24,6 +22,7 @@
 ### 🐞 Bug Fixes
 
 * Fixed Panel with modal support enabled occasionally rendering over child popovers.
+* Fixed asynchronous `editor` access in `CodeInput` through `HoistInputModel`.
 
 ## v56.4.0 - 2023-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Added new `Select.enableTooltips` prop - enable for select inputs where the text of a
   selected value might be elided due to space constraints. The tooltip will display the full text.
 * Enabled user-driven sorting for the list of available values within Grid column filters.
-* Enabled copy-to-clipboard button in JSON inputs by default.
+* Updated `CodeInput.showCopyButton` (copy-to-clipboard feature) default to true (enabled).
 
 ### ⚙️ Technical
 
@@ -21,8 +21,9 @@
 
 ### 🐞 Bug Fixes
 
-* Fixed Panel with modal support enabled occasionally rendering over child popovers.
-* Fixed asynchronous `editor` access in `CodeInput` through `HoistInputModel`.
+* Fixed layout bug where popovers triggered from a parent `Panel` with `modalSupport` active could
+  render beneath that parent's own modal dialog.
+* Fixed broken `CodeInput` copy-to-clipboard feature.
 
 ## v56.4.0 - 2023-05-10
 

--- a/desktop/cmp/input/CodeInput.ts
+++ b/desktop/cmp/input/CodeInput.ts
@@ -83,7 +83,7 @@ export interface CodeInputProps extends HoistProps, HoistInputProps, LayoutProps
      */
     readonly?: boolean;
 
-    /** True to display a copy button at bottom-right of input. */
+    /** True (default) to display a copy button at bottom-right of input. */
     showCopyButton?: boolean;
 
     /**
@@ -148,7 +148,7 @@ class CodeInputModel extends HoistInputModel {
     }
 
     get showCopyButton(): boolean {
-        return withDefault(this.componentProps.showCopyButton, false);
+        return withDefault(this.componentProps.showCopyButton, true);
     }
 
     get showFullscreenButton(): boolean {
@@ -182,14 +182,14 @@ class CodeInputModel extends HoistInputModel {
     }
 
     get actionButtons(): ReactElement[] {
-        const {showCopyButton, showFormatButton, showFullscreenButton, editor} = this;
+        const {showCopyButton, showFormatButton, showFullscreenButton} = this;
         return compact([
             showCopyButton
                 ? clipboardButton({
                       text: null,
                       title: 'Copy to clipboard',
                       successMessage: 'Contents copied to clipboard',
-                      getCopyText: () => editor.getValue()
+                      getCopyText: () => this.internalValue
                   })
                 : null,
             showFormatButton


### PR DESCRIPTION
…y default in JSON inputs

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [ ] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [ ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

