### PR TITLE
Fix mobile dialog max-height constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
       specific CSS selectors or visual tests may be affected.
 * Fixed bug where `manuallySized` was not being set properly on column state.
 * Suppressed extra top border on Grids with `hideHeaders: true`.
+* Fixed bug where mobile `Dialog`'s max height was not properly constrained to the viewport.
 
 ### ⚙️ Technical
 

--- a/mobile/cmp/dialog/Dialog.scss
+++ b/mobile/cmp/dialog/Dialog.scss
@@ -5,16 +5,23 @@
     background-color: var(--xh-backdrop-bg);
   }
 
-  & > .dialog .dialog-container {
+  & > .dialog {
+    // Constrain max height on the outer container.
+    // vh units are unreliable on mobile, as they don't account for address bar / navigation.
     display: flex;
     flex-direction: column;
-    max-width: calc(100vw - var(--xh-pad-double-px));
-    max-height: calc(100vh - var(--xh-pad-double-px));
-    // Background on inner onsen container deliberately set to *border* color - this avoids small
-    // but noticeable gaps around the edges. The dialog body gets a defined background below for
-    // the actual contents of the component.
-    background-color: var(--xh-popup-border-color);
-    border: var(--xh-popup-border-width-px) solid var(--xh-popup-border-color);
+    max-height: calc(100% - var(--xh-pad-double-px));
+
+    .dialog-container {
+      display: flex;
+      flex-direction: column;
+      max-width: calc(100vw - var(--xh-pad-double-px));
+      // Background on inner onsen container deliberately set to *border* color - this avoids small
+      // but noticeable gaps around the edges. The dialog body gets a defined background below for
+      // the actual contents of the component.
+      background-color: var(--xh-popup-border-color);
+      border: var(--xh-popup-border-width-px) solid var(--xh-popup-border-color);
+    }
   }
 
   &__title {


### PR DESCRIPTION
Fix the mobile Dialog max height to styling to prevent it becoming taller than the visible viewport. See issue https://github.com/xh/hoist-react/issues/3451

We were previously using `vh` units to achieve a similar result... however, it turns out `vh` units don't account for the url bar or navigation. Webkit bug reports have been filed, but have been responded to with "wont fix": https://nicolas-hoizey.com/articles/2015/02/18/viewport-height-is-taller-than-the-visible-part-of-the-document-in-some-mobile-browsers/#february-23rd-update 🤷 

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

