### PR TITLE
Fix mobile input refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 57.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Fixed a bug where mobile `NumberInput`, `SearchInput`, `Checkbox` and `SwitchInput` could not
+  receive refs.
+
+* ### 💥 Breaking Changes
+
+* The internal DOM structure of mobile `NumberInput`, `SearchInput`, `Checkbox` and `SwitchInput`
+  has changed. You may need to update styling that targets the inner structure of these components.
+
 ## 56.5.0 - 2023-05-26
 
 ### 🎁 New Features

--- a/mobile/cmp/input/Checkbox.scss
+++ b/mobile/cmp/input/Checkbox.scss
@@ -1,4 +1,4 @@
-.xh-input.xh-check-box {
+.xh-input.xh-check-box ons-checkbox {
   border: 1px transparent solid;
 
   &:focus-within {

--- a/mobile/cmp/input/Checkbox.ts
+++ b/mobile/cmp/input/Checkbox.ts
@@ -5,6 +5,7 @@
  * Copyright © 2023 Extremely Heavy Industries Inc.
  */
 import {HoistInputModel, HoistInputProps, useHoistInputModel} from '@xh/hoist/cmp/input';
+import {box} from '@xh/hoist/cmp/layout';
 import {hoistCmp, HoistProps} from '@xh/hoist/core';
 import {checkbox as onsenCheckbox} from '@xh/hoist/kit/onsen';
 import '@xh/hoist/mobile/register';
@@ -36,20 +37,20 @@ class CheckboxInputModel extends HoistInputModel {
 // Implementation
 //----------------------------------
 const cmp = hoistCmp.factory<CheckboxInputModel>(({model, className, ...props}, ref) => {
-    return onsenCheckbox({
-        checked: !!model.renderValue,
-
-        disabled: props.disabled,
-        modifier: props.modifier,
-        tabIndex: props.tabIndex,
-
-        style: props.style,
-
-        onBlur: model.onBlur,
-        onFocus: model.onFocus,
-        onChange: e => model.noteValueChange(e.target.checked),
-
+    return box({
+        ref,
         className,
-        ref
+        style: props.style,
+        item: onsenCheckbox({
+            checked: !!model.renderValue,
+
+            disabled: props.disabled,
+            modifier: props.modifier,
+            tabIndex: props.tabIndex,
+
+            onBlur: model.onBlur,
+            onFocus: model.onFocus,
+            onChange: e => model.noteValueChange(e.target.checked)
+        })
     });
 });

--- a/mobile/cmp/input/NumberInput.scss
+++ b/mobile/cmp/input/NumberInput.scss
@@ -1,6 +1,10 @@
 .xh-input.xh-number-input {
   background: var(--xh-input-bg);
 
+  & > ons-input {
+    flex: 1;
+  }
+
   .text-input,
   .text-input__label {
     height: 30px;

--- a/mobile/cmp/input/NumberInput.ts
+++ b/mobile/cmp/input/NumberInput.ts
@@ -5,6 +5,7 @@
  * Copyright © 2023 Extremely Heavy Industries Inc.
  */
 import {HoistInputModel, HoistInputProps, useHoistInputModel} from '@xh/hoist/cmp/input';
+import {hbox} from '@xh/hoist/cmp/layout';
 import {hoistCmp, HoistProps, StyleProps, LayoutProps, HSide} from '@xh/hoist/core';
 import {fmtNumber} from '@xh/hoist/format';
 import {input} from '@xh/hoist/kit/onsen';
@@ -234,31 +235,31 @@ const cmp = hoistCmp.factory<NumberInputModel>(
             type = hasFocus && !enableShorthandUnits ? 'number' : 'text',
             inputMode = !enableShorthandUnits ? 'decimal' : 'text';
 
-        return input({
-            type,
-            inputMode,
+        return hbox({
+            ref,
             className,
-            value: renderValue,
-            disabled: props.disabled,
-            min: props.min,
-            max: props.max,
-            placeholder: props.placeholder,
-            modifier: props.modifier,
-            tabIndex: props.tabIndex,
-
             style: {
                 ...props.style,
                 ...layoutProps,
                 width: withDefault(width, null),
                 textAlign: withDefault(props.textAlign, 'right')
             },
-            spellCheck: false,
-
-            onChange: model.onValueChange,
-            onKeyDown: model.onKeyDown,
-            onBlur: model.onBlur,
-            onFocus: model.onFocus,
-            ref
+            item: input({
+                type,
+                inputMode,
+                value: renderValue,
+                disabled: props.disabled,
+                min: props.min,
+                max: props.max,
+                placeholder: props.placeholder,
+                modifier: props.modifier,
+                tabIndex: props.tabIndex,
+                spellCheck: false,
+                onChange: model.onValueChange,
+                onKeyDown: model.onKeyDown,
+                onBlur: model.onBlur,
+                onFocus: model.onFocus
+            })
         });
     }
 );

--- a/mobile/cmp/input/SearchInput.scss
+++ b/mobile/cmp/input/SearchInput.scss
@@ -1,5 +1,10 @@
 .xh-input.xh-search-input {
   background: var(--xh-input-bg);
+
+  & > ons-search-input {
+    flex: 1;
+  }
+
   .search-input {
     height: 30px;
   }

--- a/mobile/cmp/input/SearchInput.ts
+++ b/mobile/cmp/input/SearchInput.ts
@@ -5,6 +5,7 @@
  * Copyright © 2023 Extremely Heavy Industries Inc.
  */
 import {HoistInputModel, HoistInputProps, useHoistInputModel} from '@xh/hoist/cmp/input';
+import {hbox} from '@xh/hoist/cmp/layout';
 import {hoistCmp, HoistProps, HSide} from '@xh/hoist/core';
 import {searchInput as onsenSearchInput} from '@xh/hoist/kit/onsen';
 import '@xh/hoist/mobile/register';
@@ -75,16 +76,8 @@ class SearchInputModel extends HoistInputModel {
 
 const cmp = hoistCmp.factory<SearchInputModel>(({model, className, ...props}, ref) => {
     const {width, ...layoutProps} = getLayoutProps(props);
-
-    return onsenSearchInput({
-        value: model.renderValue || '',
-
-        disabled: props.disabled,
-        modifier: props.modifier,
-        placeholder: props.placeholder,
-        spellCheck: withDefault(props.spellCheck, false),
-        tabIndex: props.tabIndex,
-
+    return hbox({
+        ref,
         className,
         style: {
             ...props.style,
@@ -92,11 +85,19 @@ const cmp = hoistCmp.factory<SearchInputModel>(({model, className, ...props}, re
             width: withDefault(width, null),
             textAlign: withDefault(props.textAlign, 'left')
         },
+        item: onsenSearchInput({
+            value: model.renderValue || '',
 
-        onChange: model.onChange,
-        onKeyDown: model.onKeyDown,
-        onBlur: model.onBlur,
-        onFocus: model.onFocus,
-        ref
+            disabled: props.disabled,
+            modifier: props.modifier,
+            placeholder: props.placeholder,
+            spellCheck: withDefault(props.spellCheck, false),
+            tabIndex: props.tabIndex,
+
+            onChange: model.onChange,
+            onKeyDown: model.onKeyDown,
+            onBlur: model.onBlur,
+            onFocus: model.onFocus
+        })
     });
 });

--- a/mobile/cmp/input/SwitchInput.scss
+++ b/mobile/cmp/input/SwitchInput.scss
@@ -1,4 +1,4 @@
-.xh-input.xh-switch-input {
+.xh-input.xh-switch-input ons-switch {
   border: 1px transparent solid;
   height: 24px;
 

--- a/mobile/cmp/input/SwitchInput.ts
+++ b/mobile/cmp/input/SwitchInput.ts
@@ -5,6 +5,7 @@
  * Copyright © 2023 Extremely Heavy Industries Inc.
  */
 import {HoistInputProps, HoistInputModel, useHoistInputModel} from '@xh/hoist/cmp/input';
+import {box} from '@xh/hoist/cmp/layout';
 import {hoistCmp, HoistProps, StyleProps} from '@xh/hoist/core';
 import {switchControl} from '@xh/hoist/kit/onsen';
 import '@xh/hoist/mobile/register';
@@ -36,20 +37,20 @@ class SwitchInputModel extends HoistInputModel {
 // Implementation
 //-----------------------
 const cmp = hoistCmp.factory<SwitchInputModel>(({model, className, ...props}, ref) => {
-    return switchControl({
-        checked: !!model.renderValue,
-
-        disabled: props.disabled,
-        modifier: props.modifier,
-        tabIndex: props.tabIndex,
-
+    return box({
+        ref,
         className,
         style: props.style,
+        item: switchControl({
+            checked: !!model.renderValue,
 
-        onBlur: model.onBlur,
-        onFocus: model.onFocus,
-        onChange: e => model.noteValueChange(e.target.checked),
+            disabled: props.disabled,
+            modifier: props.modifier,
+            tabIndex: props.tabIndex,
 
-        ref
+            onBlur: model.onBlur,
+            onFocus: model.onFocus,
+            onChange: e => model.noteValueChange(e.target.checked)
+        })
     });
 });


### PR DESCRIPTION
Mobile input refs were broken for `NumberInput`, `SearchInput`, `Checkbox` and `SwitchInput`.

You can easily see the following warning when navigating mobile toolbox when `reactProdMode: false` (prod mode squelches the warning, but the broken ref remains):

`Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?`

Note that this change necessitating changing the internal structure of these inputs. Styling has been updated to maintain our practice of applying `className` and `styles` to the outermost component.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

