### PR TITLE
Allow Cube Query to opt-out of flattening redundant children

### DIFF
--- a/data/cube/Query.ts
+++ b/data/cube/Query.ts
@@ -52,6 +52,9 @@ export interface QueryConfig {
     /** True to include leaf nodes in return.*/
     includeLeaves?: boolean;
 
+    /** True (default) to flatten single-child hierarchies into parents. */
+    flattenRedundantChildren?: boolean;
+
     /**
      * Optional function to be called for each aggregate node to determine if it should be "locked",
      * preventing drill-down into its children.  Defaults to Cube.lockFn.
@@ -79,6 +82,7 @@ export class Query {
     readonly filter: Filter;
     readonly includeRoot: boolean;
     readonly includeLeaves: boolean;
+    readonly flattenRedundantChildren: boolean;
     readonly cube: Cube;
     readonly lockFn: LockFn;
     readonly bucketSpecFn: BucketSpecFn;
@@ -93,6 +97,7 @@ export class Query {
         filter = null,
         includeRoot = false,
         includeLeaves = false,
+        flattenRedundantChildren = true,
         lockFn = cube.lockFn,
         bucketSpecFn = cube.bucketSpecFn,
         omitFn = cube.omitFn
@@ -102,6 +107,7 @@ export class Query {
         this.dimensions = this.parseDimensions(dimensions);
         this.includeRoot = includeRoot;
         this.includeLeaves = includeLeaves;
+        this.flattenRedundantChildren = flattenRedundantChildren;
         this.filter = parseFilter(filter);
         this.lockFn = lockFn;
         this.bucketSpecFn = bucketSpecFn;
@@ -117,6 +123,7 @@ export class Query {
             filter: this.filter,
             includeRoot: this.includeRoot,
             includeLeaves: this.includeLeaves,
+            flattenRedundantChildren: this.flattenRedundantChildren,
             lockFn: this.lockFn,
             bucketSpecFn: this.bucketSpecFn,
             omitFn: this.omitFn,
@@ -153,6 +160,7 @@ export class Query {
             this.cube === other.cube &&
             this.includeRoot === other.includeRoot &&
             this.includeLeaves === other.includeLeaves &&
+            this.flattenRedundantChildren === other.flattenRedundantChildren &&
             this.bucketSpecFn == other.bucketSpecFn &&
             this.omitFn == other.omitFn &&
             this.lockFn == other.lockFn

--- a/data/cube/Query.ts
+++ b/data/cube/Query.ts
@@ -52,8 +52,11 @@ export interface QueryConfig {
     /** True to include leaf nodes in return.*/
     includeLeaves?: boolean;
 
-    /** True (default) to flatten single-child hierarchies into parents. */
-    flattenRedundantChildren?: boolean;
+    /**
+     * True (default) to recursively omit single-child parents in the hierarchy.
+     * Apps can implement further omit logic using `omitFn`.
+     */
+    omitRedundantNodes?: boolean;
 
     /**
      * Optional function to be called for each aggregate node to determine if it should be "locked",
@@ -82,7 +85,7 @@ export class Query {
     readonly filter: Filter;
     readonly includeRoot: boolean;
     readonly includeLeaves: boolean;
-    readonly flattenRedundantChildren: boolean;
+    readonly omitRedundantNodes: boolean;
     readonly cube: Cube;
     readonly lockFn: LockFn;
     readonly bucketSpecFn: BucketSpecFn;
@@ -97,7 +100,7 @@ export class Query {
         filter = null,
         includeRoot = false,
         includeLeaves = false,
-        flattenRedundantChildren = true,
+        omitRedundantNodes = true,
         lockFn = cube.lockFn,
         bucketSpecFn = cube.bucketSpecFn,
         omitFn = cube.omitFn
@@ -107,7 +110,7 @@ export class Query {
         this.dimensions = this.parseDimensions(dimensions);
         this.includeRoot = includeRoot;
         this.includeLeaves = includeLeaves;
-        this.flattenRedundantChildren = flattenRedundantChildren;
+        this.omitRedundantNodes = omitRedundantNodes;
         this.filter = parseFilter(filter);
         this.lockFn = lockFn;
         this.bucketSpecFn = bucketSpecFn;
@@ -123,7 +126,7 @@ export class Query {
             filter: this.filter,
             includeRoot: this.includeRoot,
             includeLeaves: this.includeLeaves,
-            flattenRedundantChildren: this.flattenRedundantChildren,
+            omitRedundantNodes: this.omitRedundantNodes,
             lockFn: this.lockFn,
             bucketSpecFn: this.bucketSpecFn,
             omitFn: this.omitFn,
@@ -160,7 +163,7 @@ export class Query {
             this.cube === other.cube &&
             this.includeRoot === other.includeRoot &&
             this.includeLeaves === other.includeLeaves &&
-            this.flattenRedundantChildren === other.flattenRedundantChildren &&
+            this.omitRedundantNodes === other.omitRedundantNodes &&
             this.bucketSpecFn == other.bucketSpecFn &&
             this.omitFn == other.omitFn &&
             this.lockFn == other.lockFn

--- a/data/cube/row/BaseRow.ts
+++ b/data/cube/row/BaseRow.ts
@@ -65,7 +65,7 @@ export abstract class BaseRow {
 
         // 3a) Before attaching examine that we don't have a chain of redundant nodes
         // (not sure if loop needed -- are these redundant relations transitive?)
-        if (view.query.flattenRedundantChildren) {
+        if (view.query.omitRedundantNodes) {
             while (dataChildren?.length === 1) {
                 const childRow = dataChildren[0]._meta;
                 if (this.isRedundantChild(this, childRow)) {

--- a/data/cube/row/BaseRow.ts
+++ b/data/cube/row/BaseRow.ts
@@ -65,12 +65,14 @@ export abstract class BaseRow {
 
         // 3a) Before attaching examine that we don't have a chain of redundant nodes
         // (not sure if loop needed -- are these redundant relations transitive?)
-        while (dataChildren?.length === 1) {
-            const childRow = dataChildren[0]._meta;
-            if (this.isRedundantChild(this, childRow)) {
-                dataChildren = childRow.data.children;
-            } else {
-                break;
+        if (view.query.flattenRedundantChildren) {
+            while (dataChildren?.length === 1) {
+                const childRow = dataChildren[0]._meta;
+                if (this.isRedundantChild(this, childRow)) {
+                    dataChildren = childRow.data.children;
+                } else {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
See issue: https://github.com/xh/hoist-react/issues/3843

Seemed like a quick win, that would allow us to clean up some code at a flagship client app. Wasn't sure about the name, its tricky to describe what this does in just a couple of words - any suggestions welcome!

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

