### PR TITLE
Avoid spurious model lookup context changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
 * The `XH.getActiveModels` method has been renamed to `XH.getModels` for clarity and consistency.
   This is not expected to impact applications.
 
+### ⚙️ Technical
+
+* Performance improvement to `HoistComponent`:  Prevent unnecessary re-renderings resulting from
+spurious model lookup changes.
+
 ## 59.2.0 - 2023-10-16
 
 ### 🐞 Bug Fixes

--- a/core/HoistComponent.ts
+++ b/core/HoistComponent.ts
@@ -326,7 +326,7 @@ function wrapWithModel(render: RenderFn, cfg: Config): RenderFn {
                 delete props.modelRef;
                 delete props.modelConfig;
                 ctx.props = props;
-                ctx.modelLookup = insertLookup ?? modelLookup;
+                ctx.modelLookup = insertLookup?.current ?? modelLookup;
                 useOnMount(() => instanceManager.registerModelWithTestId(props.testId, model));
                 useOnUnmount(() => instanceManager.unregisterModelWithTestId(props.testId));
                 return render(props, ref);
@@ -341,7 +341,9 @@ function wrapWithModel(render: RenderFn, cfg: Config): RenderFn {
             ? managedRender()
             : createElement(HostCmp, {managedRender, key: model?.xhId});
 
-        return insertLookup ? modelLookupContextProvider({value: insertLookup, item: ret}) : ret;
+        return insertLookup?.current
+            ? modelLookupContextProvider({value: insertLookup.current, item: ret})
+            : ret;
     };
 }
 

--- a/core/HoistComponent.ts
+++ b/core/HoistComponent.ts
@@ -299,16 +299,23 @@ function wrapWithModel(render: RenderFn, cfg: Config): RenderFn {
             ].join(' | ');
         });
 
-        // 3) Create any new lookup context that needs to be established
-        // Avoid adding extra context if this model already in default context.
-        const newLookup =
+        // 3) insert any new lookup context that needs to be established.  Avoid adding if default
+        // model not changing; cache object to avoid triggering re-renders in context children
+        const insertLookup = useRef<ModelLookup>(null);
+        if (
             !publishNone &&
             model &&
             (!modelLookup ||
                 !fromContext ||
                 (publishDefault && modelLookup.lookupModel('*') !== model))
-                ? new ModelLookup(model, modelLookup, publishMode)
-                : null;
+        ) {
+            const {current} = insertLookup;
+            if (current?.model != model || current?.parent != modelLookup) {
+                insertLookup.current = new ModelLookup(model, modelLookup, publishMode);
+            }
+        } else {
+            insertLookup.current = null;
+        }
 
         // 4) Get the rendering of the component with its model context
         // 4a) Create a generic render function, that can be called immediately, or in wrapped component.
@@ -319,7 +326,7 @@ function wrapWithModel(render: RenderFn, cfg: Config): RenderFn {
                 delete props.modelRef;
                 delete props.modelConfig;
                 ctx.props = props;
-                ctx.modelLookup = newLookup ?? modelLookup;
+                ctx.modelLookup = insertLookup ?? modelLookup;
                 useOnMount(() => instanceManager.registerModelWithTestId(props.testId, model));
                 useOnUnmount(() => instanceManager.unregisterModelWithTestId(props.testId));
                 return render(props, ref);
@@ -334,7 +341,7 @@ function wrapWithModel(render: RenderFn, cfg: Config): RenderFn {
             ? managedRender()
             : createElement(HostCmp, {managedRender, key: model?.xhId});
 
-        return newLookup ? modelLookupContextProvider({value: newLookup, item: ret}) : ret;
+        return insertLookup ? modelLookupContextProvider({value: insertLookup, item: ret}) : ret;
     };
 }
 

--- a/core/HoistComponent.ts
+++ b/core/HoistComponent.ts
@@ -326,7 +326,7 @@ function wrapWithModel(render: RenderFn, cfg: Config): RenderFn {
                 delete props.modelRef;
                 delete props.modelConfig;
                 ctx.props = props;
-                ctx.modelLookup = insertLookup?.current ?? modelLookup;
+                ctx.modelLookup = insertLookup.current ?? modelLookup;
                 useOnMount(() => instanceManager.registerModelWithTestId(props.testId, model));
                 useOnUnmount(() => instanceManager.unregisterModelWithTestId(props.testId));
                 return render(props, ref);
@@ -341,7 +341,7 @@ function wrapWithModel(render: RenderFn, cfg: Config): RenderFn {
             ? managedRender()
             : createElement(HostCmp, {managedRender, key: model?.xhId});
 
-        return insertLookup?.current
+        return insertLookup.current
             ? modelLookupContextProvider({value: insertLookup.current, item: ret})
             : ret;
     };


### PR DESCRIPTION
Thanks to Colin for finding this problem.    

useContext will force a re-render whenever it value changes -- we were changing the object reference of our ModelLookup object every time we rendered it, leading to a cascade of spurious re-renders throughout the hierarchy below.

Think the not-so recent (oct. 2022) changes to TabContainer to include a RefereshContext exacerbated this problem such that components on hidden tabs  were also re-rendering on tab switch.

To see the effect of this change, simply put a console log statement in any render method within a tab and start switching tabs in the tab container.  

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

