### PR TITLE
Update Admin log viewer handling for long lines

### DIFF
--- a/admin/tabs/cluster/instances/logs/LogDisplayModel.ts
+++ b/admin/tabs/cluster/instances/logs/LogDisplayModel.ts
@@ -138,18 +138,23 @@ export class LogDisplayModel extends HoistModel {
             sizingMode: 'tiny',
             emptyText: 'No log entries found...',
             sortBy: 'rowNum|asc',
+            autosizeOptions: {mode: 'disabled'},
             store: {
                 idSpec: 'rowNum'
             },
             columns: [
                 {
                     field: {name: 'rowNum', type: 'number'},
-                    width: 4,
+                    width: 60,
+                    pinned: true,
                     cellClass: 'xh-log-display__row-number'
                 },
                 {
                     field: 'rowContent',
-                    width: 1200,
+                    // Hard-code to a very wide value - allows us to avoid autosize overhead while
+                    // ensuring that all but crazy-long lines are readable. We trust Admins can
+                    // ignore excess horizontal scrolling for this component.
+                    width: 5000,
                     autosizable: false,
                     cellClass: 'xh-log-display__row-content'
                 }
@@ -179,20 +184,11 @@ export class LogDisplayModel extends HoistModel {
     }
 
     private updateGridData(data) {
-        const {tailActive, gridModel} = this;
-        let maxRowLength = 200;
-        const gridData = data.map(row => {
-            if (row[1].length > maxRowLength) {
-                maxRowLength = row[1].length;
-            }
-            return {
+        const {tailActive, gridModel} = this,
+            gridData = data.map(row => ({
                 rowNum: row[0],
                 rowContent: row[1]
-            };
-        });
-
-        // Estimate the length of the row in pixels based on (character count) * (font size)
-        gridModel.setColumnState([{colId: 'rowContent', width: maxRowLength * 6}]);
+            }));
 
         gridModel.loadData(gridData);
 


### PR DESCRIPTION
- Remove previous heuristic around setting width of main "content" column within the log viewer based on char count. This was not accurately ensuring all content was shown, leading to unwanted truncation of longer lines.
- Replace with hard-coded 5000px width, disable autosize completely to continue avoiding overhead there, then also hard-code width and pin line number col.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

