### PR TITLE
Consolidate `GroupingChooser` value/favorites mgmt into one popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### 🎁 New Features
 
+* Updated the `GroupingChooser` UI to use a single popover for both updating the value and
+  selecting/managing favorite groupings (if enabled).
+    * Adjusted `GroupingChooserModel` API and some CSS class names and testIds of `GroupingChooser`
+      internals, although those changes are very unlikely to require app-level adjustments.
+    * Adjusted/removed (rarely used) desktop and mobile `GroupingChooser` props related to popover
+      sizing and titling.
+    * Updated the mobile UI to use a full-screen dialog, similar to `ColumnChooser`.
 * Added props to `ViewManager` to customize icons used for different types of views, and modified
   default icons for Global and Shared views.
 * Added `ViewManager.extraMenuItems` prop to allow insertion of custom, app-specific items into the

--- a/desktop/cmp/grouping/GroupingChooser.scss
+++ b/desktop/cmp/grouping/GroupingChooser.scss
@@ -22,11 +22,6 @@
         color: var(--xh-text-color-muted);
       }
     }
-
-    // We must account for the favorites icon when eliding text
-    &--with-favorites {
-      padding-right: 30px !important;
-    }
   }
 
   // Outer box is sized via layoutSupport - all nested inner elements should stretch to fill.
@@ -37,6 +32,10 @@
 
   .bp5-popover-target span {
     position: relative;
+  }
+
+  &__editor {
+    flex: 1;
   }
 
   &__list {
@@ -121,48 +120,38 @@
     padding: 2px var(--xh-tbar-item-pad-px);
   }
 
