### PR TITLE
Add 'ERROR' Severity to TrackSeverity and  Apply to rejected promise.track() calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Requires `hoist-core >= 30.0` with new APIs to support the consolidated Admin Co
       the client remained on an older version.
     * Note that a misconfigured build - where the client build version is not set to the same value
       as the server - would result in a false positive for an upgrade. The two should always match.
+*  Calls to `Promise.track()` that are rejected with an exception will be tracked with new
+   severity level of `TrackSeverity.ERROR`
 
 ## v72.5.1 - 2025-04-15
 

--- a/core/types/Interfaces.ts
+++ b/core/types/Interfaces.ts
@@ -207,7 +207,7 @@ export interface AppOptionSpec {
 /**
  * Severity levels for tracking.  Default is 'INFO'.
  */
-export type TrackSeverity = 'DEBUG' | 'INFO' | 'WARN';
+export type TrackSeverity = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 
 /**
  * Options for tracking activity on the server via TrackService.

--- a/promise/Promise.ts
+++ b/promise/Promise.ts
@@ -199,7 +199,7 @@ const enhancePromise = promisePrototype => {
             });
         },
 
-        track<T>(options: TrackOptions | string): Promise<T | undefined> {
+        track<T>(options: TrackOptions | string): Promise<T> {
             if (!options) return this;
 
             const startTime = Date.now(),

--- a/promise/Promise.ts
+++ b/promise/Promise.ts
@@ -12,11 +12,13 @@ import {
     TrackOptions,
     XH,
     Some,
-    Awaitable
+    Awaitable,
+    TimeoutExceptionConfig
 } from '@xh/hoist/core';
 import {action} from '@xh/hoist/mobx';
 import {olderThan, SECONDS} from '@xh/hoist/utils/datetime';
 import {castArray, isFunction, isNumber, isString} from 'lodash';
+import {isOmitted} from '@xh/hoist/utils/impl';
 
 /**
  * Enhancements to the Global Promise object.
@@ -39,8 +41,8 @@ declare global {
          * @param fn - catch handler
          */
         catchWhen<TResult = undefined>(
-            selector: ((e: any) => boolean) | Some<string>,
-            fn?: (reason: any) => Awaitable<TResult>
+            selector: ((e: unknown) => boolean) | Some<string>,
+            fn?: (reason: unknown) => Awaitable<TResult>
         ): Promise<T | TResult>;
 
         /**
@@ -53,7 +55,7 @@ declare global {
          * Version of `catchDefault()` that will only catch certain exceptions.
          */
         catchDefaultWhen(
-            selector: ((e: any) => boolean) | Some<string>,
+            selector: ((e: unknown) => boolean) | Some<string>,
             options: ExceptionHandlerOptions
         ): Promise<T | undefined>;
 
@@ -90,7 +92,7 @@ declare global {
          * Track a Promise (with timing) via Hoist activity tracking.
          * @param options - TrackOptions, or simply a message string.
          */
-        track(options: TrackOptions | string): Promise<T>;
+        track(options: TrackOptions | ((v: T, t: unknown) => TrackOptions) | string): Promise<T>;
     }
 }
 
