### PR TITLE
New handlers for FetchService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,7 @@
       tracking and error reporting and are available for review in the Admin Console.
     * New `XH.genUUID()` method to generate UUIDs for use as Correlation IDs or elsewhere.
 * `GridModel.contextMenu` will now accept `false` as a value to omit context menus.
-*  New global event handlers on `FetchService`. See `FetchService.addExceptionHandler()` and
-   `FetchService.addSuccessHandler()`.
-
+*  New global exception handlers on `FetchService`. See `FetchService.addExceptionHandler()`.
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
       tracking and error reporting and are available for review in the Admin Console.
     * New `XH.genUUID()` method to generate UUIDs for use as Correlation IDs or elsewhere.
 * `GridModel.contextMenu` will now accept `false` as a value to omit context menus.
-* New global exception handlers on `FetchService`. See `FetchService.addExceptionHandler()`.
+* New global interceptors on `FetchService`. See `FetchService.addInterceptor()`.
 * New property `FetchOptions.asJson` to instruct `FetchService` to decode an HTTP response as JSON.
   Note that `FetchService` methods suffixed with `Json` will set this property automatically.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@
       tracking and error reporting and are available for review in the Admin Console.
     * New `XH.genUUID()` method to generate UUIDs for use as Correlation IDs or elsewhere.
 * `GridModel.contextMenu` will now accept `false` as a value to omit context menus.
-*  New global exception handlers on `FetchService`. See `FetchService.addExceptionHandler()`.
+* New global exception handlers on `FetchService`. See `FetchService.addExceptionHandler()`.
+* New property `FetchOptions.asJson` to instruct `FetchService` to decode an HTTP response as JSON.
+  Note that `FetchService` methods suffixed with `Json` will set this property automatically.
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@
     * If set on a fetch request, Correlation IDs are passed through to downstream Hoist activity
       tracking and error reporting and are available for review in the Admin Console.
     * New `XH.genUUID()` method to generate UUIDs for use as Correlation IDs or elsewhere.
-* `GridModel` will now accept `false` as a value to omit context menus.
+* `GridModel.contextMenu` will now accept `false` as a value to omit context menus.
+*  New global event handlers on `FetchService`. See `FetchService.addExceptionHandler()` and
+   `FetchService.addSuccessHandler()`.
+
 
 ### 🐞 Bug Fixes
 


### PR DESCRIPTION
This provides support I need for being able to catch 401s, in non-SSO based scenario, and respond appropriately by bringing up.

The handler for the successful response seemed like a good thing to add at the same time for symmetry, and we have seen a couple of places where it might have been useful, and avoided the need for  overriding FetchService to look for e.g. 200 returns with `success: false` 



Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [X ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

