### PR TITLE
Add support for including hidden columns when autosizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 59.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* New `GridAutosizeOptions.includeHiddenColumns` config controls whether hidden columns should
+  also be included during the autosize process. Default of `false`. Useful when applications
+  provide quick toggles between different column sets and would prefer to take the up-front cost of
+  autosizing rather than doing it after the user loads a column set.
+
 ### 💥 Breaking Changes
 
 * Apps should update their Typescript dependency to v5.1. This should be a drop-in for most

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 ## 59.0.0-SNAPSHOT - unreleased
 
-### 🎁 New Features
-
-* New `GridAutosizeOptions.includeHiddenColumns` config controls whether hidden columns should
-  also be included during the autosize process. Default of `false`. Useful when applications
-  provide quick toggles between different column sets and would prefer to take the up-front cost of
-  autosizing rather than doing it after the user loads a column set.
-
 ### 💥 Breaking Changes
 
 * Apps should update their Typescript dependency to v5.1. This should be a drop-in for most
@@ -20,6 +13,10 @@
 
 ### 🎁 New Features
 
+* New `GridAutosizeOptions.includeHiddenColumns` config controls whether hidden columns should
+  also be included during the autosize process. Default of `false`. Useful when applications
+  provide quick toggles between different column sets and would prefer to take the up-front cost of
+  autosizing rather than doing it after the user loads a column set.
 * New `DashModel.refreshContextModel` allows apps to programmatically refresh all widgets within
   a `DashCanvas` or `DashContainer`.
 

--- a/cmp/grid/GridAutosizeOptions.ts
+++ b/cmp/grid/GridAutosizeOptions.ts
@@ -40,6 +40,12 @@ export interface GridAutosizeOptions {
     includeCollapsedChildren?: boolean;
 
     /**
+     * True to also autosize hidden columns.
+     * Note that setting this to true can have performance impacts for grids with many columns hidden by default.
+     */
+    includeHiddenColumns?: boolean;
+
+    /**
      * Columns ids to autosize, or a function for testing if the given column should be
      * autosized. Typically used when calling autosizeAsync() manually. To generally exclude
      * a column from autosizing, see the autosizable option on columns.

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -870,9 +870,11 @@ export class GridModel extends HoistModel {
     get isReady(): boolean {
         return this.agGridModel.isReady;
     }
+
     get agApi() {
         return this.agGridModel.agApi;
     }
+
     get agColumnApi() {
         return this.agGridModel.agColumnApi;
     }
@@ -880,9 +882,11 @@ export class GridModel extends HoistModel {
     get sizingMode(): SizingMode {
         return this.agGridModel.sizingMode;
     }
+
     set sizingMode(v: SizingMode) {
         this.agGridModel.sizingMode = v;
     }
+
     setSizingMode(v: SizingMode) {
         this.agGridModel.sizingMode = v;
     }
@@ -890,9 +894,11 @@ export class GridModel extends HoistModel {
     get showHover(): boolean {
         return this.agGridModel.showHover;
     }
+
     set showHover(v: boolean) {
         this.agGridModel.showHover = v;
     }
+
     setShowHover(v: boolean) {
         this.agGridModel.showHover = v;
     }
@@ -900,9 +906,11 @@ export class GridModel extends HoistModel {
     get rowBorders(): boolean {
         return this.agGridModel.rowBorders;
     }
+
     set rowBorders(v: boolean) {
         this.agGridModel.rowBorders = v;
     }
+
     setRowBorders(v: boolean) {
         this.agGridModel.rowBorders = v;
     }
@@ -910,9 +918,11 @@ export class GridModel extends HoistModel {
     get stripeRows(): boolean {
         return this.agGridModel.stripeRows;
     }
+
     set stripeRows(v: boolean) {
         this.agGridModel.stripeRows = v;
     }
+
     setStripeRows(v: boolean) {
         this.agGridModel.stripeRows = v;
     }
@@ -920,9 +930,11 @@ export class GridModel extends HoistModel {
     get cellBorders(): boolean {
         return this.agGridModel.cellBorders;
     }
+
     set cellBorders(v: boolean) {
         this.agGridModel.cellBorders = v;
     }
+
     setCellBorders(v: boolean) {
         this.agGridModel.cellBorders = v;
     }
@@ -930,9 +942,11 @@ export class GridModel extends HoistModel {
     get showCellFocus(): boolean {
         return this.agGridModel.showCellFocus;
     }
+
     set showCellFocus(v: boolean) {
         this.agGridModel.showCellFocus = v;
     }
+
     setShowCellFocus(v: boolean) {
         this.agGridModel.showCellFocus = v;
     }
@@ -940,9 +954,11 @@ export class GridModel extends HoistModel {
     get hideHeaders(): boolean {
         return this.agGridModel.hideHeaders;
     }
+
     set hideHeaders(v: boolean) {
         this.agGridModel.hideHeaders = v;
     }
+
     setHideHeaders(v: boolean) {
         this.agGridModel.hideHeaders = v;
     }
@@ -1263,10 +1279,11 @@ export class GridModel extends HoistModel {
     /**
      * Autosize columns to fit their contents.
      *
-     * @param options - overrides of default autosize options to use for this action.
+     * This method will ignore columns with a flex value or with `autosizable: false`. Hidden
+     * columns are also ignored unless {@link GridAutosizeOptions.includeHiddenColumns} has been
+     * set to true.
      *
-     * This method will ignore hidden columns, columns with a flex value, and columns with
-     * autosizable = false.
+     * @param options - optional overrides of this model's configured {@link autosizeOptions}.
      */
     @logWithDebug
     async autosizeAsync(options: GridAutosizeOptions = {}) {

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -1287,7 +1287,7 @@ export class GridModel extends HoistModel {
         }
 
         colIds = castArray(colIds).filter(id => {
-            if (!this.isColumnVisible(id)) return false;
+            if (!options.includeHiddenColumns && !this.isColumnVisible(id)) return false;
             const col = this.getColumn(id);
             return col && col.autosizable && !col.flex && includeColFn(col);
         });


### PR DESCRIPTION
Makes the experience when using "grid views" feel a lot smoother and less janky in some cases compared to autosizing after changing columns

Toolbox branch adding this to the grid tests panel: https://github.com/xh/toolbox/tree/autosizeHiddenCols

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

