### PR TITLE
Upgrade ag-grid to 31.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * ag-grid removed `ColumnApi`.  Most methods that were on `ColumnApi` are now on `GridApi`.
   As a result, Hoist-React has removed the `agColumnApi` from the `GridModel`
   Apps that use `agColumnApi` will need to update to use `agApi` instead.
+  Many methods on `agApi` are replaced with `agApi.setGridOption('property', value)`.
   All apps will need to update their ag-grid version fetch as per this [Toolbox example](https://github.com/xh/toolbox/pull/709/files/5626e21d778e1fc72f9735d2d8f011513e1ac9c6#diff-304055320a29f66ea1255446ba8f13e0f3f1b13643bcea0c0466aa60e9288a8f).
   See [What's New in AG Grid 31](https://blog.ag-grid.com/whats-new-in-ag-grid-31/) and [Upgrading to AG Grid 31](https://www.ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-31/?ref=blog.ag-grid.com) for more details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * ag-grid removed `ColumnApi`.  Most methods that were on `ColumnApi` are now on `GridApi`.
   As a result, Hoist-React has removed the `agColumnApi` from the `GridModel`
   Apps that use `agColumnApi` will need to update to use `agApi` instead.
-  Many methods on `agApi` are replaced with `agApi.setGridOption('property', value)`.
+  Many methods on `agApi` are replaced with `agApi.updateGridOptions({property: value})`.
   All apps will need to update their ag-grid version fetch as per this [Toolbox example](https://github.com/xh/toolbox/pull/709/files/5626e21d778e1fc72f9735d2d8f011513e1ac9c6#diff-304055320a29f66ea1255446ba8f13e0f3f1b13643bcea0c0466aa60e9288a8f).
   See [What's New in AG Grid 31](https://blog.ag-grid.com/whats-new-in-ag-grid-31/) and [Upgrading to AG Grid 31](https://www.ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-31/?ref=blog.ag-grid.com) for more details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * ag-grid removed `ColumnApi`.  Most methods that were on `ColumnApi` are now on `GridApi`.
   As a result, Hoist-React has removed the `agColumnApi` from the `GridModel`
   Apps that use `agColumnApi` will need to update to use `agApi` instead.
+  All apps will need to update their ag-grid version fetch as per this [Toolbox example](https://github.com/xh/toolbox/pull/709/files/5626e21d778e1fc72f9735d2d8f011513e1ac9c6#diff-304055320a29f66ea1255446ba8f13e0f3f1b13643bcea0c0466aa60e9288a8f).
   See [What's New in AG Grid 31](https://blog.ag-grid.com/whats-new-in-ag-grid-31/) and [Upgrading to AG Grid 31](https://www.ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-31/?ref=blog.ag-grid.com) for more details.
 
 ### 📚 Libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ### 💥 Breaking Changes
 * Requires update to `hoist-core >= 20.0.0`.
+* Requires update to `@ag-grid >= 31.x`.
+* ag-grid removed `ColumnApi`.  Most methods that were on `ColumnApi` are now on `GridApi`.
+  As a result, Hoist-React has removed the `agColumnApi` from the `GridModel`
+  Apps that use `agColumnApi` will need to update to use `agApi` instead.
+  See [What's New in AG Grid 31](https://blog.ag-grid.com/whats-new-in-ag-grid-31/) and [Upgrading to AG Grid 31](https://www.ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-31/?ref=blog.ag-grid.com) for more details.
+
+### 📚 Libraries
+
+* @ag-grid `30.x -> 31.x`
 
 ## 63.0.1 - 2024-04-05
 
@@ -15,7 +24,7 @@
 * New filterable fields exposed in the Admin Console for `ActivityTracking` and `ClientErrors` modules.
     * `url`, `appEnvironment`, `appVersion` in `ActivityTracking`
     * `impersonating` in `ClientErrors`
-    * 
+
 
 ## 63.0.0 - 2024-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### 💥 Breaking Changes
 
+* `HoistComponent` prop `model` removed. Use the `modelConfig` prop instead.  Put another way,
+   use the `modelConfig` prop, not the `model` prop, when passing
+   a model constructor configuration object to a component as prop.
 * Requires update to `hoist-core >= 20.0.0`.
 * Requires update to `@ag-grid >= 31.x`.
 * ag-grid removed `ColumnApi`.  Most methods that were on `ColumnApi` are now on `GridApi`.

--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -66,8 +66,7 @@
     }
   }
   &--hide-headers .ag-header {
-    border-bottom-width: 0;
-    min-height: 0 !important;
+    display: none;
   }
 
   //------------------------

--- a/cmp/ag-grid/AgGrid.ts
+++ b/cmp/ag-grid/AgGrid.ts
@@ -168,7 +168,7 @@ class AgGridLocalModel extends HoistModel {
         if (isNil(this.componentProps.headerHeight)) {
             this.addReaction({
                 track: () => [model.agApi, this.headerHeight],
-                run: ([api, headerHeight]) => api?.setHeaderHeight(headerHeight)
+                run: ([api, headerHeight]) => api?.updateGridOptions({headerHeight})
             });
         }
     }

--- a/cmp/ag-grid/AgGridModel.ts
+++ b/cmp/ag-grid/AgGridModel.ts
@@ -205,7 +205,7 @@ export class AgGridModel extends HoistModel {
      * Some of the state may be data-dependent. Specifically the expandState and filterState. It is
      * recommended that applications wait until the data has been loaded in the grid before setting
      * the state if including those elements. This method can be called immediately after the data
-     * has been loaded via agApi.setRowData
+     * has been loaded via agApi.setGridOption('rowData', data).
      */
     setState(state: AgGridState) {
         this.throwIfNotReady();
@@ -573,7 +573,7 @@ export class AgGridModel extends HoistModel {
      */
     setPinnedTopRowData(data: PlainObject[]) {
         this.throwIfNotReady();
-        this.agApi.setPinnedTopRowData(data);
+        this.agApi.setGridOption('pinnedTopRowData', data);
     }
 
     /**

--- a/cmp/ag-grid/AgGridModel.ts
+++ b/cmp/ag-grid/AgGridModel.ts
@@ -205,7 +205,7 @@ export class AgGridModel extends HoistModel {
      * Some of the state may be data-dependent. Specifically the expandState and filterState. It is
      * recommended that applications wait until the data has been loaded in the grid before setting
      * the state if including those elements. This method can be called immediately after the data
-     * has been loaded via agApi.setGridOption('rowData', data).
+     * has been loaded via agApi.updateGridOptions({rowData: data}).
      */
     setState(state: AgGridState) {
         this.throwIfNotReady();
@@ -573,7 +573,7 @@ export class AgGridModel extends HoistModel {
      */
     setPinnedTopRowData(data: PlainObject[]) {
         this.throwIfNotReady();
-        this.agApi.setGridOption('pinnedTopRowData', data);
+        this.agApi.updateGridOptions({pinnedTopRowData: data});
     }
 
     /**
@@ -590,7 +590,7 @@ export class AgGridModel extends HoistModel {
      */
     setPinnedBottomRowData(data: PlainObject[]) {
         this.throwIfNotReady();
-        this.agApi.setPinnedBottomRowData(data);
+        this.agApi.updateGridOptions({pinnedBottomRowData: data});
     }
 
     /**

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -346,9 +346,9 @@ export class GridLocalModel extends HoistModel {
     sortReaction() {
         const {model} = this;
         return {
-            track: () => [model.agColumnApi, model.sortBy],
-            run: ([colApi, sortBy]) => {
-                if (colApi && !model.externalSort) {
+            track: () => [model.agApi, model.sortBy],
+            run: ([agApi, sortBy]) => {
+                if (agApi && !model.externalSort) {
                     model.agGridModel.applySortBy(sortBy);
                 }
             }
@@ -358,9 +358,9 @@ export class GridLocalModel extends HoistModel {
     groupReaction() {
         const {model} = this;
         return {
-            track: () => [model.agColumnApi, model.groupBy],
-            run: ([colApi, groupBy]) => {
-                if (colApi) colApi.setRowGroupColumns(groupBy);
+            track: () => [model.agApi, model.groupBy],
+            run: ([agApi, groupBy]) => {
+                if (agApi) agApi.setRowGroupColumns(groupBy);
             }
         };
     }
@@ -428,9 +428,9 @@ export class GridLocalModel extends HoistModel {
 
     applyScrollOptimization() {
         if (!this.useScrollOptimization) return;
-        const {agApi, agColumnApi} = this.model,
+        const {agApi} = this.model,
             {getRowHeight} = this.agOptions,
-            params = {api: agApi, columnApi: agColumnApi, context: null} as any;
+            params = {api: agApi, context: null} as any;
 
         agApi.forEachNode(node => {
             params.node = node;
@@ -457,11 +457,11 @@ export class GridLocalModel extends HoistModel {
     columnStateReaction() {
         const {model} = this;
         return {
-            track: () => [model.agApi, model.agColumnApi, model.columnState],
-            run: ([api, colApi, colState]) => {
-                if (!api || !colApi) return;
+            track: () => [model.agApi, model.columnState],
+            run: ([api, colState]) => {
+                if (!api) return;
 
-                const agColState = colApi.getColumnState();
+                const agColState = api.getColumnState();
 
                 // 0) Insert the auto group col state if it exists, since we won't have it in our column state list
                 const autoColState = agColState.find(c => c.colId === 'ag-Grid-AutoColumn');
@@ -482,15 +482,15 @@ export class GridLocalModel extends HoistModel {
                             id = col.colId;
 
                         if (agCol.width !== col.width) {
-                            colApi.setColumnWidth(id, col.width);
+                            api.setColumnWidth(id, col.width);
                             hasChanges = true;
                         }
                         if (agCol.hide !== col.hidden) {
-                            colApi.setColumnVisible(id, !col.hidden);
+                            api.setColumnVisible(id, !col.hidden);
                             hasChanges = true;
                         }
                         if (agCol.pinned !== col.pinned) {
-                            colApi.setColumnPinned(id, col.pinned);
+                            api.setColumnPinned(id, col.pinned);
                             hasChanges = true;
                         }
                     });
@@ -498,7 +498,7 @@ export class GridLocalModel extends HoistModel {
                     // We need to tell agGrid to refresh its flexed column sizes due to
                     // a regression introduced in 25.1.0.  See #2341
                     if (hasChanges) {
-                        colApi.columnModel.refreshFlexedColumns({
+                        api.columnModel.refreshFlexedColumns({
                             updateBodyWidths: true,
                             fireResizedEvent: true
                         });
@@ -521,7 +521,7 @@ export class GridLocalModel extends HoistModel {
                 });
 
                 this.doWithPreservedState({expansion: false}, () => {
-                    colApi.applyColumnState({state: colState, applyOrder: true});
+                    api.applyColumnState({state: colState, applyOrder: true});
                 });
             }
         };
@@ -726,7 +726,7 @@ export class GridLocalModel extends HoistModel {
 
     // Catches column re-ordering, resizing AND pinning via user drag-and-drop interaction.
     onDragStopped = ev => {
-        this.model.noteAgColumnStateChanged(ev.columnApi.getColumnState());
+        this.model.noteAgColumnStateChanged(ev.api.getColumnState());
     };
 
     // Catches column resizing on call to autoSize API.
@@ -734,17 +734,17 @@ export class GridLocalModel extends HoistModel {
         if (!isDisplayed(this.viewRef.current) || !ev.finished) return;
         if (ev.source === 'uiColumnResized') {
             const colId = ev.columns[0].colId,
-                width = ev.columnApi.getColumnState().find(it => it.colId === colId)?.width;
+                width = ev.api.getColumnState().find(it => it.colId === colId)?.width;
             this.model.noteColumnManuallySized(colId, width);
         } else if (ev.source === 'autosizeColumns') {
-            this.model.noteAgColumnStateChanged(ev.columnApi.getColumnState());
+            this.model.noteAgColumnStateChanged(ev.api.getColumnState());
         }
     };
 
     // Catches row group changes triggered from ag-grid ui components
     onColumnRowGroupChanged = ev => {
         if (ev.source !== 'api' && ev.source !== 'uiColumnDragged') {
-            this.model.setGroupBy(ev.columnApi.getRowGroupColumns().map(it => it.colId));
+            this.model.setGroupBy(ev.api.getRowGroupColumns().map(it => it.colId));
         }
     };
 
@@ -755,14 +755,14 @@ export class GridLocalModel extends HoistModel {
     // Catches column pinning changes triggered from ag-grid ui components
     onColumnPinned = ev => {
         if (ev.source !== 'api' && ev.source !== 'uiColumnDragged') {
-            this.model.noteAgColumnStateChanged(ev.columnApi.getColumnState());
+            this.model.noteAgColumnStateChanged(ev.api.getColumnState());
         }
     };
 
     // Catches column visibility changes triggered from ag-grid ui components
     onColumnVisible = ev => {
         if (ev.source !== 'api' && ev.source !== 'uiColumnDragged') {
-            this.model.noteAgColumnStateChanged(ev.columnApi.getColumnState());
+            this.model.noteAgColumnStateChanged(ev.api.getColumnState());
         }
     };
 

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -186,10 +186,6 @@ export class GridLocalModel extends HoistModel {
             {clicksToEdit, selModel} = model;
 
         let ret: GridOptions = {
-            // reactiveCustomComponents is required until ag-grid v32.
-            // In v32, `reactiveCustomComponents: true` will be the default.
-            // See https://www.ag-grid.com/javascript-data-grid//grid-options/#reference-miscellaneous-reactiveCustomComponents
-            reactiveCustomComponents: true,
             animateRows: false,
             suppressColumnVirtualisation: !model.useVirtualColumns,
             getRowId: ({data}) => data.agId,

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -190,6 +190,7 @@ export class GridLocalModel extends HoistModel {
             // In v32, `reactiveCustomComponents: true` will be the default.
             // See https://www.ag-grid.com/javascript-data-grid//grid-options/#reference-miscellaneous-reactiveCustomComponents
             reactiveCustomComponents: true,
+            animateRows: false,
             suppressColumnVirtualisation: !model.useVirtualColumns,
             getRowId: ({data}) => data.agId,
             defaultColDef: {

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -453,7 +453,7 @@ export class GridLocalModel extends HoistModel {
                 if (!api) return;
 
                 this.doWithPreservedState({expansion: false, filters: true}, () => {
-                    api.setGridOption('columnDefs', this.getColumnDefs());
+                    api.updateGridOptions({columnDefs: this.getColumnDefs()});
                 });
             }
         };
@@ -649,7 +649,7 @@ export class GridLocalModel extends HoistModel {
                 agApi.applyTransaction(transaction);
             }
         } else {
-            agApi.setGridOption('rowData', newRs.list);
+            agApi.updateGridOptions({rowData: newRs.list});
         }
 
         if (model.externalSort) {

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -879,10 +879,6 @@ export class GridModel extends HoistModel {
         return this.agGridModel.agApi;
     }
 
-    get agColumnApi() {
-        return this.agGridModel.agColumnApi;
-    }
-
     get sizingMode(): SizingMode {
         return this.agGridModel.sizingMode;
     }
@@ -1809,8 +1805,8 @@ export class GridModel extends HoistModel {
         side: 'left' | 'right',
         group: ColumnGroupSpec
     ): ColumnCellClassRuleFn {
-        return ({api, column, columnApi, ...ctx}) => {
-            if (!api || !column || !columnApi) return false;
+        return ({api, column, ...ctx}) => {
+            if (!api || !column) return false;
 
             // Re-evaluate cell class rules when column is re-ordered
             // See https://www.ag-grid.com/javascript-data-grid/column-object/#reference-events
@@ -1823,7 +1819,7 @@ export class GridModel extends HoistModel {
 
             // Don't render a left-border if col is first or if prev col already has right-border
             if (side === 'left') {
-                const prevCol = columnApi.getDisplayedColBefore(column);
+                const prevCol = api.getDisplayedColBefore(column);
 
                 if (!prevCol) return false;
 
@@ -1835,8 +1831,7 @@ export class GridModel extends HoistModel {
                         ...ctx,
                         api,
                         colDef: prevColDef,
-                        column: prevCol,
-                        columnApi
+                        column: prevCol
                     })
                 ) {
                     return false;

--- a/cmp/grid/impl/ColumnWidthCalculator.ts
+++ b/cmp/grid/impl/ColumnWidthCalculator.ts
@@ -199,7 +199,7 @@ export class ColumnWidthCalculator {
                 (includeHeaderIcons || gridModel.sortBy.find(sorter => sorter.colId === colId));
 
         let showMenu =
-            (agOptions?.suppressMenu === false || (filterable && filterModel)) &&
+            (agOptions?.suppressHeaderMenuButton === false || (filterable && filterModel)) &&
             includeHeaderIcons;
 
         // If only showing menu on hover, only need to allot room if the column is filtered

--- a/core/HoistComponent.ts
+++ b/core/HoistComponent.ts
@@ -25,7 +25,7 @@ import {
     formatSelector,
     HoistModel
 } from './model';
-import {apiDeprecated, throwIf, warnIf, withDefault} from '@xh/hoist/utils/js';
+import {throwIf, warnIf, withDefault} from '@xh/hoist/utils/js';
 import {getLayoutProps, useOnMount, useOnUnmount} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {isFunction, isPlainObject, isObject} from 'lodash';
@@ -395,13 +395,7 @@ function lookupModel(props: HoistProps, modelLookup: ModelLookup, cfg: Config): 
 
     // 1) props - config
     if (spec.createFromConfig) {
-        if (isPlainObject(model)) {
-            // 1a) legacy, pre-typescript
-            apiDeprecated('model', {msg: "Use 'modelConfig' instead", v: 'v58'});
-            return {model: new selector(model), isLinked: true, fromContext: false};
-        }
         if (isPlainObject(modelConfig)) {
-            // 1b) new location
             return {model: new selector(modelConfig), isLinked: true, fromContext: false};
         }
     }

--- a/desktop/cmp/input/NumberInput.ts
+++ b/desktop/cmp/input/NumberInput.ts
@@ -11,7 +11,7 @@ import '@xh/hoist/desktop/register';
 import {fmtNumber, parseNumber} from '@xh/hoist/format';
 import {numericInput} from '@xh/hoist/kit/blueprint';
 import {wait} from '@xh/hoist/promise';
-import {apiRemoved, debounced, TEST_ID, throwIf, withDefault} from '@xh/hoist/utils/js';
+import {debounced, TEST_ID, throwIf, withDefault} from '@xh/hoist/utils/js';
 import {getLayoutProps} from '@xh/hoist/utils/react';
 import {isNaN, isNil, isNumber, round} from 'lodash';
 import {ReactElement, ReactNode, Ref, useLayoutEffect} from 'react';
@@ -113,7 +113,6 @@ export const [NumberInput, numberInput] = hoistCmp.withFactory<NumberInputProps>
     displayName: 'NumberInput',
     className: 'xh-number-input',
     render(props, ref) {
-        apiRemoved(`fill`, {test: props['fill'], msg: 'Use the `flex` prop instead.', v: '58'});
         return useHoistInputModel(cmp, props, ref, NumberInputModel);
     }
 });

--- a/desktop/cmp/input/TextArea.ts
+++ b/desktop/cmp/input/TextArea.ts
@@ -9,7 +9,7 @@ import {HoistInputModel, HoistInputProps, useHoistInputModel} from '@xh/hoist/cm
 import {hoistCmp, HoistProps, LayoutProps, StyleProps} from '@xh/hoist/core';
 import '@xh/hoist/desktop/register';
 import {textArea as bpTextarea} from '@xh/hoist/kit/blueprint';
-import {apiRemoved, TEST_ID, withDefault} from '@xh/hoist/utils/js';
+import {TEST_ID, withDefault} from '@xh/hoist/utils/js';
 import {getLayoutProps} from '@xh/hoist/utils/react';
 import {Ref} from 'react';
 import './TextArea.scss';
@@ -46,7 +46,6 @@ export const [TextArea, textArea] = hoistCmp.withFactory<TextAreaProps>({
     displayName: 'TextArea',
     className: 'xh-text-area',
     render(props, ref) {
-        apiRemoved(`fill`, {test: props['fill'], msg: 'Use the `flex` prop instead.', v: '58'});
         return useHoistInputModel(cmp, props, ref, TextAreaInputModel);
     }
 });

--- a/kit/ag-grid/index.ts
+++ b/kit/ag-grid/index.ts
@@ -24,7 +24,6 @@ export let agGridVersion = null;
 export type {
     GridOptions,
     GridApi,
-    ColumnApi,
     SortDirection,
     ColDef,
     ColGroupDef,
@@ -49,8 +48,8 @@ export type {
     ColumnGroup as AgColumnGroup
 } from '@ag-grid-community/core';
 
-const MIN_VERSION = '30.0.0';
-const MAX_VERSION = '30.*.*';
+const MIN_VERSION = '31.2.0';
+const MAX_VERSION = '31.*.*';
 
 /**
  * Expose application versions of ag-Grid to Hoist.

--- a/package.json
+++ b/package.json
@@ -86,9 +86,9 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@ag-grid-community/client-side-row-model": "30.x",
-    "@ag-grid-community/core": "30.x",
-    "@ag-grid-community/react": "30.x",
+    "@ag-grid-community/client-side-row-model": "31.x",
+    "@ag-grid-community/core": "31.x",
+    "@ag-grid-community/react": "31.x",
     "@xh/hoist-dev-utils": "8.x",
     "csstype": "3.x",
     "eslint": "8.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,22 +7,25 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@ag-grid-community/client-side-row-model@30.x":
-  version "30.2.1"
-  resolved "https://registry.yarnpkg.com/@ag-grid-community/client-side-row-model/-/client-side-row-model-30.2.1.tgz#88c0b2d17555c16316c34f7ef22f4642f1f75d2a"
-  integrity sha512-LeFAsq2RuDXwjoUVLqlUgBYTHyCbyQozaQ4JY8SzBEABc8bOanIfsY3YONUckn+KWtRUrH5nGYA8bBeGrc20MQ==
+"@ag-grid-community/client-side-row-model@31.x":
+  version "31.2.0"
+  resolved "https://registry.yarnpkg.com/@ag-grid-community/client-side-row-model/-/client-side-row-model-31.2.0.tgz#f799bbbd3b7c9054442445942f9c331aba8305a4"
+  integrity sha512-fiXFGUaOCZdJ5QSJaWIyeA+hzjOe0+KzU1PdxqUdUZiNmDv/MFQQd99Biyk76OS6i8eWDFcC1O/V7owfVTWflw==
   dependencies:
-    "@ag-grid-community/core" "~30.2.1"
+    "@ag-grid-community/core" "31.2.0"
+    tslib "^2.3.0"
 
-"@ag-grid-community/core@30.x", "@ag-grid-community/core@~30.2.1":
-  version "30.2.1"
-  resolved "https://registry.yarnpkg.com/@ag-grid-community/core/-/core-30.2.1.tgz#9e4dcc4178ae2821ea3e4a637e5538a5455ae4d3"
-  integrity sha512-jGRBfRFsLwxch8GJGjbVI2FVbB+/fy1s4mm8//+kOkcPFlq4BbLFELvU4Kupwk1YkhduxUC50GTYyFzmF0rSIQ==
+"@ag-grid-community/core@31.2.0", "@ag-grid-community/core@31.x":
+  version "31.2.0"
+  resolved "https://registry.yarnpkg.com/@ag-grid-community/core/-/core-31.2.0.tgz#d9df3fd9906578c9bdcb3ec57658bce2966445b0"
+  integrity sha512-297AR2Z0i6zdpo+d1riWE9TpbsQ956Sd3rkgnjDaFzgGClsdy0SwInBs2281CHjaLQAhPzFelZ5XwcDTxHl4Tw==
+  dependencies:
+    tslib "^2.3.0"
 
-"@ag-grid-community/react@30.x":
-  version "30.2.1"
-  resolved "https://registry.yarnpkg.com/@ag-grid-community/react/-/react-30.2.1.tgz#32d641ad1e2b73fe1f409f0e32692c1f3b4fcd9e"
-  integrity sha512-bSrEh/zVI5oL0pf4cXRvZYiLuMjzWhyS0o5THzS4fqifmPczmH0HU3iTgQjH6QUNHAX3Ch4ZficVWdD005j/vw==
+"@ag-grid-community/react@31.x":
+  version "31.2.0"
+  resolved "https://registry.yarnpkg.com/@ag-grid-community/react/-/react-31.2.0.tgz#355a0fffdbaa61f77e84404d308fdcd755886f84"
+  integrity sha512-lOAoH0c2pGMQqxtEzhzXswf3HLeEVCnDM/TlHJpqKTcydhyW1Cfulr4/uJuZL7h28gLSpLawu+rlGCTgac8NKw==
   dependencies:
     prop-types "^15.8.1"
 
@@ -1578,9 +1581,9 @@
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.33":
-  version "4.17.43"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz#10d8444be560cb789c4735aea5eac6e5af45df54"
-  integrity sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.0.tgz#3ae8ab3767d98d0b682cda063c3339e1e86ccfaa"
+  integrity sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -1664,9 +1667,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "20.12.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.3.tgz#d6658c2c7776c1cad93534bb45428195ed840c65"
-  integrity sha512-sD+ia2ubTeWrOu+YMF+MTAB7E+O7qsMqAbMfW7DG3K1URwhZ5hN1pLlRVGbf4wDFzSfikL05M17EyorS86jShw==
+  version "20.12.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.5.tgz#74c4f31ab17955d0b5808cdc8fd2839526ad00b3"
+  integrity sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==
   dependencies:
     undici-types "~5.26.4"
 
@@ -1691,9 +1694,9 @@
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
 "@types/react-dom@*":
-  version "18.2.23"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.23.tgz#112338760f622a16d64271b408355f2f27f6302c"
-  integrity sha512-ZQ71wgGOTmDYpnav2knkjr3qXdAFu0vsk8Ci5w3pGAIdj7/kKAyn+VsQDhXsmzzzepAiI9leWMmubXz690AI/A==
+  version "18.2.24"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.24.tgz#8dda8f449ae436a7a6e91efed8035d4ab03ff759"
+  integrity sha512-cN6upcKd8zkGy4HU9F1+/s98Hrp6D4MOcippK4PoE8OZRngohHZpbJn1GsaDLz87MqvHNoT13nHvNqM9ocRHZg==
   dependencies:
     "@types/react" "*"
 
@@ -2584,9 +2587,9 @@ camel-case@^4.1.2:
     tslib "^2.0.3"
 
 caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599:
-  version "1.0.30001605"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz#ca12d7330dd8bcb784557eb9aa64f0037870d9d6"
-  integrity sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==
+  version "1.0.30001607"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001607.tgz#b91e8e033f6bca4e13d3d45388d87fa88931d9a5"
+  integrity sha512-WcvhVRjXLKFB/kmOFVwELtMxyhq3iM/MvmXcyCe2PNf166c39mptscOc/45TTS96n2gpNV2z7+NakArTWZCQ3w==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -3272,9 +3275,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.668:
-  version "1.4.724"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.724.tgz#e0a86fe4d3d0e05a4d7b032549d79608078f830d"
-  integrity sha512-RTRvkmRkGhNBPPpdrgtDKvmOEYTrPlXDfc0J/Nfq5s29tEahAwhiX4mmhNzj6febWMleulxVYPh7QwCSL/EldA==
+  version "1.4.729"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.729.tgz#8477d21e2a50993781950885b2731d92ad532c00"
+  integrity sha512-bx7+5Saea/qu14kmPTDHQxkp2UnziG3iajUQu3BxFvCOnpAJdDbMV4rSl+EqFDkkpNNVUFlR1kDfpL59xfy1HA==
 
 emoji-regex@^10.3.0:
   version "10.3.0"
@@ -3320,9 +3323,9 @@ env-paths@^2.2.1:
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 envinfo@^7.7.3:
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.11.1.tgz#2ffef77591057081b0129a8fd8cf6118da1b94e1"
-  integrity sha512-8PiZgZNIB4q/Lw4AhOvAfB/ityHAd2bli3lESSWmWSzSsl5dKpy5N1d1Rfkd2teq/g9xN90lc6o98DOjMeYHpg==
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.12.0.tgz#b56723b39c2053d67ea5714f026d05d4f5cc7acd"
+  integrity sha512-Iw9rQJBGpJRd3rwXm9ft/JiGoAZmLxxJZELYDQoPRZ4USVhkKtIcNBPw6U+/K2mBpaqM25JSV6Yl4Az9vO2wJg==
 
 enzyme-shallow-equal@^1.0.0:
   version "1.0.7"
@@ -7498,7 +7501,7 @@ ts-api-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.3.0.tgz#4b490e27129f1e8e686b45cc4ab63714dc60eea1"
   integrity sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@~2.6.2:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.0, tslib@~2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -7578,9 +7581,9 @@ typed-array-length@^1.0.6:
     possible-typed-array-names "^1.0.0"
 
 typescript@5.x:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
-  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.4.tgz#eb2471e7b0a5f1377523700a21669dce30c2d952"
+  integrity sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==
 
 typescript@~5.1.6:
   version "5.1.6"


### PR DESCRIPTION
This can be reviewed in Toolbox with its corresponding PR: https://github.com/xh/toolbox/pull/709
This is a breaking change even if an app made no use of `ColumnApi` (which has been removed) because the version getting logic in an app's`Bootstrap.ts` file will need to be redone as in the [Toolbox example.](https://github.com/xh/toolbox/pull/709/files/5626e21d778e1fc72f9735d2d8f011513e1ac9c6#diff-304055320a29f66ea1255446ba8f13e0f3f1b13643bcea0c0466aa60e9288a8f)

See [What's New in AG Grid 31](https://blog.ag-grid.com/whats-new-in-ag-grid-31/) and [Upgrading to AG Grid 31](https://www.ag-grid.com/javascript-data-grid/upgrading-to-ag-grid-31/?ref=blog.ag-grid.com) for more details.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

