### PR TITLE
Fix persist decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 * Made `GridModel.defaultGroupSortFn` null-safe and improved type signature.
 * Disable `dashCanvasAddViewButton` if there are no `menuItems` to show.
 * Fixed `@persist` decorator.
+* Fixed bug where `@bindable` decorator would initialize lazily. Note that applications must
+  call `makeObservable()` on the decorated class to ensure that the decorator is applied correctly.
 
 ### ⚙️ Typescript API Adjustments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@
 * Fixed drag-and-drop usability issues with the mobile `ColChooser`.
 * Made `GridModel.defaultGroupSortFn` null-safe and improved type signature.
 * Disable `dashCanvasAddViewButton` if there are no `menuItems` to show.
-* Fixed `@persist` decorator.
-* Fixed bug where `@bindable` decorator would initialize lazily. Note that applications must
-  call `makeObservable()` on the decorated class to ensure that the decorator is applied correctly.
+* Improvements to `@bindable` and `@persist` to handle lifecycle-related bugs. Note that previously
+  `@bindable` would work even if `makeObservable()` was not called, but this is no longer the case.
+  Please ensure that `makeObservable()` is called in your model's constructor when using `@bindable`.
 
 ### ⚙️ Typescript API Adjustments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Fixed drag-and-drop usability issues with the mobile `ColChooser`.
 * Made `GridModel.defaultGroupSortFn` null-safe and improved type signature.
 * Disable `dashCanvasAddViewButton` if there are no `menuItems` to show.
+* Fixed `@persist` decorator.
 
 ### ⚙️ Typescript API Adjustments
 

--- a/core/HoistBaseDecorators.ts
+++ b/core/HoistBaseDecorators.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
-import {waitFor} from '@xh/hoist/promise';
+import {wait} from '@xh/hoist/promise';
 import {observable} from 'mobx';
 import {logError, throwIf} from '../utils/js';
 import {HoistBaseClass, PersistableState, PersistenceProvider, PersistOptions} from './';
@@ -105,7 +105,8 @@ function createPersistDescriptor(
             }
         });
 
-        waitFor(() => this.hasOwnProperty(property)).thenAction(() => propertyAvailable.set(true));
+        // Wait for next tick to ensure property is available on the instance before observing.
+        wait().then(() => propertyAvailable.set(true));
 
         hasInitialized = true;
         return ret;

--- a/core/HoistBaseDecorators.ts
+++ b/core/HoistBaseDecorators.ts
@@ -100,7 +100,8 @@ function createPersistDescriptor(
                 }
             });
 
-            // Wait for next tick to ensure property is available on the instance before observing.
+            // Wait for next tick to ensure construction has completed and property has been made
+            // observable via makeObservable.
             wait().thenAction(() => propertyAvailable.set(true));
 
             return ret;

--- a/mobx/decorators.ts
+++ b/mobx/decorators.ts
@@ -5,7 +5,6 @@
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
 import {upperFirst} from 'lodash';
-import {getOrCreate} from '../utils/js';
 
 /**
  * Decorator to mark a property as observable and also provide a simple MobX action of the
@@ -40,7 +39,12 @@ function createBindable(target, name, descriptor, isRef) {
     }
 
     // 2) Record on class, so we can later create on *instance* in makeObservable.
-    getOrCreate(target, '_xhBindableProperties', () => ({}))[name] = isRef;
+    // (Be sure to create cloned list since this will exist on prototype superclasses of this class)
+    const key = '_xhBindableProperties';
+    if (!target.hasOwnProperty(key)) {
+        target[key] = {...target[key]};
+    }
+    target[key][name] = isRef;
 
     // 3) Return original descriptor.
     return descriptor;

--- a/mobx/decorators.ts
+++ b/mobx/decorators.ts
@@ -42,7 +42,6 @@ function createBindable(target, name, descriptor, isRef) {
     // 2) Record on class, so we can later create on *instance* in makeObservable.
     getOrCreate(target, '_xhBindableProperties', () => ({}))[name] = isRef;
 
-    // 5) Return the get/set to be placed on prototype.  (If makeObservable() never called, or called
-    // late, the non-enumerable property will still be available.)
+    // 3) Return original descriptor.
     return descriptor;
 }

--- a/mobx/decorators.ts
+++ b/mobx/decorators.ts
@@ -44,7 +44,7 @@ function createBindable(target, name, descriptor, isRef) {
     if (!target.hasOwnProperty(key)) {
         target[key] = {...target[key]};
     }
-    target[key][name] = isRef;
+    target[key][name] = {isRef};
 
     // 3) Return original descriptor.
     return descriptor;

--- a/mobx/decorators.ts
+++ b/mobx/decorators.ts
@@ -5,7 +5,6 @@
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
 import {upperFirst} from 'lodash';
-import {observable, runInAction} from 'mobx';
 import {getOrCreate} from '../utils/js';
 
 /**
@@ -40,38 +39,8 @@ function createBindable(target, name, descriptor, isRef) {
         Object.defineProperty(target, setterName, {value});
     }
 
-    // 2) Place a hidden getter on prototype that wraps the backing observable.
-    const {initializer} = descriptor,
-        propName = `_${name}_bindable`,
-        valName = `_${name}_bindable_value`;
-    Object.defineProperty(target, propName, {
-        get() {
-            return getOrCreate(this, valName, () => {
-                const initVal = initializer?.call(this);
-                return isRef ? observable.box(initVal, {deep: false}) : observable.box(initVal);
-            });
-        }
-    });
-
-    // 3) Create the descriptor for a getter/setter pair..
-    descriptor = {
-        get() {
-            return this[propName].get();
-        },
-        set(v) {
-            runInAction(() => this[propName].set(v));
-        },
-        enumerable: true,
-        configurable: true
-    };
-
-    // 4) Record on class, so we can later create on *instance* in makeObservable.
-    // (Be sure to create cloned list for *this* particular class.)
-    const key = '_xhBindableProperties';
-    if (!target.hasOwnProperty(key)) {
-        target[key] = {...target[key]};
-    }
-    target[key][name] = descriptor;
+    // 2) Record on class, so we can later create on *instance* in makeObservable.
+    getOrCreate(target, '_xhBindableProperties', () => ({}))[name] = isRef;
 
     // 5) Return the get/set to be placed on prototype.  (If makeObservable() never called, or called
     // late, the non-enumerable property will still be available.)

--- a/mobx/overrides.ts
+++ b/mobx/overrides.ts
@@ -24,7 +24,7 @@ export function makeObservable(
 ) {
     // Finish creating 'bindable' properties for this instance.
     const bindables = target._xhBindableProperties;
-    forEach(bindables, (isRef, name) => {
+    forEach(bindables, ({isRef}, name) => {
         const propName = `_${name}_bindable`,
             initVal = target[name];
         target[propName] = isRef ? observable.box(initVal, {deep: false}) : observable.box(initVal);
@@ -46,8 +46,8 @@ export function makeObservable(
 /**
  * An enhanced version of the native mobx isObservableProp
  */
-export function isObservableProp(target: any, propertyKey: PropertyKey) {
+export function isObservableProp(target: any, propertyKey: PropertyKey): boolean {
     return (
-        baseIsObservableProp(target, propertyKey) || target?._xhBindableProperties?.[propertyKey]
+        baseIsObservableProp(target, propertyKey) || !!target?._xhBindableProperties?.[propertyKey]
     );
 }


### PR DESCRIPTION
I noticed this issue on a client app.  Tab state was initialized from saved prefKey value, but changing tab state in the app did not trigger a write to prefKey.

This issue can also be observed in toolbox on the inspector's `active` property.

-Colin

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

