### PR TITLE
Handle instance changes

### DIFF
--- a/svc/EnvironmentService.ts
+++ b/svc/EnvironmentService.ts
@@ -128,7 +128,7 @@ export class EnvironmentService extends HoistService {
     private async pollServerAsync() {
         let data;
         try {
-            data = await XH.fetchJson({url: 'xh/pollEnvironment'});
+            data = await XH.fetchJson({url: 'xh/environmentPoll'});
         } catch (e) {
             this.logError('Error polling server environment', e);
             return;
@@ -144,7 +144,7 @@ export class EnvironmentService extends HoistService {
         if (appVersion != XH.getEnv('appVersion') || appBuild != XH.getEnv('appBuild')) {
             // force the user to refresh or prompt the user to refresh via the banner according to config
             // build checked to trigger refresh across SNAPSHOT updates in lower environments
-            const {onVersionChange} = this.pollConfig;
+            const {onVersionChange} = pollConfig;
             switch (onVersionChange) {
                 case 'promptReload':
                     XH.appContainerModel.showUpdateBanner(appVersion, appBuild);

--- a/svc/EnvironmentService.ts
+++ b/svc/EnvironmentService.ts
@@ -135,10 +135,10 @@ export class EnvironmentService extends HoistService {
         }
 
         // Update config/interval, and server info
-        const {pollConfig, serverInstance, appVersion, appBuild} = data;
+        const {pollConfig, instanceName, appVersion, appBuild} = data;
         this.pollConfig = pollConfig;
         this.pollTimer.setInterval(this.pollIntervalMs);
-        this.setServerInfo(serverInstance, appVersion, appBuild);
+        this.setServerInfo(instanceName, appVersion, appBuild);
 
         // Handle version change
         if (appVersion != XH.getEnv('appVersion') || appBuild != XH.getEnv('appBuild')) {


### PR DESCRIPTION
Slightly different take on this, main differences from ATM proposal are:

- the seperation of things into two endpoints, to distinguish between the full download on init (including admin info) and the lightweight heartbeat, optimized for frequent calling.

- the simplification of both of these two things into *non-whitelisted* endpoints.  Specifically, would actually like to be able to monitor this polling check in app AuthModel implementations (PRs coming soon), so as to recognize auth problems, and potentially address with banners or idling of the app.

Considered actually working auth failure into the handling here, but think we can keep it decoupled with our new hooks on FetchService.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

