### PR TITLE
Fix SelectEditor to ensure new value is flushed before editing stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * `GridModel` will now accept `false` as a value to omit context menus.
 
+### 🐞 Bug Fixes
+
+* Fixed `SelectEditor` to ensure new value is flushed before editing stops.
+
 ### ⚙️ Technical
 
 * Remove context menus from column choosers.

--- a/desktop/cmp/grid/editors/SelectEditor.ts
+++ b/desktop/cmp/grid/editors/SelectEditor.ts
@@ -7,6 +7,7 @@
 import {hoistCmp} from '@xh/hoist/core';
 import {select, SelectProps} from '@xh/hoist/desktop/cmp/input';
 import '@xh/hoist/desktop/register';
+import {wait} from '@xh/hoist/promise';
 import {EditorProps} from './EditorProps';
 import './Editors.scss';
 import {useInlineEditorModel} from './impl/InlineEditorModel';
@@ -26,7 +27,9 @@ export const [SelectEditor, selectEditor] = hoistCmp.withFactory<SelectEditorPro
                 hideDropdownIndicator: true,
                 hideSelectedOptionCheck: true,
                 selectOnFocus: false,
-                onCommit: flushOnCommit ? () => props.agParams.stopEditing() : null,
+                onCommit: flushOnCommit
+                    ? () => wait().then(() => props.agParams.stopEditing())
+                    : null,
                 rsOptions: {
                     styles: {
                         menu: styles => ({


### PR DESCRIPTION
Resolves #3747 

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

