### PR TITLE
TS Fix: allow `string | number`, not just `number` on StoreFilterField `width` prop

### DIFF
--- a/cmp/store/StoreFilterField.ts
+++ b/cmp/store/StoreFilterField.ts
@@ -75,8 +75,8 @@ export interface StoreFilterFieldProps extends DefaultHoistProps {
      */
     store?: Store;
 
-    /** Width of the input in pixels. */
-    width?: number;
+    /** Width of the input in pixels or string with unit. */
+    width?: string | number;
 }
 
 /**


### PR DESCRIPTION
TS Fix: allow "string | number", not just "number" on StoreFilterField "width" prop, since underlying TextInput in desktop and mobile takes "string | number" for "width".   A string width like '100%' can be useful when the StoreFilterField is the only field in a narrow "picker" grid's toolbar, and you want the field's width to adjust with the user's adjustment of the grid panel width, so that the field's clear button always stays visible.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry:not required, just a TS fix
- [X] Reviewed for breaking changes: not a breaking change
- [X] Updated doc comments / prop-types: docs updated
- [X] Reviewed and tested on Mobile: reviewed, testing not required.
- [X] Created Toolbox branch: not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.