@@ -169,43 +171,67 @@ export function never<T>(): Promise<T> {
 //--------------------------------
 const enhancePromise = promisePrototype => {
     Object.assign(promisePrototype, {
-        thenAction(fn) {
+        thenAction<T, TResult>(fn: (value: T) => Awaitable<TResult>): Promise<TResult> {
             return this.then(action(fn));
         },
 
-        catchWhen(selector, fn) {
-            return this.catch(e => {
+        catchWhen<T, TResult = undefined>(
+            selector: ((e: unknown) => boolean) | Some<string>,
+            fn?: (reason: unknown) => Awaitable<TResult>
+        ): Promise<T | TResult> {
+            return this.catch((e: unknown) => {
                 this.throwIfFailsSelector(e, selector);
                 return fn ? fn(e) : undefined;
             });
         },
 
-        catchDefault(options) {
-            return this.catch(e => XH.handleException(e, options));
+        catchDefault<T>(options?: ExceptionHandlerOptions): Promise<T | undefined> {
+            return this.catch((e: unknown) => XH.handleException(e, options));
         },
 
-        catchDefaultWhen(selector, options) {
-            return this.catch(e => {
+        catchDefaultWhen<T>(
+            selector: ((e: unknown) => boolean) | Some<string>,
+            options: ExceptionHandlerOptions
+        ): Promise<T | undefined> {
+            return this.catch((e: unknown) => {
                 this.throwIfFailsSelector(e, selector);
                 return XH.handleException(e, options);
             });
         },
 
-        track(options) {
-            if (!options || (isFunction(options.omit) ? options.omit() : options.omit)) return this;
-            if (isString(options)) options = {message: options};
+        track<T>(
+            options: TrackOptions | ((v: T, t: unknown) => TrackOptions) | string
+        ): Promise<T | undefined> {
+            if (!options) return this;
 
-            const startTime = Date.now();
-            return this.finally(() => {
-                XH.track({
-                    timestamp: startTime,
-                    elapsed: Date.now() - startTime,
-                    ...options
-                });
-            });
+            const startTime = Date.now(),
+                doTrack = (v: T, t: unknown) => {
+                    const opts: TrackOptions = isString(options)
+                        ? {message: options}
+                        : isFunction(options)
+                          ? options(v, t)
+                          : {...options};
+
+                    opts.timestamp = startTime;
+                    opts.elapsed = Date.now() - startTime;
+                    if (t != null) opts.severity = 'ERROR';
+
+                    XH.track(opts);
+                };
+
+            return this.then(
+                (v: T) => {
+                    doTrack(v, null);
+                    return v;
+                },
+                (t: unknown) => {
+                    doTrack(null, t);
+                    throw t;
+                }
+            );
         },
 
-        tap(onFulfillment) {
+        tap<T>(onFulfillment: (value: T) => any): Promise<T> {
             let ret = null;
             const resolveFn = data => {
                 ret = data;
@@ -215,13 +241,14 @@ const enhancePromise = promisePrototype => {
             return this.then(resolveFn).then(() => ret);
         },
 
-        wait(interval) {
+        wait<T>(interval: number): Promise<T> {
             return this.finally(() => wait(interval));
         },
 
-        timeout(config) {
-            if (config == null) return this;
-            if (isNumber(config)) config = {interval: config};
+        timeout<T>(spec: PromiseTimeoutSpec): Promise<T> {
+            if (spec == null) return this;
+
+            const config: TimeoutExceptionConfig = isNumber(spec) ? {interval: spec} : spec;
             const interval = config.interval;
 
             let completed = false;
@@ -236,14 +263,14 @@ const enhancePromise = promisePrototype => {
             return Promise.race([deadline, promise]);
         },
 
-        linkTo(cfg) {
+        linkTo<T>(cfg: PromiseLinkSpec): Promise<T> {
             if (!cfg) return this;
 
-            if (cfg.isTaskObserver) {
+            if (cfg instanceof TaskObserver) {
                 cfg = {observer: cfg};
             }
 
-            if (cfg.observer && !(isFunction(cfg.omit) ? cfg.omit() : cfg.omit)) {
+            if (cfg.observer && !isOmitted(cfg)) {
                 cfg.observer.linkTo(TaskObserver.forPromise({promise: this, message: cfg.message}));
             }
             return this;
@@ -252,7 +279,7 @@ const enhancePromise = promisePrototype => {
         //--------------------------------
         // Implementation
         //--------------------------------
-        throwIfFailsSelector(e, selector) {
+        throwIfFailsSelector(e: any, selector: any) {
             const fn = isFunction(selector) ? selector : e => castArray(selector).includes(e.name);
             if (!fn(e)) throw e;
         }

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -168,6 +168,6 @@ interface ActivityTrackingConfig {
     levels?: Array<{
         username: string | '*';
         category: string | '*';
-        severity: 'DEBUG' | 'INFO' | 'WARN';
+        severity: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
     }>;
 }


### PR DESCRIPTION
This is a minor change to introduce a new 'ERROR' severity to our tracking.
It includes some unrelated typescript enhancements

This also helps set us up to provide a potentially dynamic tracking function that could be passed the received promise resolution -- but I pulled that portion of the change for now pending further discussion.

Hopefully this change is relatively simple and mergable.
See also eponymous Hoist core PR.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

