### PR TITLE
Promote supported properties as part of DataViewModel API

### DIFF
--- a/cmp/dataview/DataViewModel.ts
+++ b/cmp/dataview/DataViewModel.ts
@@ -13,7 +13,8 @@ import {
     RowClassFn,
     RowClassRuleFn,
     GridSorterLike,
-    GridContextMenuSpec
+    GridContextMenuSpec,
+    GridGroupSortFn
 } from '@xh/hoist/cmp/grid';
 import {HoistModel, LoadSpec, managed, PlainObject, Some} from '@xh/hoist/core';
 import {
@@ -52,6 +53,16 @@ export interface DataViewConfig {
     /** Function used to render group rows. */
     groupRowRenderer?: GroupRowRenderer;
 
+    /** True (default) to show a count of group member rows within each full-width group row. */
+    showGroupRowCounts?: boolean;
+
+    /**
+     * Function to use to sort full-row groups.  Called with two group values to compare
+     * in the form of a standard JS comparator.  Default is an ascending string sort.
+     * Set to `null` to prevent sorting of groups.
+     */
+    groupSortFn?: GridGroupSortFn;
+
     /** Sort specification. */
     sortBy?: Some<GridSorterLike>;
 
@@ -60,6 +71,9 @@ export interface DataViewConfig {
 
     /** Text/HTML to display if view has no records.*/
     emptyText?: ReactNode;
+
+    /** True (default) to hide empty text until after the Store has been loaded at least once. */
+    hideEmptyTextBeforeLoad?: boolean;
 
     /** True to highlight the currently hovered row.*/
     showHover?: boolean;
@@ -136,9 +150,12 @@ export class DataViewModel extends HoistModel {
             groupBy,
             groupRowHeight,
             groupRowRenderer,
+            showGroupRowCounts,
+            groupSortFn,
             sortBy,
             selModel,
             emptyText,
+            hideEmptyTextBeforeLoad,
             showHover = false,
             rowBorders = false,
             stripeRows = false,
@@ -178,11 +195,14 @@ export class DataViewModel extends HoistModel {
             selModel,
             contextMenu,
             emptyText,
+            hideEmptyTextBeforeLoad,
             showHover,
             rowBorders,
             stripeRows,
             groupBy,
             groupRowRenderer,
+            showGroupRowCounts,
+            groupSortFn,
             rowClassFn,
             rowClassRules,
             onRowClicked,


### PR DESCRIPTION
After re-examining the DataViewModel API, we've made explicit the support for `groupSortFn`, `showGroupRowCounts`, and `hideEmptyTextBeforeLoad`. Our previous "escape hatch" to pass parameters to GridModel did not call attention to the lack of formal support for these properties -- recent changes (#3421) have highlighted this and motivated this corresponding change.

Associated toolbox PR: https://github.com/xh/toolbox/pull/662

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

