### PR TITLE
Mobile `TabContainer` now flexes properly within flexbox containers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 66.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Mobile `TabContainer` now flexes properly within flexbox containers.
+
 ## 65.0.0 - 2024-06-26
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 TRIVIAL - dependencies only)

--- a/mobile/cmp/tab/impl/Tabs.scss
+++ b/mobile/cmp/tab/impl/Tabs.scss
@@ -26,6 +26,9 @@
 }
 
 .xh-tab-container {
+  position: relative;
+  flex: auto;
+
   &--top .tabbar {
     border-bottom: var(--xh-border-solid);
   }


### PR DESCRIPTION
Previous styling inherited from Onsen was `position: absolute`. This meant that it obscured other children within a flex container, always filling the entire container.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

