### PR TITLE
RelativeTimeStamp with localDateMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@
 
 ### 🎁 New Features
 
+* `RelativeTimestamp` component accepts new option `localDateMode` to calculate differences without time portions.
 * Added `Column.sortToBottom` which supports always sorting specified values to the bottom,
   regardless of sort direction.
+
+### 💥 Breaking Changes
+
+* `RelativeTimestamp` component's `ref` now returns object `{model, domEl}`.  An app that was using
+  `ref.current` to access the `RelativeTimestamp` DOM element should now get the DOM element through `ref.current.domEl`.  A survey of
+  known Hoist apps did not bring up any instances of `RelativeTimestamp`s `ref` being used, but we mention this
+  just in case.
 
 ## 59.2.0 - 2023-10-16
 

--- a/cmp/relativetimestamp/RelativeTimestamp.ts
+++ b/cmp/relativetimestamp/RelativeTimestamp.ts
@@ -4,7 +4,6 @@
  *
  * Copyright © 2023 Extremely Heavy Industries Inc.
  */
-import {MutableRefObject, useImperativeHandle} from 'react';
 import moment from 'moment';
 import {box, span} from '@xh/hoist/cmp/layout';
 import {
@@ -68,10 +67,6 @@ export interface RelativeTimestampOptions {
     localDateMode?: boolean;
 }
 
-export interface RelativeTimestampRef {
-    model: HoistModel & {lastRun: Date; relativeTo: Date | number};
-    domEl: HTMLElement;
-}
 /**
  * A component to display the approximate amount of time between a given timestamp and now in a
  * friendly, human readable format (e.g. '6 minutes ago' or 'two hours from now').
@@ -82,15 +77,8 @@ export const [RelativeTimestamp, relativeTimestamp] = hoistCmp.withFactory<Relat
     displayName: 'RelativeTimestamp',
     className: 'xh-relative-timestamp',
 
-    render(
-        {className, bind, timestamp, options, ...rest},
-        ref: MutableRefObject<RelativeTimestampRef | HTMLElement>
-    ) {
+    render({className, bind, timestamp, options, ...rest}, ref) {
         const impl = useLocalModel(RelativeTimestampLocalModel);
-        useImperativeHandle(ref, () => {
-            const domEl = ref.current as HTMLElement;
-            return {model: impl, domEl};
-        });
 
         return box({
             className,
@@ -109,7 +97,6 @@ class RelativeTimestampLocalModel extends HoistModel {
     override xhImpl = true;
 
     @observable display: string = '';
-    @observable lastRun: Date;
 
     model: HoistModel;
 
@@ -118,10 +105,6 @@ class RelativeTimestampLocalModel extends HoistModel {
         runFn: () => this.refreshDisplay(),
         interval: 5 * SECONDS
     });
-
-    get relativeTo(): Date | number {
-        return this.componentProps.options.relativeTo ?? this.lastRun;
-    }
 
     get timestamp(): Date | number {
         const {model} = this,
@@ -151,7 +134,6 @@ class RelativeTimestampLocalModel extends HoistModel {
     @action
     private refreshDisplay() {
         this.display = getRelativeTimestamp(this.timestamp, this.options);
-        this.lastRun = this.timer.lastRun;
     }
 }
 

--- a/cmp/relativetimestamp/RelativeTimestamp.ts
+++ b/cmp/relativetimestamp/RelativeTimestamp.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2023 Extremely Heavy Industries Inc.
  */
-import {useImperativeHandle} from 'react';
+import {MutableRefObject, useImperativeHandle} from 'react';
 import moment from 'moment';
 import {box, span} from '@xh/hoist/cmp/layout';
 import {
@@ -69,6 +69,10 @@ export interface RelativeTimestampOptions {
     localDateMode?: boolean;
 }
 
+export interface RelativeTimestampRef {
+    model: HoistModel & {lastRun: Date};
+    domEl: HTMLElement;
+}
 /**
  * A component to display the approximate amount of time between a given timestamp and now in a
  * friendly, human readable format (e.g. '6 minutes ago' or 'two hours from now').
@@ -79,9 +83,12 @@ export const [RelativeTimestamp, relativeTimestamp] = hoistCmp.withFactory<Relat
     displayName: 'RelativeTimestamp',
     className: 'xh-relative-timestamp',
 
-    render({className, ...props}, ref) {
+    render({className, ...props}, ref: MutableRefObject<RelativeTimestampRef | HTMLElement>) {
         const impl = useLocalModel(RelativeTimestampLocalModel);
-        useImperativeHandle(ref, () => impl);
+        useImperativeHandle(ref, () => {
+            const domEl = ref.current as HTMLElement;
+            return {model: impl, domEl};
+        });
 
         return box({
             className,

--- a/cmp/relativetimestamp/RelativeTimestamp.ts
+++ b/cmp/relativetimestamp/RelativeTimestamp.ts
@@ -119,7 +119,7 @@ class RelativeTimestampLocalModel extends HoistModel {
         interval: 5 * SECONDS
     });
 
-    get relativeTo() {
+    get relativeTo(): Date | number {
         return this.componentProps.options.relativeTo ?? this.lastRun;
     }
 


### PR DESCRIPTION
Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile: the changes are good on mobile.
- [x] Created Toolbox branch / PR:  https://github.com/xh/toolbox/tree/relativeTimeStampLocalDateMode 
 /  https://github.com/xh/toolbox/pull/680

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

This resolves issue #3507.
A `localDateMode` has been added to always present durations with days as the smallest unit, and to calculate diffs in whole days.

A fix has also been applied to override moment's humanize calculation even when `localDateMode` is false but the duration is determined by moment to be in days.  In this situation moment rounds days up when convention does not.   The fix brings the output back in line with convention.

Finally, the component's `ref` prop now returns an object with the model and domEl, rather than just the domEl.


**Changes in toolbox:**  

1. all of the component's options are now available to adjust via controls, as in this screenshot.
2. timestamp adjustment controls are now datepickers, that allow for more deliberate testing of specific scenarios.

<img width="916" alt="image" src="https://github.com/xh/hoist-react/assets/2573928/b08565a1-95f9-4a8d-967e-003bb367301c">

