### PR TITLE
Further refinements to `ViewManager`

### DIFF
--- a/cmp/viewmanager/View.ts
+++ b/cmp/viewmanager/View.ts
@@ -31,6 +31,10 @@ export class View<T extends PlainObject = PlainObject> {
         return this.info?.group;
     }
 
+    get description(): string {
+        return this.info?.description;
+    }
+
     get token(): string {
         return this.info?.token ?? null;
     }

--- a/cmp/viewmanager/View.ts
+++ b/cmp/viewmanager/View.ts
@@ -27,6 +27,10 @@ export class View<T extends PlainObject = PlainObject> {
         return this.info?.name ?? 'Default';
     }
 
+    get group(): string {
+        return this.info?.group;
+    }
+
     get token(): string {
         return this.info?.token ?? null;
     }
@@ -41,6 +45,14 @@ export class View<T extends PlainObject = PlainObject> {
 
     get isGlobal(): boolean {
         return this.info?.isGlobal ?? false;
+    }
+
+    get isShared(): boolean {
+        return this.info?.isShared ?? false;
+    }
+
+    get isOwned(): boolean {
+        return this.info?.isOwned ?? false;
     }
 
     get lastUpdated(): number {

--- a/cmp/viewmanager/View.ts
+++ b/cmp/viewmanager/View.ts
@@ -64,7 +64,7 @@ export class View<T extends PlainObject = PlainObject> {
     }
 
     get typedName(): string {
-        return `${this.model.typeDisplayName} '${this.name}'`;
+        return `${this.model.typeDisplayName} "${this.name}"`;
     }
 
     static fromBlob<T>(blob: JsonBlob, model: ViewManagerModel): View<T> {

--- a/cmp/viewmanager/View.ts
+++ b/cmp/viewmanager/View.ts
@@ -55,6 +55,10 @@ export class View<T extends PlainObject = PlainObject> {
         return this.info?.isOwned ?? false;
     }
 
+    get isCurrentView(): boolean {
+        return this.token === this.model.view.token;
+    }
+
     get lastUpdated(): number {
         return this.info?.lastUpdated ?? null;
     }

--- a/cmp/viewmanager/ViewInfo.ts
+++ b/cmp/viewmanager/ViewInfo.ts
@@ -49,21 +49,33 @@ export class ViewInfo {
     constructor(blob: JsonBlob, model: ViewManagerModel) {
         this.token = blob.token;
         this.type = blob.type;
-        this.owner = blob.owner;
         this.name = blob.name;
         this.description = blob.description;
+        this.owner = blob.owner;
+        this.isGlobal = !this.owner;
 
         const meta = (blob.meta ?? {}) as PlainObject;
         this.group = meta.group ?? null;
-        this.isGlobal = !!meta.isGlobal;
         this.isDefaultPinned = !!(this.isGlobal && meta.defaultPinned);
-        this.isShared = !!(this.isGlobal || meta.isShared);
+        this.isShared = !!(!this.isGlobal && meta.isShared);
 
         // Round to seconds.  See: https://github.com/xh/hoist-core/issues/423
         this.dateCreated = Math.round(blob.dateCreated / SECONDS) * SECONDS;
         this.lastUpdated = Math.round(blob.lastUpdated / SECONDS) * SECONDS;
         this.lastUpdatedBy = blob.lastUpdatedBy;
         this.model = model;
+    }
+
+    get isOwned(): boolean {
+        return this.owner === XH.getUsername();
+    }
+
+    get isEditable(): boolean {
+        return this.isOwned || (this.isGlobal && this.model.manageGlobal);
+    }
+
+    get isCurrentView(): boolean {
+        return this.token === this.model.view.token;
     }
 
     /**
@@ -83,15 +95,7 @@ export class ViewInfo {
         return this.model.isUserPinned(this);
     }
 
-    get isOwned(): boolean {
-        return this.owner === XH.getUsername();
-    }
-
     get typedName(): string {
         return `${this.model.typeDisplayName} '${this.name}'`;
-    }
-
-    get isCurrentView(): boolean {
-        return this.token === this.model.view.token;
     }
 }

--- a/cmp/viewmanager/ViewInfo.ts
+++ b/cmp/viewmanager/ViewInfo.ts
@@ -44,7 +44,7 @@ export class ViewInfo {
     lastUpdated: number;
     lastUpdatedBy: string;
 
-    private readonly model: ViewManagerModel;
+    readonly model: ViewManagerModel;
 
     constructor(blob: JsonBlob, model: ViewManagerModel) {
         this.token = blob.token;
@@ -89,5 +89,9 @@ export class ViewInfo {
 
     get typedName(): string {
         return `${this.model.typeDisplayName} '${this.name}'`;
+    }
+
+    get isCurrentView(): boolean {
+        return this.token === this.model.view.token;
     }
 }

--- a/cmp/viewmanager/ViewInfo.ts
+++ b/cmp/viewmanager/ViewInfo.ts
@@ -19,10 +19,7 @@ export class ViewInfo {
     /** Description of the view. **/
     readonly description: string;
 
-    /**
-     * User that can write this view.  Typically, the original creator.
-     * Null if the view is global.
-     */
+    /** User owning this view. Null if the view is global.*/
     readonly owner: string;
 
     /** Is the owner making this view accessible to others? Always true for global views. */
@@ -42,7 +39,8 @@ export class ViewInfo {
 
     /**
      * Original meta-data on views associated JsonBlob.
-     * Not typically used by applications;
+     * Not typically used by applications.
+     * @internal
      */
     readonly meta: PlainObject;
 

--- a/cmp/viewmanager/ViewInfo.ts
+++ b/cmp/viewmanager/ViewInfo.ts
@@ -1,6 +1,7 @@
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {ViewManagerModel} from './ViewManagerModel';
 import {JsonBlob} from '@xh/hoist/svc';
+import {PlainObject, XH} from '@xh/hoist/core';
 
 /**
  * Metadata describing {@link View} managed by {@link ViewManagerModel}.
@@ -9,7 +10,7 @@ export class ViewInfo {
     /** Unique Id */
     readonly token: string;
 
-    /** App-defined type discriminator, as per {@link ViewManagerConfig.type}. */
+    /** App-defined type discriminator. */
     readonly type: string;
 
     /** User-supplied descriptive name. */
@@ -18,11 +19,26 @@ export class ViewInfo {
     /** Description of the view. **/
     readonly description: string;
 
+    /**
+     * User that can write this view.  Typically, the original creator.
+     * Null if the view is global.
+     */
+    readonly owner: string;
+
+    /** Is the owner making this view accessible to others? Always true for global views. */
+    readonly isShared: boolean;
+
     /** True if this view is global and visible to all users. */
     readonly isGlobal: boolean;
 
-    /** Original creator of the view, and the only user with access to it if not global. */
-    readonly owner: string;
+    /** Optional group name used for bucketing this view in display. */
+    readonly group: string;
+
+    /**
+     * Should this view be pinned by users by default?
+     * This value is intended to be used for global views only.
+     */
+    readonly isDefaultPinned: boolean;
 
     dateCreated: number;
     lastUpdated: number;
@@ -36,7 +52,13 @@ export class ViewInfo {
         this.owner = blob.owner;
         this.name = blob.name;
         this.description = blob.description;
-        this.isGlobal = blob.acl === '*';
+
+        const meta = (blob.meta ?? {}) as PlainObject;
+        this.group = meta.group ?? null;
+        this.isGlobal = !!meta.isGlobal;
+        this.isDefaultPinned = !!(this.isGlobal && meta.defaultPinned);
+        this.isShared = !!(this.isGlobal || meta.isShared);
+
         // Round to seconds.  See: https://github.com/xh/hoist-core/issues/423
         this.dateCreated = Math.round(blob.dateCreated / SECONDS) * SECONDS;
         this.lastUpdated = Math.round(blob.lastUpdated / SECONDS) * SECONDS;
@@ -45,11 +67,24 @@ export class ViewInfo {
     }
 
     /**
-     * True if user has tagged this view as a favorite. Note that a user's list of favorite views
-     * is persisted via `ViewManagerModel.persistWith` and *not* stored in the blob itself.
+     * True if this view should appear on the users easy access menu.
+     *
+     * This value is computed with the user persisted state along with the View's
+     * `defaultPinned` property.
      */
-    get isFavorite(): boolean {
-        return this.model.isFavorite(this.token);
+    get isPinned(): boolean {
+        return this.isUserPinned ?? this.isDefaultPinned;
+    }
+
+    /**
+     * The user indicated pin state for this view, or null if user has not indicated a preference.
+     */
+    get isUserPinned(): boolean | null {
+        return this.model.isUserPinned(this);
+    }
+
+    get isOwned(): boolean {
+        return this.owner === XH.getUsername();
     }
 
     get typedName(): string {

--- a/cmp/viewmanager/ViewInfo.ts
+++ b/cmp/viewmanager/ViewInfo.ts
@@ -40,6 +40,12 @@ export class ViewInfo {
      */
     readonly isDefaultPinned: boolean;
 
+    /**
+     * Original meta-data on views associated JsonBlob.
+     * Not typically used by applications;
+     */
+    readonly meta: PlainObject;
+
     dateCreated: number;
     lastUpdated: number;
     lastUpdatedBy: string;
@@ -52,12 +58,12 @@ export class ViewInfo {
         this.name = blob.name;
         this.description = blob.description;
         this.owner = blob.owner;
+        this.meta = (blob.meta as PlainObject) ?? {};
         this.isGlobal = !this.owner;
 
-        const meta = (blob.meta ?? {}) as PlainObject;
-        this.group = meta.group ?? null;
-        this.isDefaultPinned = !!(this.isGlobal && meta.defaultPinned);
-        this.isShared = !!(!this.isGlobal && meta.isShared);
+        this.group = this.meta.group ?? null;
+        this.isDefaultPinned = !!(this.isGlobal && this.meta.isDefaultPinned);
+        this.isShared = !!(!this.isGlobal && this.meta.isShared);
 
         // Round to seconds.  See: https://github.com/xh/hoist-core/issues/423
         this.dateCreated = Math.round(blob.dateCreated / SECONDS) * SECONDS;

--- a/cmp/viewmanager/ViewInfo.ts
+++ b/cmp/viewmanager/ViewInfo.ts
@@ -102,6 +102,6 @@ export class ViewInfo {
     }
 
     get typedName(): string {
-        return `${this.model.typeDisplayName} '${this.name}'`;
+        return `${this.model.typeDisplayName} "${this.name}"`;
     }
 }

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -10,7 +10,6 @@ import {
     ExceptionHandlerOptions,
     HoistModel,
     LoadSpec,
-    managed,
     PersistableState,
     PersistenceProvider,
     PersistOptions,
@@ -25,12 +24,11 @@ import {fmtDateTime} from '@xh/hoist/format';
 import {action, bindable, makeObservable, observable, runInAction, when} from '@xh/hoist/mobx';
 import {olderThan, SECONDS} from '@xh/hoist/utils/datetime';
 import {executeIfFunction, pluralize, throwIf} from '@xh/hoist/utils/js';
-import {find, isEqual, isNil, isObject, lowerCase, without} from 'lodash';
+import {find, isEmpty, isEqual, isNil, isObject, lowerCase, pickBy} from 'lodash';
 import {ReactNode} from 'react';
-import {SaveAsDialogModel} from './SaveAsDialogModel';
 import {ViewInfo} from './ViewInfo';
 import {View} from './View';
-import {ViewToBlobApi} from './ViewToBlobApi';
+import {ViewToBlobApi, ViewCreateSpec} from './ViewToBlobApi';
 
 export interface ViewManagerConfig {
     /**
@@ -45,8 +43,10 @@ export interface ViewManagerConfig {
      */
     enableDefault?: boolean;
 
-    /** True (default) to allow user to mark views as favorites. Requires `persistWith`. */
-    enableFavorites?: boolean;
+    /**
+     * True (default) to allow users to share their views with other users.
+     */
+    enableSharing?: boolean;
 
     /**
      * Function to determine the initial view for a user, when no view has already been persisted.
@@ -97,8 +97,8 @@ export interface ViewManagerConfig {
 }
 
 export interface ViewManagerPersistOptions extends PersistOptions {
-    /** True to persist favorites or provide specific PersistOptions. (Default true) */
-    persistFavorites?: boolean | PersistOptions;
+    /** True to persist pinning preferences or provide specific PersistOptions. (Default true) */
+    persistPinning?: boolean | PersistOptions;
 
     /** True to include pending value or provide specific PersistOptions. (Default false) */
     persistPendingValue?: boolean | PersistOptions;
@@ -112,8 +112,8 @@ export interface ViewManagerPersistOptions extends PersistOptions {
  *    models can be bound to a single ViewManagerModel, allowing a single view to capture the state
  *    of multiple components - e.g. grouping and filtering options along with grid state.
  *  - Views are persisted back to the server as JsonBlob objects.
- *  - Views can be private to their owner, or optionally enabled for global use by (all) other users.
- *  - Views can be marked as favorites for quick access.
+ *  - Views can be private to their owner, or optionally enabled for sharing to (all) other users.
+ *  - Views can be marked as pinned for quick access.
  *  - See the desktop {@link ViewManager} component - the initial Hoist UI for this model.
  */
 export class ViewManagerModel<T = PlainObject> extends HoistModel {
@@ -146,7 +146,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
     readonly globalDisplayName: string;
     readonly enableAutoSave: boolean;
     readonly enableDefault: boolean;
-    readonly enableFavorites: boolean;
+    readonly enableSharing: boolean;
     readonly manageGlobal: boolean;
     readonly settleTime: number;
     readonly initialViewSpec: (views: ViewInfo[]) => ViewInfo;
@@ -155,8 +155,14 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
     @observable.ref view: View<T> = null;
     /** Loaded saved view library - both private and global */
     @observable.ref views: ViewInfo[] = [];
-    /** List of tokens for the user's favorite views. */
-    @observable.ref favorites: string[] = [];
+
+    /**
+     * Map of user's preferred pinned state for views.
+     *
+     * Note that the actual pinned state for the views is determined by this value, layered
+     * over the default state of the views themselves.
+     */
+    @observable.ref userPinned: Record<string, boolean> = {};
 
     /**
      * True if user has opted-in to automatically saving changes to personal views (if auto-save
@@ -174,9 +180,6 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
      * TaskObserver linked to {@link saveAsync}.
      */
     saveTask: TaskObserver;
-
-    @observable manageDialogOpen = false;
-    @managed saveAsDialogModel: SaveAsDialogModel;
 
     //-----------------------
     // Private, internal state.
@@ -211,32 +214,37 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
 
     get isViewSavable(): boolean {
         const {view, manageGlobal} = this;
-        return !view.isDefault && (manageGlobal || !view.isGlobal);
+        return view.isOwned || (view.isGlobal && manageGlobal);
     }
 
     get isViewAutoSavable(): boolean {
         const {enableAutoSave, autoSave, view} = this;
-        return enableAutoSave && autoSave && !view.isGlobal && !view.isDefault;
+        return enableAutoSave && autoSave && !view.isShared && !view.isDefault;
     }
 
     get autoSaveUnavailableReason(): string {
         const {view, isViewAutoSavable, typeDisplayName, globalDisplayName} = this;
         if (isViewAutoSavable) return null;
         if (view.isGlobal) return `Cannot auto-save ${globalDisplayName} ${typeDisplayName}.`;
+        if (view.isShared) return `Cannot auto-save shared ${typeDisplayName}.`;
         if (view.isDefault) return `Cannot auto-save default ${typeDisplayName}.`;
         return null;
     }
 
-    get favoriteViews(): ViewInfo[] {
-        return this.views.filter(it => it.isFavorite);
+    get pinnedViews(): ViewInfo[] {
+        return this.views.filter(it => it.isPinned);
     }
 
     get globalViews(): ViewInfo[] {
         return this.views.filter(it => it.isGlobal);
     }
 
-    get privateViews(): ViewInfo[] {
-        return this.views.filter(it => !it.isGlobal);
+    get sharedViews(): ViewInfo[] {
+        return this.views.filter(it => it.isShared);
+    }
+
+    get ownedViews(): ViewInfo[] {
+        return this.views.filter(it => it.isOwned);
     }
 
     /** True if any async tasks are pending. */
@@ -257,8 +265,8 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         manageGlobal = false,
         enableAutoSave = true,
         enableDefault = true,
+        enableSharing = true,
         settleTime = 250,
-        enableFavorites = true,
         initialViewSpec = null
     }: ViewManagerConfig) {
         super();
@@ -275,8 +283,8 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         this.persistWith = persistWith;
         this.manageGlobal = executeIfFunction(manageGlobal) ?? false;
         this.enableDefault = enableDefault;
+        this.enableSharing = enableSharing;
         this.enableAutoSave = enableAutoSave;
-        this.enableFavorites = enableFavorites;
         this.settleTime = settleTime;
         this.initialViewSpec = initialViewSpec;
 
@@ -287,7 +295,6 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
             message: `Saving ${this.typeDisplayName}...`
         });
 
-        this.saveAsDialogModel = new SaveAsDialogModel(this);
         this.api = new ViewToBlobApi(this);
     }
 
@@ -322,6 +329,12 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         await this.loadViewAsync(info).catch(e => this.handleException(e));
     }
 
+    async saveAsAsync(spec: ViewCreateSpec): Promise<void> {
+        const view = await this.api.createViewAsync({...spec, value: this.getValue()});
+        this.noteSuccess(`Created ${view.typedName}`);
+        this.refreshAsync();
+    }
+
     //------------------------
     // Saving/resetting
     //------------------------
@@ -345,15 +358,6 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
             this.handleException(e, {
                 message: `Failed to save ${view.typedName}.  If this persists consider \`Save As...\`.`
             });
-        }
-        this.refreshAsync();
-    }
-
-    async saveAsAsync(): Promise<void> {
-        const view = (await this.saveAsDialogModel.openAsync()) as View<T>;
-        if (view) {
-            this.setAsView(view);
-            this.noteSuccess(`Saved ${view.typedName}`);
         }
         this.refreshAsync();
     }
@@ -389,40 +393,29 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
     }
 
     //------------------
-    // Favorites
+    // Pinning
     //------------------
-    toggleFavorite(token: string) {
-        this.isFavorite(token) ? this.removeFavorite(token) : this.addFavorite(token);
+    togglePinned(view: ViewInfo) {
+        view.isPinned ? this.userUnpin(view) : this.userPin(view);
     }
 
     @action
-    addFavorite(token: string) {
-        this.favorites = [...this.favorites, token];
+    userPin(view: ViewInfo) {
+        this.userPinned = {...this.userPinned, [view.token]: true};
     }
 
     @action
-    removeFavorite(token: string) {
-        this.favorites = without(this.favorites, token);
+    userUnpin(view: ViewInfo) {
+        this.userPinned = {...this.userPinned, [view.token]: false};
     }
 
-    isFavorite(token: string) {
-        return this.favorites.includes(token);
+    isUserPinned(view: ViewInfo): boolean | null {
+        return this.userPinned[view.token];
     }
 
     //-----------------
     // Management
     //-----------------
-    @action
-    openManageDialog() {
-        this.manageDialogOpen = true;
-        this.refreshAsync();
-    }
-
-    @action
-    closeManageDialog() {
-        this.manageDialogOpen = false;
-    }
-
     async validateViewNameAsync(name: string, existing: ViewInfo = null): Promise<string> {
         const maxLength = 50;
         name = name?.trim();
@@ -588,21 +581,24 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
     //------------------
     private initPersist(options: ViewManagerPersistOptions) {
         const {
-            persistFavorites = true,
+            persistPinning = true,
             persistPendingValue = false,
             path = 'viewManager',
             ...rootPersistWith
         } = options;
 
-        // Favorites, potentially in dedicated location
-        if (this.enableFavorites && persistFavorites) {
-            const opts = isObject(persistFavorites) ? persistFavorites : rootPersistWith;
+        // Pinning potentially in dedicated location
+        if (persistPinning) {
+            const opts = isObject(persistPinning) ? persistPinning : rootPersistWith;
             PersistenceProvider.create({
-                persistOptions: {path: `${path}.favorites`, ...opts},
+                persistOptions: {path: `${path}.pinning`, ...opts},
                 target: {
-                    getPersistableState: () => new PersistableState(this.favorites),
+                    getPersistableState: () => new PersistableState(this.userPinned),
                     setPersistableState: ({value}) => {
-                        this.favorites = value.filter(tkn => this.views.some(v => v.token === tkn));
+                        const {views} = this;
+                        this.userPinned = !isEmpty(views) // Clean state iff views loaded!
+                            ? pickBy(value, (_, tkn) => views.some(v => v.token === tkn))
+                            : value;
                     }
                 },
                 owner: this

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -554,7 +554,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
             msgs.push(
                 span(
                     `This is a ${globalDisplayName} ${typeDisplayName}.`,
-                    strong('Changes will be visible to ALL users.')
+                    strong('Changes will be visible to all users.')
                 )
             );
         }

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -332,6 +332,8 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
     async saveAsAsync(spec: ViewCreateSpec): Promise<void> {
         const view = await this.api.createViewAsync({...spec, value: this.getValue()});
         this.noteSuccess(`Created ${view.typedName}`);
+        this.userPin(view.info);
+        this.setAsView(view);
         this.refreshAsync();
     }
 

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -235,12 +235,19 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         return this.views.filter(it => it.isPinned);
     }
 
-    get globalViews(): ViewInfo[] {
-        return this.views.filter(it => it.isGlobal);
-    }
-
+    /** Views owned by me */
     get ownedViews(): ViewInfo[] {
         return this.views.filter(it => it.isOwned);
+    }
+
+    /** Views shared *with* me */
+    get sharedViews(): ViewInfo[] {
+        return this.views.filter(it => it.isShared && !it.isOwned);
+    }
+
+    /** Global views */
+    get globalViews(): ViewInfo[] {
+        return this.views.filter(it => it.isGlobal);
     }
 
     /** True if any async tasks are pending. */

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -557,7 +557,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         if (isGlobal) {
             msgs.push(
                 span(
-                    `This is a ${globalDisplayName} ${typeDisplayName}.`,
+                    `This is a ${globalDisplayName} ${typeDisplayName}. `,
                     strong('Changes will be visible to all users.')
                 )
             );
@@ -565,7 +565,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         if (isStale) {
             msgs.push(
                 span(
-                    `This ${typeDisplayName} was updated by ${latestInfo.lastUpdatedBy} on ${fmtDateTime(latestInfo.lastUpdated)}.`,
+                    `This ${typeDisplayName} was updated by ${latestInfo.lastUpdatedBy} on ${fmtDateTime(latestInfo.lastUpdated)}. `,
                     strong('Your change may override those changes.')
                 )
             );
@@ -576,11 +576,11 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
             confirmProps: {
                 text: 'Yes, save changes',
                 intent: 'primary',
-                outlined: true
+                outlined: true,
+                autoFocus: false
             },
             cancelProps: {
-                text: 'Cancel',
-                autoFocus: true
+                text: 'Cancel'
             }
         });
     }

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -425,7 +425,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         if (name.length > maxLength) {
             return `Name cannot be longer than ${maxLength} characters`;
         }
-        if (this.views.some(view => view.name === name && view.token != existing?.token)) {
+        if (this.ownedViews.some(view => view.name === name && view.token != existing?.token)) {
             return `A ${this.typeDisplayName} with name '${name}' already exists`;
         }
         return null;

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -239,10 +239,6 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         return this.views.filter(it => it.isGlobal);
     }
 
-    get sharedViews(): ViewInfo[] {
-        return this.views.filter(it => it.isShared);
-    }
-
     get ownedViews(): ViewInfo[] {
         return this.views.filter(it => it.isOwned);
     }

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -216,7 +216,13 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
 
     get isViewAutoSavable(): boolean {
         const {enableAutoSave, autoSave, view} = this;
-        return enableAutoSave && autoSave && !view.isShared && !view.isDefault;
+        return (
+            enableAutoSave &&
+            autoSave &&
+            !view.isShared &&
+            !view.isDefault &&
+            !XH.identityService.isImpersonating
+        );
     }
 
     get autoSaveUnavailableReason(): string {
@@ -225,6 +231,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         if (view.isGlobal) return `Cannot auto-save ${globalDisplayName} ${typeDisplayName}.`;
         if (view.isShared) return `Cannot auto-save shared ${typeDisplayName}.`;
         if (view.isDefault) return `Cannot auto-save default ${typeDisplayName}.`;
+        if (XH.identityService.isImpersonating) return `Auto-save disabled during impersonation.`;
         return null;
     }
 

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -433,7 +433,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
             return `Name cannot be longer than ${maxLength} characters`;
         }
         if (this.ownedViews.some(view => view.name === name && view.token != existing?.token)) {
-            return `A ${this.typeDisplayName} with name '${name}' already exists`;
+            return `A ${this.typeDisplayName} with name '${name}' already exists.`;
         }
         return null;
     }

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -59,11 +59,10 @@ export interface ViewManagerConfig {
     initialViewSpec?: (views: ViewInfo[]) => ViewInfo;
 
     /**
-     * Delay after state has been set on associated components before they will be observed for
-     * any further state changes.  Larger values may be useful when providing state to complex
-     * components such as dashboards or grids that may create dirty state immediately after load.
-     *
-     * Specified in milliseconds.  Default is 250.
+     * Delay (in ms) to wait after state has been set on associated components before listening for
+     * further state changes. The long default wait 1000ms is intended to avoid a false positive
+     * dirty indicator when linking to complex components such as dashboards or grids that can
+     * report immediate changes to state due to internal processing or rendering.
      */
     settleTime?: number;
 
@@ -176,9 +175,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
      */
     selectTask: TaskObserver;
 
-    /**
-     * TaskObserver linked to {@link saveAsync}.
-     */
+    /** TaskObserver linked to {@link saveAsync}. */
     saveTask: TaskObserver;
 
     //-----------------------
@@ -197,7 +194,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
     providers: ViewManagerProvider<any>[] = [];
 
     /**
-     * Data access for persisting views
+     * Data access for persisting views.
      * @internal
      */
     api: ViewToBlobApi<T>;
@@ -269,7 +266,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         enableAutoSave = true,
         enableDefault = true,
         enableSharing = true,
-        settleTime = 250,
+        settleTime = 1000,
         initialViewSpec = null
     }: ViewManagerConfig) {
         super();

--- a/cmp/viewmanager/ViewToBlobApi.ts
+++ b/cmp/viewmanager/ViewToBlobApi.ts
@@ -103,9 +103,9 @@ export class ViewToBlobApi<T> {
                 blob = await XH.jsonBlobService.updateAsync(view.token, {
                     name: name.trim(),
                     description: description?.trim(),
+                    owner: isGlobal ? null : XH.getUsername(),
                     acl: isGlobal || isShared ? '*' : null,
-                    owner: isGlobal ? null : view.owner,
-                    meta: isGlobal ? {group, isGlobal: true, isDefaultPinned} : {group, isShared}
+                    meta: isGlobal ? {group, isDefaultPinned} : {group, isShared}
                 });
             const ret = View.fromBlob(blob, this.model);
             this.trackChange('Updated View Info', ret);

--- a/cmp/viewmanager/ViewToBlobApi.ts
+++ b/cmp/viewmanager/ViewToBlobApi.ts
@@ -118,16 +118,15 @@ export class ViewToBlobApi<T> {
         }
     }
 
-    /** Promote/demote a view from global visibility/ownership status. */
-    async toggleViewIsGlobalAsync(view: ViewInfo): Promise<View<T>> {
+    /** Promote a view to global visibility/ownership status. */
+    async makeViewGlobalAsync(view: ViewInfo): Promise<View<T>> {
         try {
             this.ensureEditable(view);
             const meta = view.meta,
-                isGlobal = !view.isGlobal,
                 blob = await XH.jsonBlobService.updateAsync(view.token, {
-                    owner: isGlobal ? null : XH.getUsername(),
-                    acl: isGlobal ? '*' : null,
-                    meta: omit(meta, ['isShared', 'isDefaultPinned'])
+                    owner: null,
+                    acl: '*',
+                    meta: omit(meta, ['isShared'])
                 });
             const ret = View.fromBlob(blob, this.model);
             this.trackChange('Updated View Info', ret);

--- a/cmp/viewmanager/ViewToBlobApi.ts
+++ b/cmp/viewmanager/ViewToBlobApi.ts
@@ -7,7 +7,7 @@
 
 import {PlainObject, XH} from '@xh/hoist/core';
 import {pluralize, throwIf} from '@xh/hoist/utils/js';
-import {omit} from 'lodash';
+import {omit, pick} from 'lodash';
 import {ViewInfo} from './ViewInfo';
 import {View} from './View';
 import {ViewManagerModel} from './ViewManagerModel';
@@ -126,7 +126,7 @@ export class ViewToBlobApi<T> {
                     meta: omit(meta, ['isShared'])
                 });
             const ret = View.fromBlob(blob, this.model);
-            this.trackChange('Updated View Info', ret);
+            this.trackChange('Made View Global', ret);
             return ret;
         } catch (e) {
             throw XH.exception({message: `Unable to update ${view.typedName}`, cause: e});
@@ -169,7 +169,7 @@ export class ViewToBlobApi<T> {
         XH.track({
             message,
             category: 'Views',
-            data: {name: v.name, token: v.token, isGlobal: v.isGlobal, type: v.type}
+            data: pick(v, ['name', 'token', 'isGlobal', 'type'])
         });
     }
 

--- a/cmp/viewmanager/ViewToBlobApi.ts
+++ b/cmp/viewmanager/ViewToBlobApi.ts
@@ -29,12 +29,11 @@ export interface ViewUpdateSpec {
 }
 
 /**
- * Class for accessing and updating views using JSON Blobs Service.
- *
+ * Class for accessing and updating views using {@link JsonBlobService}.
  * @internal
  */
 export class ViewToBlobApi<T> {
-    private model: ViewManagerModel<T>;
+    private readonly model: ViewManagerModel<T>;
 
     constructor(model: ViewManagerModel<T>) {
         this.model = model;
@@ -43,9 +42,7 @@ export class ViewToBlobApi<T> {
     //---------------
     // Load/search.
     //---------------
-    /**
-     * Fetch metadata for all views that this user has access to.
-     */
+    /** Fetch metadata for all views accessible by current user. */
     async fetchViewInfosAsync(): Promise<ViewInfo[]> {
         const {model} = this;
         try {
@@ -75,7 +72,7 @@ export class ViewToBlobApi<T> {
     }
 
     //-----------------
-    // Crud
+    // CRUD
     //-----------------
     /** Create a new view, owned by the current user.*/
     async createViewAsync(spec: ViewCreateSpec): Promise<View<T>> {
@@ -97,7 +94,7 @@ export class ViewToBlobApi<T> {
         }
     }
 
-    /** Update all aspects of a views metadata.*/
+    /** Update all aspects of a view's metadata.*/
     async updateViewInfoAsync(view: ViewInfo, updates: ViewUpdateSpec): Promise<View<T>> {
         try {
             this.ensureEditable(view);

--- a/cmp/viewmanager/ViewToBlobApi.ts
+++ b/cmp/viewmanager/ViewToBlobApi.ts
@@ -16,7 +16,6 @@ export interface ViewCreateSpec {
     group: string;
     description: string;
     isShared: boolean;
-    isPinned: boolean;
     value?: PlainObject;
 }
 

--- a/cmp/viewmanager/ViewToBlobApi.ts
+++ b/cmp/viewmanager/ViewToBlobApi.ts
@@ -11,42 +11,65 @@ import {ViewInfo} from './ViewInfo';
 import {View} from './View';
 import {ViewManagerModel} from './ViewManagerModel';
 
+export interface ViewCreateSpec {
+    name: string;
+    group: string;
+    description: string;
+    isShared: boolean;
+    isPinned: boolean;
+    value?: PlainObject;
+}
+
+export interface ViewUpdateSpec {
+    name: string;
+    group: string;
+    description: string;
+    isShared: boolean;
+    isGlobal: boolean;
+    isDefaultPinned: boolean;
+}
+
 /**
  * Class for accessing and updating views using JSON Blobs Service.
  *
  * @internal
  */
 export class ViewToBlobApi<T> {
-    private owner: ViewManagerModel<T>;
+    private model: ViewManagerModel<T>;
 
-    constructor(owner: ViewManagerModel<T>) {
-        this.owner = owner;
+    constructor(model: ViewManagerModel<T>) {
+        this.model = model;
     }
 
     //---------------
     // Load/search.
     //---------------
+    /**
+     * Fetch metadata for all views that this user has access to.
+     */
     async fetchViewInfosAsync(): Promise<ViewInfo[]> {
-        const {owner} = this;
+        const {model} = this;
         try {
             const blobs = await XH.jsonBlobService.listAsync({
-                type: owner.type,
+                type: model.type,
                 includeValue: false
             });
-            return blobs.map(b => new ViewInfo(b, owner));
+            return blobs.map(b => new ViewInfo(b, model));
         } catch (e) {
             throw XH.exception({
-                message: `Unable to fetch ${pluralize(owner.typeDisplayName)}`,
+                message: `Unable to fetch ${pluralize(model.typeDisplayName)}`,
                 cause: e
             });
         }
     }
 
+    /** Fetch the latest version of a view. */
     async fetchViewAsync(info: ViewInfo): Promise<View<T>> {
-        if (!info) return View.createDefault(this.owner);
+        const {model} = this;
+        if (!info) return View.createDefault(model);
         try {
             const blob = await XH.jsonBlobService.getAsync(info.token);
-            return View.fromBlob(blob, this.owner);
+            return View.fromBlob(blob, model);
         } catch (e) {
             throw XH.exception({message: `Unable to fetch ${info.typedName}`, cause: e});
         }
@@ -55,36 +78,37 @@ export class ViewToBlobApi<T> {
     //-----------------
     // Crud
     //-----------------
-    async createViewAsync(name: string, description: string, value: PlainObject): Promise<View<T>> {
-        const {owner} = this;
+    /** Create a new private view, owned by the current user.*/
+    async createViewAsync(spec: ViewCreateSpec): Promise<View<T>> {
+        const {model} = this;
         try {
             const blob = await XH.jsonBlobService.createAsync({
-                type: owner.type,
-                name: name.trim(),
-                description: description?.trim(),
-                value
+                type: model.type,
+                name: spec.name,
+                description: spec.description,
+                meta: {group: spec.group, isShared: spec.isShared},
+                value: spec.value
             });
-            const ret = View.fromBlob(blob, owner);
+            const ret = View.fromBlob(blob, model);
             this.trackChange('Created View', ret);
             return ret;
         } catch (e) {
-            throw XH.exception({message: `Unable to create ${owner.typeDisplayName}`, cause: e});
+            throw XH.exception({message: `Unable to create ${model.typeDisplayName}`, cause: e});
         }
     }
 
-    async updateViewInfoAsync(
-        view: ViewInfo,
-        name: string,
-        description: string,
-        isGlobal: boolean
-    ): Promise<View<T>> {
+    /** Update all aspects of a views metadata.*/
+    async updateViewInfoAsync(view: ViewInfo, updates: ViewUpdateSpec): Promise<View<T>> {
         try {
-            const blob = await XH.jsonBlobService.updateAsync(view.token, {
-                name: name.trim(),
-                description: description?.trim(),
-                acl: isGlobal ? '*' : null
-            });
-            const ret = View.fromBlob(blob, this.owner);
+            const {name, group, description, isShared, isGlobal, isDefaultPinned} = updates,
+                blob = await XH.jsonBlobService.updateAsync(view.token, {
+                    name: name.trim(),
+                    description: description?.trim(),
+                    acl: isGlobal || isShared ? '*' : null,
+                    owner: isGlobal ? null : view.owner,
+                    meta: isGlobal ? {group, isGlobal: true, isDefaultPinned} : {group, isShared}
+                });
+            const ret = View.fromBlob(blob, this.model);
             this.trackChange('Updated View Info', ret);
             return ret;
         } catch (e) {
@@ -92,10 +116,11 @@ export class ViewToBlobApi<T> {
         }
     }
 
+    /** Update a view's value. */
     async updateViewValueAsync(view: View<T>, value: Partial<T>): Promise<View<T>> {
         try {
             const blob = await XH.jsonBlobService.updateAsync(view.token, {value});
-            const ret = View.fromBlob(blob, this.owner);
+            const ret = View.fromBlob(blob, this.model);
             if (ret.isGlobal) {
                 this.trackChange('Updated Global View definition', ret);
             }
@@ -108,6 +133,7 @@ export class ViewToBlobApi<T> {
         }
     }
 
+    /** Delete a view. */
     async deleteViewAsync(view: ViewInfo) {
         try {
             await XH.jsonBlobService.archiveAsync(view.token);

--- a/cmp/viewmanager/index.ts
+++ b/cmp/viewmanager/index.ts
@@ -1,4 +1,3 @@
 export * from './ViewManagerModel';
 export * from './ViewInfo';
 export * from './View';
-export * from './SaveAsDialogModel';

--- a/cmp/viewmanager/index.ts
+++ b/cmp/viewmanager/index.ts
@@ -1,3 +1,4 @@
 export * from './ViewManagerModel';
 export * from './ViewInfo';
 export * from './View';
+export * from './ViewToBlobApi';

--- a/desktop/cmp/viewmanager/ViewManager.scss
+++ b/desktop/cmp/viewmanager/ViewManager.scss
@@ -36,5 +36,20 @@
       color: var(--xh-text-color-muted);
       font-size: var(--xh-font-size-small-px);
     }
+
+    &__help-text {
+      display: flex;
+      align-items: center;
+      gap: var(--xh-pad-px);
+      margin: var(--xh-pad-px);
+      padding: var(--xh-pad-px);
+      border: var(--xh-border-solid);
+      border-radius: var(--xh-border-radius-px);
+      background-color: var(--xh-bg-alt);
+
+      .xh-icon {
+        font-size: 1.2em;
+      }
+    }
   }
 }

--- a/desktop/cmp/viewmanager/ViewManager.scss
+++ b/desktop/cmp/viewmanager/ViewManager.scss
@@ -1,32 +1,6 @@
 .xh-view-manager {
   align-items: center;
 
-  &__menu-item {
-    &:hover {
-      .xh-view-manager__menu-item__fave-toggle {
-        opacity: 1;
-        color: var(--xh-yellow);
-      }
-    }
-
-    &__fave-toggle {
-      opacity: 0;
-
-      &:hover {
-        color: var(--xh-yellow-light) !important;
-      }
-
-      &--active {
-        opacity: 1;
-        color: var(--xh-yellow);
-      }
-
-      &--active:hover {
-        color: var(--xh-yellow-light) !important;
-      }
-    }
-  }
-
   //------------------------
   // Dialogs
   //------------------------

--- a/desktop/cmp/viewmanager/ViewManager.scss
+++ b/desktop/cmp/viewmanager/ViewManager.scss
@@ -9,8 +9,16 @@
     &__form {
       padding: var(--xh-pad-px);
 
-      .xh-form-field.xh-form-field-readonly .xh-form-field-readonly-display {
-        padding: 0;
+      .xh-form-field.xh-form-field-readonly {
+        &:not(.xh-form-field-inline) {
+          .xh-form-field-label {
+            border-bottom: var(--xh-border-solid);
+          }
+        }
+
+        .xh-form-field-readonly-display {
+          padding: 0;
+        }
       }
 
       .xh-form-field .xh-form-field-info {

--- a/desktop/cmp/viewmanager/ViewManager.ts
+++ b/desktop/cmp/viewmanager/ViewManager.ts
@@ -63,16 +63,12 @@ export const [ViewManager, viewManager] = hoistCmp.withFactory<ViewManagerProps>
         showRevertButton = 'never',
         buttonSide = 'right'
     }: ViewManagerProps) {
-        const localModel = useLocalModel(() => new ViewManagerLocalModel(model)),
-            save = saveButton({model: localModel, mode: showSaveButton, ...saveButtonProps}),
-            revert = revertButton({
-                model: localModel,
-                mode: showRevertButton,
-                ...revertButtonProps
-            }),
+        const locModel = useLocalModel(() => new ViewManagerLocalModel(model)),
+            save = saveButton({model: locModel, mode: showSaveButton, ...saveButtonProps}),
+            revert = revertButton({model: locModel, mode: showRevertButton, ...revertButtonProps}),
             menu = popover({
-                item: menuButton(menuButtonProps),
-                content: viewMenu({model: localModel}),
+                item: menuButton({model: locModel, ...menuButtonProps}),
+                content: viewMenu({model: locModel}),
                 placement: 'bottom-start',
                 popoverClassName: 'xh-view-manager__popover'
             });
@@ -81,8 +77,8 @@ export const [ViewManager, viewManager] = hoistCmp.withFactory<ViewManagerProps>
                 className,
                 items: buttonSide == 'left' ? [revert, save, menu] : [menu, save, revert]
             }),
-            manageDialog({model: !localModel.manageDialogModel}),
-            saveAsDialog({model: !localModel.saveAsDialogModel})
+            manageDialog({model: locModel.manageDialogModel}),
+            saveAsDialog({model: locModel.saveAsDialogModel})
         );
     }
 });

--- a/desktop/cmp/viewmanager/ViewManager.ts
+++ b/desktop/cmp/viewmanager/ViewManager.ts
@@ -7,13 +7,14 @@
 
 import {box, fragment, hbox} from '@xh/hoist/cmp/layout';
 import {spinner} from '@xh/hoist/cmp/spinner';
-import {hoistCmp, HoistProps, uses} from '@xh/hoist/core';
+import {hoistCmp, HoistProps, useLocalModel, uses} from '@xh/hoist/core';
 import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
 import {button, ButtonProps} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {popover} from '@xh/hoist/kit/blueprint';
 import {startCase} from 'lodash';
 import {viewMenu} from './ViewMenu';
+import {ViewManagerLocalModel} from './ViewManagerLocalModel';
 import {manageDialog} from './dialog/ManageDialog';
 import {saveAsDialog} from './dialog/SaveAsDialog';
 
@@ -39,10 +40,6 @@ export interface ViewManagerProps extends HoistProps<ViewManagerModel> {
     showRevertButton?: ViewManagerStateButtonMode;
     /** Side the save and revert buttons should appear on (default 'right') */
     buttonSide?: 'left' | 'right';
-    /** True to render private views in sub-menu (Default false) */
-    showPrivateViewsInSubMenu?: boolean;
-    /** True to render global views in sub-menu (Default false) */
-    showGlobalViewsInSubMenu?: boolean;
 }
 
 /**
@@ -64,15 +61,18 @@ export const [ViewManager, viewManager] = hoistCmp.withFactory<ViewManagerProps>
         revertButtonProps,
         showSaveButton = 'whenDirty',
         showRevertButton = 'never',
-        buttonSide = 'right',
-        showPrivateViewsInSubMenu = false,
-        showGlobalViewsInSubMenu = false
+        buttonSide = 'right'
     }: ViewManagerProps) {
-        const save = saveButton({mode: showSaveButton, ...saveButtonProps}),
-            revert = revertButton({mode: showRevertButton, ...revertButtonProps}),
+        const localModel = useLocalModel(() => new ViewManagerLocalModel(model)),
+            save = saveButton({model: localModel, mode: showSaveButton, ...saveButtonProps}),
+            revert = revertButton({
+                model: localModel,
+                mode: showRevertButton,
+                ...revertButtonProps
+            }),
             menu = popover({
                 item: menuButton(menuButtonProps),
-                content: viewMenu({showPrivateViewsInSubMenu, showGlobalViewsInSubMenu}),
+                content: viewMenu({model: localModel}),
                 placement: 'bottom-start',
                 popoverClassName: 'xh-view-manager__popover'
             });
@@ -81,15 +81,15 @@ export const [ViewManager, viewManager] = hoistCmp.withFactory<ViewManagerProps>
                 className,
                 items: buttonSide == 'left' ? [revert, save, menu] : [menu, save, revert]
             }),
-            manageDialog({omit: !model.manageDialogOpen}),
-            saveAsDialog()
+            manageDialog({model: !localModel.manageDialogModel}),
+            saveAsDialog({model: !localModel.saveAsDialogModel})
         );
     }
 });
 
-const menuButton = hoistCmp.factory<ViewManagerModel>({
+const menuButton = hoistCmp.factory<ViewManagerLocalModel>({
     render({model, ...rest}) {
-        const {view, typeDisplayName, isLoading} = model;
+        const {view, typeDisplayName, isLoading} = model.parent;
         return button({
             className: 'xh-view-manager__menu-button',
             text: view.isDefault ? `Default ${startCase(typeDisplayName)}` : view.name,
@@ -106,40 +106,46 @@ const menuButton = hoistCmp.factory<ViewManagerModel>({
     }
 });
 
-const saveButton = hoistCmp.factory<ViewManagerModel>({
+const saveButton = hoistCmp.factory<ViewManagerLocalModel>({
     render({model, mode, ...rest}) {
         if (hideStateButton(model, mode)) return null;
+        const {parent, saveAsDialogModel} = model,
+            {typeDisplayName, isLoading, isValueDirty} = parent;
         return button({
             className: 'xh-view-manager__save-button',
             icon: Icon.save(),
-            tooltip: `Save changes to this ${model.typeDisplayName}`,
+            tooltip: `Save changes to this ${typeDisplayName}`,
             intent: 'primary',
-            disabled: !model.isValueDirty || model.isLoading,
+            disabled: !isValueDirty || isLoading,
             onClick: () => {
-                model.isViewSavable ? model.saveAsync() : model.saveAsAsync();
+                parent.isViewSavable ? parent.saveAsync() : saveAsDialogModel.open();
             },
             ...rest
         });
     }
 });
 
-const revertButton = hoistCmp.factory<ViewManagerModel>({
+const revertButton = hoistCmp.factory<ViewManagerLocalModel>({
     render({model, mode, ...rest}) {
         if (hideStateButton(model, mode)) return null;
+        const {typeDisplayName, isLoading, isValueDirty} = model.parent;
         return button({
             className: 'xh-view-manager__revert-button',
             icon: Icon.reset(),
-            tooltip: `Revert changes to this ${model.typeDisplayName}`,
+            tooltip: `Revert changes to this ${typeDisplayName}`,
             intent: 'danger',
-            disabled: !model.isValueDirty || model.isLoading,
-            onClick: () => model.resetAsync(),
+            disabled: !isValueDirty || isLoading,
+            onClick: () => model.parent.resetAsync(),
             ...rest
         });
     }
 });
 
-function hideStateButton(model: ViewManagerModel, mode: ViewManagerStateButtonMode): boolean {
+function hideStateButton(model: ViewManagerLocalModel, mode: ViewManagerStateButtonMode): boolean {
+    const {parent} = model;
     return (
-        mode === 'never' || (mode === 'whenDirty' && !model.isValueDirty) || model.isViewAutoSavable
+        mode === 'never' ||
+        (mode === 'whenDirty' && !parent.isValueDirty) ||
+        parent.isViewAutoSavable
     );
 }

--- a/desktop/cmp/viewmanager/ViewManagerLocalModel.ts
+++ b/desktop/cmp/viewmanager/ViewManagerLocalModel.ts
@@ -1,0 +1,28 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2024 Extremely Heavy Industries Inc.
+ */
+
+import {HoistModel, managed} from '@xh/hoist/core';
+import {ManageDialogModel} from './dialog/ManageDialogModel';
+import {SaveAsDialogModel} from './dialog/SaveAsDialogModel';
+import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
+
+export class ViewManagerLocalModel extends HoistModel {
+    readonly parent: ViewManagerModel;
+
+    @managed
+    readonly manageDialogModel: ManageDialogModel;
+
+    @managed
+    readonly saveAsDialogModel: SaveAsDialogModel;
+
+    constructor(parent: ViewManagerModel) {
+        super();
+        this.parent = parent;
+        this.manageDialogModel = new ManageDialogModel(parent);
+        this.saveAsDialogModel = new SaveAsDialogModel(parent);
+    }
+}

--- a/desktop/cmp/viewmanager/ViewMenu.ts
+++ b/desktop/cmp/viewmanager/ViewMenu.ts
@@ -46,7 +46,7 @@ function getNavMenuItems(model: ViewManagerModel): ReactNode[] {
     if (!isEmpty(global)) {
         ret.push(
             menuDivider({title: `${startCase(globalDisplayName)}  ${pluralName}`}),
-            ...getGroupedMenuItems(owned, model)
+            ...getGroupedMenuItems(global, model)
         );
     }
     if (!isEmpty(other)) {
@@ -178,14 +178,14 @@ function viewMenuItem(view: ViewInfo, model: ViewManagerModel): ReactNode {
     const icon = view.isCurrentView ? Icon.check() : Icon.placeholder(),
         title = [];
 
-    if (view.isShared) title.push(view.owner);
+    if (!view.isOwned && view.owner) title.push(view.owner);
     if (view.description) title.push(view.description);
 
     return menuItem({
         className: 'xh-view-manager__menu-item',
         key: view.token,
         text: view.name,
-        title: title.join('|'),
+        title: title.join(' | '),
         icon,
         onClick: () => model.selectViewAsync(view)
     });

--- a/desktop/cmp/viewmanager/ViewMenu.ts
+++ b/desktop/cmp/viewmanager/ViewMenu.ts
@@ -40,7 +40,6 @@ function getNavMenuItems(model: ViewManagerModel): ReactNode[] {
         ret = [];
 
     // Main Views items by type
-    // TODO -- be smart?  If more than, say n for any cat, start nesting them in submenus?
     if (!isEmpty(ownedViews)) {
         ret.push(
             menuDivider({title: `My ${pluralName}`}),

--- a/desktop/cmp/viewmanager/ViewMenu.ts
+++ b/desktop/cmp/viewmanager/ViewMenu.ts
@@ -34,7 +34,7 @@ export const viewMenu = hoistCmp.factory<ViewManagerLocalModel>({
 function getNavMenuItems(model: ViewManagerModel): ReactNode[] {
     const {enableDefault, view, typeDisplayName, globalDisplayName} = model,
         ownedViews = groupBy(filter(model.ownedViews, 'isPinned'), 'group'),
-        globalViews = groupBy(filter(model.ownedViews, 'isPinned'), 'group'),
+        globalViews = groupBy(filter(model.globalViews, 'isPinned'), 'group'),
         sharedViews = groupBy(filter(model.sharedViews, 'isPinned'), 'owner'),
         pluralName = pluralize(startCase(typeDisplayName)),
         ret = [];

--- a/desktop/cmp/viewmanager/ViewMenu.ts
+++ b/desktop/cmp/viewmanager/ViewMenu.ts
@@ -175,16 +175,9 @@ function getGroupedMenuItems(views: ViewInfo[], model: ViewManagerModel): ReactN
 }
 
 function viewMenuItem(view: ViewInfo, model: ViewManagerModel): ReactNode {
-    const icon =
-        view.token == model.view.token
-            ? Icon.check()
-            : view.isGlobal
-              ? Icon.globe()
-              : view.isShared
-                ? Icon.user()
-                : Icon.placeholder();
+    const icon = view.isCurrentView ? Icon.check() : Icon.placeholder(),
+        title = [];
 
-    const title = [];
     if (view.isShared) title.push(view.owner);
     if (view.description) title.push(view.description);
 

--- a/desktop/cmp/viewmanager/ViewMenu.ts
+++ b/desktop/cmp/viewmanager/ViewMenu.ts
@@ -5,7 +5,7 @@
  * Copyright © 2024 Extremely Heavy Industries Inc.
  */
 
-import {box, div, filler, fragment, hbox, span} from '@xh/hoist/cmp/layout';
+import {box} from '@xh/hoist/cmp/layout';
 import {spinner} from '@xh/hoist/cmp/spinner';
 import {hoistCmp} from '@xh/hoist/core';
 import {ViewManagerModel, ViewInfo} from '@xh/hoist/cmp/viewmanager';
@@ -14,188 +14,186 @@ import {Icon} from '@xh/hoist/icon';
 import {menu, menuDivider, menuItem} from '@xh/hoist/kit/blueprint';
 import {wait} from '@xh/hoist/promise';
 import {consumeEvent, pluralize} from '@xh/hoist/utils/js';
-import {isEmpty, startCase} from 'lodash';
+import {each, groupBy, isEmpty, orderBy, some, startCase} from 'lodash';
 import {ReactNode} from 'react';
-import {ViewManagerProps} from './ViewManager';
+import {ViewManagerLocalModel} from './ViewManagerLocalModel';
 
 /**
  * Default Menu used by ViewManager.
  */
-export const viewMenu = hoistCmp.factory<ViewManagerProps>({
-    render({model, showPrivateViewsInSubMenu, showGlobalViewsInSubMenu}) {
-        const {
-            enableAutoSave,
-            autoSaveUnavailableReason,
-            autoSave,
-            enableDefault,
-            isViewSavable,
-            view,
-            typeDisplayName,
-            globalDisplayName,
-            favoriteViews,
-            views,
-            isValueDirty,
-            privateViews,
-            globalViews,
-            loadModel
-        } = model;
-
-        const pluralName = pluralize(startCase(typeDisplayName)),
-            myPluralName = `My  ${pluralName}`,
-            globalPluralName = `${startCase(globalDisplayName)}  ${pluralName}`,
-            items = [];
-        if (!isEmpty(favoriteViews)) {
-            items.push(
-                menuDivider({title: 'Favorites'}),
-                ...favoriteViews.map(info => {
-                    return menuItem({
-                        key: `${info.token}-favorite`,
-                        icon: view.token === info.token ? Icon.check() : Icon.placeholder(),
-                        text: textAndFaveToggle({info}),
-                        onClick: () => model.selectViewAsync(info),
-                        title: info.description
-                    });
-                })
-            );
-        }
-
-        if (!isEmpty(privateViews)) {
-            const privateItems = privateViews.map(it => buildMenuItem(it, model));
-            if (showPrivateViewsInSubMenu) {
-                items.push(
-                    menuDivider({omit: isEmpty(items)}),
-                    menuItem({
-                        text: myPluralName,
-                        shouldDismissPopover: false,
-                        items: privateItems
-                    })
-                );
-            } else {
-                items.push(menuDivider({title: myPluralName}), ...privateItems);
-            }
-        }
-
-        if (!isEmpty(globalViews)) {
-            const globalItems = globalViews.map(it => buildMenuItem(it, model));
-            if (showGlobalViewsInSubMenu) {
-                items.push(
-                    menuDivider({omit: isEmpty(items)}),
-                    menuItem({
-                        text: globalPluralName,
-                        shouldDismissPopover: false,
-                        items: globalItems
-                    })
-                );
-            } else {
-                items.push(menuDivider({title: globalPluralName}), ...globalItems);
-            }
-        }
-
+export const viewMenu = hoistCmp.factory<ViewManagerLocalModel>({
+    render({model}) {
         return menu({
             className: 'xh-view-manager__menu',
-            items: [
-                ...items,
-                menuDivider({omit: !enableDefault || isEmpty(items)}),
-                menuItem({
-                    icon: view.isDefault ? Icon.check() : Icon.placeholder(),
-                    text: `Default ${startCase(typeDisplayName)}`,
-                    omit: !enableDefault,
-                    onClick: () => model.selectViewAsync(null)
-                }),
-                menuDivider(),
-                menuItem({
-                    icon: Icon.save(),
-                    text: 'Save',
-                    disabled: !isViewSavable || !isValueDirty,
-                    onClick: () => model.saveAsync()
-                }),
-                menuItem({
-                    icon: Icon.placeholder(),
-                    text: 'Save As...',
-                    onClick: () => model.saveAsAsync()
-                }),
-                menuItem({
-                    icon: Icon.reset(),
-                    text: `Revert`,
-                    disabled: !isValueDirty,
-                    onClick: () => model.resetAsync()
-                }),
-                menuDivider({omit: !enableAutoSave}),
-                menuItem({
-                    omit: !enableAutoSave,
-                    text: switchInput({
-                        label: 'Auto Save',
-                        value: !autoSaveUnavailableReason && autoSave,
-                        disabled: !!autoSaveUnavailableReason,
-                        onChange: v => (model.autoSave = v),
-                        inline: true
-                    }),
-                    title: autoSaveUnavailableReason,
-                    shouldDismissPopover: false
-                }),
-                menuDivider(),
-                menuItem({
-                    icon: Icon.gear(),
-                    disabled: isEmpty(views),
-                    text: `Manage ${pluralName}...`,
-                    onClick: () => model.openManageDialog()
-                }),
-                menuItem({
-                    icon: !loadModel.isPending
-                        ? Icon.refresh()
-                        : box({
-                              height: 20,
-                              item: spinner({width: 16.25, height: 16.25})
-                          }),
-                    disabled: loadModel.isPending,
-                    text: `Refresh ${pluralName}`,
-                    onClick: e => {
-                        // Ensure at least 100ms delay to render spinner
-                        Promise.all([wait(100), model.refreshAsync()]).linkTo(loadModel);
-                        consumeEvent(e);
-                    }
-                })
-            ]
+            items: [...getNavMenuItems(model.parent), menuDivider(), ...getOtherMenuItems(model)]
         });
     }
 });
 
-function buildMenuItem(data: ViewInfo, model: ViewManagerModel): ReactNode {
-    const selected = data.token === model.view.token,
-        icon = selected ? Icon.check() : Icon.placeholder();
+function getNavMenuItems(model: ViewManagerModel): ReactNode[] {
+    const {enableDefault, view, typeDisplayName, globalDisplayName, pinnedViews} = model,
+        {owned, global, other} = groupBy(pinnedViews, v =>
+            v.isOwned ? 'owned' : v.isGlobal ? 'global' : 'other'
+        ),
+        pluralName = pluralize(startCase(typeDisplayName)),
+        ret = [];
 
-    return menuItem({
-        className: 'xh-view-manager__menu-item',
-        key: data.token,
-        icon,
-        text: textAndFaveToggle({info: data}),
-        title: data.description,
-        onClick: () => model.selectViewAsync(data)
+    // Main Views items by type
+    // TODO -- be smart?  If more than, say n for any cat, start nesting them in submenus?
+    if (!isEmpty(owned)) {
+        ret.push(menuDivider({title: `My  ${pluralName}`}), ...getGroupedMenuItems(owned, model));
+    }
+    if (!isEmpty(global)) {
+        ret.push(
+            menuDivider({title: `${startCase(globalDisplayName)}  ${pluralName}`}),
+            ...getGroupedMenuItems(owned, model)
+        );
+    }
+    if (!isEmpty(other)) {
+        ret.push(
+            menuDivider({title: `Other ${pluralName}`}),
+            ...orderBy(
+                other.map(v => viewMenuItem(v, model)),
+                ['name', 'owner']
+            )
+        );
+    }
+
+    if (enableDefault) {
+        ret.push(
+            menuDivider({omit: isEmpty(ret)}),
+            menuItem({
+                className: 'xh-view-manager__menu-item',
+                icon: view.isDefault ? Icon.check() : Icon.placeholder(),
+                text: `Default ${startCase(typeDisplayName)}`,
+                onClick: () => model.selectViewAsync(null)
+            })
+        );
+    }
+
+    return ret;
+}
+
+function getOtherMenuItems(model: ViewManagerLocalModel): ReactNode[] {
+    const {parent} = model;
+    const {
+        enableAutoSave,
+        autoSaveUnavailableReason,
+        autoSave,
+        isViewSavable,
+        views,
+        isValueDirty,
+        loadModel,
+        typeDisplayName
+    } = parent;
+
+    const pluralName = pluralize(startCase(typeDisplayName));
+
+    return [
+        menuItem({
+            icon: Icon.save(),
+            text: 'Save',
+            disabled: !isViewSavable || !isValueDirty,
+            onClick: () => parent.saveAsync()
+        }),
+        menuItem({
+            icon: Icon.placeholder(),
+            text: 'Save As...',
+            onClick: () => model.saveAsDialogModel.open()
+        }),
+        menuItem({
+            icon: Icon.reset(),
+            text: `Revert`,
+            disabled: !isValueDirty,
+            onClick: () => parent.resetAsync()
+        }),
+        menuDivider({omit: !enableAutoSave}),
+        menuItem({
+            omit: !enableAutoSave,
+            text: switchInput({
+                label: 'Auto Save',
+                value: !autoSaveUnavailableReason && autoSave,
+                disabled: !!autoSaveUnavailableReason,
+                onChange: v => (parent.autoSave = v),
+                inline: true
+            }),
+            title: autoSaveUnavailableReason,
+            shouldDismissPopover: false
+        }),
+        menuDivider(),
+        menuItem({
+            icon: Icon.gear(),
+            disabled: isEmpty(views),
+            text: `Manage ${pluralName}...`,
+            onClick: () => model.manageDialogModel.open()
+        }),
+        menuItem({
+            icon: !loadModel.isPending
+                ? Icon.refresh()
+                : box({
+                      height: 20,
+                      item: spinner({width: 16.25, height: 16.25})
+                  }),
+            disabled: loadModel.isPending,
+            text: `Refresh ${pluralName}`,
+            onClick: e => {
+                // Ensure at least 100ms delay to render spinner
+                Promise.all([wait(100), parent.refreshAsync()]).linkTo(loadModel);
+                consumeEvent(e);
+            }
+        })
+    ];
+}
+
+function getGroupedMenuItems(views: ViewInfo[], model: ViewManagerModel): ReactNode[] {
+    // Create grouped tree...
+    let nodes: (ViewInfo | {name: string; groupViews: ViewInfo[]; isSelected: boolean})[] = [],
+        selectedToken = model.view.token,
+        byGroup = groupBy(views, v => v.group ?? 'ungrouped');
+
+    each(byGroup, (groupViews, name) => {
+        if (name != 'ungrouped') {
+            nodes.push({name, groupViews, isSelected: some(groupViews, {token: selectedToken})});
+        } else {
+            nodes.push(...groupViews);
+        }
+    });
+
+    // ...sort groups first, then alpha by name. But could easily intersperse instead
+    nodes = orderBy(nodes, [v => v instanceof ViewInfo, 'name']);
+
+    return nodes.map(n => {
+        return n instanceof ViewInfo
+            ? viewMenuItem(n, model)
+            : menuItem({
+                  text: n.name,
+                  icon: n.isSelected ? Icon.check() : Icon.placeholder(),
+                  shouldDismissPopover: false,
+                  items: n.groupViews.map(v => viewMenuItem(v, model))
+              });
     });
 }
 
-const textAndFaveToggle = hoistCmp.factory<ViewManagerModel>({
-    render({model, info}) {
-        const {isFavorite, name} = info;
-        return hbox({
-            alignItems: 'center',
-            items: [
-                span({style: {paddingRight: 5}, item: name}),
-                fragment({
-                    omit: !model.enableFavorites,
-                    items: [
-                        filler(),
-                        div({
-                            className: `xh-view-manager__menu-item__fave-toggle ${isFavorite ? 'xh-view-manager__menu-item__fave-toggle--active' : ''}`,
-                            item: Icon.favorite({prefix: isFavorite ? 'fas' : 'far'}),
-                            onClick: e => {
-                                consumeEvent(e);
-                                model.toggleFavorite(info.token);
-                            }
-                        })
-                    ]
-                })
-            ]
-        });
-    }
-});
+function viewMenuItem(view: ViewInfo, model: ViewManagerModel): ReactNode {
+    const icon =
+        view.token == model.view.token
+            ? Icon.check()
+            : view.isGlobal
+              ? Icon.globe()
+              : view.isShared
+                ? Icon.user()
+                : Icon.placeholder();
+
+    const title = [];
+    if (view.isShared) title.push(view.owner);
+    if (view.description) title.push(view.description);
+
+    return menuItem({
+        className: 'xh-view-manager__menu-item',
+        key: view.token,
+        text: view.name,
+        title: title.join('|'),
+        icon,
+        onClick: () => model.selectViewAsync(view)
+    });
+}

--- a/desktop/cmp/viewmanager/dialog/EditForm.ts
+++ b/desktop/cmp/viewmanager/dialog/EditForm.ts
@@ -12,7 +12,7 @@ import {hoistCmp, uses, XH} from '@xh/hoist/core';
 import {EditFormModel} from '@xh/hoist/desktop/cmp/viewmanager/dialog/EditFormModel';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {formField} from '@xh/hoist/desktop/cmp/form';
-import {select, textArea, textInput} from '@xh/hoist/desktop/cmp/input';
+import {checkbox, select, textArea, textInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {getGroupOptions} from '@xh/hoist/desktop/cmp/viewmanager/dialog/Utils';
@@ -30,13 +30,15 @@ export const editForm = hoistCmp.factory({
         if (!view) return null;
 
         const {viewManagerModel} = parent,
-            {manageGlobal, globalDisplayName} = viewManagerModel,
-            {lastUpdated, lastUpdatedBy, owner, isOwned} = view;
+            {globalDisplayName} = viewManagerModel,
+            {lastUpdated, lastUpdatedBy} = view;
 
         return panel({
             item: form({
                 fieldDefaults: {
-                    commitOnChange: true
+                    commitOnChange: true,
+                    inline: true,
+                    minimal: true
                 },
                 item: vframe({
                     className: 'xh-view-manager__manage-dialog__form',
@@ -72,24 +74,32 @@ export const editForm = hoistCmp.factory({
                                       })
                         }),
                         formField({
+                            field: 'isShared',
+                            label: 'Shared?',
+                            item: checkbox(),
+                            omit: formModel.values.isGlobal
+                        }),
+                        formField({
+                            field: 'isDefaultPinned',
+                            label: 'Default Pin?',
+                            item: checkbox(),
+                            omit: !formModel.values.isGlobal
+                        }),
+                        formField({
                             field: 'isGlobal',
-                            label: 'Visibility',
+                            label: 'Ownership',
                             item: select({
                                 options: [
-                                    {value: true, label: startCase(globalDisplayName)},
-                                    {
-                                        value: false,
-                                        label: `Private to ${isOwned ? 'me' : owner}`
-                                    }
+                                    {value: false, label: 'Owned by you'},
+                                    {value: true, label: startCase(globalDisplayName)}
                                 ],
                                 enableFilter: false
-                            }),
-                            omit: !manageGlobal
+                            })
                         }),
                         hbox({
                             omit: !model.showSaveButton,
-                            style: {margin: '10px 20px'},
                             items: [
+                                filler(),
                                 button({
                                     text: 'Save Changes',
                                     icon: Icon.check(),
@@ -105,7 +115,8 @@ export const editForm = hoistCmp.factory({
                                     tooltip: 'Revert changes',
                                     minimal: false,
                                     onClick: () => formModel.reset()
-                                })
+                                }),
+                                filler()
                             ]
                         }),
                         filler(),

--- a/desktop/cmp/viewmanager/dialog/EditForm.ts
+++ b/desktop/cmp/viewmanager/dialog/EditForm.ts
@@ -85,28 +85,7 @@ export const editForm = hoistCmp.factory({
                             omit: !isGlobal
                         }),
                         vspacer(20),
-                        hbox({
-                            omit: !model.showSaveButton,
-                            items: [
-                                filler(),
-                                button({
-                                    text: 'Save Changes',
-                                    icon: Icon.check(),
-                                    intent: 'success',
-                                    minimal: false,
-                                    disabled: !formModel.isValid,
-                                    onClick: () => model.saveAsync()
-                                }),
-                                hspacer(),
-                                button({
-                                    icon: Icon.reset(),
-                                    tooltip: 'Revert changes',
-                                    minimal: false,
-                                    onClick: () => formModel.reset()
-                                }),
-                                filler()
-                            ]
-                        }),
+                        formButtons({omit: formModel.readonly}),
                         filler(),
                         div({
                             className: 'xh-view-manager__manage-dialog__metadata',
@@ -120,25 +99,51 @@ export const editForm = hoistCmp.factory({
     }
 });
 
+const formButtons = hoistCmp.factory<EditFormModel>({
+    render({model}) {
+        const {formModel, parent, view} = model;
+        return formModel.isDirty
+            ? hbox(
+                  filler(),
+                  button({
+                      text: 'Save Changes',
+                      icon: Icon.check(),
+                      intent: 'success',
+                      minimal: false,
+                      disabled: !formModel.isValid,
+                      onClick: () => model.saveAsync()
+                  }),
+                  hspacer(),
+                  button({
+                      icon: Icon.reset(),
+                      tooltip: 'Revert changes',
+                      minimal: false,
+                      onClick: () => formModel.reset()
+                  }),
+                  filler()
+              )
+            : hbox(
+                  filler(),
+                  button({
+                      text: `Make ${capitalize(parent.globalDisplayName)}`,
+                      icon: Icon.globe(),
+                      omit: !view.isEditable || view.isGlobal || !parent.manageGlobal,
+                      onClick: () => parent.makeGlobalAsync(view)
+                  }),
+                  button({
+                      text: 'Delete',
+                      icon: Icon.delete(),
+                      intent: 'danger',
+                      onClick: () => parent.deleteAsync([view])
+                  }),
+                  filler()
+              );
+    }
+});
+
 const bbar = hoistCmp.factory<EditFormModel>({
     render({model}) {
-        const {parent, view} = model;
-        return toolbar(
-            button({
-                text: 'Delete',
-                icon: Icon.delete(),
-                intent: 'danger',
-                omit: !view.isEditable,
-                onClick: () => parent.deleteAsync([view])
-            }),
-            button({
-                text: `Make ${capitalize(parent.globalDisplayName)}`,
-                icon: Icon.globe(),
-                omit: !view.isEditable || view.isGlobal || !parent.manageGlobal,
-                onClick: () => parent.makeGlobalAsync(view)
-            }),
-            filler(),
-            button({text: 'Close', onClick: () => parent.close()})
-        );
+        const {parent} = model;
+        return toolbar(filler(), button({text: 'Close', onClick: () => parent.close()}));
     }
 });

--- a/desktop/cmp/viewmanager/dialog/EditForm.ts
+++ b/desktop/cmp/viewmanager/dialog/EditForm.ts
@@ -15,6 +15,7 @@ import {formField} from '@xh/hoist/desktop/cmp/form';
 import {select, textArea, textInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
+import {getGroupOptions} from '@xh/hoist/desktop/cmp/viewmanager/dialog/Utils';
 import {fmtDateTime} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
 import {startCase} from 'lodash';
@@ -28,9 +29,9 @@ export const editForm = hoistCmp.factory({
         const {formModel, view, parent} = model;
         if (!view) return null;
 
-        const {manageGlobal, globalDisplayName} = parent,
-            {lastUpdated, lastUpdatedBy, owner} = view,
-            isOwnView = owner === XH.getUsername();
+        const {viewManagerModel} = parent,
+            {manageGlobal, globalDisplayName} = viewManagerModel,
+            {lastUpdated, lastUpdatedBy, owner, isOwned} = view;
 
         return panel({
             item: form({
@@ -43,6 +44,18 @@ export const editForm = hoistCmp.factory({
                         formField({
                             field: 'name',
                             item: textInput()
+                        }),
+                        formField({
+                            field: 'group',
+                            item: select({
+                                enableCreate: true,
+                                enableClear: true,
+                                placeholder: 'Select optional group....',
+                                options: getGroupOptions(
+                                    model.parent.viewManagerModel,
+                                    view.isOwned ? 'owned' : 'global'
+                                )
+                            })
                         }),
                         formField({
                             field: 'description',
@@ -66,7 +79,7 @@ export const editForm = hoistCmp.factory({
                                     {value: true, label: startCase(globalDisplayName)},
                                     {
                                         value: false,
-                                        label: `Private to ${isOwnView ? 'me' : owner}`
+                                        label: `Private to ${isOwned ? 'me' : owner}`
                                     }
                                 ],
                                 enableFilter: false

--- a/desktop/cmp/viewmanager/dialog/EditForm.ts
+++ b/desktop/cmp/viewmanager/dialog/EditForm.ts
@@ -135,13 +135,7 @@ const bbar = hoistCmp.factory<EditFormModel>({
                 text: `Make ${capitalize(parent.globalDisplayName)}`,
                 icon: Icon.globe(),
                 omit: !view.isEditable || view.isGlobal || !parent.manageGlobal,
-                onClick: () => parent.toggleGlobalAsync(view)
-            }),
-            button({
-                text: `Make personal`,
-                icon: Icon.user(),
-                omit: !view.isEditable || !view.isGlobal,
-                onClick: () => parent.toggleGlobalAsync(view)
+                onClick: () => parent.makeGlobalAsync(view)
             }),
             filler(),
             button({text: 'Close', onClick: () => parent.close()})

--- a/desktop/cmp/viewmanager/dialog/EditFormModel.ts
+++ b/desktop/cmp/viewmanager/dialog/EditFormModel.ts
@@ -53,8 +53,8 @@ export class EditFormModel extends HoistModel {
 
         if (view.isOwned && view.isShared != isShared) {
             const msg: ReactNode = !isShared
-                ? `Your ${view.typedName} will no longer be visible to ALL other ${XH.appName} users.`
-                : `Your ${view.typedName} will become visible to ALL other ${XH.appName} users.`;
+                ? `Your ${view.typedName} will no longer be visible to all other ${XH.appName} users.`
+                : `Your ${view.typedName} will become visible to all other ${XH.appName} users.`;
             const msgs = [msg, strong('Are you sure you want to proceed?')];
 
             const confirmed = await XH.confirm({

--- a/desktop/cmp/viewmanager/dialog/EditFormModel.ts
+++ b/desktop/cmp/viewmanager/dialog/EditFormModel.ts
@@ -36,11 +36,6 @@ export class EditFormModel extends HoistModel {
         return this.parent.loadModel;
     }
 
-    get showSaveButton(): boolean {
-        const {formModel, parent} = this;
-        return formModel.isDirty && !formModel.readonly && !parent.loadModel.isPending;
-    }
-
     constructor(parent: ManageDialogModel) {
         super();
         makeObservable(this);

--- a/desktop/cmp/viewmanager/dialog/EditFormModel.ts
+++ b/desktop/cmp/viewmanager/dialog/EditFormModel.ts
@@ -26,11 +26,12 @@ export class EditFormModel extends HoistModel {
 
     @action
     setView(view: ViewInfo) {
-        const {formModel, parent} = this;
+        const {formModel} = this;
         this.view = view;
-        if (!view) return null;
-        formModel.init(view);
-        formModel.readonly = view.isGlobal && !parent.manageGlobal;
+        if (view) {
+            formModel.init(view);
+            formModel.readonly = !view.isEditable;
+        }
     }
 
     get loadTask(): TaskObserver {
@@ -62,12 +63,14 @@ export class EditFormModel extends HoistModel {
             (view.isGlobal || isGlobal) && !manageGlobal,
             `Cannot save changes to ${globalDisplayName} ${typeDisplayName} - missing required permission.`
         );
+        const oldIsPublic = view.isShared || view.isGlobal,
+            newIsPublic = isShared || isGlobal;
 
-        if ((isShared || isGlobal) != view.isShared) {
-            const msg: ReactNode = view.isShared
+        if (oldIsPublic != newIsPublic) {
+            const msg: ReactNode = !newIsPublic
                 ? span(
                       `The selected ${typeDisplayName} will revert to being private to you `,
-                      strong('It will no longer be available to ALL users.')
+                      strong('It will no longer be available to other users.')
                   )
                 : `This ${typeDisplayName} will become visible to all other ${XH.appName} users.`;
             const msgs = [msg, 'Are you sure you want to proceed?'];

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -10,10 +10,9 @@ import {tabContainer} from '@xh/hoist/cmp/tab';
 import {filler, frame, hframe, placeholder} from '@xh/hoist/cmp/layout';
 import {storeFilterField} from '@xh/hoist/cmp/store';
 import {hoistCmp, uses} from '@xh/hoist/core';
-import {switchInput} from '@xh/hoist/desktop/cmp/input';
 import {editForm} from './EditForm';
 import {ManageDialogModel} from './ManageDialogModel';
-import {button} from '@xh/hoist/desktop/cmp/button';
+import {button, refreshButton} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
@@ -63,10 +62,8 @@ const viewPanel = hoistCmp.factory<ManageDialogModel>({
                     includeFields: ['name', 'group'],
                     onFilterChange: f => (model.filter = f)
                 }),
-                switchInput({
-                    bind: 'showInGroups',
-                    label: 'Show in Groups?'
-                })
+                filler(),
+                refreshButton({onClick: () => model.refreshAsync()})
             ]
         });
     }

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -10,7 +10,6 @@ import {tabContainer} from '@xh/hoist/cmp/tab';
 import {filler, frame, hframe, placeholder} from '@xh/hoist/cmp/layout';
 import {storeFilterField} from '@xh/hoist/cmp/store';
 import {hoistCmp, uses} from '@xh/hoist/core';
-import {editForm} from './EditForm';
 import {ManageDialogModel} from './ManageDialogModel';
 import {button, refreshButton} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
@@ -19,6 +18,8 @@ import {Icon} from '@xh/hoist/icon';
 import {dialog} from '@xh/hoist/kit/blueprint';
 import {pluralize} from '@xh/hoist/utils/js';
 import {capitalize} from 'lodash';
+import {viewMultiPanel} from './ViewMultiPanel';
+import {viewPanel} from './ViewPanel';
 
 /**
  * Default management dialog for ViewManager
@@ -44,8 +45,19 @@ export const manageDialog = hoistCmp.factory({
             onClose: () => model.close(),
             item: panel({
                 item: hframe(
-                    viewPanel(),
-                    count == 0 ? placeholderPanel() : count > 1 ? multiSelectionPanel() : editForm()
+                    selectorPanel(),
+                    panel({
+                        item:
+                            count == 0
+                                ? placeholderPanel()
+                                : count > 1
+                                  ? viewMultiPanel()
+                                  : viewPanel(),
+                        bbar: toolbar(
+                            filler(),
+                            button({text: 'Close', onClick: () => model.close()})
+                        )
+                    })
                 ),
                 mask: [updateTask, loadTask]
             })
@@ -53,7 +65,7 @@ export const manageDialog = hoistCmp.factory({
     }
 });
 
-const viewPanel = hoistCmp.factory<ManageDialogModel>({
+const selectorPanel = hoistCmp.factory<ManageDialogModel>({
     render({model}) {
         return panel({
             modelConfig: {defaultSize: 650, side: 'left', collapsible: false},
@@ -87,32 +99,6 @@ export const viewsGrid = hoistCmp.factory<GridModel>({
 
 const placeholderPanel = hoistCmp.factory<ManageDialogModel>({
     render({model}) {
-        return panel({
-            item: placeholder(Icon.gears(), `Select a ${model.typeDisplayName}`),
-            bbar: toolbar(filler(), button({text: 'Close', onClick: () => model.close()}))
-        });
-    }
-});
-
-const multiSelectionPanel = hoistCmp.factory<ManageDialogModel>({
-    render({model}) {
-        const {selectedViews} = model;
-        return panel({
-            item: placeholder(
-                Icon.gears(),
-                `${selectedViews.length} selected ${pluralize(model.typeDisplayName)}`
-            ),
-            bbar: toolbar(
-                button({
-                    text: 'Delete',
-                    icon: Icon.delete(),
-                    intent: 'danger',
-                    disabled: !model.canDelete,
-                    onClick: () => model.deleteAsync(selectedViews)
-                }),
-                filler(),
-                button({text: 'Close', onClick: () => model.close()})
-            )
-        });
+        return placeholder(Icon.gears(), `Select a ${model.typeDisplayName}`);
     }
 });

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -12,7 +12,7 @@ import {tabContainer} from '@xh/hoist/cmp/tab';
 import {hoistCmp, uses} from '@xh/hoist/core';
 import {button, refreshButton} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
-import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
+import {toolbar, toolbarSep} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
 import {dialog} from '@xh/hoist/kit/blueprint';
 import {pluralize} from '@xh/hoist/utils/js';
@@ -32,7 +32,14 @@ export const manageDialog = hoistCmp.factory({
     render({model, className}) {
         if (!model.isOpen) return null;
 
-        const {typeDisplayName, updateTask, loadTask, selectedViews} = model,
+        const {
+                typeDisplayName,
+                updateTask,
+                loadTask,
+                selectedViews,
+                selectedView,
+                selectedViewIsActive
+            } = model,
             count = selectedViews.length;
 
         return dialog({
@@ -55,6 +62,15 @@ export const manageDialog = hoistCmp.factory({
                                   : viewPanel(),
                         bbar: toolbar(
                             filler(),
+                            button({
+                                text: selectedViewIsActive
+                                    ? 'Currently Active'
+                                    : 'Activate + Close',
+                                onClick: () => model.activateSelectedViewAndClose(),
+                                disabled: selectedViewIsActive,
+                                omit: !selectedView
+                            }),
+                            toolbarSep({omit: !selectedView}),
                             button({text: 'Close', onClick: () => model.close()})
                         )
                     })

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -36,7 +36,7 @@ export const manageDialog = hoistCmp.factory({
             icon: Icon.gear(),
             className,
             isOpen: true,
-            style: {width: '800px', maxWidth: '90vm', minHeight: '430px'},
+            style: {width: '800px', maxWidth: '90vm', minHeight: '500px'},
             canOutsideClickClose: false,
             onClose: () => model.close(),
             item: panel({

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -22,7 +22,7 @@ import {viewMultiPanel} from './ViewMultiPanel';
 import {viewPanel} from './ViewPanel';
 
 /**
- * Default management dialog for ViewManager
+ * Default management dialog for ViewManager.
  */
 export const manageDialog = hoistCmp.factory({
     displayName: 'ManageDialog',

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -5,10 +5,12 @@
  * Copyright © 2024 Extremely Heavy Industries Inc.
  */
 
+import {grid, GridModel} from '@xh/hoist/cmp/grid';
 import {tabContainer} from '@xh/hoist/cmp/tab';
-import {filler, hframe, placeholder} from '@xh/hoist/cmp/layout';
+import {filler, frame, hframe, placeholder} from '@xh/hoist/cmp/layout';
 import {storeFilterField} from '@xh/hoist/cmp/store';
 import {hoistCmp, uses} from '@xh/hoist/core';
+import {switchInput} from '@xh/hoist/desktop/cmp/input';
 import {editForm} from './EditForm';
 import {ManageDialogModel} from './ManageDialogModel';
 import {button} from '@xh/hoist/desktop/cmp/button';
@@ -25,7 +27,7 @@ import {capitalize} from 'lodash';
 export const manageDialog = hoistCmp.factory({
     displayName: 'ManageDialog',
     className: 'xh-view-manager__manage-dialog',
-    model: uses(ManageDialogModel),
+    model: uses(() => ManageDialogModel),
 
     render({model, className}) {
         if (!model.isOpen) return null;
@@ -36,7 +38,7 @@ export const manageDialog = hoistCmp.factory({
             icon: Icon.gear(),
             className,
             isOpen: true,
-            style: {width: '900px', maxWidth: '90vm', minHeight: '500px'},
+            style: {width: '1000px', maxWidth: '90vm', minHeight: '500px'},
             canOutsideClickClose: false,
             onClose: () => model.close(),
             item: panel({
@@ -53,15 +55,33 @@ export const manageDialog = hoistCmp.factory({
 const viewPanel = hoistCmp.factory<ManageDialogModel>({
     render({model}) {
         return panel({
-            modelConfig: {defaultSize: 400, side: 'left', collapsible: false},
+            modelConfig: {defaultSize: 650, side: 'left', collapsible: false},
             item: tabContainer(),
             bbar: [
                 storeFilterField({
                     autoApply: false,
                     includeFields: ['name', 'group'],
                     onFilterChange: f => (model.filter = f)
+                }),
+                switchInput({
+                    bind: 'showInGroups',
+                    label: 'Show in Groups?'
                 })
             ]
+        });
+    }
+});
+
+export const viewsGrid = hoistCmp.factory<GridModel>({
+    render({model}) {
+        return frame({
+            paddingTop: 5,
+            item: grid({
+                model,
+                agOptions: {
+                    suppressMakeColumnVisibleAfterUnGroup: true
+                }
+            })
         });
     }
 });

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -36,7 +36,7 @@ export const manageDialog = hoistCmp.factory({
             icon: Icon.gear(),
             className,
             isOpen: true,
-            style: {width: '800px', maxWidth: '90vm', minHeight: '500px'},
+            style: {width: '900px', maxWidth: '90vm', minHeight: '500px'},
             canOutsideClickClose: false,
             onClose: () => model.close(),
             item: panel({
@@ -53,7 +53,7 @@ export const manageDialog = hoistCmp.factory({
 const viewPanel = hoistCmp.factory<ManageDialogModel>({
     render({model}) {
         return panel({
-            modelConfig: {defaultSize: 350, side: 'left', collapsible: false},
+            modelConfig: {defaultSize: 400, side: 'left', collapsible: false},
             item: tabContainer(),
             bbar: [
                 storeFilterField({

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -32,14 +32,7 @@ export const manageDialog = hoistCmp.factory({
     render({model, className}) {
         if (!model.isOpen) return null;
 
-        const {
-                typeDisplayName,
-                updateTask,
-                loadTask,
-                selectedViews,
-                selectedView,
-                selectedViewIsActive
-            } = model,
+        const {typeDisplayName, updateTask, loadTask, selectedViews} = model,
             count = selectedViews.length;
 
         return dialog({
@@ -47,7 +40,7 @@ export const manageDialog = hoistCmp.factory({
             icon: Icon.gear(),
             className,
             isOpen: true,
-            style: {width: '1000px', maxWidth: '90vm', minHeight: '550px'},
+            style: {width: '1000px', maxWidth: '90vw', minHeight: '550px'},
             canOutsideClickClose: false,
             onClose: () => model.close(),
             item: panel({
@@ -60,19 +53,7 @@ export const manageDialog = hoistCmp.factory({
                                 : count > 1
                                   ? viewMultiPanel()
                                   : viewPanel(),
-                        bbar: toolbar(
-                            filler(),
-                            button({
-                                text: selectedViewIsActive
-                                    ? 'Currently Active'
-                                    : 'Activate + Close',
-                                onClick: () => model.activateSelectedViewAndClose(),
-                                disabled: selectedViewIsActive,
-                                omit: !selectedView
-                            }),
-                            toolbarSep({omit: !selectedView}),
-                            button({text: 'Close', onClick: () => model.close()})
-                        )
+                        bbar: bbar()
                     })
                 ),
                 mask: [updateTask, loadTask]
@@ -93,7 +74,7 @@ const selectorPanel = hoistCmp.factory<ManageDialogModel>({
                     onFilterChange: f => (model.filter = f)
                 }),
                 filler(),
-                refreshButton({onClick: () => model.refreshAsync()})
+                refreshButton({model})
             ]
         });
     }
@@ -123,5 +104,22 @@ export const viewsGrid = hoistCmp.factory<GridModel>({
 const placeholderPanel = hoistCmp.factory<ManageDialogModel>({
     render({model}) {
         return placeholder(Icon.gears(), `Select a ${model.typeDisplayName}`);
+    }
+});
+
+const bbar = hoistCmp.factory<ManageDialogModel>({
+    render({model}) {
+        const {selectedView} = model;
+        return toolbar(
+            filler(),
+            button({
+                text: selectedView?.isCurrentView ? 'Currently Active' : 'Activate + Close',
+                onClick: () => model.activateSelectedViewAndClose(),
+                disabled: selectedView?.isCurrentView,
+                omit: !selectedView
+            }),
+            toolbarSep({omit: !selectedView}),
+            button({text: 'Close', onClick: () => model.close()})
+        );
     }
 });

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -6,11 +6,10 @@
  */
 
 import {grid, GridModel} from '@xh/hoist/cmp/grid';
-import {tabContainer} from '@xh/hoist/cmp/tab';
-import {filler, frame, hframe, placeholder} from '@xh/hoist/cmp/layout';
+import {div, filler, hframe, placeholder, vframe} from '@xh/hoist/cmp/layout';
 import {storeFilterField} from '@xh/hoist/cmp/store';
+import {tabContainer} from '@xh/hoist/cmp/tab';
 import {hoistCmp, uses} from '@xh/hoist/core';
-import {ManageDialogModel} from './ManageDialogModel';
 import {button, refreshButton} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
@@ -18,6 +17,7 @@ import {Icon} from '@xh/hoist/icon';
 import {dialog} from '@xh/hoist/kit/blueprint';
 import {pluralize} from '@xh/hoist/utils/js';
 import {capitalize} from 'lodash';
+import {ManageDialogModel} from './ManageDialogModel';
 import {viewMultiPanel} from './ViewMultiPanel';
 import {viewPanel} from './ViewPanel';
 
@@ -84,15 +84,22 @@ const selectorPanel = hoistCmp.factory<ManageDialogModel>({
 });
 
 export const viewsGrid = hoistCmp.factory<GridModel>({
-    render({model}) {
-        return frame({
+    render({model, helpText}) {
+        return vframe({
             paddingTop: 5,
-            item: grid({
-                model,
-                agOptions: {
-                    suppressMakeColumnVisibleAfterUnGroup: true
-                }
-            })
+            items: [
+                grid({
+                    model,
+                    agOptions: {
+                        suppressMakeColumnVisibleAfterUnGroup: true
+                    }
+                }),
+                div({
+                    item: helpText,
+                    omit: !helpText,
+                    className: 'xh-view-manager__manage-dialog__help-text'
+                })
+            ]
         });
     }
 });

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -8,7 +8,7 @@
 import {tabContainer} from '@xh/hoist/cmp/tab';
 import {filler, hframe, placeholder} from '@xh/hoist/cmp/layout';
 import {storeFilterField} from '@xh/hoist/cmp/store';
-import {creates, hoistCmp} from '@xh/hoist/core';
+import {hoistCmp, uses} from '@xh/hoist/core';
 import {editForm} from './EditForm';
 import {ManageDialogModel} from './ManageDialogModel';
 import {button} from '@xh/hoist/desktop/cmp/button';
@@ -25,9 +25,10 @@ import {capitalize} from 'lodash';
 export const manageDialog = hoistCmp.factory({
     displayName: 'ManageDialog',
     className: 'xh-view-manager__manage-dialog',
-    model: creates(ManageDialogModel),
+    model: uses(ManageDialogModel),
 
     render({model, className}) {
+        if (!model.isOpen) return null;
         const {typeDisplayName, updateTask, loadTask, selectedViews} = model;
         const count = selectedViews.length;
         return dialog({
@@ -57,7 +58,7 @@ const viewPanel = hoistCmp.factory<ManageDialogModel>({
             bbar: [
                 storeFilterField({
                     autoApply: false,
-                    includeFields: ['name'],
+                    includeFields: ['name', 'group'],
                     onFilterChange: f => (model.filter = f)
                 })
             ]

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -30,14 +30,16 @@ export const manageDialog = hoistCmp.factory({
 
     render({model, className}) {
         if (!model.isOpen) return null;
-        const {typeDisplayName, updateTask, loadTask, selectedViews} = model;
-        const count = selectedViews.length;
+
+        const {typeDisplayName, updateTask, loadTask, selectedViews} = model,
+            count = selectedViews.length;
+
         return dialog({
             title: `Manage ${capitalize(pluralize(typeDisplayName))}`,
             icon: Icon.gear(),
             className,
             isOpen: true,
-            style: {width: '1000px', maxWidth: '90vm', minHeight: '500px'},
+            style: {width: '1000px', maxWidth: '90vm', minHeight: '550px'},
             canOutsideClickClose: false,
             onClose: () => model.close(),
             item: panel({

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -256,6 +256,11 @@ export class ManageDialogModel extends HoistModel {
             sortBy: 'name',
             showGroupRowCounts: false,
             groupBy: ['group'],
+            groupSortFn: (a, b) => {
+                if (a == '') return 1;
+                if (b == '') return -1;
+                return a.localeCompare(b);
+            },
             selModel: 'multiple',
             contextMenu: null,
             sizingMode: 'standard',

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -282,7 +282,7 @@ export class ManageDialogModel extends HoistModel {
                     {name: 'view', type: 'auto'}
                 ]
             },
-            autosizeOptions: {mode: GridAutosizeMode.MANAGED},
+            autosizeOptions: {mode: GridAutosizeMode.DISABLED},
             columns: [
                 {field: 'name', flex: true},
                 {field: 'group', hidden: true},
@@ -291,7 +291,6 @@ export class ManageDialogModel extends HoistModel {
                 {
                     colId: 'isPinned',
                     field: 'view',
-                    autosizable: false,
                     width: 40,
                     align: 'center',
                     headerName: Icon.pin(),

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -187,8 +187,16 @@ export class ManageDialogModel extends HoistModel {
         const msgs: ReactNode[] = [`Are you sure you want to delete ${confirmStr}?`];
         if (some(views, v => v.isGlobal || v.isShared)) {
             count > 1
-                ? msgs.push(strong('Some public views will no longer be available to ALL users.'))
-                : msgs.push(strong('This public view will no longer be available to ALL users.'));
+                ? msgs.push(
+                      strong(
+                          `This includes at least one public ${typeDisplayName}, which will be removed for all users.`
+                      )
+                  )
+                : msgs.push(
+                      strong(
+                          `This is a public ${typeDisplayName} and will be removed for all users.`
+                      )
+                  );
         }
 
         const confirmed = await XH.confirm({

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -291,6 +291,7 @@ export class ManageDialogModel extends HoistModel {
                 {
                     colId: 'isPinned',
                     field: 'view',
+                    autosizable: false,
                     width: 40,
                     align: 'center',
                     headerName: Icon.pin(),

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -133,8 +133,8 @@ export class ManageDialogModel extends HoistModel {
         return this.doUpdateAsync(view, update).linkTo(this.updateTask).catchDefault();
     }
 
-    async toggleGlobalAsync(view: ViewInfo) {
-        return this.doToggleGlobalAsync(view).linkTo(this.updateTask).catchDefault();
+    async makeGlobalAsync(view: ViewInfo) {
+        return this.doMakeGlobalAsync(view).linkTo(this.updateTask).catchDefault();
     }
 
     //------------------------
@@ -212,13 +212,13 @@ export class ManageDialogModel extends HoistModel {
         await this.refreshAsync();
     }
 
-    private async doToggleGlobalAsync(view: ViewInfo) {
+    private async doMakeGlobalAsync(view: ViewInfo) {
         const {globalDisplayName, typeDisplayName} = this.viewManagerModel,
-            {typedName} = view;
-        const msg: ReactNode = view.isGlobal
-            ? `The ${typedName} will become a personal ${typeDisplayName} and will no longer be visible to ALL other ${XH.appName} users.`
-            : `The ${typedName} will become a ${globalDisplayName} ${typeDisplayName} visible to ALL other ${XH.appName} users.`;
-        const msgs = [msg, strong('Are you sure you want to proceed?')];
+            {typedName} = view,
+            msgs = [
+                `The ${typedName} will become a ${globalDisplayName} ${typeDisplayName} visible to ALL other ${XH.appName} users.`,
+                strong('Are you sure you want to proceed?')
+            ];
 
         const confirmed = await XH.confirm({
             message: fragment(msgs.map(m => p(m))),
@@ -232,7 +232,7 @@ export class ManageDialogModel extends HoistModel {
         if (!confirmed) return;
 
         const {viewManagerModel} = this;
-        const updated = await viewManagerModel.api.toggleViewIsGlobalAsync(view);
+        const updated = await viewManagerModel.api.makeViewGlobalAsync(view);
         await viewManagerModel.refreshAsync();
         await this.refreshAsync();
         await this.selectViewAsync(updated.info); // reselect -- will have moved tabs!

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -189,12 +189,12 @@ export class ManageDialogModel extends HoistModel {
             count > 1
                 ? msgs.push(
                       strong(
-                          `This includes at least one public ${typeDisplayName}, which will be removed for all users.`
+                          `This includes at least one public ${typeDisplayName}, to be deleted for all users.`
                       )
                   )
                 : msgs.push(
                       strong(
-                          `This is a public ${typeDisplayName} and will be removed for all users.`
+                          `This is a public ${typeDisplayName} and will be deleted for all users.`
                       )
                   );
         }

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -361,20 +361,23 @@ export class ManageDialogModel extends HoistModel {
     }
 
     private get ownedTabTitle(): ReactNode {
-        const title = `My ${startCase(pluralize(this.typeDisplayName))}`,
-            store = this.ownedGridModel.store;
-        return hbox(title, badge({item: store.allCount, omit: store.empty}));
+        return hbox(
+            `My ${startCase(pluralize(this.typeDisplayName))}`,
+            badge(this.ownedGridModel.store.allCount)
+        );
     }
 
     private get globalTabTitle(): ReactNode {
-        const title = `${startCase(this.globalDisplayName)} ${startCase(pluralize(this.typeDisplayName))}`,
-            store = this.globalGridModel.store;
-        return hbox(title, badge({item: store.allCount, omit: store.empty}));
+        return hbox(
+            `${startCase(this.globalDisplayName)} ${startCase(pluralize(this.typeDisplayName))}`,
+            badge(this.globalGridModel.store.allCount)
+        );
     }
 
     private get sharedTabTitle(): ReactNode {
-        const title = `Shared ${startCase(pluralize(this.typeDisplayName))}`,
-            store = this.sharedGridModel.store;
-        return hbox(title, badge({item: store.allCount, omit: store.empty}));
+        return hbox(
+            `Shared ${startCase(pluralize(this.typeDisplayName))}`,
+            badge(this.sharedGridModel.store.allCount)
+        );
     }
 }

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -67,6 +67,10 @@ export class ManageDialogModel extends HoistModel {
         return this.gridModel.selectedRecords.map(it => it.data.view) as ViewInfo[];
     }
 
+    get selectedViewIsActive(): boolean {
+        return this.selectedView?.token === this.viewManagerModel.view?.token;
+    }
+
     get manageGlobal(): boolean {
         return this.viewManagerModel.manageGlobal;
     }
@@ -99,6 +103,11 @@ export class ManageDialogModel extends HoistModel {
     @action
     close() {
         this.isOpen = false;
+    }
+
+    activateSelectedViewAndClose() {
+        this.viewManagerModel.selectViewAsync(this.selectedView);
+        this.close();
     }
 
     override async doLoadAsync(loadSpec: LoadSpec) {

--- a/desktop/cmp/viewmanager/dialog/SaveAsDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/SaveAsDialog.ts
@@ -99,7 +99,7 @@ const formPanel = hoistCmp.factory<SaveAsDialogModel>({
 
 const bbar = hoistCmp.factory<SaveAsDialogModel>({
     render({model}) {
-        const {typeDisplayName} = model;
+        const {typeDisplayName} = model.parent;
         return toolbar(
             filler(),
             button({

--- a/desktop/cmp/viewmanager/dialog/SaveAsDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/SaveAsDialog.ts
@@ -6,16 +6,16 @@
  */
 
 import {form} from '@xh/hoist/cmp/form';
-import {filler, vframe} from '@xh/hoist/cmp/layout';
+import {filler, hbox, vframe} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
-import {SaveAsDialogModel} from '@xh/hoist/cmp/viewmanager/';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {formField} from '@xh/hoist/desktop/cmp/form';
-import {textArea, textInput} from '@xh/hoist/desktop/cmp/input';
+import {checkbox, textArea, textInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {dialog} from '@xh/hoist/kit/blueprint';
 import {startCase} from 'lodash';
+import {SaveAsDialogModel} from './SaveAsDialogModel';
 
 /**
  * Default Save As dialog used by ViewManager.
@@ -34,7 +34,7 @@ export const saveAsDialog = hoistCmp.factory<SaveAsDialogModel>({
             isOpen: true,
             style: {width: 500},
             canOutsideClickClose: false,
-            onClose: () => model.cancel(),
+            onClose: () => model.close(),
             item: formPanel()
         });
     }
@@ -61,12 +61,30 @@ const formPanel = hoistCmp.factory<SaveAsDialogModel>({
                             })
                         }),
                         formField({
+                            field: 'group',
+                            item: textInput({selectOnFocus: true})
+                        }),
+                        formField({
                             field: 'description',
                             item: textArea({
                                 selectOnFocus: true,
                                 height: 90
                             })
-                        })
+                        }),
+                        hbox(
+                            formField({
+                                field: 'isShared',
+                                inline: true,
+                                omit: !model.parent.enableSharing,
+                                item: checkbox()
+                            }),
+                            formField({
+                                field: 'isPinned',
+                                inline: true,
+                                info: 'Show this view on menu?',
+                                item: checkbox()
+                            })
+                        )
                     ]
                 })
             }),
@@ -83,7 +101,7 @@ const bbar = hoistCmp.factory<SaveAsDialogModel>({
             filler(),
             button({
                 text: 'Cancel',
-                onClick: () => model.cancel()
+                onClick: () => model.close()
             }),
             button({
                 text: `Save as new ${startCase(typeDisplayName)}`,

--- a/desktop/cmp/viewmanager/dialog/SaveAsDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/SaveAsDialog.ts
@@ -10,13 +10,13 @@ import {filler, hbox, vframe} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {formField} from '@xh/hoist/desktop/cmp/form';
-import {checkbox, select, textArea, textInput} from '@xh/hoist/desktop/cmp/input';
+import {select, switchInput, textArea, textInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
-import {getGroupOptions} from './Utils';
 import {dialog} from '@xh/hoist/kit/blueprint';
 import {startCase} from 'lodash';
 import {SaveAsDialogModel} from './SaveAsDialogModel';
+import {getGroupOptions} from './Utils';
 
 /**
  * Default Save As dialog used by ViewManager.
@@ -76,7 +76,7 @@ const formPanel = hoistCmp.factory<SaveAsDialogModel>({
                             field: 'description',
                             item: textArea({
                                 selectOnFocus: true,
-                                height: 90
+                                height: 70
                             })
                         }),
                         hbox(
@@ -85,7 +85,7 @@ const formPanel = hoistCmp.factory<SaveAsDialogModel>({
                                 label: 'Share?',
                                 labelTextAlign: 'left',
                                 omit: !model.parent.enableSharing,
-                                item: checkbox()
+                                item: switchInput()
                             })
                         )
                     ]

--- a/desktop/cmp/viewmanager/dialog/SaveAsDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/SaveAsDialog.ts
@@ -10,9 +10,10 @@ import {filler, hbox, vframe} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {formField} from '@xh/hoist/desktop/cmp/form';
-import {checkbox, textArea, textInput} from '@xh/hoist/desktop/cmp/input';
+import {checkbox, select, textArea, textInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
+import {getGroupOptions} from './Utils';
 import {dialog} from '@xh/hoist/kit/blueprint';
 import {startCase} from 'lodash';
 import {SaveAsDialogModel} from './SaveAsDialogModel';
@@ -45,7 +46,9 @@ const formPanel = hoistCmp.factory<SaveAsDialogModel>({
         return panel({
             item: form({
                 fieldDefaults: {
-                    commitOnChange: true
+                    commitOnChange: true,
+                    inline: true,
+                    minimal: true
                 },
                 item: vframe({
                     className: 'xh-view-manager__save-dialog__form',
@@ -62,7 +65,12 @@ const formPanel = hoistCmp.factory<SaveAsDialogModel>({
                         }),
                         formField({
                             field: 'group',
-                            item: textInput({selectOnFocus: true})
+                            item: select({
+                                enableCreate: true,
+                                enableClear: true,
+                                placeholder: 'Select optional group....',
+                                options: getGroupOptions(model.parent, 'owned')
+                            })
                         }),
                         formField({
                             field: 'description',
@@ -74,14 +82,9 @@ const formPanel = hoistCmp.factory<SaveAsDialogModel>({
                         hbox(
                             formField({
                                 field: 'isShared',
-                                inline: true,
+                                label: 'Share?',
+                                labelTextAlign: 'left',
                                 omit: !model.parent.enableSharing,
-                                item: checkbox()
-                            }),
-                            formField({
-                                field: 'isPinned',
-                                inline: true,
-                                info: 'Show this view on menu?',
                                 item: checkbox()
                             })
                         )

--- a/desktop/cmp/viewmanager/dialog/SaveAsDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/SaveAsDialogModel.ts
@@ -40,14 +40,19 @@ export class SaveAsDialogModel extends HoistModel {
 
     @action
     open() {
-        const src = this.parent.view,
-            name = !src.name.startsWith('Copy of') ? `Copy of ${src.name}` : src.name;
-        this.formModel.init({
+        const {parent, formModel} = this,
+            src = parent.view,
+            name = parent.ownedViews.some(it => it.name === src.name)
+                ? `Copy of ${src.name}`
+                : src.name;
+
+        formModel.init({
             name,
             group: src.group,
-            description: null,
+            description: src.description,
             isShared: false
         });
+
         this.isOpen = true;
     }
 

--- a/desktop/cmp/viewmanager/dialog/SaveAsDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/SaveAsDialogModel.ts
@@ -19,18 +19,6 @@ export class SaveAsDialogModel extends HoistModel {
     @managed readonly formModel: FormModel;
     @observable isOpen: boolean = false;
 
-    get type(): string {
-        return this.parent.type;
-    }
-
-    get typeDisplayName(): string {
-        return this.parent.typeDisplayName;
-    }
-
-    get globalDisplayName(): string {
-        return this.parent.globalDisplayName;
-    }
-
     constructor(parent: ViewManagerModel) {
         super();
         makeObservable(this);

--- a/desktop/cmp/viewmanager/dialog/SaveAsDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/SaveAsDialogModel.ts
@@ -40,7 +40,14 @@ export class SaveAsDialogModel extends HoistModel {
 
     @action
     open() {
-        this.formModel.init(this.parent.view?.info ?? {});
+        const src = this.parent.view,
+            name = !src.name.startsWith('Copy of') ? `Copy of ${src.name}` : src.name;
+        this.formModel.init({
+            name,
+            group: src.group,
+            description: null,
+            isShared: false
+        });
         this.isOpen = true;
     }
 
@@ -70,15 +77,14 @@ export class SaveAsDialogModel extends HoistModel {
                 },
                 {name: 'group'},
                 {name: 'description'},
-                {name: 'isShared'},
-                {name: 'isPinned'}
+                {name: 'isShared'}
             ]
         });
     }
 
     private async doSaveAsAsync() {
         let {formModel, parent} = this,
-            {name, group, description, isShared, isPinned} = formModel.getData(),
+            {name, group, description, isShared} = formModel.getData(),
             isValid = await formModel.validateAsync();
 
         if (!isValid) return;
@@ -87,8 +93,7 @@ export class SaveAsDialogModel extends HoistModel {
             name: name.trim(),
             group: group?.trim(),
             description: description?.trim(),
-            isShared,
-            isPinned
+            isShared
         });
     }
 }

--- a/desktop/cmp/viewmanager/dialog/Utils.ts
+++ b/desktop/cmp/viewmanager/dialog/Utils.ts
@@ -1,0 +1,21 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2024 Extremely Heavy Industries Inc.
+ */
+
+import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
+import {SelectOption} from '@xh/hoist/core';
+import {map, uniq} from 'lodash';
+
+export function getGroupOptions(model: ViewManagerModel, type: 'owned' | 'global'): SelectOption[] {
+    const views = type == 'owned' ? model.ownedViews : model.globalViews;
+    const ret: SelectOption[] = [];
+    uniq(map(views, 'group'))
+        .sort()
+        .forEach(g => {
+            if (g != null) ret.push({label: g, value: g});
+        });
+    return ret;
+}

--- a/desktop/cmp/viewmanager/dialog/Utils.ts
+++ b/desktop/cmp/viewmanager/dialog/Utils.ts
@@ -11,11 +11,8 @@ import {map, uniq} from 'lodash';
 
 export function getGroupOptions(model: ViewManagerModel, type: 'owned' | 'global'): SelectOption[] {
     const views = type == 'owned' ? model.ownedViews : model.globalViews;
-    const ret: SelectOption[] = [];
-    uniq(map(views, 'group'))
+    return uniq(map(views, 'group'))
         .sort()
-        .forEach(g => {
-            if (g != null) ret.push({label: g, value: g});
-        });
-    return ret;
+        .filter(g => g != null)
+        .map(g => ({label: g, value: g}));
 }

--- a/desktop/cmp/viewmanager/dialog/ViewMultiPanel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewMultiPanel.ts
@@ -50,7 +50,7 @@ const buttons = hoistCmp.factory<ManageDialogModel>({
                     text: allPinned ? 'Unpin from your Menu' : 'Pin to your Menu',
                     icon: Icon.pin({
                         prefix: allPinned ? 'fas' : 'far',
-                        className: allPinned ? 'xh-yellow' : 'xh-text-color-muted'
+                        className: allPinned ? 'xh-yellow' : ''
                     }),
                     width: 200,
                     outlined: true,

--- a/desktop/cmp/viewmanager/dialog/ViewMultiPanel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewMultiPanel.ts
@@ -23,14 +23,12 @@ export const viewMultiPanel = hoistCmp.factory({
         return panel({
             item: vframe({
                 className: 'xh-view-manager__manage-dialog__form',
-                items: [
-                    placeholder(
-                        Icon.gears(),
-                        `${views.length} selected ${pluralize(model.typeDisplayName)}`
-                    ),
+                item: placeholder(
+                    Icon.gears(),
+                    `${views.length} selected ${pluralize(model.typeDisplayName)}`,
                     vspacer(),
                     buttons()
-                ]
+                )
             })
         });
     }

--- a/desktop/cmp/viewmanager/dialog/ViewMultiPanel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewMultiPanel.ts
@@ -1,0 +1,72 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2024 Extremely Heavy Industries Inc.
+ */
+
+import {placeholder, vbox, vframe, vspacer} from '@xh/hoist/cmp/layout';
+import {hoistCmp, uses} from '@xh/hoist/core';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {Icon} from '@xh/hoist/icon';
+import {pluralize} from '@xh/hoist/utils/js';
+import {every, isEmpty, some} from 'lodash';
+import {ManageDialogModel} from './ManageDialogModel';
+
+export const viewMultiPanel = hoistCmp.factory({
+    model: uses(() => ManageDialogModel),
+    render({model}) {
+        const views = model.selectedViews;
+        if (isEmpty(views)) return null;
+
+        return panel({
+            item: vframe({
+                className: 'xh-view-manager__manage-dialog__form',
+                items: [
+                    placeholder(
+                        Icon.gears(),
+                        `${views.length} selected ${pluralize(model.typeDisplayName)}`
+                    ),
+                    vspacer(),
+                    buttons()
+                ]
+            })
+        });
+    }
+});
+
+const buttons = hoistCmp.factory<ManageDialogModel>({
+    render({model}) {
+        const views = model.selectedViews,
+            allEditable = every(views, 'isEditable'),
+            allPinned = every(views, 'isPinned'),
+            allUnpinned = !some(views, 'isPinned');
+
+        return vbox({
+            style: {gap: 10, alignItems: 'center'},
+            items: [
+                button({
+                    text: allPinned ? 'Unpin from your Menu' : 'Pin to your Menu',
+                    icon: Icon.pin({
+                        prefix: allPinned ? 'fas' : 'far',
+                        className: allPinned ? 'xh-yellow' : 'xh-text-color-muted'
+                    }),
+                    width: 200,
+                    outlined: true,
+                    omit: !(allPinned || allUnpinned),
+                    onClick: () => model.togglePinned(views)
+                }),
+                button({
+                    text: 'Delete',
+                    icon: Icon.delete(),
+                    width: 200,
+                    outlined: true,
+                    intent: 'danger',
+                    omit: !allEditable,
+                    onClick: () => model.deleteAsync(views)
+                })
+            ]
+        });
+    }
+});

--- a/desktop/cmp/viewmanager/dialog/ViewPanel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewPanel.ts
@@ -12,8 +12,7 @@ import {button} from '@xh/hoist/desktop/cmp/button';
 import {formField} from '@xh/hoist/desktop/cmp/form';
 import {select, switchInput, textArea, textInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
-import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
-import {EditFormModel} from '@xh/hoist/desktop/cmp/viewmanager/dialog/EditFormModel';
+import {ViewPanelModel} from '@xh/hoist/desktop/cmp/viewmanager/dialog/ViewPanelModel';
 import {getGroupOptions} from '@xh/hoist/desktop/cmp/viewmanager/dialog/Utils';
 import {fmtDateTime} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
@@ -22,8 +21,8 @@ import {capitalize} from 'lodash';
 /**
  * Form to edit or view details on a single saved view within the ViewManager manage dialog.
  */
-export const editForm = hoistCmp.factory({
-    model: uses(EditFormModel),
+export const viewPanel = hoistCmp.factory({
+    model: uses(ViewPanelModel),
     render({model}) {
         const {view} = model;
         if (!view) return null;
@@ -91,13 +90,12 @@ export const editForm = hoistCmp.factory({
                         })
                     ]
                 })
-            }),
-            bbar: bbar()
+            })
         });
     }
 });
 
-const formButtons = hoistCmp.factory<EditFormModel>({
+const formButtons = hoistCmp.factory<ViewPanelModel>({
     render({model}) {
         const {formModel, parent, view} = model,
             {readonly} = formModel,
@@ -135,7 +133,7 @@ const formButtons = hoistCmp.factory<EditFormModel>({
                           }),
                           width: 200,
                           outlined: true,
-                          onClick: () => parent.togglePinned(view)
+                          onClick: () => parent.togglePinned([view])
                       }),
                       button({
                           text: `Promote to ${capitalize(parent.globalDisplayName)} ${parent.typeDisplayName}`,
@@ -156,12 +154,5 @@ const formButtons = hoistCmp.factory<EditFormModel>({
                       })
                   ]
               });
-    }
-});
-
-const bbar = hoistCmp.factory<EditFormModel>({
-    render({model}) {
-        const {parent} = model;
-        return toolbar(filler(), button({text: 'Close', onClick: () => parent.close()}));
     }
 });

--- a/desktop/cmp/viewmanager/dialog/ViewPanel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewPanel.ts
@@ -128,7 +128,7 @@ const formButtons = hoistCmp.factory<ViewPanelModel>({
                           text: isPinned ? 'Unpin from your Menu' : 'Pin to your Menu',
                           icon: Icon.pin({
                               prefix: isPinned ? 'fas' : 'far',
-                              className: isPinned ? 'xh-yellow' : 'xh-text-color-muted'
+                              className: isPinned ? 'xh-yellow' : null
                           }),
                           width: 200,
                           outlined: true,

--- a/desktop/cmp/viewmanager/dialog/ViewPanel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewPanel.ts
@@ -47,7 +47,6 @@ export const viewPanel = hoistCmp.factory({
                             item: select({
                                 enableCreate: true,
                                 enableClear: true,
-                                placeholder: 'Select optional group....',
                                 options: getGroupOptions(
                                     model.parent.viewManagerModel,
                                     view.isOwned ? 'owned' : 'global'

--- a/desktop/cmp/viewmanager/dialog/ViewPanel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewPanel.ts
@@ -43,6 +43,10 @@ export const viewPanel = hoistCmp.factory({
                             item: textInput()
                         }),
                         formField({
+                            field: 'owner',
+                            omit: isEditable
+                        }),
+                        formField({
                             field: 'group',
                             item: select({
                                 enableCreate: true,
@@ -70,7 +74,7 @@ export const viewPanel = hoistCmp.factory({
                             inline: true,
                             item: switchInput(),
                             readonlyRenderer: v => (v ? 'Yes' : 'No'),
-                            omit: isGlobal
+                            omit: isGlobal || !isEditable
                         }),
                         formField({
                             field: 'isDefaultPinned',

--- a/desktop/cmp/viewmanager/dialog/ViewPanelModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewPanelModel.ts
@@ -9,27 +9,20 @@ import {FormModel} from '@xh/hoist/cmp/form';
 import {fragment, p, strong} from '@xh/hoist/cmp/layout';
 import {HoistModel, managed, TaskObserver, XH} from '@xh/hoist/core';
 import {ManageDialogModel} from './ManageDialogModel';
-import {makeObservable, action, observable} from '@xh/hoist/mobx';
+import {makeObservable} from '@xh/hoist/mobx';
 import {ViewInfo} from '@xh/hoist/cmp/viewmanager';
 import {ReactNode} from 'react';
 
 /**
  * Backing model for EditForm
  */
-export class EditFormModel extends HoistModel {
+export class ViewPanelModel extends HoistModel {
     parent: ManageDialogModel;
 
     @managed formModel: FormModel;
-    @observable.ref view: ViewInfo;
 
-    @action
-    setView(view: ViewInfo) {
-        const {formModel} = this;
-        this.view = view;
-        if (view) {
-            formModel.init(view);
-            formModel.readonly = !view.isEditable;
-        }
+    get view(): ViewInfo {
+        return this.parent.selectedView;
     }
 
     get loadTask(): TaskObserver {
@@ -39,8 +32,17 @@ export class EditFormModel extends HoistModel {
     constructor(parent: ManageDialogModel) {
         super();
         makeObservable(this);
-        this.formModel = this.createFormModel();
         this.parent = parent;
+        const formModel = (this.formModel = this.createFormModel());
+        this.addReaction({
+            track: () => this.view,
+            run: view => {
+                if (view) {
+                    formModel.init(view);
+                    formModel.readonly = !view.isEditable;
+                }
+            }
+        });
     }
 
     async saveAsync() {

--- a/desktop/cmp/viewmanager/dialog/ViewPanelModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewPanelModel.ts
@@ -35,12 +35,13 @@ export class ViewPanelModel extends HoistModel {
         makeObservable(this);
 
         this.parent = parent;
-        const formModel = (this.formModel = this.createFormModel());
+        this.formModel = this.createFormModel();
 
         this.addReaction({
             track: () => this.view,
             run: view => {
                 if (view) {
+                    const {formModel} = this;
                     formModel.init({
                         ...view,
                         owner: view.owner ?? capitalize(parent.globalDisplayName)

--- a/desktop/cmp/viewmanager/dialog/ViewPanelModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewPanelModel.ts
@@ -32,8 +32,10 @@ export class ViewPanelModel extends HoistModel {
     constructor(parent: ManageDialogModel) {
         super();
         makeObservable(this);
+
         this.parent = parent;
         const formModel = (this.formModel = this.createFormModel());
+
         this.addReaction({
             track: () => this.view,
             run: view => {
@@ -41,7 +43,8 @@ export class ViewPanelModel extends HoistModel {
                     formModel.init(view);
                     formModel.readonly = !view.isEditable;
                 }
-            }
+            },
+            fireImmediately: true
         });
     }
 

--- a/desktop/cmp/viewmanager/dialog/ViewPanelModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewPanelModel.ts
@@ -8,6 +8,7 @@
 import {FormModel} from '@xh/hoist/cmp/form';
 import {fragment, p, strong} from '@xh/hoist/cmp/layout';
 import {HoistModel, managed, TaskObserver, XH} from '@xh/hoist/core';
+import {capitalize} from 'lodash';
 import {ManageDialogModel} from './ManageDialogModel';
 import {makeObservable} from '@xh/hoist/mobx';
 import {ViewInfo} from '@xh/hoist/cmp/viewmanager';
@@ -40,7 +41,10 @@ export class ViewPanelModel extends HoistModel {
             track: () => this.view,
             run: view => {
                 if (view) {
-                    formModel.init(view);
+                    formModel.init({
+                        ...view,
+                        owner: view.owner ?? capitalize(parent.globalDisplayName)
+                    });
                     formModel.readonly = !view.isEditable;
                 }
             },
@@ -100,6 +104,7 @@ export class ViewPanelModel extends HoistModel {
                         }
                     ]
                 },
+                {name: 'owner'},
                 {name: 'group'},
                 {name: 'description'},
                 {name: 'isShared'},

--- a/svc/JsonBlobService.ts
+++ b/svc/JsonBlobService.ts
@@ -5,7 +5,7 @@
  * Copyright © 2024 Extremely Heavy Industries Inc.
  */
 import {HoistService, LoadSpec, PlainObject, XH} from '@xh/hoist/core';
-import {pickBy} from 'lodash';
+import {isUndefined, omitBy} from 'lodash';
 
 export interface JsonBlob {
     /** Either null for private blobs or special token "*" for globally shared blobs. */
@@ -91,9 +91,9 @@ export class JsonBlobService extends HoistService {
     /** Modify mutable properties of an existing JSONBlob, as identified by its unique token. */
     async updateAsync(
         token: string,
-        {acl, description, meta, name, value}: Partial<JsonBlob>
+        {acl, description, meta, name, owner, value}: Partial<JsonBlob>
     ): Promise<JsonBlob> {
-        const update = pickBy({acl, description, meta, name, value}, (v, k) => v !== undefined);
+        const update = omitBy({acl, description, meta, name, owner, value}, isUndefined);
         return XH.fetchJson({
             url: 'xh/updateJsonBlob',
             params: {

--- a/svc/storage/BaseStorageService.ts
+++ b/svc/storage/BaseStorageService.ts
@@ -59,7 +59,7 @@ export abstract class BaseStorageService extends HoistService {
     }
 
     clear() {
-        this.storeInstance().clear();
+        this.storeInstance.clear();
     }
 
     keys(): string[] {


### PR DESCRIPTION
## TODOs:

- [ ] When deleting a view that is the active view, we should auto-select default / first available view. Currently the deleted view stays in place.
- [ ] Auto-save menu option does not disable when global view selected if already on/enabled
- [x] When saving-as a global or shared view (not one of your own views), don't prepend "Copy of" to the suggested name.  
  - Maybe never prepend? We could use unmodified name if copying global\shared, blank out name if your own
- [ ] refresh button within mgr dialog does not trigger full refresh from server

## Nice-to-haves

- [ ] Option within manager dialog to saveAs selected view
- [ ] Warn within mgr on sel change if there are unsaved changes to prev view