### PR TITLE
Ensure `FilterFieldSpec.values` compacted to remove nulls

### DIFF
--- a/data/filter/BaseFilterFieldSpec.ts
+++ b/data/filter/BaseFilterFieldSpec.ts
@@ -6,7 +6,7 @@
  */
 import {HoistBase} from '@xh/hoist/core';
 import {Field, Store, FieldFilter, FieldType, genDisplayName, View} from '@xh/hoist/data';
-import {isEmpty} from 'lodash';
+import {compact, isArray, isEmpty} from 'lodash';
 import {FieldFilterOperator} from './Types';
 
 export interface BaseFilterFieldSpecConfig {
@@ -72,7 +72,11 @@ export abstract class BaseFilterFieldSpec extends HoistBase {
         this.displayName = displayName ?? sourceField?.displayName ?? genDisplayName(field);
         this.ops = this.parseOperators(ops);
         this.forceSelection = forceSelection ?? false;
-        this.values = values ?? (this.isBoolFieldType ? [true, false] : null);
+        this.values = isArray(values)
+            ? compact(values)
+            : this.isBoolFieldType
+              ? [true, false]
+              : null;
         this.hasExplicitValues = !isEmpty(this.values);
         this.enableValues = this.hasExplicitValues || (enableValues ?? this.isEnumerableByDefault);
     }


### PR DESCRIPTION
- Nulls within provided values appear to break `FilterChooser` - suggestions don't show, and general typeahead support is compromised.
- Compact provided values in ctor processing.
- Repeat in admin activity tracking, where we mutate these directly (in an unsupported way).

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

