### PR TITLE
Breaking change to signature of `waitFor()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@
     * `DashModel|GroupingChooserModel|FilterChooserModel|PanelModel|TabContainerModel.provider`
     * `PersistenceProvider.clearRaw()`
 * Renamed `ZoneGridModelPersistOptions.persistMappings`, adding the trailing `s` for consistency.
-* Updated `JsonBlobService.listAsync` to inline `loadSpec` with all other args in a single object.
+* Changed signature of `JsonBlobService.listAsync()` to inline `loadSpec` with all other args in a
+  single options object.
+* Changed signature of `waitFor()` to take its optional `interval` and `timeout` arguments in a
+  single options object.
 
 ### 🎁 New Features
 

--- a/promise/Promise.ts
+++ b/promise/Promise.ts
@@ -121,21 +121,20 @@ export function wait<T>(interval: number = 0): Promise<T> {
 }
 
 /**
- * Return a promise that will resolve after a condition has been met, polling at the specified
- * interval.
- *
- * @param condition - function that should return true when condition is met
+ * Return a promise that will resolve after a condition has been met, or reject if timed out.
+ * @param condition - function returning true when expected condition is met.
  * @param interval - milliseconds to wait between checks (default 50). Note that the actual time
  *      will be subject to the minimum delay for `setTimeout()` in the browser.
  * @param timeout - milliseconds after which the Promise should be rejected (default 5000).
  */
 export function waitFor(
     condition: () => boolean,
-    interval: number = 50,
-    timeout: number = 5 * SECONDS
+    {interval = 50, timeout = 5 * SECONDS}: {interval?: number; timeout?: number} = {}
 ): Promise<void> {
-    const startTime = Date.now();
+    if (!isNumber(interval) || interval <= 0) throw new Error('Invalid interval');
+    if (!isNumber(timeout) || timeout <= 0) throw new Error('Invalid timeout');
 
+    const startTime = Date.now();
     return new Promise((resolve, reject) => {
         const resolveOnMet = () => {
             if (condition()) {


### PR DESCRIPTION
+ Take optional `interval` and `timeout` arguments in a single options object - allow for easier (common) customization of timeout without needing to think about interval.
+ Fixes #3825

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

