### PR TITLE
Restore disabling of blueprint animations on popovers and tooltips (had b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 65.0.0-SNAPSHOT - unreleased
 
-### ⚙️ Technical
+### 🐞 Bug Fixes
 * Restore disabling of Blueprint animations on popovers and tooltips (regression in v63.0.0)
 
 ## 64.0.2 - 2024-05-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 65.0.0-SNAPSHOT - unreleased
-
+### ⚙️ Technical
+* Restore disabling of Blueprint animations on popovers and tooltips (regression in v63.0.0)
 
 ## 64.0.1 - 2024-05-19
 

--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -57,24 +57,37 @@
   background-color: var(--xh-backdrop-bg);
 }
 
-// Squelch popover scale transition - unlike Dialog with its `transitionName` prop, Popover
-// does not appear to provide a way to turn off its transition without also losing the (often
-// desirable) arrow pointing to its target. Variables below required for the include to function.
-$pt-transition-ease: cubic-bezier(0.4, 1, 0.75, 0.9) !default;
-$pt-transition-ease-bounce: cubic-bezier(0.54, 1.12, 0.38, 1.11) !default;
-$pt-transition-duration: 100ms !default;
+// On Popover and Tooltip components, squelch scale & opacity transition - unlike Dialog with its `transitionName` prop,
+// Popover, and consequently Tooltip, do not appear to provide a way to turn off
+// their transitions without also losing the (often desirable) arrow pointing to their targets.
+// These rules override the scale and opacity starting values of enter and exit classes by setting them to
+// their final 'end of transition' values, which has the effect of preventing/short circuiting transitions.
+// BlueprintJs' own Popover.minimal uses this same approach to disable its transitions.
+// (it appears from testing that overriding these rules with any value will squelch the transition, but
+// we might as well use the final values to be explicit.)
+.bp5-popover-transition-container {
+  &.bp5-popover-enter,
+  &.bp5-popover-appear {
+    opacity: 1;
+  }
 
-.bp5-popover {
-  // This override is taken from the popover source SCSS - there it is scoped under the minimal class.
-  // https://github.com/palantir/blueprint/blob/1bfd1e42303d2626bfc3923eec2195ab4dc696d2/packages/core/src/components/popover/_popover.scss#L54
-  @include react-transition(
-    'bp5-popover',
-    (
-      transform: scale(1) scale(1)
-    ),
-    $duration: 0,
-    $after: '> &'
-  );
+  &.bp5-popover-exit {
+    opacity: 0;
+  }
+
+  &.bp5-popover-enter,
+  &.bp5-popover-appear {
+    > .bp5-popover {
+      transform: scale(1);
+    }
+  }
+
+  &.bp5-popover-exit-active,
+  &.bp5-popover-exit {
+    > .bp5-popover {
+      transform: scale(0);
+    }
+  }
 }
 
 //------------------------


### PR DESCRIPTION
…een disabled, but the animations came back on the BP5 upgrade)

This can be tested on the column chooser button in our toolbox demo grids, which opens a popover.
I also added a blueprint tooltip in my local, to test tooltips, and saw that they had no animations with this change.

The BP animations are very fast (300ms), but some users found them annoying anyways, and we had them turned off before, on BP 4.

This new css brings back the 'turn off' by matching and overriding the new BP5 css specificity without use of react-transition.  It might be an improvement, in that it turns off the opacity animation, too, not just the scale animation.

Fast animations are hard to inspect.  But Chrome Dev Tools has a tab for animations:
<img width="772" alt="image" src="https://github.com/xh/hoist-react/assets/2573928/cf0bd555-7663-46fe-a404-1ff85c840c13">


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry.
- [x] Reviewed for breaking changes: not a breaking change
- [x] Updated doc comments: not required.
- [x] Reviewed and tested on Mobile: not required
- [x] Created Toolbox branch / PR: not required

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

