### PR TITLE
Replace globals with color.adjust, as per stylelint recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ for more details.
 
 * NumberEditor no longer activates on keypress of letter characters.
 * Removed initial `ping` call `FetchService` init.
+* Sass color functions now use `color.adjust` instead of globals
 
 ### 📚 Libraries
 

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -18,12 +18,12 @@
 
 //noinspection CssInvalidFunction
 @function mc-muted($color-name, $color-variant, $amount:30%, $lighten-amount:10%) {
-  @return lighten(desaturate(material-color($color-name, $color-variant), $amount), $lighten-amount);
+  @return color.adjust(material-color($color-name, $color-variant), $saturation: $amount * -1, $lightness: $lighten-amount);
 }
 
 //noinspection CssInvalidFunction
 @function mc-trans($color-name, $color-variant, $amount:0.5) {
-  @return transparentize(material-color($color-name, $color-variant), $amount);
+  @return color.adjust(material-color($color-name, $color-variant), $alpha: $amount * -1);
 }
 
 body {


### PR DESCRIPTION
Could use:
`color.adjust` or `color.scale`

Docs (https://sass-lang.com/documentation/modules/color/) recommend `color.scale` for most usecases, except that `color.adjust` more faithfully reproduces effect of former methods.

I went with `color.adjust`.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes: not a breaking change
- [x] Updated doc comments / prop-types: not required.
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: not required

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

