### PR TITLE
DataViewConfig no longer extends from GridConfig.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * `DataViewConfig` no longer directly supports the passing of `GridConfig` parameters.
   Instead, all direct `GridConfig` toggles must be passed through the new `gridOptions`
-  parameter. See PR ![3421](https://github.com/xh/hoist-react/pull/3421)
+  parameter.
 
 ## 58.0.1 - 2023-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 59.0.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes
+
+* `DataViewConfig` no longer directly supports the passing of `GridConfig` parameters.
+  Instead, all direct `GridConfig` toggles must be passed through the new `gridOptions`
+  parameter. See PR ![3421](https://github.com/xh/hoist-react/pull/3421)
+
 ## 58.0.1 - 2023-07-13
 
 ### 🐞 Bug Fixes

--- a/cmp/dataview/DataViewModel.ts
+++ b/cmp/dataview/DataViewModel.ts
@@ -33,12 +33,8 @@ import {ReactNode} from 'react';
 /**
  * Configuration for a DataView.
  *
- *  Additional properties not specified here will be passed to the underlying
- *  GridModel. Note this is for advanced usage - not all configs supported, and many will
- *  override DataView defaults in ways that will break this component.
  */
-export interface DataViewConfig extends GridConfig {
-    // TODO: Accept grid keys without publicizing them?
+export interface DataViewConfig {
     /** A Store instance, or a config to create one. */
     store?: Store | StoreConfig;
 
@@ -105,6 +101,13 @@ export interface DataViewConfig extends GridConfig {
      * the row's data. (Note that this may be null - e.g. for clicks on full-width group rows.)
      */
     onRowDoubleClicked?: (e: any) => void;
+
+    /**
+     * "escape hatch" object to pass directly to GridModel. Note these options may be used
+     * / overwritten by the framework itself, and are not all guaranteed to be compatible
+     * with its usages of GridModel.
+     */
+    gridOptions?: GridOptions;
 }
 
 export type ItemHeightFn = (params: {
@@ -145,7 +148,7 @@ export class DataViewModel extends HoistModel {
             rowClassRules,
             onRowClicked,
             onRowDoubleClicked,
-            ...restArgs
+            gridOptions
         } = config;
 
         throwIf(
@@ -186,7 +189,7 @@ export class DataViewModel extends HoistModel {
             onRowClicked,
             onRowDoubleClicked,
             columns,
-            ...restArgs
+            ...gridOptions
         });
     }
 
@@ -262,3 +265,11 @@ export class DataViewModel extends HoistModel {
         return this.gridModel.setSortBy(sorters);
     }
 }
+
+/**
+ * the `GridOptions` interface contains all `GridConfig` properties, less those
+ * specified in the above `DataViewConfig`, allowing an "escape hatch" for
+ * developers to alter the underlying `GridConfig`. Note that such alteration is
+ * not guaranteed by the DataView and may have unintended consequences.
+ */
+export interface GridOptions extends Omit<GridConfig, keyof DataViewConfig> {}

--- a/cmp/dataview/DataViewModel.ts
+++ b/cmp/dataview/DataViewModel.ts
@@ -103,11 +103,11 @@ export interface DataViewConfig {
     onRowDoubleClicked?: (e: any) => void;
 
     /**
-     * "escape hatch" object to pass directly to GridModel. Note these options may be used
+     * "Escape hatch" object to pass directly to GridModel. Note these options may be used
      * / overwritten by the framework itself, and are not all guaranteed to be compatible
      * with its usages of GridModel.
      */
-    gridOptions?: GridOptions;
+    gridOptions?: Omit<GridConfig, keyof DataViewConfig>;
 }
 
 export type ItemHeightFn = (params: {
@@ -265,11 +265,3 @@ export class DataViewModel extends HoistModel {
         return this.gridModel.setSortBy(sorters);
     }
 }
-
-/**
- * the `GridOptions` interface contains all `GridConfig` properties, less those
- * specified in the above `DataViewConfig`, allowing an "escape hatch" for
- * developers to alter the underlying `GridConfig`. Note that such alteration is
- * not guaranteed by the DataView and may have unintended consequences.
- */
-export interface GridOptions extends Omit<GridConfig, keyof DataViewConfig> {}


### PR DESCRIPTION
Resolves  #3419.

DataViewConfig no longer extends from GridConfig. Instead, any additional configs can be set through `gridOptions: GridOptions`, which is an interface of all `GridConfig` properties, less those specified in `DataViewConfig` (ie, those that were previously extended). 

This is a *breaking* change and all applications that rely on passing such properties will need to update their usage of DataViewConfig. An example of such a change is provided:

Before:
```ts
dataViewModel = new DataViewModel({
    itemHeight: 80,
    onKeyDown: () => {...}
});
```

After:
```ts
dataViewModel = new DataViewModel({
    itemHeight: 80,
    gridOptions: {
        onKeyDown: () => {...}
    }
});
```

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

