### PR TITLE
Maintain focus on textInput on textInput clearButton click.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@
 
  * Added `Column.sortToBottom` which supports always sorting specified values to the bottom,
   regardless of sort direction.
- * Clicking on the right hand clear button in a `textInput` now maintains focus on the `textInput`,
-   allowing a user to quickly type something else into the field.  This behaviour already existed
-   on the `select` input.
+ * Clicking on the right hand clear button in a `textInput` (desktop and mobile)
+   now maintains focus on the `textInput`, allowing a user to quickly type something else into
+   the field.  This behaviour already existed on the `select` input.
 
 ### 💥 Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 
  * Added `Column.sortToBottom` which supports always sorting specified values to the bottom,
   regardless of sort direction.
+ * Clicking on the right hand clear button in a `textInput` now maintains focus on the `textInput`,
+   allowing a user to quickly type something else into the field.  This behaviour already existed
+   on the `select` input.
 
 ### 💥 Breaking Changes
 

--- a/desktop/cmp/input/TextInput.ts
+++ b/desktop/cmp/input/TextInput.ts
@@ -174,6 +174,7 @@ const clearButton = hoistCmp.factory<TextInputModel>(({model}) =>
         onClick: () => {
             model.noteValueChange(null);
             model.doCommit();
+            model.focus();
         }
     })
 );

--- a/mobile/cmp/input/TextInput.ts
+++ b/mobile/cmp/input/TextInput.ts
@@ -150,6 +150,7 @@ const clearButton = hoistCmp.factory<TextInputModel>(({model}) =>
         onClick: () => {
             model.noteValueChange(null);
             model.doCommit();
+            model.focus();
         }
     })
 );


### PR DESCRIPTION
Clicking on the right hand clear button in a `textInput` (mobile or desktop) now maintains focus on the `textInput`,
allowing a user to quickly type something else into the field.  This behaviour already existed
on the `select` input.

The loss of focus is really annoying when using the storeFilterField.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes: not a breaking change.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile: change applied to mobile, too.  Tested.
- [x] Created Toolbox branch / PR:  not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

