### PR TITLE
Ensure `DashCanvas` layout updated if window resized while hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Flex inner title element added to `Panel` headers in v59.0, and set `display:flex` on the new
   element itself. Restores previous flexbox container behavior (when not L/R collapsed) for apps
   that are providing custom components as titles.
+* `DashCanvas` now properly updates its layout when shown if the browser window had been resized
+  while the component was hidden (e.g. in an inactive tab).
 
 ## 59.0.1 - 2023-08-17
 

--- a/desktop/cmp/dash/canvas/DashCanvas.ts
+++ b/desktop/cmp/dash/canvas/DashCanvas.ts
@@ -5,11 +5,13 @@
  * Copyright © 2023 Extremely Heavy Industries Inc.
  */
 import {ContextMenu} from '@blueprintjs/core';
+import composeRefs from '@seznam/compose-react-refs';
 import {div, vbox, vspacer} from '@xh/hoist/cmp/layout';
 import {elementFactory, hoistCmp, HoistProps, refreshContextView, uses, XH} from '@xh/hoist/core';
 import {dashCanvasAddViewButton} from '@xh/hoist/desktop/cmp/button/DashCanvasAddViewButton';
 import '@xh/hoist/desktop/register';
 import {Classes, overlay} from '@xh/hoist/kit/blueprint';
+import {useOnVisibleChange} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import ReactGridLayout, {WidthProvider} from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
@@ -36,9 +38,15 @@ export const [DashCanvas, dashCanvas] = hoistCmp.withFactory<DashCanvasProps>({
     className: 'xh-dash-canvas',
     model: uses(DashCanvasModel),
 
-    render({className, model}) {
+    render({className, model}, ref) {
         const isDraggable = !model.layoutLocked,
             isResizable = !model.layoutLocked;
+
+        ref = composeRefs(
+            ref,
+            model.ref,
+            useOnVisibleChange(viz => model.onVisibleChange(viz))
+        );
 
         return refreshContextView({
             model: model.refreshContextModel,
@@ -48,7 +56,7 @@ export const [DashCanvas, dashCanvas] = hoistCmp.withFactory<DashCanvasProps>({
                     isDraggable ? `${className}--draggable` : null,
                     isResizable ? `${className}--resizable` : null
                 ),
-                ref: model.ref,
+                ref,
                 onContextMenu: e => onContextMenu(e, model),
                 items: [
                     reactGridLayout({


### PR DESCRIPTION
* `DashCanvas` now properly updates its layout when shown if the browser window had been resized while the component was hidden (e.g. in an inactive tab).
* Fixes #3215

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

