### PR TITLE
HotFix: fix groupingChooser to work with popper2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐞 Bug Fixes
 
+* Fixed issue with GroupingChooser: dragged items were not correctly positioned.
 * Removed extraneous internal padding override to Blueprint menu styles. Fixes overhang of menu
   divider borders and avoids possible triggering of horizontal scrollbars.
 

--- a/desktop/cmp/grouping/GroupingChooser.ts
+++ b/desktop/cmp/grouping/GroupingChooser.ts
@@ -195,7 +195,11 @@ const dimensionRow = hoistCmp.factory<GroupingChooserModel>({
                 let transform = dndProps.draggableProps.style.transform;
                 if (dndState.isDragging || dndState.isDropAnimating) {
                     let rowValues = parseTransform(transform),
-                        popoverValues = parseTransform(model.popoverRef.current.style.transform);
+                        pStyle = model.popoverRef.current.style,
+                        popoverValues = {
+                            top: parsePixelStr(pStyle.top),
+                            left: parsePixelStr(pStyle.left)
+                        };
 
                     // Account for drop animation
                     if (dndState.isDropAnimating) {
@@ -204,9 +208,9 @@ const dimensionRow = hoistCmp.factory<GroupingChooserModel>({
                     }
 
                     // Subtract the popover's X / Y translation from the row's
-                    if (!isEmpty(rowValues) && !isEmpty(popoverValues)) {
-                        const x = rowValues[0] - popoverValues[0],
-                            y = rowValues[1] - popoverValues[1];
+                    if (!isEmpty(rowValues)) {
+                        const x = rowValues[0] - popoverValues.left,
+                            y = rowValues[1] - popoverValues.top;
                         transform = `translate(${x}px, ${y}px)`;
                     }
                 }
@@ -293,6 +297,12 @@ function parseTransform(transformStr) {
         ?.replace('3d', '')
         .match(/[-]{0,1}[\d]*[.]{0,1}[\d]+/g)
         ?.map(it => parseInt(it));
+}
+
+function parsePixelStr(pixelStr) {
+    const raw = pixelStr?.replace(/px$/, '');
+
+    return raw ? parseFloat(raw) : 0;
 }
 
 /**

--- a/desktop/cmp/grouping/GroupingChooser.ts
+++ b/desktop/cmp/grouping/GroupingChooser.ts
@@ -300,9 +300,8 @@ function parseTransform(transformStr) {
 }
 
 function parsePixelStr(pixelStr) {
-    const raw = pixelStr?.replace(/px$/, '');
-
-    return raw ? parseFloat(raw) : 0;
+    const raw = parseFloat(pixelStr);
+    return isNaN(raw) ? 0 : raw;
 }
 
 /**

--- a/desktop/cmp/grouping/GroupingChooser.ts
+++ b/desktop/cmp/grouping/GroupingChooser.ts
@@ -195,10 +195,10 @@ const dimensionRow = hoistCmp.factory<GroupingChooserModel>({
                 let transform = dndProps.draggableProps.style.transform;
                 if (dndState.isDragging || dndState.isDropAnimating) {
                     let rowValues = parseTransform(transform),
-                        pStyle = model.popoverRef.current.style,
+                        pPos = model.popoverRef.current.getBoundingClientRect(),
                         popoverValues = {
-                            top: parsePixelStr(pStyle.top),
-                            left: parsePixelStr(pStyle.left)
+                            x: pPos.left,
+                            y: pPos.top
                         };
 
                     // Account for drop animation
@@ -209,8 +209,8 @@ const dimensionRow = hoistCmp.factory<GroupingChooserModel>({
 
                     // Subtract the popover's X / Y translation from the row's
                     if (!isEmpty(rowValues)) {
-                        const x = rowValues[0] - popoverValues.left,
-                            y = rowValues[1] - popoverValues.top;
+                        const x = rowValues[0] - popoverValues.x,
+                            y = rowValues[1] - popoverValues.y;
                         transform = `translate(${x}px, ${y}px)`;
                     }
                 }
@@ -292,16 +292,11 @@ const addDimensionControl = hoistCmp.factory<GroupingChooserModel>({
  * Works for both `translate` and `translate3d`
  * e.g. `translate3d(250px, 150px, 0px)` is equivalent to [250, 150, 0]
  */
-function parseTransform(transformStr) {
+function parseTransform(transformStr: string): number[] {
     return transformStr
         ?.replace('3d', '')
         .match(/[-]{0,1}[\d]*[.]{0,1}[\d]+/g)
         ?.map(it => parseInt(it));
-}
-
-function parsePixelStr(pixelStr) {
-    const raw = parseFloat(pixelStr);
-    return isNaN(raw) ? 0 : raw;
 }
 
 /**


### PR DESCRIPTION
This fixes this issue:

![image](https://github.com/xh/hoist-react/assets/2573928/a1b16e1d-2fdf-4bc9-bff6-461be849b531)

caused by the the BP5 upgrade's move to popper2.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

