### PR TITLE
Fix `Grid` regression where pinned columns were automatically un-pinn…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### 🐞 Bug Fixes
 * The `Record.descendants` and `Record.allDescendants` getters were incorrectly returning the
  record itself. This has been fixed.
+* Fixed `Grid` regression where pinned columns were automatically un-pinned when the viewport became
+ too small to accommodate them.
 
 ## 66.0.2 - 2024-07-17
 

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -254,7 +254,9 @@ export class GridLocalModel extends HoistModel {
             suppressClickEdit: clicksToEdit !== 1 && clicksToEdit !== 2,
             stopEditingWhenCellsLoseFocus: true,
             suppressLastEmptyLineOnPaste: true,
-            suppressClipboardApi: true
+            suppressClipboardApi: true,
+            // Override AG-Grid's default behavior of automatically unpinning columns to make the center viewport visible
+            processUnpinnedColumns: () => []
         };
 
         // Platform specific defaults


### PR DESCRIPTION
…ed when the viewport became

 too small to accommodate them.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

