### PR TITLE
Remove windows-unfriendly script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "lint:all": "yarn lint:ts && yarn lint:js && yarn lint:styles",
     "lint:js": "eslint --ext .js,.jsx .",
     "lint:ts": "eslint --ext .ts,.tsx .",
-    "tsc": "./node_modules/typescript/bin/tsc",
     "lint:styles": "stylelint \"**/*.s?(a|c)ss\"",
     "prepare": "husky"
   },


### PR DESCRIPTION
@lbwexler you had added this line a long while back (maybe when doing the initial Typescript stuff?) but this doesn't work on windows and causes the pre-commit hooks to fail (which really messes up merges in intellij). I could maybe figure out how to make this work on windows but pretty sure it shouldn't be needed.

Do you remember why this was added? There should be an executable installed in `node_modules/.bin` to run the local install of `tsc` so we should not need to alias it like this in our package.json - curious if you guys have issues with this script removed on your macs

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

