### PR TITLE
Use baked-in client `XH.appVersion|Build` for upgrade check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## v73.0.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+
+* Updated the background version checking performed by `EnvironmentService` to use the app version
+  and build information baked into the client build when comparing against the latest values from
+  the server. Previously the versions loaded from the server on init were used as the baseline.
+  * The two versions *should* be the same, but in cases where a browser "restores" a tab and
+    re-inits an app without reloading the code itself, the upgrade check would miss the fact that
+    the client remained on an older version.
+  * Note that a misconfigured build - where the client build version is not set to the same value as
+    the server - would result in a false positive for an upgrade. The two should always match.
+
 ## v72.5.1 - 2025-04-15
 
 ### 🐞 Bug Fixes

--- a/svc/EnvironmentService.ts
+++ b/svc/EnvironmentService.ts
@@ -113,7 +113,9 @@ export class EnvironmentService extends HoistService {
     }
 
     /**
-     * Update critical environment information from server.
+     * Update critical environment information from server, including current app version + build,
+     * upgrade prompt mode, and alert banner.
+     *
      * @internal - not for app use. Called by `pollTimer` and as needed by Hoist code.
      */
     async pollServerAsync() {
@@ -125,15 +127,15 @@ export class EnvironmentService extends HoistService {
             return;
         }
 
-        // Update config/interval, and server info
+        // Update config/interval, server info, and alert banner.
         const {pollConfig, instanceName, alertBanner, appVersion, appBuild} = data;
         this.pollConfig = pollConfig;
         this.pollTimer.setInterval(this.pollIntervalMs);
         this.setServerInfo(instanceName, appVersion, appBuild);
         XH.alertBannerService.updateBanner(alertBanner);
 
-        // Handle version change
-        if (appVersion != XH.getEnv('appVersion') || appBuild != XH.getEnv('appBuild')) {
+        // Handle version change - compare to constants baked into client build.
+        if (appVersion != XH.appVersion || appBuild != XH.appBuild) {
             // force the user to refresh or prompt the user to refresh via the banner according to config
             // build checked to trigger refresh across SNAPSHOT updates in lower environments
             const {onVersionChange} = pollConfig;


### PR DESCRIPTION
* Previously the versions loaded from the server on init were used as the baseline.
* The two versions *should* be the same, but in cases where a browser "restores" a tab and re-inits an app without reloading the code itself, the upgrade check would miss the fact that the client remained on an older version.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

