### PR TITLE
Fix mobile TabContainer switcher sizing and position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * `TreeMap` and `SplitTreeMap` are now cross-platform and can be used in mobile applications.
   Their import paths have changed from `@xh/hoist/desktop/cmp/treemap` to `@xh/hoist/cmp/treemap`.
 * The `RefreshButton` `model` prop has been renamed `target` for clarity and consistency.
+
 ### 🎁 New Features
 
 * Major Improvements to ViewManager component
@@ -26,6 +27,11 @@
   tab local data across reloads.
 * Added support for `AuthZeroClientConfig.audience` to support improved configuration of Auth0 OAuth
   clients requesting access tokens, covering cases when third-party cookies are blocked.
+
+### 🐞 Bug Fixes
+
+* Fixed sizing and position of mobile `TabContainer` switcher, particularly when the switcher is
+  positioned with `top` orientation.
 
 ### ⚙️ Technical
 

--- a/mobile/cmp/tab/impl/Tabs.scss
+++ b/mobile/cmp/tab/impl/Tabs.scss
@@ -26,6 +26,9 @@
 }
 
 .xh-tab-container {
+  // Override Onsen's tabbar height CSS var
+  --tabbar-height: var(--xh-tbar-min-size-px);
+
   position: relative;
   flex: auto;
 
@@ -48,10 +51,6 @@
       height: var(--xh-tbar-min-size-px);
       line-height: var(--xh-tbar-min-size-px);
       color: var(--xh-text-color);
-    }
-
-    &__content {
-      bottom: var(--xh-tbar-min-size-px);
     }
   }
 


### PR DESCRIPTION
Leverages Onsen's CSS var to fix issue: https://github.com/xh/hoist-react/issues/3819 

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

