### PR TITLE
Version checking and forcing refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@
 
 ### 🎁 New Features
 
-* Deprecated config `xhAppVersionCheckEnabled` in favor of object based `xhAppVersionCheck`. Apps
-  will seamlessly migrate the existing value to this new config's `shouldUpdate` flag. The new
-  config also supports a `shouldRequireRefresh` flag, which will force users to refresh their
-  clients upon detecting a version update. (requires `hoist-core >= v16.4.0`).
+* Deprecated config `xhAppVersionCheckEnabled` in favor of object based `xhAppVersionCheck`. Apps will
+  seamlessly migrate the existing value to this new config's `mode` flag. While backwards compatible
+  with older versions of hoist-core, the new `forceReload` mode requires `hoist-core >= v16.4.0`.
 * Enhance `NumberFormatOptions.colorSpec` to accept custom CSS properties in addition to class names
 * Enhance `TabSwitcher` to allow navigation using arrow keys when focused.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### 🎁 New Features
 
+* Deprecated config `xhAppVersionCheckEnabled` in favor of object based `xhAppVersionCheck`. Apps
+  will seamlessly migrate the existing value to this new config's `shouldUpdate` flag. The new
+  config also supports a `shouldRequireRefresh` flag, which will force users to refresh their
+  clients upon detecting a version update. (requires `hoist-core >= v16.4.0`).
 * Enhance `NumberFormatOptions.colorSpec` to accept custom CSS properties in addition to class names
 * Enhance `TabSwitcher` to allow navigation using arrow keys when focused.
 

--- a/svc/EnvironmentService.ts
+++ b/svc/EnvironmentService.ts
@@ -97,10 +97,13 @@ export class EnvironmentService extends HoistService {
     }
 
     private startVersionChecking() {
+        // Todo: Remove use of `xhAppVersionCheckSecs` in future
+        const interval =
+            XH.getConf('xhAppVersionCheck', {})?.interval ??
+            XH.getConf('xhAppVersionCheckSecs', null);
         Timer.create({
             runFn: this.checkServerVersionAsync,
-            interval: 'xhAppVersionCheckSecs',
-            intervalUnits: SECONDS
+            interval: interval * SECONDS
         });
     }
 


### PR DESCRIPTION
+ Deprecate config `xhAppVersionCheckEnabled` in favor of object based `xhAppVersionCheck`.
+ Add support for `shouldRequireRefresh` flag

See corresponding hoist-core PR: https://github.com/xh/hoist-core/pull/299

Note that while this PR requires the hoist-core change for the `shouldRequireRefresh`, `shouldUpdate` will continue to work with prior versions of hoist-core.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

