### PR TITLE
Prevent native browser context menu on Dash Canvas surfaces.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Modify `TabContainerModel` to make more methods `protected`, improving extensibility for advanced
 use-cases.
 
+### 🐞 Bug Fixes
+
+* Prevent native browser context menu on Dash Canvas surfaces. It can hide the Dash Canvas custom
+  context menu when an app's `showBrowserContextMenu` flag is `true`.
+
 ## v72.1.0 - 2025-02-13
 
 ### 🎁 New Features

--- a/desktop/cmp/dash/canvas/DashCanvas.ts
+++ b/desktop/cmp/dash/canvas/DashCanvas.ts
@@ -115,6 +115,8 @@ const emptyContainerOverlay = hoistCmp.factory<DashCanvasModel>(({model}) => {
 });
 
 const onContextMenu = (e, model) => {
+    e.preventDefault();
+
     const {classList} = e.target;
     if (
         classList.contains('react-grid-layout') ||

--- a/desktop/cmp/dash/canvas/DashCanvas.ts
+++ b/desktop/cmp/dash/canvas/DashCanvas.ts
@@ -18,7 +18,7 @@ import {
 import {dashCanvasAddViewButton} from '@xh/hoist/desktop/cmp/button/DashCanvasAddViewButton';
 import '@xh/hoist/desktop/register';
 import {Classes, overlay} from '@xh/hoist/kit/blueprint';
-import {TEST_ID} from '@xh/hoist/utils/js';
+import {consumeEvent, TEST_ID} from '@xh/hoist/utils/js';
 import classNames from 'classnames';
 import ReactGridLayout, {WidthProvider} from 'react-grid-layout';
 import {DashCanvasModel} from './DashCanvasModel';
@@ -115,8 +115,6 @@ const emptyContainerOverlay = hoistCmp.factory<DashCanvasModel>(({model}) => {
 });
 
 const onContextMenu = (e, model) => {
-    e.preventDefault();
-
     const {classList} = e.target;
     if (
         classList.contains('react-grid-layout') ||
@@ -127,6 +125,7 @@ const onContextMenu = (e, model) => {
             x = clientX + model.ref.current.scrollLeft,
             y = clientY + model.ref.current.scrollTop;
 
+        consumeEvent(e);
         showContextMenu(
             dashCanvasContextMenu({
                 dashCanvasModel: model,


### PR DESCRIPTION
Bug fix: Prevent native browser context menu on Dash Canvas surfaces. It can hide the Dash Canvas custom context menu when an app's `showBrowserContextMenu` flag is `true`
![dashCanvasCMHidden](https://github.com/user-attachments/assets/d11ef262-28c3-4bd7-ad2e-7b670cf6a85b)



Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry.
- [x] Reviewed for breaking changes: not a breaking change
- [x] Updated doc comments / prop-types: not required
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch / PR: not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

