### PR TITLE
Avoid no-op state updates in DashContainerModel, shorten debounce

### DIFF
--- a/desktop/cmp/dash/container/DashContainerModel.ts
+++ b/desktop/cmp/dash/container/DashContainerModel.ts
@@ -24,7 +24,17 @@ import {wait} from '@xh/hoist/promise';
 import {isOmitted} from '@xh/hoist/utils/impl';
 import {debounced, ensureUniqueBy, throwIf} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
-import {cloneDeep, defaultsDeep, find, isFinite, isNil, last, reject, startCase} from 'lodash';
+import {
+    cloneDeep,
+    defaultsDeep,
+    find,
+    isEqual,
+    isFinite,
+    isNil,
+    last,
+    reject,
+    startCase
+} from 'lodash';
 import {createRoot} from 'react-dom/client';
 import {DashConfig, DashModel} from '../';
 import {DashViewModel, DashViewState} from '../DashViewModel';
@@ -371,13 +381,15 @@ export class DashContainerModel
         this.publishState();
     }
 
-    @debounced(1000)
+    @debounced(100)
     private publishState() {
         const {goldenLayout} = this;
         if (!goldenLayout) return;
-        runInAction(() => {
-            this.state = convertGLToState(goldenLayout, this);
-        });
+
+        const newState = convertGLToState(goldenLayout, this);
+        if (!isEqual(this.state, newState)) {
+            runInAction(() => (this.state = newState));
+        }
     }
 
     private onItemDestroyed(item) {


### PR DESCRIPTION
- Changes to GoldenLayout state often do not result in actual diffs to processed Hoist state - don't publish a new state object if that's the case.
- Shorten debounce on `publishState()` - allows actual state change to be reported in a much more timely fashion.
- Removing debounce entirely throws - looks like an initial timing / render / model lookup issue, which could warrant further investigation to see if we can handle it better.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [ ] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [ ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

