### PR TITLE
Embed activity detail within Clients tab

### DIFF
--- a/admin/columns/Rest.ts
+++ b/admin/columns/Rest.ts
@@ -17,6 +17,7 @@ export const dateCreatedNoYear: ColumnSpec = {
     ...Col.dateTimeSec,
     field: {name: 'dateCreated', type: 'date'},
     tooltip: true,
+    align: 'right',
     renderer: dateTimeRenderer({fmt: 'MMM DD HH:mm:ss'})
 };
 

--- a/admin/columns/Tracking.ts
+++ b/admin/columns/Tracking.ts
@@ -13,6 +13,8 @@ import {fmtDate, fmtSpan, numberRenderer} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
 import {ReactElement} from 'react';
 
+const autosizeMaxWidth = 400;
+
 export const appBuild: ColumnSpec = {
     field: {
         name: 'appBuild',
@@ -74,7 +76,7 @@ export const correlationId: ColumnSpec = {
 export const data: ColumnSpec = {
     field: {name: 'data', type: 'json'},
     width: 250,
-    autosizeMaxWidth: 400
+    autosizeMaxWidth
 };
 
 export const day: ColumnSpec = {
@@ -179,7 +181,7 @@ export const error: ColumnSpec = {
         type: 'string'
     },
     width: 250,
-    autosizeMaxWidth: 400,
+    autosizeMaxWidth,
     renderer: e => fmtSpan(e, {className: 'xh-font-family-mono xh-font-size-small'})
 };
 
@@ -211,7 +213,7 @@ export const msg: ColumnSpec = {
         aggregator: 'UNIQUE'
     },
     width: 250,
-    autosizeMaxWidth: 400
+    autosizeMaxWidth
 };
 
 export const severity: ColumnSpec = {
@@ -267,13 +269,13 @@ export const url: ColumnSpec = {
         displayName: 'URL'
     },
     width: 250,
-    autosizeMaxWidth: 400
+    autosizeMaxWidth
 };
 
 export const urlPathOnly: ColumnSpec = {
     field: url.field,
     width: 250,
-    autosizeMaxWidth: 400,
+    autosizeMaxWidth,
     tooltip: true,
     renderer: v => {
         if (!v) return null;
@@ -293,7 +295,8 @@ export const userAgent: ColumnSpec = {
         isDimension: true,
         aggregator: 'UNIQUE'
     },
-    width: 130
+    width: 130,
+    autosizeMaxWidth
 };
 
 export const userAlertedFlag: ColumnSpec = {

--- a/admin/tabs/activity/tracking/ActivityTrackingPanel.ts
+++ b/admin/tabs/activity/tracking/ActivityTrackingPanel.ts
@@ -155,7 +155,7 @@ const aggregateView = hoistCmp.factory<ActivityTrackingModel>(({model}) => {
             persistWith: {...model.persistWith, path: 'aggPanel'}
         },
         tbar: toolbar({
-            // compact: true,
+            compact: true,
             items: [
                 groupingChooser({flex: 10, maxWidth: 300}),
                 filler(),

--- a/admin/tabs/activity/tracking/detail/ActivityDetailModel.ts
+++ b/admin/tabs/activity/tracking/detail/ActivityDetailModel.ts
@@ -6,17 +6,32 @@
  */
 import {exportFilename} from '@xh/hoist/admin/AdminUtils';
 import * as Col from '@xh/hoist/admin/columns';
+import {ActivityTrackingDataFieldSpec} from '@xh/hoist/admin/tabs/activity/tracking/datafields/DataFieldsEditorModel';
 import {FormModel} from '@xh/hoist/cmp/form';
-import {GridModel} from '@xh/hoist/cmp/grid';
-import {HoistModel, lookup, managed} from '@xh/hoist/core';
+import {ColumnSpec, GridModel} from '@xh/hoist/cmp/grid';
+import {HoistModel, lookup, managed, PersistOptions, PlainObject} from '@xh/hoist/core';
 import {StoreRecord} from '@xh/hoist/data';
 import {timestampReplacer} from '@xh/hoist/format';
 import {action, bindable, computed, makeObservable, observable} from '@xh/hoist/mobx';
-import {get} from 'lodash';
-import {ActivityTrackingModel} from '../ActivityTrackingModel';
+import {get, isString} from 'lodash';
+
+/**
+ * Interface to cover the two usages of this component - {@link ActivityTrackingModel} and {@link ClientDetailModel}
+ */
+export interface ActivityDetailProvider {
+    isActivityDetailProvider: true;
+    trackLogs: PlainObject[];
+    persistWith?: PersistOptions;
+    colDefaults?: Record<string, Partial<ColumnSpec>>;
+    dataFields?: ActivityTrackingDataFieldSpec[];
+    dataFieldCols?: ColumnSpec[];
+}
 
 export class ActivityDetailModel extends HoistModel {
-    @lookup(ActivityTrackingModel) activityTrackingModel: ActivityTrackingModel;
+    @lookup(model => {
+        return model.isActivityDetailProvider ?? false;
+    })
+    parentModel: ActivityDetailProvider;
 
     @managed @observable.ref gridModel: GridModel;
     @managed @observable.ref formModel: FormModel;
@@ -31,14 +46,22 @@ export class ActivityDetailModel extends HoistModel {
     /** Stringified, pretty-printed, optionally path-filtered `data` payload. */
     @observable formattedData: string;
 
+    get dataFields(): ActivityTrackingDataFieldSpec[] {
+        return this.parentModel?.dataFields ?? [];
+    }
+
+    get dataFieldCols(): ColumnSpec[] {
+        return this.parentModel?.dataFieldCols ?? [];
+    }
+
     @computed
     get hasExtraTrackData(): boolean {
-        return this.gridModel.selectedRecord?.data.data != null;
+        return this.gridModel?.selectedRecord?.data.data != null;
     }
 
     @computed
     get hasSelection() {
-        return this.gridModel.selectedRecord != null;
+        return this.gridModel?.selectedRecord != null;
     }
 
     constructor() {
@@ -47,17 +70,22 @@ export class ActivityDetailModel extends HoistModel {
     }
 
     override onLinked() {
-        this.markPersist('formattedDataFilterPath', this.activityTrackingModel.persistWith);
+        if (this.parentModel.persistWith) {
+            this.persistWith = {...this.parentModel.persistWith, path: 'activityDetail'};
+            this.markPersist('formattedDataFilterPath', {
+                path: `${this.persistWith.path}.formattedDataFilterPath`
+            });
+        }
 
         this.addReaction(
             {
-                track: () => this.activityTrackingModel.dataFields,
+                track: () => this.dataFields,
                 run: () => this.createAndSetCoreModels(),
                 fireImmediately: true
             },
             {
-                track: () => this.activityTrackingModel.gridModel.selectedRecord,
-                run: aggRec => this.showActivityEntriesAsync(aggRec)
+                track: () => this.parentModel.trackLogs,
+                run: trackLogs => this.showTrackLogsAsync(trackLogs)
             },
             {
                 track: () => this.gridModel.selectedRecord,
@@ -73,27 +101,10 @@ export class ActivityDetailModel extends HoistModel {
     //------------------
     // Implementation
     //------------------
-    private async showActivityEntriesAsync(aggRec: StoreRecord) {
-        const {gridModel} = this,
-            leaves = this.getAllLeafRows(aggRec);
-
-        gridModel.loadData(leaves);
+    private async showTrackLogsAsync(trackLogs: PlainObject[]) {
+        const {gridModel} = this;
+        gridModel.loadData(trackLogs);
         await gridModel.preSelectFirstAsync();
-    }
-
-    // Extract all leaf, track-entry-level rows from an aggregate record (at any level).
-    private getAllLeafRows(aggRec: StoreRecord, ret = []) {
-        if (!aggRec) return [];
-
-        if (aggRec.children.length) {
-            aggRec.children.forEach(childRec => this.getAllLeafRows(childRec, ret));
-        } else if (aggRec.raw.leafRows) {
-            aggRec.raw.leafRows.forEach(leaf => {
-                ret.push({...leaf});
-            });
-        }
-
-        return ret;
     }
 
     /** Extract data from a (detail) grid record and flush it into our form for display. */
@@ -139,11 +150,13 @@ export class ActivityDetailModel extends HoistModel {
     }
 
     private createGridModel(): GridModel {
-        const hidden = true,
+        const {persistWith, parentModel, dataFieldCols} = this,
+            colDefaults = parentModel.colDefaults ?? {},
+            hidden = true,
             pinned = true;
 
         return new GridModel({
-            persistWith: {...this.activityTrackingModel.persistWith, path: 'detailGrid'},
+            persistWith: persistWith ? {...persistWith, path: `${persistWith.path}.grid`} : null,
             sortBy: 'dateCreated|desc',
             colChooserModel: true,
             enableExport: true,
@@ -174,8 +187,11 @@ export class ActivityDetailModel extends HoistModel {
                 {...Col.urlPathOnly},
                 {...Col.data, hidden},
                 {...Col.dateCreatedNoYear, displayName: 'Timestamp'},
-                ...this.activityTrackingModel.dataFieldCols
-            ]
+                ...dataFieldCols
+            ].map(it => {
+                const fieldName = isString(it.field) ? it.field : it.field.name;
+                return {...it, ...colDefaults[fieldName]};
+            })
         });
     }
 

--- a/admin/tabs/activity/tracking/detail/ActivityDetailView.ts
+++ b/admin/tabs/activity/tracking/detail/ActivityDetailView.ts
@@ -37,11 +37,12 @@ export const activityDetailView = hoistCmp.factory({
 const tbar = hoistCmp.factory<ActivityDetailModel>(({model}) => {
     const {gridModel} = model;
     return toolbar({
+        compact: true,
         items: [
             filler(),
             gridCountLabel({unit: 'entry'}),
             '-',
-            gridFindField({gridModel, key: gridModel.xhId}),
+            gridFindField({gridModel, key: gridModel.xhId, width: 250}),
             colChooserButton({gridModel}),
             exportButton()
         ]
@@ -50,6 +51,8 @@ const tbar = hoistCmp.factory<ActivityDetailModel>(({model}) => {
 
 // Discrete outer panel to retain sizing across master/detail selection changes.
 const detailRecPanel = hoistCmp.factory<ActivityDetailModel>(({model}) => {
+    const {persistWith} = model;
+
     return panel({
         collapsedTitle: 'Activity Details',
         collapsedIcon: Icon.info(),
@@ -57,10 +60,9 @@ const detailRecPanel = hoistCmp.factory<ActivityDetailModel>(({model}) => {
         modelConfig: {
             side: 'bottom',
             defaultSize: 400,
-            persistWith: {
-                ...model.activityTrackingModel.persistWith,
-                path: 'singleActivityDetailPanel'
-            }
+            persistWith: persistWith
+                ? {...persistWith, path: `${persistWith.path}.singleActivityDetailPanel`}
+                : null
         },
         item: detailRecForm()
     });

--- a/admin/tabs/client/clients/ClientsModel.ts
+++ b/admin/tabs/client/clients/ClientsModel.ts
@@ -73,6 +73,8 @@ export class ClientsModel extends BaseAdminTabModel {
     }
 
     override async doLoadAsync(loadSpec: LoadSpec) {
+        const {gridModel} = this;
+
         try {
             const data = await XH.fetchJson({
                 url: 'clientAdmin/allClients',
@@ -80,12 +82,15 @@ export class ClientsModel extends BaseAdminTabModel {
             });
             if (loadSpec.isStale) return;
 
-            this.gridModel.loadData(data);
+            gridModel.loadData(data);
+            gridModel.preSelectFirstAsync();
             runInAction(() => {
                 this.lastRefresh = Date.now();
             });
         } catch (e) {
-            if (loadSpec.isStale) return;
+            if (loadSpec.isStale || loadSpec.isAutoRefresh) return;
+
+            gridModel.clear();
             XH.handleException(e, {alertType: 'toast'});
         }
     }

--- a/admin/tabs/client/clients/ClientsPanel.ts
+++ b/admin/tabs/client/clients/ClientsPanel.ts
@@ -4,9 +4,10 @@
  *
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
+import {clientDetailPanel} from '@xh/hoist/admin/tabs/client/clients/activity/ClientDetailPanel';
 import {errorMessage} from '@xh/hoist/cmp/error';
 import {grid, gridCountLabel} from '@xh/hoist/cmp/grid';
-import {filler, fragment, p} from '@xh/hoist/cmp/layout';
+import {filler, fragment, hframe, p} from '@xh/hoist/cmp/layout';
 import {relativeTimestamp} from '@xh/hoist/cmp/relativetimestamp';
 import {storeFilterField} from '@xh/hoist/cmp/store';
 import {creates, hoistCmp, XH} from '@xh/hoist/core';
@@ -48,7 +49,7 @@ export const clientsPanel = hoistCmp.factory<ClientsModel>({
                 colChooserButton(),
                 exportButton()
             ],
-            item: grid(),
+            items: hframe(grid(), clientDetailPanel()),
             mask: 'onLoad',
             ref: model.viewRef
         });

--- a/admin/tabs/client/clients/activity/ClientDetail.scss
+++ b/admin/tabs/client/clients/activity/ClientDetail.scss
@@ -1,0 +1,24 @@
+.xh-admin-client-detail {
+  &__header {
+    align-items: center;
+    background-color: var(--xh-grid-bg-odd);
+    border-bottom: var(--xh-border-solid);
+    padding: var(--xh-pad-px);
+
+    h2 {
+      flex: 1;
+      font-weight: normal;
+      margin: 0;
+
+      .xh-icon {
+        font-size: 0.8em;
+        margin-right: 0.3em;
+      }
+    }
+
+    &__meta {
+      flex: none;
+      align-items: flex-end;
+    }
+  }
+}

--- a/admin/tabs/client/clients/activity/ClientDetailModel.ts
+++ b/admin/tabs/client/clients/activity/ClientDetailModel.ts
@@ -1,0 +1,83 @@
+import {ClientsModel} from '@xh/hoist/admin/tabs/client/clients/ClientsModel';
+import {ColumnSpec} from '@xh/hoist/cmp/grid';
+import {HoistModel, LoadSpec, lookup, PlainObject, XH} from '@xh/hoist/core';
+import {StoreRecord} from '@xh/hoist/data';
+import {bindable, computed, makeObservable} from '@xh/hoist/mobx';
+import {ReactNode} from 'react';
+import {ActivityDetailProvider} from '../../../activity/tracking/detail/ActivityDetailModel';
+
+export class ClientDetailModel extends HoistModel implements ActivityDetailProvider {
+    @lookup(ClientsModel) clientsModel: ClientsModel;
+
+    readonly isActivityDetailProvider = true;
+
+    /** Client tabID for which to load and show activity. */
+    @bindable tabId: string;
+    @bindable.ref trackLogs: PlainObject[] = [];
+
+    get selectedRec(): StoreRecord {
+        return this.clientsModel?.gridModel.selectedRecord;
+    }
+
+    @computed
+    get hasSelection(): boolean {
+        return !!this.selectedRec;
+    }
+
+    get title(): ReactNode {
+        return this.selectedRec?.data.user ?? 'Client Activity';
+    }
+
+    /** For child {@link ActivityDetailModel}. */
+    readonly colDefaults: Record<string, Partial<ColumnSpec>> = {
+        username: {hidden: true},
+        impersonatingFlag: {hidden: true},
+        tabId: {hidden: true},
+        loadId: {hidden: false},
+        device: {hidden: true}
+    };
+
+    constructor() {
+        super();
+        makeObservable(this);
+    }
+
+    override onLinked() {
+        super.onLinked();
+
+        this.addReaction(
+            {
+                track: () => this.clientsModel.gridModel.selectedRecord,
+                run: rec => (this.tabId = rec?.get('tabId'))
+            },
+            {
+                track: () => this.tabId,
+                run: () => this.loadAsync(),
+                debounce: 300
+            }
+        );
+    }
+
+    override async doLoadAsync(loadSpec: LoadSpec) {
+        const {tabId} = this;
+
+        if (!tabId) {
+            this.trackLogs = [];
+            return;
+        }
+
+        try {
+            this.trackLogs = await XH.postJson({
+                url: 'trackLogAdmin',
+                body: {
+                    filters: {field: 'tabId', op: '=', value: tabId}
+                }
+            });
+        } catch (e) {
+            if (loadSpec.isStale || !loadSpec.isAutoRefresh) return;
+
+            XH.handleException(e, {alertType: 'toast'});
+            this.trackLogs = [];
+        }
+    }
+}

--- a/admin/tabs/client/clients/activity/ClientDetailPanel.ts
+++ b/admin/tabs/client/clients/activity/ClientDetailPanel.ts
@@ -1,0 +1,63 @@
+import {isOpen} from '@xh/hoist/admin/columns';
+import {activityDetailView} from '@xh/hoist/admin/tabs/activity/tracking/detail/ActivityDetailView';
+import {ClientDetailModel} from '@xh/hoist/admin/tabs/client/clients/activity/ClientDetailModel';
+import {h2, hbox, placeholder, vbox} from '@xh/hoist/cmp/layout';
+import {mask} from '@xh/hoist/cmp/mask';
+import {relativeTimestamp} from '@xh/hoist/cmp/relativetimestamp';
+import {creates, hoistCmp} from '@xh/hoist/core';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {Icon} from '@xh/hoist/icon';
+import './ClientDetail.scss';
+
+export const clientDetailPanel = hoistCmp.factory({
+    displayName: 'ClientDetailPanel',
+    model: creates(ClientDetailModel),
+
+    render({model}) {
+        return panel({
+            className: 'xh-admin-client-detail',
+            collapsedTitle: model.title,
+            collapsedIcon: Icon.analytics(),
+            compactHeader: true,
+            modelConfig: {side: 'right', defaultSize: '40%'},
+            item: model.hasSelection
+                ? clientDetail()
+                : placeholder(Icon.analytics(), 'Select a client to view activity...')
+        });
+    }
+});
+
+const clientDetail = hoistCmp.factory<ClientDetailModel>(({model}) => {
+    const {data} = model.selectedRec;
+    return panel({
+        items: [
+            hbox({
+                className: 'xh-admin-client-detail__header',
+                items: [
+                    h2(isOpen.renderer(data.isOpen, null), data.user),
+                    vbox({
+                        className: 'xh-admin-client-detail__header__meta',
+                        items: [
+                            relativeTimestamp({
+                                timestamp: data.createdTime,
+                                options: {prefix: 'Session established'}
+                            }),
+                            relativeTimestamp({
+                                timestamp: data.lastReceivedTime,
+                                options: {prefix: 'Last heartbeat', emptyResult: 'No heartbeat yet'}
+                            })
+                        ]
+                    })
+                ]
+            }),
+            panel({
+                item: activityDetailView(),
+                mask: mask({
+                    bind: model.loadModel,
+                    spinner: true,
+                    message: 'Loading activity...'
+                })
+            })
+        ]
+    });
+});


### PR DESCRIPTION
- New `ActivityDetailProvider` interface for common parent models to allow us to re-use `ClientDetailModel` + view.
- Assorted UI/UX tweaks

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

