### PR TITLE
Fix mobile Toast intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ for more details.
   display an ellipsis to indicate they have been clipped.
 * Improved `RestGridModel.actionWarning` behavior to suppress any warning when the provided function
   returns a falsy value.
+* Fixed mobile `Toast` intent styling.
 
 ### ⚙️ Technical
 

--- a/mobile/appcontainer/Toast.scss
+++ b/mobile/appcontainer/Toast.scss
@@ -13,6 +13,22 @@
     box-shadow: 0 2px 20px rgba(0, 0, 0, 0.5);
   }
 
+  &.toast-bg-intent-primary .toast {
+    background-color: var(--xh-intent-primary);
+  }
+
+  &.toast-bg-intent-danger .toast {
+    background-color: var(--xh-intent-danger);
+  }
+
+  &.toast-bg-intent-success .toast {
+    background-color: var(--xh-intent-success);
+  }
+
+  &.toast-bg-intent-warning .toast {
+    background-color: var(--xh-intent-warning);
+  }
+
   .toast__message {
     margin: 0;
     display: flex;

--- a/mobile/appcontainer/Toast.ts
+++ b/mobile/appcontainer/Toast.ts
@@ -21,7 +21,7 @@ export const toast = hoistCmp.factory({
 
     render({model}) {
         const {icon, message, intent, actionButtonProps} = model,
-            cls = `xh-toast xh-bg-intent-${intent}`;
+            cls = `xh-toast toast-bg-intent-${intent}`;
 
         return onsenToast({
             visible: true,


### PR DESCRIPTION
We cannot use our standard `xh-bg-intent-xxx` classes for Onsen toasts, as the element we actually want to style is an inner div that we do not have a direct hook into.

See issue: https://github.com/xh/hoist-react/issues/3657

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

