### PR TITLE
Improve model selector type

### DIFF
--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -255,7 +255,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
      * Use the static {@link createAsync} factory to create an instance of this model and await its
      * initial load before binding to persistable components.
      */
-    constructor({
+    private constructor({
         type,
         instance = 'default',
         typeDisplayName,

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -255,7 +255,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
      * Use the static {@link createAsync} factory to create an instance of this model and await its
      * initial load before binding to persistable components.
      */
-    private constructor({
+    constructor({
         type,
         instance = 'default',
         typeDisplayName,

--- a/core/model/HoistModel.ts
+++ b/core/model/HoistModel.ts
@@ -221,6 +221,6 @@ export abstract class HoistModel extends HoistBase implements Loadable {
     }
 }
 
-export interface HoistModelClass<T extends HoistModel> extends Function {
-    prototype: T;
+export interface HoistModelClass<T extends HoistModel> {
+    new (...args: any[]): T;
 }

--- a/core/model/HoistModel.ts
+++ b/core/model/HoistModel.ts
@@ -11,6 +11,7 @@ import {DefaultHoistProps, HoistBase, LoadSpecConfig, managed, PlainObject} from
 import {instanceManager} from '../impl/InstanceManager';
 import {Loadable, LoadSpec, LoadSupport} from '../load';
 import {ModelSelector} from './';
+import {Class} from 'type-fest';
 
 /**
  * Core superclass for stateful Models in Hoist. Models are used throughout the toolkit and
@@ -221,6 +222,4 @@ export abstract class HoistModel extends HoistBase implements Loadable {
     }
 }
 
-export interface HoistModelClass<T extends HoistModel> {
-    new (...args: any[]): T;
-}
+export type HoistModelClass<T extends HoistModel> = Class<T>;

--- a/core/model/HoistModel.ts
+++ b/core/model/HoistModel.ts
@@ -222,4 +222,4 @@ export abstract class HoistModel extends HoistBase implements Loadable {
     }
 }
 
-export type HoistModelClass<T extends HoistModel> = Class<T>;
+export type HoistModelClass<T extends HoistModel> = Class<T> | {prototype: Pick<T, keyof T>};

--- a/desktop/cmp/tab/TabSwitcher.ts
+++ b/desktop/cmp/tab/TabSwitcher.ts
@@ -30,7 +30,7 @@ import {
 } from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {compact, isEmpty, isFinite} from 'lodash';
-import {CSSProperties, ReactElement} from 'react';
+import {CSSProperties, ReactElement, KeyboardEvent} from 'react';
 
 /**
  * Component to indicate and control the active tab of a TabContainer.

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -24,7 +24,7 @@ import {viewPanel} from './ViewPanel';
 /**
  * Default management dialog for ViewManager.
  */
-export const manageDialog = hoistCmp.factory<ManageDialogModel>({
+export const manageDialog = hoistCmp.factory({
     displayName: 'ManageDialog',
     className: 'xh-view-manager__manage-dialog',
     model: uses(() => ManageDialogModel),

--- a/desktop/cmp/viewmanager/dialog/ViewMultiPanel.ts
+++ b/desktop/cmp/viewmanager/dialog/ViewMultiPanel.ts
@@ -14,7 +14,7 @@ import {pluralize} from '@xh/hoist/utils/js';
 import {every, isEmpty} from 'lodash';
 import {ManageDialogModel} from './ManageDialogModel';
 
-export const viewMultiPanel = hoistCmp.factory<ManageDialogModel>({
+export const viewMultiPanel = hoistCmp.factory({
     model: uses(() => ManageDialogModel),
     render({model}) {
         const views = model.selectedViews;


### PR DESCRIPTION
Turns out our homemade class definition was a little *too* close to a general function definition, and was capturing that.

This alternative from typefest works better, and seems more standard, although it precludes HoistModels with private constructors, like our new ViewManagerModel.  Think that's probably ok.

Other changes here and in toolbox were unrelated, just pickups from the stricter typing.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

