### PR TITLE
Prevent 'mousedown' events within Select from closing Popovers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
   multi-line full-width rows. Each row is broken into four zones for top/bottom and left/right,
   each of which can mapped to render one or more fields.
 
+### 🐞 Bug Fixes
+
+* Fixed bug where interacting with a `Select` within a `Popover` can inadvertently cause the
+  popover to close. If your app already has special handling in place to prevent this, you should
+  be able to unwind it after upgrading.
+
 ### 💥 Breaking Changes
 
 * The `XH.getActiveModels` method has been renamed to `XH.getModels` for clarity and consistency.

--- a/desktop/cmp/button/ZoneMapperButton.ts
+++ b/desktop/cmp/button/ZoneMapperButton.ts
@@ -13,7 +13,6 @@ import {zoneMapper} from '@xh/hoist/desktop/cmp/zoneGrid/impl/ZoneMapper';
 import {Icon} from '@xh/hoist/icon';
 import {popover, Position} from '@xh/hoist/kit/blueprint';
 import {stopPropagation, withDefault} from '@xh/hoist/utils/js';
-import {MENU_PORTAL_ID} from '@xh/hoist/desktop/cmp/input';
 import {button, ButtonProps} from './Button';
 
 export interface ZoneMapperButtonProps extends ButtonProps {
@@ -71,18 +70,11 @@ export const [ZoneMapperButton, zoneMapperButton] = hoistCmp.withFactory<ZoneMap
                     zoneMapper({model: mapperModel})
                 ]
             }),
-            onInteraction: (willOpen, e?) => {
-                if (isOpen && !willOpen) {
-                    // Prevent clicks with Select controls from closing popover
-                    const selectPortal = document.getElementById(MENU_PORTAL_ID),
-                        selectPortalClick = selectPortal?.contains(e?.target),
-                        selectValueClick = e?.target?.classList.contains('xh-select__single-value');
-
-                    if (!selectPortalClick && !selectValueClick) {
-                        mapperModel.close();
-                    }
-                } else if (!isOpen && willOpen) {
+            onInteraction: (nextOpenState, e) => {
+                if (nextOpenState) {
                     mapperModel.openPopover();
+                } else {
+                    mapperModel.close();
                 }
             }
         });

--- a/desktop/cmp/grouping/GroupingChooser.ts
+++ b/desktop/cmp/grouping/GroupingChooser.ts
@@ -8,13 +8,13 @@ import {GroupingChooserModel} from '@xh/hoist/cmp/grouping';
 import {box, div, filler, fragment, hbox, vbox} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
 import {button, ButtonProps} from '@xh/hoist/desktop/cmp/button';
-import {MENU_PORTAL_ID, select} from '@xh/hoist/desktop/cmp/input';
+import {select} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import '@xh/hoist/desktop/register';
 import {Icon} from '@xh/hoist/icon';
 import {menu, menuDivider, menuItem, popover} from '@xh/hoist/kit/blueprint';
 import {dragDropContext, draggable, droppable} from '@xh/hoist/kit/react-beautiful-dnd';
-import {getTestId, TEST_ID} from '@xh/hoist/utils/js';
+import {elemWithin, getTestId, TEST_ID} from '@xh/hoist/utils/js';
 import {splitLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {compact, isEmpty, sortBy} from 'lodash';
@@ -117,7 +117,7 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory<GroupingC
                         isOpen &&
                         nextOpenState === false &&
                         e?.target &&
-                        !targetIsControlButtonOrPortal(e.target)
+                        !elemWithin(e.target, 'xh-grouping-chooser-button--with-favorites')
                     ) {
                         model.commitPendingValueAndClose();
                     }
@@ -303,23 +303,6 @@ function getDimOptions(dims, model) {
         return {value: dimName, label: model.getDimDisplayName(dimName)};
     });
     return sortBy(ret, 'label');
-}
-
-function targetIsControlButtonOrPortal(target) {
-    const selectPortal = document.getElementById(MENU_PORTAL_ID)?.contains(target),
-        selectClick = targetWithin(target, 'xh-select__single-value'),
-        editorClick = targetWithin(target, 'xh-grouping-chooser-button--with-favorites');
-    return selectPortal || selectClick || editorClick;
-}
-
-/**
- * Determines whether any of the target's parents have a specific class name
- */
-function targetWithin(target, className): boolean {
-    for (let elem = target; elem; elem = elem.parentElement) {
-        if (elem.classList.contains(className)) return true;
-    }
-    return false;
 }
 
 //------------------

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -28,7 +28,7 @@ import {
 } from '@xh/hoist/kit/react-select';
 import {action, bindable, makeObservable, observable, override} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
-import {getTestId, TEST_ID, throwIf, withDefault} from '@xh/hoist/utils/js';
+import {elemWithin, getTestId, TEST_ID, throwIf, withDefault} from '@xh/hoist/utils/js';
 import {createObservableRef, getLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import debouncePromise from 'debounce-promise';
@@ -786,6 +786,15 @@ const cmp = hoistCmp.factory<SelectInputModel>(({model, className, ...props}, re
             // note: menuIsOpen will be undefined on AsyncSelect due to a react-select bug.
             const menuIsOpen = model.reactSelect?.state?.menuIsOpen;
             if (menuIsOpen && (e.key === 'Escape' || e.key === 'Enter')) {
+                e.stopPropagation();
+            }
+        },
+        onMouseDown: e => {
+            // Some internal elements, like the dropdown indicator and the rendered single value,
+            // fire 'mousedown' events. These can bubble and inadvertently close Popovers that
+            // contain Selects.
+            const target = e?.target as HTMLElement;
+            if (target && elemWithin(target, 'bp4-popover')) {
                 e.stopPropagation();
             }
         },

--- a/utils/js/DomUtils.ts
+++ b/utils/js/DomUtils.ts
@@ -92,7 +92,7 @@ export function observeVisibleChange(fn: (visible: boolean) => any, node: Elemen
 }
 
 /**
- * Determines whether an element has a parent with a specific class name
+ * Determines whether an element has an ancestor with a specific class name
  */
 export function elemWithin(target: HTMLElement, className: string): boolean {
     for (let elem = target; elem; elem = elem.parentElement) {

--- a/utils/js/DomUtils.ts
+++ b/utils/js/DomUtils.ts
@@ -92,6 +92,16 @@ export function observeVisibleChange(fn: (visible: boolean) => any, node: Elemen
 }
 
 /**
+ * Determines whether an element has a parent with a specific class name
+ */
+export function elemWithin(target: HTMLElement, className: string): boolean {
+    for (let elem = target; elem; elem = elem.parentElement) {
+        if (elem.classList.contains(className)) return true;
+    }
+    return false;
+}
+
+/**
  * A convenience handler that will call 'stopPropagation'
  * and 'preventDefault' on an event.
  */


### PR DESCRIPTION
Prevent 'mousedown' events within Select from closing Popovers.
See issue https://github.com/xh/hoist-react/issues/3516

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

