### PR TITLE
Panel dragger workaround for Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## 69.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Added a workaround for a bug where Panel drag resizing was broken in Safari.
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW )
 * The `INITIALIZING` AppState has been replaced with more fine-grained states (see below).  This
-is not expected to effect any applications.
+is not expected to affect any applications.
 
 ### 🎁 New Features
 

--- a/desktop/cmp/panel/impl/dragger/DraggerModel.ts
+++ b/desktop/cmp/panel/impl/dragger/DraggerModel.ts
@@ -254,7 +254,9 @@ export class DraggerModel extends HoistModel {
     }
 
     private isValidMouseEvent(e) {
-        return e.buttons && e.buttons !== 0;
+        // Note: We fall back to deprecated 'which' to work around a Safari issue where `buttons`
+        // was not being set. We may be able to remove in the future.
+        return (e.buttons && e.buttons !== 0) || (e.which && e.which !== 0);
     }
 
     private isValidTouchEvent(e) {


### PR DESCRIPTION
Safari is not setting `buttons` or `button` to `1` on Drag events, which is causing our Panel resizing to early out.
See: https://github.com/xh/hoist-react/issues/3797

This workaround adds a fallback check to the deprecated `MouseEvent.which` property, which *is* being set:
https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/which#value_for_mouseevent_non-standard

As a deprecated API we obviously should not rely on it, but I **think** its safe to use as fall back for this specific issue in lieu of a better solution.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

