### PR TITLE
Fix expand/collapse button styling within resizable splitter

### DIFF
--- a/desktop/cmp/panel/impl/Splitter.scss
+++ b/desktop/cmp/panel/impl/Splitter.scss
@@ -18,9 +18,9 @@
     .xh-resizable-collapser-btn {
       width: 50px;
       height: 10px;
-      background-color: var(--xh-resizable-button-bg);
-      border-left: 1px solid var(--xh-resizable-border-color);
-      border-right: 1px solid var(--xh-resizable-border-color);
+      background-color: var(--xh-resizable-button-bg) !important;
+      border-left: 1px solid var(--xh-resizable-border-color) !important;
+      border-right: 1px solid var(--xh-resizable-border-color) !important;
     }
   }
 
@@ -32,9 +32,9 @@
     .xh-resizable-collapser-btn {
       width: 10px;
       height: 50px;
-      background-color: var(--xh-resizable-button-bg);
-      border-bottom: 1px solid var(--xh-resizable-border-color);
-      border-top: 1px solid var(--xh-resizable-border-color);
+      background-color: var(--xh-resizable-button-bg) !important;
+      border-bottom: 1px solid var(--xh-resizable-border-color) !important;
+      border-top: 1px solid var(--xh-resizable-border-color) !important;
     }
   }
 }


### PR DESCRIPTION
Our resizable splitter button styles were not being applied, due to the high-level of specificity in our main button styles. Particularly noticeable in dark mode where we were also losing the border.

Before:
<img width="142" alt="Screenshot 2023-06-23 at 11 27 42" src="https://github.com/xh/hoist-react/assets/3017757/e087682b-0b5a-4373-bd8e-7f437be09426"> <img width="138" alt="Screenshot 2023-06-23 at 11 27 31" src="https://github.com/xh/hoist-react/assets/3017757/41d08fe1-a1ad-4082-acae-2234117a7272">

After:
<img width="174" alt="Screenshot 2023-06-23 at 11 27 12" src="https://github.com/xh/hoist-react/assets/3017757/4cc79f59-d816-4923-bdfb-b57e4cfafc06"> <img width="160" alt="Screenshot 2023-06-23 at 11 27 19" src="https://github.com/xh/hoist-react/assets/3017757/2a73d4f7-c802-4c68-ac0b-f012b22dd13f">



Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

