### PR TITLE
Fix `ButtonGroup` borders incorrect when `vertical: true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 * Fixed sizing and position of mobile `TabContainer` switcher, particularly when the switcher is
   positioned with `top` orientation.
+* Fixed styling of `ButtonGroup` in vertical orientations.
 
 ### ⚙️ Technical
 

--- a/desktop/cmp/button/Button.scss
+++ b/desktop/cmp/button/Button.scss
@@ -113,6 +113,11 @@
             border-radius: 0 0 var(--xh-button-border-radius-px) var(--xh-button-border-radius-px);
           }
         }
+
+        // Outlined buttons should avoid doubled-up inner borders.
+        &.xh-button--outlined:not(:last-child) {
+          border-bottom: none;
+        }
       }
     }
   }

--- a/desktop/cmp/button/Button.scss
+++ b/desktop/cmp/button/Button.scss
@@ -56,31 +56,10 @@
         padding: var(--xh-pad-half-px) var(--xh-pad-px);
       }
 
-      // Standard and outlined have borders - remove standard radius in between adjacent buttons so
-      // they seamlessly combine their inner borders.
-      border-radius: 0;
-      &.xh-button--standard,
-      &.xh-button--outlined {
-        &:first-child {
-          border-bottom-left-radius: var(--xh-button-border-radius-px);
-          border-top-left-radius: var(--xh-button-border-radius-px);
-        }
-
-        &:last-child {
-          border-bottom-right-radius: var(--xh-button-border-radius-px);
-          border-top-right-radius: var(--xh-button-border-radius-px);
-        }
-      }
-
       // Minimal has no borders - radius is made visible by background shading when hovered or
       // pressed, and looks more natural without any radius.
       &.xh-button--minimal {
         border-radius: 0;
-      }
-
-      // Outlined buttons should avoid doubled-up inner borders.
-      &.xh-button--outlined:not(:last-child) {
-        border-right: none;
       }
 
       &.xh-button--enabled {
@@ -90,6 +69,49 @@
         &:focus {
           outline: var(--xh-focus-outline) !important;
           outline-offset: var(--xh-focus-outline-offset-px) !important;
+        }
+      }
+    }
+
+    // Horizontal mode only styles
+    &:not(.bp5-vertical) {
+      .xh-button.bp5-button {
+        // Standard and outlined have borders - remove standard radius in between adjacent buttons so
+        // they seamlessly combine their inner borders.
+        border-radius: 0;
+        &.xh-button--standard,
+        &.xh-button--outlined {
+          &:first-child {
+            border-radius: var(--xh-button-border-radius-px) 0 0 var(--xh-button-border-radius-px);
+          }
+
+          &:last-child {
+            border-radius: 0 var(--xh-button-border-radius-px) var(--xh-button-border-radius-px) 0;
+          }
+        }
+
+        // Outlined buttons should avoid doubled-up inner borders.
+        &.xh-button--outlined:not(:last-child) {
+          border-right: none;
+        }
+      }
+    }
+
+    // Vertical mode only styles
+    &.bp5-vertical {
+      .xh-button.bp5-button {
+        // Standard and outlined have borders - remove standard radius in between adjacent buttons so
+        // they seamlessly combine their inner borders.
+        border-radius: 0;
+        &.xh-button--standard,
+        &.xh-button--outlined {
+          &:first-child {
+            border-radius: var(--xh-button-border-radius-px) var(--xh-button-border-radius-px) 0 0;
+          }
+
+          &:last-child {
+            border-radius: 0 0 var(--xh-button-border-radius-px) var(--xh-button-border-radius-px);
+          }
         }
       }
     }


### PR DESCRIPTION
See issue: https://github.com/xh/hoist-react/issues/3268

Vertical:
![Screenshot 2024-12-27 at 16 44 23](https://github.com/user-attachments/assets/c8177a29-1024-412b-8c63-e2a8adf73266)

Horizontal:
![Screenshot 2024-12-27 at 16 45 04](https://github.com/user-attachments/assets/7dce033a-b827-4427-b3f7-f60b129c7e46)


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

