### PR TITLE
expand type of emptyText to allow all reactNodes

### DIFF
--- a/cmp/dataview/DataViewModel.ts
+++ b/cmp/dataview/DataViewModel.ts
@@ -28,6 +28,7 @@ import {
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import {throwIf} from '@xh/hoist/utils/js';
 import {isFunction, isNumber} from 'lodash';
+import {ReactNode} from 'react';
 
 /**
  * Configuration for a DataView.
@@ -63,7 +64,7 @@ export interface DataViewConfig extends GridConfig {
     selModel?: StoreSelectionModel | StoreSelectionConfig | 'single' | 'multiple' | 'disabled';
 
     /** Text/HTML to display if view has no records.*/
-    emptyText?: string;
+    emptyText?: ReactNode;
 
     /** True to highlight the currently hovered row.*/
     showHover?: boolean;


### PR DESCRIPTION
Redefine the type of `emptyText`, expanding from `string`s to `ReactNode`, allowing the embedded of more complex fallback messages. Mirrors the interface set in ![GridConfig](https://github.com/xh/hoist-react/blob/3d1837cad27dc3ea7f811a410c481633b64cd64e/cmp/grid/GridModel.ts#L147).

This is a dependency of toolbox PR

-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

