### PR TITLE
Option in About dialog to send client health report on-demand

### DIFF
--- a/desktop/appcontainer/AboutDialog.ts
+++ b/desktop/appcontainer/AboutDialog.ts
@@ -45,11 +45,10 @@ export const aboutDialog = hoistCmp.factory({
                     button({
                         text: 'Send Client Health Report',
                         icon: Icon.health(),
-                        omit: !XH.trackService.enabled,
+                        omit: !XH.clientHealthService.enabled,
                         onClick: async () => {
                             try {
-                                XH.clientHealthService.sendReport({trackOpts: {severity: 'INFO'}});
-                                await XH.trackService.pushPendingAsync();
+                                await XH.clientHealthService.sendReportAsync();
                                 XH.successToast('Client health report successfully submitted.');
                             } catch (e) {
                                 XH.handleException('Error sending client health report', e);

--- a/desktop/appcontainer/AboutDialog.ts
+++ b/desktop/appcontainer/AboutDialog.ts
@@ -48,7 +48,7 @@ export const aboutDialog = hoistCmp.factory({
                         omit: !XH.trackService.enabled,
                         onClick: async () => {
                             try {
-                                XH.clientHealthService.sendReport();
+                                XH.clientHealthService.sendReport({trackOpts: {severity: 'INFO'}});
                                 await XH.trackService.pushPendingAsync();
                                 XH.successToast('Client health report successfully submitted.');
                             } catch (e) {

--- a/desktop/appcontainer/AboutDialog.ts
+++ b/desktop/appcontainer/AboutDialog.ts
@@ -42,10 +42,25 @@ export const aboutDialog = hoistCmp.factory({
                     item: model.getTable()
                 }),
                 toolbar(
+                    button({
+                        text: 'Send Client Health Report',
+                        icon: Icon.health(),
+                        omit: !XH.trackService.enabled,
+                        onClick: async () => {
+                            try {
+                                XH.clientHealthService.sendReport();
+                                await XH.trackService.pushPendingAsync();
+                                XH.successToast('Client health report successfully submitted.');
+                            } catch (e) {
+                                XH.handleException('Error sending client health report', e);
+                            }
+                        }
+                    }),
                     filler(),
                     button({
                         text: 'Close',
                         intent: 'primary',
+                        outlined: true,
                         onClick: onClose
                     })
                 )

--- a/kit/onsen/theme.scss
+++ b/kit/onsen/theme.scss
@@ -118,6 +118,11 @@ body.xh-app.xh-mobile {
     color: var(--xh-text-color);
   }
 
+  // Toast - ensure z-index exceeds dialogs
+  ons-toast {
+    z-index: 30001 !important;
+  }
+
   // Remove outlines
   .tabbar__button:focus {
     outline: none;

--- a/mobile/appcontainer/AboutDialog.scss
+++ b/mobile/appcontainer/AboutDialog.scss
@@ -6,7 +6,7 @@
 
   th {
     text-align: right;
-    vertical-align: top;
+    vertical-align: middle;
     white-space: nowrap;
     background-color: var(--xh-bg-alt);
     border-bottom: var(--xh-border-solid);

--- a/mobile/appcontainer/AboutDialog.ts
+++ b/mobile/appcontainer/AboutDialog.ts
@@ -34,11 +34,10 @@ export const aboutDialog = hoistCmp.factory({
                 button({
                     text: 'Send Client Health Report',
                     icon: Icon.health(),
-                    omit: !XH.trackService.enabled,
+                    omit: !XH.clientHealthService.enabled,
                     onClick: async () => {
                         try {
-                            XH.clientHealthService.sendReport({trackOpts: {severity: 'INFO'}});
-                            await XH.trackService.pushPendingAsync();
+                            await XH.clientHealthService.sendReportAsync();
                             XH.successToast({
                                 message: 'Client health report submitted.',
                                 timeout: 2000

--- a/mobile/appcontainer/AboutDialog.ts
+++ b/mobile/appcontainer/AboutDialog.ts
@@ -37,7 +37,7 @@ export const aboutDialog = hoistCmp.factory({
                     omit: !XH.trackService.enabled,
                     onClick: async () => {
                         try {
-                            XH.clientHealthService.sendReport();
+                            XH.clientHealthService.sendReport({trackOpts: {severity: 'INFO'}});
                             await XH.trackService.pushPendingAsync();
                             XH.successToast({
                                 message: 'Client health report submitted.',

--- a/mobile/appcontainer/AboutDialog.ts
+++ b/mobile/appcontainer/AboutDialog.ts
@@ -30,7 +30,31 @@ export const aboutDialog = hoistCmp.factory({
             className: 'xh-about-dialog',
             item: model.getTable(),
             isOpen: model.isOpen,
-            bbar: [filler(), button({text: 'Close', onClick: () => model.hide()})]
+            bbar: [
+                button({
+                    text: 'Send Client Health Report',
+                    icon: Icon.health(),
+                    omit: !XH.trackService.enabled,
+                    onClick: async () => {
+                        try {
+                            XH.clientHealthService.sendReport();
+                            await XH.trackService.pushPendingAsync();
+                            XH.successToast({
+                                message: 'Client health report submitted.',
+                                timeout: 2000
+                            });
+                        } catch (e) {
+                            XH.handleException('Error sending client health report', e);
+                        }
+                    }
+                }),
+                filler(),
+                button({
+                    text: 'Close',
+                    outlined: true,
+                    onClick: () => model.hide()
+                })
+            ]
         });
     }
 });

--- a/svc/ClientHealthService.ts
+++ b/svc/ClientHealthService.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
-import {HoistService, PageState, PlainObject, XH} from '@xh/hoist/core';
+import {HoistService, PageState, PlainObject, TrackOptions, XH} from '@xh/hoist/core';
 import {Timer} from '@xh/hoist/utils/async';
 import {MINUTES} from '@xh/hoist/utils/datetime';
 import {withFormattedTimestamps} from '@xh/hoist/format';
@@ -65,13 +65,14 @@ export class ClientHealthService extends HoistService {
      * Generate and submit a report to the server, via TrackService.
      * @internal - apps should enable via config and allow this service to submit on timer.
      */
-    sendReport() {
+    sendReport(opts: {trackOpts?: Partial<TrackOptions>} = {}) {
         const {intervalMins, ...rest} = XH.trackService.conf.clientHealthReport ?? {};
 
         XH.track({
             category: 'App',
             message: 'Submitted health report',
             ...rest,
+            ...opts.trackOpts,
             data: {
                 clientId: XH.clientId,
                 sessionId: XH.sessionId,

--- a/svc/ClientHealthService.ts
+++ b/svc/ClientHealthService.ts
@@ -11,11 +11,12 @@ import {withFormattedTimestamps} from '@xh/hoist/format';
 import {pick, round} from 'lodash';
 
 /**
- * Service for gathering data about client health.
+ * Service for gathering data about the current state and health of the client app, for submission
+ * to the server or review on the console during interactive troubleshooting.
  *
- * Hoist sends this data once on application load, and can be configured to send
- * it at regularly scheduled intervals.  Configure via soft-config property
- * 'xhActivityTracking.clientHealthReport'.
+ * Hoist sends this data once on application load and can be configured to send at regular intervals
+ * throughout a user's session via the `xhActivityTracking.clientHealthReport` app config. Reports
+ * are submitted via activity tracking for review within the Admin Console.
  */
 export class ClientHealthService extends HoistService {
     static instance: ClientHealthService;
@@ -31,9 +32,7 @@ export class ClientHealthService extends HoistService {
         });
     }
 
-    /**
-     * Main entry point.  Return a default report of client health.
-     */
+    /** @returns a customizable report with metrics capturing client app/session state. */
     getReport(): ClientHealthReport {
         return {
             general: this.getGeneral(),
@@ -43,15 +42,13 @@ export class ClientHealthService extends HoistService {
         };
     }
 
-    /** Get report, suitable for viewing in console. **/
+    /** @returns a report, formatted for easier viewing in console. **/
     getFormattedReport(): PlainObject {
         return withFormattedTimestamps(this.getReport());
     }
 
     /**
-     * Register a new source for client health report data. No-op if background health report is
-     * not generally enabled via `xhActivityTrackingConfig.clientHealthReport.intervalMins`.
-     *
+     * Register a new source for app-specific data to be sent with each report.
      * @param key - key under which to report the data - can be used to remove this source later.
      * @param callback - function returning serializable to include with each report.
      */
@@ -62,6 +59,25 @@ export class ClientHealthService extends HoistService {
     /** Unregister a previously-enabled source for client health report data. */
     removeSource(key: string) {
         this.sources.delete(key);
+    }
+
+    /**
+     * Generate and submit a report to the server, via TrackService.
+     * @internal - apps should enable via config and allow this service to submit on timer.
+     */
+    sendReport() {
+        const {intervalMins, ...rest} = XH.trackService.conf.clientHealthReport ?? {};
+
+        XH.track({
+            category: 'App',
+            message: 'Submitted health report',
+            ...rest,
+            data: {
+                clientId: XH.clientId,
+                sessionId: XH.sessionId,
+                ...this.getReport()
+            }
+        });
     }
 
     // -----------------------------------
@@ -115,24 +131,6 @@ export class ClientHealthService extends HoistService {
             }
         });
         return ret;
-    }
-
-    //------------------
-    // Implementation
-    //------------------
-    private sendReport() {
-        const {intervalMins, ...rest} = XH.trackService.conf.clientHealthReport ?? {};
-
-        XH.track({
-            category: 'App',
-            message: 'Submitted health report',
-            ...rest,
-            data: {
-                clientId: XH.clientId,
-                sessionId: XH.sessionId,
-                ...this.getReport()
-            }
-        });
     }
 }
 

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -90,10 +90,11 @@ export class TrackService extends HoistService {
         this.pushPendingBuffered();
     }
 
-    //------------------
-    // Implementation
-    //------------------
-    private async pushPendingAsync() {
+    /**
+     * Flush the queue of pending activity tracking messages to the server.
+     * @internal - apps should generally allow this service to manage w/its internal debounce.
+     */
+    async pushPendingAsync() {
         const {pending} = this;
         if (isEmpty(pending)) return;
 
@@ -105,6 +106,9 @@ export class TrackService extends HoistService {
         });
     }
 
+    //------------------
+    // Implementation
+    //------------------
     @debounced(10 * SECONDS)
     private pushPendingBuffered() {
         this.pushPendingAsync();


### PR DESCRIPTION
- Fix to ensure mobile toasts are shown above fullscreen dialogs.
- Make `XH.clientHealthService.sendReport()` public, although comment as internal.
- Same with `XH.trackService.pushPendingAsync()`.
- Tweak to about table alignment on mobile.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

