### PR TITLE
Fix mobile number input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
       specific CSS selectors or visual tests may be affected.
 * Fixed bug where `manuallySized` was not being set properly on column state.
 * Suppressed extra top border on Grids with `hideHeaders: true`.
+* Fixed bug where mobile `NumberInput` would clear when trying to enter decimals.
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
       specific CSS selectors or visual tests may be affected.
 * Fixed bug where `manuallySized` was not being set properly on column state.
 * Suppressed extra top border on Grids with `hideHeaders: true`.
-* Fixed bug where mobile `NumberInput` would clear when trying to enter decimals.
+* Fixed bug where mobile `NumberInput` would clear when trying to enter decimals on certain devices.
 
 ### ⚙️ Technical
 

--- a/mobile/cmp/input/NumberInput.ts
+++ b/mobile/cmp/input/NumberInput.ts
@@ -90,7 +90,6 @@ export const [NumberInput, numberInput] = hoistCmp.withFactory<NumberInputProps>
 class NumberInputModel extends HoistInputModel {
     override xhImpl = true;
 
-    static numericValidator = /((\.\d+)|(\d+(\.\d+)?))\b/i;
     static shorthandValidator = /((\.\d+)|(\d+(\.\d+)?))([kmb])\b/i;
 
     constructor() {
@@ -233,28 +232,20 @@ class NumberInputModel extends HoistInputModel {
 const cmp = hoistCmp.factory<NumberInputModel>(
     ({model, className, enableShorthandUnits, ...props}, ref) => {
         const {width, ...layoutProps} = getLayoutProps(props),
-            {hasFocus} = model,
             renderValue = model.formatRenderValue(model.renderValue),
-            inputMode = enableShorthandUnits ? 'text' : 'decimal',
-            // Constrain valid characters when editing values, but not when displaying formatted values.
-            pattern = !hasFocus
-                ? null
-                : enableShorthandUnits
-                ? NumberInputModel.shorthandValidator
-                : NumberInputModel.numericValidator;
+            inputMode = enableShorthandUnits ? 'text' : 'decimal';
 
+        // Using type=text rather than type=number, to support shorthand units and rich
+        // rendering but also because of issues with typing in decimal point (see #3450)
+        // Rely on inputMode, and Hoist's parsing to enforce numbers only.
         return input({
             inputMode,
-            pattern,
             className,
             value: renderValue,
             disabled: props.disabled,
-            min: props.min,
-            max: props.max,
             placeholder: props.placeholder,
             modifier: props.modifier,
             tabIndex: props.tabIndex,
-
             style: {
                 ...props.style,
                 ...layoutProps,


### PR DESCRIPTION
Mobile number input was previously using `type=number` to constrain input to numbers. Unfortunately, browser validation interprets decimals as non-numeric and clears the input. My best guess as to why this is a recent regression is that browsers have gotten stricter about complying with the spec.

According to the docs, it is better to user `type=text` and a regex pattern to constrain valid inputs: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#using_number_inputs

We can continue to rely on `inputMode` to bring up the correct device keyboard, and use the pattern to only allow either numeric characters or numeric + shorthand units.

See issue [3450](https://github.com/xh/hoist-react/issues/3450)

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

