### PR TITLE
Add flag to Column to sort nulls to the bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🎁 New Features
 
-* Added `Column.bottomNullSort` - when true, columms will always sort null values to the bottom,
+* Added `Column.sortToBottom` which supports always sorting specified values to the bottom,
   regardless of sort direction.
 
 ### 🐞 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## 59.2.0 - 2023-10-16
+## 60.0.0-SNAPSHOT - unreleased
 
 ### 🎁 New Features
 
 * Added `Column.sortToBottom` which supports always sorting specified values to the bottom,
   regardless of sort direction.
+
+## 59.2.0 - 2023-10-16
 
 ### 🐞 Bug Fixes
 * Fix to pass correct arguments to `ErrorMessageProps.actionFn` and `ErrorMessageProps.detailsFn`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 60.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* Added `Column.bottomNullSort` - when true, columms will always sort null values to the bottom,
+  regardless of sort direction.
+
 ### 🐞 Bug Fixes
 * Fix to pass correct arguments to `ErrorMessageProps.actionFn` and `ErrorMessageProps.detailsFn`
 * Better default error text in `ErrorMessage`

--- a/cmp/grid/GridSorter.ts
+++ b/cmp/grid/GridSorter.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2023 Extremely Heavy Industries Inc.
  */
-import {isNumber, isNil, isString, isEmpty, isFunction} from 'lodash';
+import {isNumber, isNil, isString} from 'lodash';
 
 export type GridSorterLike = GridSorterSpec | string | GridSorter;
 
@@ -49,38 +49,16 @@ export class GridSorter {
     }
 
     /** Comparator to use with instances of GridSorter.*/
-    comparator(v1: any, v2: any, sortToBottom: Array<any | ((v: any) => boolean)>) {
+    comparator(v1, v2) {
         if (this.abs) {
             v1 = isNumber(v1) ? Math.abs(v1) : v1;
             v2 = isNumber(v2) ? Math.abs(v2) : v2;
         }
-        return GridSorter.defaultComparator(v1, v2, sortToBottom, this.sort);
+        return GridSorter.defaultComparator(v1, v2);
     }
 
     /** Static comparator to use when a GridSorter instance is not available.*/
-    static defaultComparator(
-        v1: any,
-        v2: any,
-        sortToBottom: Array<any | ((v: any) => boolean)>,
-        sortDir: 'asc' | 'desc'
-    ) {
-        if (!isEmpty(sortToBottom)) {
-            let v1ToBottom = null,
-                v2ToBottom = null;
-
-            sortToBottom.forEach((it, idx) => {
-                const fn = isFunction(it) ? v => it(v) : v => v === it;
-                if (isNil(v1ToBottom) && fn(v1)) v1ToBottom = idx;
-                if (isNil(v2ToBottom) && fn(v2)) v2ToBottom = idx;
-            });
-
-            if (!isNil(v1ToBottom) && !isNil(v2ToBottom)) {
-                return (v1ToBottom - v2ToBottom) * (sortDir === 'asc' ? 1 : -1);
-            }
-            if (!isNil(v1ToBottom)) return sortDir === 'asc' ? 1 : -1;
-            if (!isNil(v2ToBottom)) return sortDir === 'asc' ? -1 : 1;
-        }
-
+    static defaultComparator(v1, v2) {
         if (isNil(v1) && isNil(v2)) return 0;
         if (isNil(v1)) return -1;
         if (isNil(v2)) return 1;

--- a/cmp/grid/GridSorter.ts
+++ b/cmp/grid/GridSorter.ts
@@ -49,19 +49,19 @@ export class GridSorter {
     }
 
     /** Comparator to use with instances of GridSorter.*/
-    comparator(v1, v2) {
+    comparator(v1: any, v2: any, bottomNull: boolean) {
         if (this.abs) {
             v1 = isNumber(v1) ? Math.abs(v1) : v1;
             v2 = isNumber(v2) ? Math.abs(v2) : v2;
         }
-        return GridSorter.defaultComparator(v1, v2);
+        return GridSorter.defaultComparator(v1, v2, bottomNull, this.sort);
     }
 
     /** Static comparator to use when a GridSorter instance is not available.*/
-    static defaultComparator(v1, v2) {
+    static defaultComparator(v1: any, v2: any, bottomNull: boolean, sortDir: 'asc' | 'desc') {
         if (isNil(v1) && isNil(v2)) return 0;
-        if (isNil(v1)) return -1;
-        if (isNil(v2)) return 1;
+        if (isNil(v1)) return bottomNull && sortDir === 'asc' ? 1 : -1;
+        if (isNil(v2)) return bottomNull && sortDir === 'asc' ? -1 : 1;
 
         if (v1.toNumber) v1 = v1.toNumber();
         if (v2.toNumber) v2 = v2.toNumber();


### PR DESCRIPTION
I'm not 100% sure on the flag name `bottomNullSort` - suggestions welcome

Apps that implement custom Column.comparators should *not* need to make any adjustments, as long as they fall back to the provided defaultComparator.

See Toolbox example: https://github.com/xh/toolbox/pull/678

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

