### PR TITLE
Fix bug where `SplitTreeMap` would not render errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Below are breaking changes that most apps will need to address:
 ### 🐞 Bug Fixes
 
 * ZoneGrid columns' renders always need to be marked as complex
+* Fixed bug where `ErrorMessage` would not render if only a `message` was provided.
 
 
 ## 62.0.1 - 2024-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Below are breaking changes that most apps will need to address:
 ### 🐞 Bug Fixes
 
 * ZoneGrid columns' renders always need to be marked as complex
-* Fixed bug where `ErrorMessage` would not render if only a `message` was provided.
+* Fixed bug where `SplitTreeMap` would not properly render errors as intended.
 
 
 ## 62.0.1 - 2024-03-28

--- a/desktop/cmp/error/ErrorMessage.ts
+++ b/desktop/cmp/error/ErrorMessage.ts
@@ -72,7 +72,7 @@ export const [ErrorMessage, errorMessage] = hoistCmp.withFactory<ErrorMessagePro
             ...rest
         } = props;
 
-        if (isNil(error) && !message) return null;
+        if (isNil(error)) return null;
 
         if (!message) {
             if (isString(error)) {

--- a/desktop/cmp/error/ErrorMessage.ts
+++ b/desktop/cmp/error/ErrorMessage.ts
@@ -72,7 +72,7 @@ export const [ErrorMessage, errorMessage] = hoistCmp.withFactory<ErrorMessagePro
             ...rest
         } = props;
 
-        if (isNil(error)) return null;
+        if (isNil(error) && !message) return null;
 
         if (!message) {
             if (isString(error)) {

--- a/desktop/cmp/treemap/SplitTreeMap.ts
+++ b/desktop/cmp/treemap/SplitTreeMap.ts
@@ -126,5 +126,5 @@ const mapTitle = hoistCmp.factory<SplitTreeMapModel>(({model, isPrimary}) => {
 });
 
 const errorPanel = hoistCmp.factory(({errors}) =>
-    errorMessage({message: fragment(errors.map(e => p(e)))})
+    errorMessage({error: errors.join(' '), message: fragment(errors.map(e => p(e)))})
 );


### PR DESCRIPTION
… provided

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

