### PR TITLE
Disable dashCanvasAddViewButton if there are no menuItems to show.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and new properties on `TrackLog`.
 
 * Fixed drag-and-drop usability issues with the mobile `ColChooser`.
 * Made `GridModel.defaultGroupSortFn` null-safe and improved type signature.
+* Disable `dashCanvasAddViewButton` if there are no `menuItems` to show.
 
 ### ⚙️ Typescript API Adjustments
 

--- a/desktop/cmp/button/DashCanvasAddViewButton.ts
+++ b/desktop/cmp/button/DashCanvasAddViewButton.ts
@@ -41,6 +41,7 @@ export const [DashCanvasAddViewButton, dashCanvasAddViewButton] =
                     ref,
                     icon: withDefault(icon, Icon.add()),
                     text: withDefault(text, dashCanvasModel.addViewButtonText),
+                    disabled: !menuItems.length,
                     ...rest
                 }),
                 content: contextMenu({menuItems})


### PR DESCRIPTION
This fix prevents this kind of ugly:

![emptyMenu](https://github.com/user-attachments/assets/b75d70a3-db02-4dbe-b51e-497f73cca295)

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes: NOT a breaking change.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

