### PR TITLE
`ViewManagerModel.settleTime` improvements and `preserveUnsavedChanges` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 74.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
++ Add `ViewManagerModel.preserveUnsavedChanges` flag to opt-out of that behaviour.
+
+### 🐞 Bug Fixes
++ Improves `ViewManagerModel.settleTime` by comparing to when the view is pushed to components
+  rather than when view is loaded from the server.
+
 ## v73.0.1 - 2025-05-19
 
 ### 🐞 Bug Fixes

--- a/cmp/viewmanager/View.ts
+++ b/cmp/viewmanager/View.ts
@@ -27,12 +27,6 @@ export class View<T extends PlainObject = PlainObject> {
      */
     readonly value: Partial<T> = null;
 
-    /**
-     * Defaulted to value, but may be updated during ViewManagerModel's settleTime to be
-     * the "settled" state after loading. Used for comparison to determine dirtiness.
-     */
-    settledValue: Partial<T> = null;
-
     private readonly model: ViewManagerModel;
 
     get name(): string {
@@ -98,7 +92,6 @@ export class View<T extends PlainObject = PlainObject> {
     constructor(info: ViewInfo, value: Partial<T>, model: ViewManagerModel) {
         this.info = info;
         this.value = value;
-        this.settledValue = value;
         this.model = model;
     }
 }

--- a/cmp/viewmanager/View.ts
+++ b/cmp/viewmanager/View.ts
@@ -27,6 +27,12 @@ export class View<T extends PlainObject = PlainObject> {
      */
     readonly value: Partial<T> = null;
 
+    /**
+     * Defaulted to value, but may be updated during ViewManagerModel's settleTime to be
+     * the "settled" state after loading. Used for comparison to determine dirtiness.
+     */
+    settledValue: Partial<T> = null;
+
     private readonly model: ViewManagerModel;
 
     get name(): string {
@@ -92,6 +98,7 @@ export class View<T extends PlainObject = PlainObject> {
     constructor(info: ViewInfo, value: Partial<T>, model: ViewManagerModel) {
         this.info = info;
         this.value = value;
+        this.settledValue = value;
         this.model = model;
     }
 }

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -447,6 +447,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         }
     }
 
+    /** @internal Called by ViewManagerProvider. */
     noteStatePushed() {
         this.lastPushed = Date.now();
     }

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -421,13 +421,14 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
 
     @action
     setValue(value: Partial<T>) {
+        value = this.cleanState(value);
+
         const {view, pendingValue, lastPushed, settleTime} = this;
         if (!pendingValue && settleTime && !olderThan(lastPushed, settleTime)) {
-            return;
+            this.view.settledValue = value;
         }
 
-        value = this.cleanState(value);
-        if (!isEqual(value, view.value)) {
+        if (!isEqual(value, view.settledValue)) {
             this.pendingValue = {
                 token: pendingValue ? pendingValue.token : view.token,
                 baseUpdated: pendingValue ? pendingValue.baseUpdated : view.lastUpdated,

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -552,7 +552,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         }
 
         this.addReaction(
-            this.pendingValueReaction(),
+            this.preserveUnsavedChanges ? this.pendingValueReaction() : null,
             this.autoSaveReaction(),
             ...this.stateReactions(initialState)
         );
@@ -561,10 +561,7 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
     private pendingValueReaction(): ReactionSpec {
         return {
             track: () => this.pendingValue,
-            run: v => {
-                if (!this.preserveUnsavedChanges) return;
-                XH.sessionStorageService.set(this.pendingValueStorageKey, v);
-            }
+            run: v => XH.sessionStorageService.set(this.pendingValueStorageKey, v)
         };
     }
 

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -430,14 +430,13 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
 
     @action
     setValue(value: Partial<T>) {
-        value = this.cleanState(value);
-
         const {view, pendingValue, lastPushed, settleTime} = this;
         if (!pendingValue && settleTime && !olderThan(lastPushed, settleTime)) {
-            this.view.settledValue = value;
+            return;
         }
 
-        if (!isEqual(value, view.settledValue)) {
+        value = this.cleanState(value);
+        if (!isEqual(value, view.value)) {
             this.pendingValue = {
                 token: pendingValue ? pendingValue.token : view.token,
                 baseUpdated: pendingValue ? pendingValue.baseUpdated : view.lastUpdated,

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -437,7 +437,6 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
             this.view.settledValue = value;
         }
 
-        // Todo: Consider how this interacts with the localStorage pending state
         if (!isEqual(value, view.settledValue)) {
             this.pendingValue = {
                 token: pendingValue ? pendingValue.token : view.token,

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -448,6 +448,10 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         }
     }
 
+    noteStatePushed() {
+        this.lastPushed = Date.now();
+    }
+
     //------------------
     // Pinning
     //------------------
@@ -603,7 +607,6 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
             .thenAction(latest => {
                 this.setAsView(latest, pendingValue?.token == token ? pendingValue : null);
                 this.providers.forEach(it => it.pushStateToTarget());
-                this.lastPushed = Date.now();
             })
             .linkTo(this.selectTask);
     }

--- a/core/persist/provider/ViewManagerProvider.ts
+++ b/core/persist/provider/ViewManagerProvider.ts
@@ -19,11 +19,13 @@ export class ViewManagerProvider<S> extends PersistenceProvider<S> {
         throwIf(!viewManagerModel, `ViewManagerProvider requires a 'viewManagerModel'.`);
         this.viewManagerModel = viewManagerModel;
         viewManagerModel.providers.push(this);
+        viewManagerModel.noteStatePushed();
     }
 
     pushStateToTarget() {
         const state = this.read();
         this.target.setPersistableState(state ? state : this.defaultState);
+        this.viewManagerModel.noteStatePushed();
     }
 
     //----------------

--- a/core/persist/provider/ViewManagerProvider.ts
+++ b/core/persist/provider/ViewManagerProvider.ts
@@ -5,6 +5,7 @@
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
 
+import {Persistable} from '@xh/hoist/core';
 import {throwIf} from '@xh/hoist/utils/js';
 import {pull} from 'lodash';
 import {PersistenceProvider, PersistenceProviderConfig} from '../PersistenceProvider';
@@ -19,7 +20,6 @@ export class ViewManagerProvider<S> extends PersistenceProvider<S> {
         throwIf(!viewManagerModel, `ViewManagerProvider requires a 'viewManagerModel'.`);
         this.viewManagerModel = viewManagerModel;
         viewManagerModel.providers.push(this);
-        viewManagerModel.noteStatePushed();
     }
 
     pushStateToTarget() {
@@ -31,6 +31,11 @@ export class ViewManagerProvider<S> extends PersistenceProvider<S> {
     //----------------
     // Implementation
     //----------------
+    override bindToTarget(target: Persistable<S>) {
+        super.bindToTarget(target);
+        this.viewManagerModel.noteStatePushed();
+    }
+
     override readRaw() {
         return this.viewManagerModel.getValue();
     }


### PR DESCRIPTION
+ Improve `ViewManagerModel.settleTime` by updating `lastPushed` when changes are pushed rather than when view is loaded.
+ Add ViewManagerModel.preserveUnsavedChanges flag to opt-out of that behaviour.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

