### PR TITLE
Make initialState null-safe in ViewManagerModel.stateReactions

### DIFF
--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -540,7 +540,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
             {
                 track: () => this.view?.token,
                 run: tkn => dataAccess.updateStateAsync({currentView: tkn}),
-                fireImmediately: this.view?.token !== initialState.currentView
+                fireImmediately: this.view?.token !== initialState?.currentView
             }
         ];
     }


### PR DESCRIPTION
In `ViewManagerModel.initAsync`, `initialState` will be `undefined` if the call to `dataAccess.fetchDataAsync()` fails.  This change prevents that method from throwing under those circumstances.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

