### PR TITLE
Fix cleanup in useOnScroll hook

### DIFF
--- a/utils/react/Hooks.ts
+++ b/utils/react/Hooks.ts
@@ -74,9 +74,17 @@ export function useOnVisibleChange(fn: (visible: boolean) => any): (node: any) =
  * @returns callback ref to be placed on target component
  */
 export function useOnScroll(fn: (ev: Event) => any): (node: any) => void {
-    return useCallback(node => {
-        node?.addEventListener('scroll', fn);
-    }, []);
+    const elRef = useRef<Element | null>(null);
+    useOnUnmount(() => elRef.current?.removeEventListener('scroll', fn));
+
+    return useCallback(
+        node => {
+            elRef.current?.removeEventListener('scroll', fn);
+            elRef.current = node;
+            node?.addEventListener('scroll', fn);
+        },
+        [fn]
+    );
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure `useOnScroll` unsubscribes when element changes or unmounts

## Testing
- `yarn lint:code` *(fails: Cannot find module 'eslint/config')*
- `npx tsc --noEmit` *(fails to locate deps)*

------
https://chatgpt.com/codex/tasks/task_e_68405816ab88832ba9ca2af0b17f1886