### PR TITLE
Null check on summaryRecords before accessing / using value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v73.0.0-SNAPSHOT - unreleased
 
 * Support for reporting Client Version in Admin WebSockets tab.
+* NULL check when accessing records in Store to prevent a thrown error
 
 ## v72.2.0 - 2025-03-13
 

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -18,6 +18,7 @@ import {
     isEmpty,
     isFunction,
     isNil,
+    isNull,
     isString,
     values,
     remove as lodashRemove,
@@ -692,6 +693,8 @@ export class Store extends HoistBase {
      * for backwards compat with app code predating support for multiple {@link summaryRecords}.
      */
     get summaryRecord(): StoreRecord {
+        if (isNull(this.summaryRecords)) return null;
+
         throwIf(
             this.summaryRecords.length > 1,
             'Store has multiple summary records - must access via Store.summaryRecords.'


### PR DESCRIPTION
For https://github.com/xh/hoist-react/issues/3950

Hoist P/R Checklist
-------------------

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.
