### PR TITLE
Fix `datePicker` dates wrapping when used within a grid within a dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fix timing issue with missing validation for records added immediately to new store.
 * Mobile `TabContainer` now flexes properly within flexbox containers.
+* Fixed CSS bug in which datePicker dates wrapped when datepicker was used in a grid inside a dialogBody.
 
 ## 65.0.0 - 2024-06-26
 

--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -50,8 +50,9 @@
     word-break: break-word;
 
     // ensure that date numbers in the datepicker do not wrap
-    // if the datepicker's portal is rendered inside a dialogBody
-    // which happens to the datepicker used grid dateEditor.
+    // if the datepicker's portal is rendered inside a dialogBody,
+    // which happens to the datepicker when it is used in a grid dateEditor
+    // in a grid used inside a dialogBody.
     .bp5-datepicker {
       word-break: normal;
     }

--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -47,12 +47,14 @@
     margin: 0;
     padding: var(--xh-pad-double-px);
     background: var(--xh-popup-bg);
+
+    // See https://github.com/xh/hoist-react/issues/862 for why this is necessary. Note need for
+    // datepicker workaround below - indicates that this might be a problematic solution in general
+    // to the original issue, but after a few years that's been the only reported issue, so...
     word-break: break-word;
 
-    // ensure that date numbers in the datepicker do not wrap
-    // if the datepicker's portal is rendered inside a dialogBody,
-    // which happens to the datepicker when it is used in a grid dateEditor
-    // in a grid used inside a dialogBody.
+    // Ensure that date numbers in the datepicker do not wrap if the datePicker portal is rendered
+    // inside a dialogBody - e.g. `dateEditor` in a grid in a dialog. See comment on #862.
     .bp5-datepicker {
       word-break: normal;
     }

--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -48,6 +48,13 @@
     padding: var(--xh-pad-double-px);
     background: var(--xh-popup-bg);
     word-break: break-word;
+
+    // ensure that date numbers in the datepicker do not wrap
+    // if the datepicker's portal is rendered inside a dialogBody
+    // which happens to the datepicker used grid dateEditor.
+    .bp5-datepicker {
+      word-break: normal;
+    }
   }
 }
 


### PR DESCRIPTION
…sed in a grid inside a dialogBody.

Resolves the issue described here:  https://github.com/xh/hoist-react/issues/862#issuecomment-2195113273

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry: added.
- [x] Reviewed for breaking changes: not a breaking change.
- [x] Updated doc comments / prop-types: not required.
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

