### PR TITLE
Workaround for `BooleanEditor.quickToggle` and keyboard tab interaction

### DIFF
--- a/desktop/cmp/grid/editors/BooleanEditor.ts
+++ b/desktop/cmp/grid/editors/BooleanEditor.ts
@@ -49,11 +49,23 @@ export const [BooleanEditor, booleanEditor] = hoistCmp.withFactory<BooleanEditor
     }
 });
 
-function useInstantEditor({onValueChange, initialValue, stopEditing}: CustomCellEditorProps, ref) {
+function useInstantEditor(
+    {onValueChange, initialValue, stopEditing, eventKey, eGridCell}: CustomCellEditorProps,
+    ref
+) {
+    // Don't toggle if the user has tabbed into the editor. See https://github.com/xh/hoist-react/issues/3943.
+    // Fortunately, `eventKey` is null for tab, so we can use that to accept other keyboard events.
+    // Unfortunately, it is also null for mouse events, so we check if the grid cell is currently
+    // underneath the mouse position via `:hover` selector.
     useEffect(() => {
-        onValueChange(!initialValue);
+        const els = document.querySelectorAll(':hover'),
+            topEl = els[els.length - 1];
+
+        if (eventKey || topEl === eGridCell) {
+            onValueChange(!initialValue);
+        }
         stopEditing();
-    }, [stopEditing, initialValue, onValueChange]);
+    }, [stopEditing, initialValue, onValueChange, eventKey, eGridCell]);
 
     return null;
 }


### PR DESCRIPTION
Fixes https://github.com/xh/hoist-react/issues/3943

I'm not entirely happy with this workaround - however, I spent far too long trying different approaches to no avail. Its still a net positive over the previous behaviour. If anybody has any better solutions I'm all ears :)

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [ ] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [ ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