-  &__favorite-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 30px;
-    height: 20px;
-    position: absolute;
-    top: 0;
-    right: 0;
-    cursor: pointer;
-    color: var(--xh-text-color-muted);
+  &__favorites {
+    flex: 1;
+    border-left: 1px solid var(--xh-popup-border-color);
 
-    &:hover {
-      color: var(--xh-text-color);
+    --xh-menu-border: none;
+
+    .bp5-menu {
+      padding: 0;
     }
 
-    .xh-toolbar--compact & {
-      height: 15px;
+    &__add-btn {
+      flex: none;
+      margin: var(--xh-pad-px) auto;
     }
 
-    // Matched to FilterChooser equivalent.
-    & > .svg-inline--fa {
-      width: 12px;
-    }
-  }
-
-  &__favorite {
-    align-items: center;
-    max-width: 50vw;
-
-    .xh-button {
-      padding: 0 !important;
-      min-width: 20px !important;
-      min-height: 20px !important;
-      visibility: hidden;
-    }
-
-    &:hover {
-      background-color: var(--xh-bg-highlight);
+    &__favorite {
+      align-items: center;
+      max-width: 50vw;
 
       .xh-button {
-        visibility: unset;
+        padding: 0 !important;
+        min-width: 20px !important;
+        min-height: 20px !important;
+        visibility: hidden;
+      }
+
+      &:hover {
+        background-color: var(--xh-bg-highlight);
+
+        .xh-button {
+          visibility: unset;
+        }
       }
     }
   }

--- a/mobile/appcontainer/FeedbackDialog.ts
+++ b/mobile/appcontainer/FeedbackDialog.ts
@@ -7,6 +7,7 @@
 import {FeedbackDialogModel} from '@xh/hoist/appcontainer/FeedbackDialogModel';
 import {filler} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
 import {button} from '@xh/hoist/mobile/cmp/button';
 import {dialog} from '@xh/hoist/mobile/cmp/dialog';
 import {textArea} from '@xh/hoist/mobile/cmp/input';
@@ -41,6 +42,9 @@ export const feedbackDialog = hoistCmp.factory({
                 }),
                 button({
                     text: 'Send',
+                    icon: Icon.mail(),
+                    intent: 'primary',
+                    outlined: true,
                     onClick: () => model.submitAsync()
                 })
             ]

--- a/mobile/appcontainer/OptionsDialog.ts
+++ b/mobile/appcontainer/OptionsDialog.ts
@@ -57,8 +57,10 @@ export const optionsDialog = hoistCmp.factory({
                     onClick: () => model.hide()
                 }),
                 button({
-                    text: 'Save',
+                    text: 'Apply',
                     icon: reloadRequired ? Icon.refresh() : Icon.check(),
+                    intent: 'primary',
+                    outlined: true,
                     disabled: !formModel.isDirty,
                     onClick: () => model.saveAsync()
                 })

--- a/mobile/cmp/grid/impl/ColChooser.ts
+++ b/mobile/cmp/grid/impl/ColChooser.ts
@@ -60,7 +60,6 @@ export const [ColChooser, colChooser] = hoistCmp.withFactory<ColChooserProps>({
                     onDragEnd: impl.onDragEnd,
                     items: [
                         panel({
-                            title: 'Visible Columns',
                             className: 'xh-col-chooser__section',
                             scrollable: true,
                             items: [
@@ -119,8 +118,10 @@ export const [ColChooser, colChooser] = hoistCmp.withFactory<ColChooserProps>({
                     onClick: () => model.close()
                 }),
                 button({
-                    text: 'Save',
+                    text: 'Apply',
                     icon: Icon.check(),
+                    intent: 'primary',
+                    outlined: true,
                     onClick: () => {
                         model.commit();
                         model.close();

--- a/mobile/cmp/grouping/GroupingChooser.scss
+++ b/mobile/cmp/grouping/GroupingChooser.scss
@@ -16,18 +16,23 @@
     }
   }
 
+  &__editor {
+    .xh-panel__content {
+      padding: var(--xh-pad-px);
+    }
+  }
+
   &__row {
     display: flex;
     align-items: center;
     background-color: var(--xh-bg);
-    height: 35px;
+    height: 45px;
     flex-shrink: 0;
 
     &__grabber {
       display: flex;
       align-items: center;
       justify-content: center;
-      height: 30px;
       width: 30px;
     }
 
@@ -49,30 +54,46 @@
   }
 
   &__add-control {
-    padding: var(--xh-pad-half-px);
+    // Align with already-added level controls.
+    padding: 5px 40px 5px 30px;
   }
 
-  &__favorite {
-    height: 35px;
-    align-items: center;
+  &__favorites {
+    // Fix at 50% of dialog height, preventing panel's default flex:auto
+    flex: none !important;
+    height: 50%;
 
-    .xh-button {
-      justify-content: left;
+    // Section heading style for internal title (like colChooser)
+    .xh-panel-header {
+      background-color: var(--xh-appbar-bg);
+      color: var(--xh-appbar-title-color);
+      padding-left: var(--xh-pad-px);
     }
-  }
-}
 
-.xh-grouping-chooser-popover {
-  .dialog {
-    min-width: unset;
-  }
+    .xh-panel__content {
+      padding: var(--xh-pad-px);
+    }
 
-  .xh-dialog__inner {
-    padding: 0;
-  }
+    // Empty state placeholder - don't flex as it pushes add button down.
+    .xh-placeholder {
+      flex: none;
+      margin: var(--xh-pad-px);
+    }
 
-  &__content {
-    padding: 3px var(--xh-pad-half-px);
-    min-width: 240px; // Required to allow for toolbars
+    // Individual favorite items (hBoxes w/buttons)
+    &__favorite {
+      flex: none !important;
+      height: 35px;
+      align-items: center;
+
+      .xh-button {
+        justify-content: left;
+      }
+    }
+
+    &__add-btn {
+      width: 200px;
+      margin: var(--xh-pad-px) auto;
+    }
   }
 }

--- a/mobile/cmp/grouping/GroupingChooser.ts
+++ b/mobile/cmp/grouping/GroupingChooser.ts
@@ -5,14 +5,14 @@
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
 import {GroupingChooserModel} from '@xh/hoist/cmp/grouping';
-import {box, div, filler, hbox, placeholder, span, vbox, vframe} from '@xh/hoist/cmp/layout';
+import {box, div, filler, hbox, placeholder, span} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {dragDropContext, draggable, droppable} from '@xh/hoist/kit/react-beautiful-dnd';
 import {button, ButtonProps} from '@xh/hoist/mobile/cmp/button';
-import {dialog} from '@xh/hoist/mobile/cmp/dialog';
 import {select} from '@xh/hoist/mobile/cmp/input';
 import '@xh/hoist/mobile/register';
+import {dialogPanel, panel} from '@xh/hoist/mobile/cmp/panel';
 import {splitLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {compact, isEmpty, sortBy} from 'lodash';
@@ -20,14 +20,10 @@ import {compact, isEmpty, sortBy} from 'lodash';
 import './GroupingChooser.scss';
 
 export interface GroupingChooserProps extends ButtonProps<GroupingChooserModel> {
+    /** Custom title for editor dialog, or null to suppress. */
+    dialogTitle?: string;
     /** Text to represent empty state (i.e. value = null or [])*/
     emptyText?: string;
-    /** Title for popover (default "GROUP BY") or null to suppress. */
-    popoverTitle?: string;
-    /** Min height in pixels of the popover inner content (excl. header & toolbar). */
-    popoverMinHeight?: number;
-    /** Width in pixels of the popover menu itself. */
-    popoverWidth?: number;
 }
 
 /**
@@ -40,15 +36,7 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory<GroupingC
     className: 'xh-grouping-chooser',
 
     render(
-        {
-            model,
-            className,
-            emptyText = 'Ungrouped',
-            popoverWidth = 270,
-            popoverMinHeight,
-            popoverTitle = 'Group By',
-            ...rest
-        },
+        {model, className, dialogTitle = 'Choose Group By', emptyText = 'Ungrouped', ...rest},
         ref
     ) {
         const {value, allowEmpty} = model,
@@ -60,74 +48,55 @@ export const [GroupingChooser, groupingChooser] = hoistCmp.withFactory<GroupingC
             className,
             ...layoutProps,
             items: [
-                popoverCmp({popoverTitle, popoverWidth, popoverMinHeight, emptyText}),
                 button({
                     className: 'xh-grouping-chooser-button',
                     item: span(label),
                     ...buttonProps,
                     onClick: () => model.toggleEditor()
                 }),
-                favoritesButton()
+                dialogCmp({dialogTitle, emptyText})
             ]
         });
     }
 });
 
-//---------------------------
-// Popover
-//---------------------------
-const popoverCmp = hoistCmp.factory<GroupingChooserModel>(
-    ({model, popoverTitle, popoverWidth, popoverMinHeight, emptyText}) => {
-        const {editorIsOpen, favoritesIsOpen, isValid, value} = model,
-            isOpen = editorIsOpen || favoritesIsOpen,
-            addFavoriteDisabled = isEmpty(value) || !!model.isFavorite(value);
-
-        return dialog({
-            isOpen,
-            title: favoritesIsOpen ? 'Favorites' : popoverTitle,
-            icon: favoritesIsOpen ? Icon.favorite({prefix: 'fas'}) : Icon.treeList(),
-            className: 'xh-grouping-chooser-popover',
-            content: vframe({
-                className: 'xh-grouping-chooser-popover__content',
-                width: popoverWidth,
-                minHeight: popoverMinHeight,
-                item: favoritesIsOpen ? favoritesMenu() : editor({emptyText})
-            }),
-            onCancel: () => model.closePopover(),
-            buttons: favoritesIsOpen
-                ? [
-                      button({
-                          icon: Icon.add(),
-                          flex: 1,
-                          text: 'Add current',
-                          disabled: addFavoriteDisabled,
-                          onClick: () => model.addFavorite(model.value)
-                      })
-                  ]
-                : [
-                      filler(),
-                      button({
-                          text: 'Cancel',
-                          minimal: true,
-                          onClick: () => model.closePopover()
-                      }),
-                      button({
-                          icon: Icon.check(),
-                          text: 'Apply',
-                          disabled: !isValid,
-                          onClick: () => model.commitPendingValueAndClose()
-                      })
-                  ]
+const dialogCmp = hoistCmp.factory<GroupingChooserModel>({
+    render({model, dialogTitle, emptyText}) {
+        return dialogPanel({
+            isOpen: model.editorIsOpen,
+            title: dialogTitle,
+            icon: Icon.treeList(),
+            items: [editor({emptyText}), favoritesChooser({omit: !model.persistFavorites})],
+            bbar: [
+                filler(),
+                button({
+                    text: 'Cancel',
+                    minimal: true,
+                    onClick: () => model.closeEditor()
+                }),
+                button({
+                    text: 'Apply',
+                    icon: Icon.check(),
+                    intent: 'primary',
+                    outlined: true,
+                    disabled: !model.isValid,
+                    onClick: () => model.commitPendingValueAndClose()
+                })
+            ]
         });
     }
-);
+});
 
 //------------------
 // Editor
 //------------------
 const editor = hoistCmp.factory({
     render({emptyText}) {
-        return vbox(dimensionList({emptyText}), addDimensionControl());
+        return panel({
+            className: 'xh-grouping-chooser__editor',
+            scrollable: true,
+            items: [dimensionList({emptyText}), addDimensionControl()]
+        });
     }
 });
 
@@ -222,7 +191,7 @@ const addDimensionControl = hoistCmp.factory<GroupingChooserModel>({
                     // ensure the Select loses its internal input state.
                     key: JSON.stringify(options),
                     options,
-                    placeholder: 'Add...',
+                    placeholder: 'Add level...',
                     flex: 1,
                     width: null,
                     hideDropdownIndicator: true,
@@ -247,35 +216,37 @@ function getDimOptions(dims, model) {
 //------------------
 // Favorites
 //------------------
-const favoritesButton = hoistCmp.factory<GroupingChooserModel>({
+const favoritesChooser = hoistCmp.factory<GroupingChooserModel>({
     render({model}) {
-        if (!model.persistFavorites) return null;
-        return button({
+        const {favoritesOptions: options, isAddFavoriteEnabled} = model,
+            items = isEmpty(options)
+                ? [placeholder('No favorites saved.')]
+                : options.map(it => favoriteItem(it));
+
+        return panel({
+            title: 'Favorites',
             icon: Icon.favorite(),
-            minimal: true,
-            className: 'xh-grouping-chooser__favorite-button',
-            onClick: () => model.toggleFavoritesMenu()
+            className: 'xh-grouping-chooser__favorites',
+            scrollable: true,
+            items: [
+                ...items,
+                button({
+                    text: 'Add current',
+                    icon: Icon.add({intent: 'success'}),
+                    className: 'xh-grouping-chooser__favorites__add-btn',
+                    outlined: true,
+                    omit: !isAddFavoriteEnabled,
+                    onClick: () => model.addPendingAsFavorite()
+                })
+            ]
         });
     }
 });
 
-const favoritesMenu = hoistCmp.factory<GroupingChooserModel>({
-    render({model}) {
-        const options = model.favoritesOptions;
-
-        if (isEmpty(options)) {
-            return placeholder('No favorites saved...');
-        }
-
-        const items = options.map(it => favoriteMenuItem(it));
-        return div({items});
-    }
-});
-
-const favoriteMenuItem = hoistCmp.factory<GroupingChooserModel>({
+const favoriteItem = hoistCmp.factory<GroupingChooserModel>({
     render({model, value, label}) {
         return hbox({
-            className: 'xh-grouping-chooser__favorite',
+            className: 'xh-grouping-chooser__favorites__favorite',
             items: [
                 button({
                     text: label,
@@ -283,7 +254,7 @@ const favoriteMenuItem = hoistCmp.factory<GroupingChooserModel>({
                     flex: 1,
                     onClick: () => {
                         model.setValue(value);
-                        model.closePopover();
+                        model.closeEditor();
                     }
                 }),
                 button({

--- a/mobile/cmp/panel/DialogPanel.scss
+++ b/mobile/cmp/panel/DialogPanel.scss
@@ -23,6 +23,11 @@
       & > .xh-panel {
         width: 100%;
         height: 100%;
+
+        // Additional padding on dialog panel's own header.
+        > .xh-panel-header {
+          padding: 10px;
+        }
       }
     }
   }


### PR DESCRIPTION
- Avoid two distinct popovers - show existing UIs for adjusting grouping chooser value (levels) and favorites (if enabled) side-by-side in a single popover.
- Update mobile to match, now using a full-screen dialogPanel, as with columnChooser
- Minor adjustments to CSS classnames and testIds to support
- Remove unused props / properties related to showing distinct favorites menu
- Minor tweaks to some built-in mobile dialog buttons and dialog header padding for consistency/polish.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

