### PR TITLE
Pass token, not viewInfo and surface raw errors to make API more flexible.

### DIFF
--- a/cmp/viewmanager/DataAccess.ts
+++ b/cmp/viewmanager/DataAccess.ts
@@ -48,14 +48,14 @@ export class DataAccess<T> {
     }
 
     /** Fetch the latest version of a view. */
-    async fetchViewAsync(info: ViewInfo): Promise<View<T>> {
+    async fetchViewAsync(token: String): Promise<View<T>> {
         const {model} = this;
-        if (!info) return View.createDefault(model);
+        if (!token) return View.createDefault(model);
         try {
-            const raw = await XH.fetchJson({url: 'xhView/get', params: {token: info.token}});
+            const raw = await XH.fetchJson({url: 'xhView/get', params: {token}});
             return View.fromBlob(raw, model);
         } catch (e) {
-            throw XH.exception({message: `Unable to fetch ${info.typedName}`, cause: e});
+            throw XH.exception({message: `Unable to fetch view with token ${token}`, cause: e});
         }
     }
 

--- a/cmp/viewmanager/DataAccess.ts
+++ b/cmp/viewmanager/DataAccess.ts
@@ -48,7 +48,7 @@ export class DataAccess<T> {
     }
 
     /** Fetch the latest version of a view. */
-    async fetchViewAsync(token: String): Promise<View<T>> {
+    async fetchViewAsync(token: string): Promise<View<T>> {
         const {model} = this;
         if (!token) return View.createDefault(model);
         try {

--- a/cmp/viewmanager/ViewInfo.ts
+++ b/cmp/viewmanager/ViewInfo.ts
@@ -5,6 +5,7 @@
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
 import {SECONDS} from '@xh/hoist/utils/datetime';
+import {throwIf} from '@xh/hoist/utils/js';
 import {ViewManagerModel} from './ViewManagerModel';
 import {JsonBlob} from '@xh/hoist/svc';
 import {PlainObject, XH} from '@xh/hoist/core';
@@ -57,6 +58,8 @@ export class ViewInfo {
     readonly model: ViewManagerModel;
 
     constructor(blob: JsonBlob, model: ViewManagerModel) {
+        throwIf(blob.type !== model.type, 'View type does not match ViewManager type.');
+
         this.token = blob.token;
         this.type = blob.type;
         this.name = blob.name;

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -509,8 +509,8 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
             });
 
             // 2) Initialize/choose initial view.  Null is ok, and will yield default.
-            let initialView,
-                initialTkn = initialState.currentView;
+            let initialView: ViewInfo,
+                initialTkn: string = initialState.currentView;
             if (isUndefined(initialTkn)) {
                 initialView = this.initialViewSpec?.(views);
             } else if (!isNull(initialTkn)) {
@@ -519,7 +519,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
                 initialView = null;
             }
 
-            await this.loadViewAsync(initialView, this.pendingValue);
+            await this.loadViewAsync(initialView?.token, this.pendingValue);
         } catch (e) {
             // Always ensure at least default view is installed (other state defaults are fine)
             this.loadViewAsync(null, this.pendingValue);

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -357,7 +357,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
             return;
         }
 
-        await this.loadViewAsync(info).catch(e => this.handleException(e));
+        return this.loadViewAsync(info);
     }
 
     async saveAsAsync(spec: ViewCreateSpec): Promise<void> {

--- a/desktop/cmp/viewmanager/ViewManager.ts
+++ b/desktop/cmp/viewmanager/ViewManager.ts
@@ -118,7 +118,7 @@ const menuButton = hoistCmp.factory<ViewManagerLocalModel>({
 const saveButton = hoistCmp.factory<ViewManagerLocalModel>({
     render({model, mode, ...rest}) {
         if (hideStateButton(model, mode)) return null;
-        const {parent, saveAsDialogModel} = model,
+        const {parent} = model,
             {typeDisplayName, isLoading, isValueDirty} = parent;
         return button({
             className: 'xh-view-manager__save-button',
@@ -126,9 +126,7 @@ const saveButton = hoistCmp.factory<ViewManagerLocalModel>({
             tooltip: `Save changes to this ${typeDisplayName}`,
             intent: 'primary',
             disabled: !isValueDirty || isLoading,
-            onClick: () => {
-                parent.isViewSavable ? parent.saveAsync() : saveAsDialogModel.open();
-            },
+            onClick: () => model.saveAsync(),
             ...rest
         });
     }
@@ -144,7 +142,7 @@ const revertButton = hoistCmp.factory<ViewManagerLocalModel>({
             tooltip: `Revert changes to this ${typeDisplayName}`,
             intent: 'danger',
             disabled: !isValueDirty || isLoading,
-            onClick: () => model.parent.resetAsync(),
+            onClick: () => model.revertAsync(),
             ...rest
         });
     }

--- a/desktop/cmp/viewmanager/ViewManagerLocalModel.ts
+++ b/desktop/cmp/viewmanager/ViewManagerLocalModel.ts
@@ -23,6 +23,24 @@ export class ViewManagerLocalModel extends HoistModel {
     @bindable
     isVisible = true;
 
+    async saveAsync() {
+        const {parent} = this,
+            {view} = parent;
+
+        if (!parent.isViewSavable) {
+            this.saveAsDialogModel.open();
+            return;
+        }
+
+        return parent.saveAsync().catchDefault({
+            message: `Failed to save ${view.typedName}.  If this persists consider \`Save As...\`.`
+        });
+    }
+
+    async revertAsync() {
+        return this.parent.resetAsync().catchDefault();
+    }
+
     constructor(parent: ViewManagerModel) {
         super();
         makeObservable(this);

--- a/desktop/cmp/viewmanager/ViewMenu.ts
+++ b/desktop/cmp/viewmanager/ViewMenu.ts
@@ -63,7 +63,7 @@ function getNavMenuItems(model: ViewManagerModel): ReactNode[] {
                 className: 'xh-view-manager__menu-item',
                 icon: view.isDefault ? Icon.check() : Icon.placeholder(),
                 text: `Default ${startCase(typeDisplayName)}`,
-                onClick: () => model.selectViewAsync(null)
+                onClick: () => model.selectViewAsync(null).catchDefault()
             })
         );
     }
@@ -168,6 +168,6 @@ function viewMenuItem(view: ViewInfo, model: ViewManagerModel): ReactNode {
         text: view.name,
         title: title.join(' | '),
         icon,
-        onClick: () => model.selectViewAsync(view)
+        onClick: () => model.selectViewAsync(view).catchDefault()
     });
 }

--- a/desktop/cmp/viewmanager/ViewMenu.ts
+++ b/desktop/cmp/viewmanager/ViewMenu.ts
@@ -89,7 +89,7 @@ function getOtherMenuItems(model: ViewManagerLocalModel): ReactNode[] {
             icon: Icon.save(),
             text: 'Save',
             disabled: !isViewSavable || !isValueDirty,
-            onClick: () => parent.saveAsync()
+            onClick: () => model.saveAsync()
         }),
         menuItem({
             icon: Icon.placeholder(),
@@ -100,7 +100,7 @@ function getOtherMenuItems(model: ViewManagerLocalModel): ReactNode[] {
             icon: Icon.reset(),
             text: `Revert`,
             disabled: !isValueDirty,
-            onClick: () => parent.resetAsync()
+            onClick: () => model.revertAsync()
         }),
         menuDivider({omit: !enableAutoSave}),
         menuItem({
@@ -168,6 +168,6 @@ function viewMenuItem(view: ViewInfo, model: ViewManagerModel): ReactNode {
         text: view.name,
         title: title.join(' | '),
         icon,
-        onClick: () => model.selectViewAsync(view.token).catchDefault()
+        onClick: () => model.selectViewAsync(view).catchDefault()
     });
 }

--- a/desktop/cmp/viewmanager/ViewMenu.ts
+++ b/desktop/cmp/viewmanager/ViewMenu.ts
@@ -168,6 +168,6 @@ function viewMenuItem(view: ViewInfo, model: ViewManagerModel): ReactNode {
         text: view.name,
         title: title.join(' | '),
         icon,
-        onClick: () => model.selectViewAsync(view).catchDefault()
+        onClick: () => model.selectViewAsync(view.token).catchDefault()
     });
 }

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -86,7 +86,7 @@ export class ManageDialogModel extends HoistModel {
     }
 
     activateSelectedViewAndClose() {
-        this.viewManagerModel.selectViewAsync(this.selectedView.token).catchDefault();
+        this.viewManagerModel.selectViewAsync(this.selectedView).catchDefault();
         this.close();
     }
 

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -86,7 +86,7 @@ export class ManageDialogModel extends HoistModel {
     }
 
     activateSelectedViewAndClose() {
-        this.viewManagerModel.selectViewAsync(this.selectedView);
+        this.viewManagerModel.selectViewAsync(this.selectedView).catchDefault();
         this.close();
     }
 

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -86,7 +86,7 @@ export class ManageDialogModel extends HoistModel {
     }
 
     activateSelectedViewAndClose() {
-        this.viewManagerModel.selectViewAsync(this.selectedView).catchDefault();
+        this.viewManagerModel.selectViewAsync(this.selectedView.token).catchDefault();
         this.close();
     }
 


### PR DESCRIPTION
In my routable views implemention in which routes have view tokens,

I had to do this when the route got a new token:

```
const info = viewMngr.views.find(v => v.token === token);
if (!info) {
    try {
           await XH.jsonBlobService.getAsync(token)
    } catch (e) {
     // handle view doesn't exist & view not shared errors


    }
   
    viewMngr.selectViewAsync(info);
}

```


After this change, the flow is simplified to:

```
 try {
      await viewMngr.selectViewAsync(info);
    } catch (e) {
     // handle view doesn't exist & view not shared errors
}
```

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [ ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

