### PR TITLE
RelativeTimeStamp localDateMode v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,11 @@
   regardless of sort direction.
 * `RelativeTimestamp` component accepts new option `localDateMode` to display differences based
    on calendar days.
+*
 ### 💥 Breaking Changes
 
 * The `XH.getActiveModels` method has been renamed to `XH.getModels` for clarity and consistency.
   This is not expected to impact applications.
-* `RelativeTimestamp` component's `ref` now returns object `{model, domEl}`.  An app that was using
-  `ref.current` to access the `RelativeTimestamp` DOM element should now get the DOM element through `ref.current.domEl`.  A survey of
-  known Hoist apps did not bring up any instances of `RelativeTimestamp`s `ref` being used, but we mention this
-  just in case.
 
 ## 59.2.0 - 2023-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@
 
 * Added `Column.sortToBottom` which supports always sorting specified values to the bottom,
   regardless of sort direction.
-* `RelativeTimestamp` component accepts new option `localDateMode` to calculate differences without time portions.
-
+* `RelativeTimestamp` component accepts new option `localDateMode` to display differences based
+   on calendar days.
 ### 💥 Breaking Changes
 
 * The `XH.getActiveModels` method has been renamed to `XH.getModels` for clarity and consistency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@
 
 ### 🎁 New Features
 
+* `RelativeTimestamp` component accepts new option `localDateMode` to calculate differences without time portions.
 * Added `Column.sortToBottom` which supports always sorting specified values to the bottom,
   regardless of sort direction.
+
+### 💥 Breaking Changes
+
+* `RelativeTimestamp` component's `ref` now returns object `{model, domEl}`.  An app that was using
+  `ref.current` to access the `RelativeTimestamp` DOM element should now get the DOM element through `ref.current.domEl`.  A survey of
+  known Hoist apps did not bring up any instances of `RelativeTimestamp`s `ref` being used, but we mention this
+  just in case.
 
 ## 59.2.0 - 2023-10-16
 

--- a/cmp/relativetimestamp/RelativeTimestamp.ts
+++ b/cmp/relativetimestamp/RelativeTimestamp.ts
@@ -4,7 +4,6 @@
  *
  * Copyright © 2023 Extremely Heavy Industries Inc.
  */
-import {MutableRefObject, useImperativeHandle} from 'react';
 import moment from 'moment';
 import {box, span} from '@xh/hoist/cmp/layout';
 import {
@@ -68,10 +67,6 @@ export interface RelativeTimestampOptions {
     localDateMode?: boolean;
 }
 
-export interface RelativeTimestampRef {
-    model: HoistModel & {lastRun: Date; relativeTo: Date | number};
-    domEl: HTMLElement;
-}
 /**
  * A component to display the approximate amount of time between a given timestamp and now in a
  * friendly, human readable format (e.g. '6 minutes ago' or 'two hours from now').
@@ -82,15 +77,8 @@ export const [RelativeTimestamp, relativeTimestamp] = hoistCmp.withFactory<Relat
     displayName: 'RelativeTimestamp',
     className: 'xh-relative-timestamp',
 
-    render(
-        {className, bind, timestamp, options, ...rest},
-        ref: MutableRefObject<RelativeTimestampRef | HTMLElement>
-    ) {
+    render({className, bind, timestamp, options, ...rest}, ref) {
         const impl = useLocalModel(RelativeTimestampLocalModel);
-        useImperativeHandle(ref, () => {
-            const domEl = ref.current as HTMLElement;
-            return {model: impl, domEl};
-        });
 
         return box({
             className,
@@ -109,7 +97,6 @@ class RelativeTimestampLocalModel extends HoistModel {
     override xhImpl = true;
 
     @observable display: string = '';
-    @observable lastRun: Date;
 
     model: HoistModel;
 
@@ -118,10 +105,6 @@ class RelativeTimestampLocalModel extends HoistModel {
         runFn: () => this.refreshDisplay(),
         interval: 5 * SECONDS
     });
-
-    get relativeTo(): Date | number {
-        return this.componentProps.options.relativeTo ?? this.lastRun;
-    }
 
     get timestamp(): Date | number {
         const {model} = this,
@@ -151,7 +134,6 @@ class RelativeTimestampLocalModel extends HoistModel {
     @action
     private refreshDisplay() {
         this.display = getRelativeTimestamp(this.timestamp, this.options);
-        this.lastRun = this.timer.lastRun;
     }
 }
 

--- a/cmp/relativetimestamp/RelativeTimestamp.ts
+++ b/cmp/relativetimestamp/RelativeTimestamp.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2023 Extremely Heavy Industries Inc.
  */
-import {useImperativeHandle} from 'react';
+import {MutableRefObject, useImperativeHandle} from 'react';
 import moment from 'moment';
 import {box, span} from '@xh/hoist/cmp/layout';
 import {
@@ -69,6 +69,10 @@ export interface RelativeTimestampOptions {
     localDateMode?: boolean;
 }
 
+export interface RelativeTimestampRef {
+    model: HoistModel & {lastRun: Date};
+    domEl: HTMLElement;
+}
 /**
  * A component to display the approximate amount of time between a given timestamp and now in a
  * friendly, human readable format (e.g. '6 minutes ago' or 'two hours from now').
@@ -79,9 +83,12 @@ export const [RelativeTimestamp, relativeTimestamp] = hoistCmp.withFactory<Relat
     displayName: 'RelativeTimestamp',
     className: 'xh-relative-timestamp',
 
-    render({className, ...props}, ref) {
+    render({className, ...props}, ref: MutableRefObject<RelativeTimestampRef | HTMLElement>) {
         const impl = useLocalModel(RelativeTimestampLocalModel);
-        useImperativeHandle(ref, () => impl);
+        useImperativeHandle(ref, () => {
+            const domEl = ref.current as HTMLElement;
+            return {model: impl, domEl};
+        });
 
         return box({
             className,

--- a/cmp/relativetimestamp/RelativeTimestamp.ts
+++ b/cmp/relativetimestamp/RelativeTimestamp.ts
@@ -119,7 +119,7 @@ class RelativeTimestampLocalModel extends HoistModel {
         interval: 5 * SECONDS
     });
 
-    get relativeTo() {
+    get relativeTo(): Date | number {
         return this.componentProps.options.relativeTo ?? this.lastRun;
     }
 


### PR DESCRIPTION
This is a refactor of Colin's work in the related branch, that I think better clarifies what we are doing, and how it differs from Moment.

Am curious if folks think we really need the mode 'limited' -- could either discard completely, or fold in to default as Colin has done.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

