### PR TITLE
Further refinements to the `GroupingChooser` desktop UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## v75.0.0-SNAPSHOT - unreleased
+## v74.1.1 - 2025-07-02
+
+### 🎁 New Features
+
+* Further refinements to the `GroupingChooser` desktop UI.
+  * Added new props `favoritesSide` and `favoritesTitle`.
+  * Deprecated `popoverTitle` prop - use `editorTitle` instead.
+  * Moved "Save as Favorite" button to a new compact toolbar within the popover.
 
 ## v74.1.0 - 2025-06-30
 

--- a/cmp/grouping/GroupingChooserModel.ts
+++ b/cmp/grouping/GroupingChooserModel.ts
@@ -266,6 +266,11 @@ export class GroupingChooserModel extends HoistModel {
         );
     }
 
+    @computed
+    get hasFavorites() {
+        return !isEmpty(this.favorites);
+    }
+
     @action
     setFavorites(favorites: string[][]) {
         this.favorites = favorites.filter(v => this.validateValue(v));

--- a/desktop/cmp/grouping/GroupingChooser.scss
+++ b/desktop/cmp/grouping/GroupingChooser.scss
@@ -121,8 +121,23 @@
   }
 
   &__favorites {
-    flex: 1;
-    border-left: 1px solid var(--xh-popup-border-color);
+    &--top {
+      border-bottom: 1px solid var(--xh-popup-border-color);
+    }
+
+    &--right {
+      flex: 1;
+      border-left: 1px solid var(--xh-popup-border-color);
+    }
+
+    &--bottom {
+      border-top: 1px solid var(--xh-popup-border-color);
+    }
+
+    &--left {
+      flex: 1;
+      border-right: 1px solid var(--xh-popup-border-color);
+    }
 
     --xh-menu-border: none;
 
@@ -130,14 +145,8 @@
       padding: 0;
     }
 
-    &__add-btn {
-      flex: none;
-      margin: var(--xh-pad-px) auto;
-    }
-
     &__favorite {
       align-items: center;
-      max-width: 50vw;
 
       .xh-button {
         padding: 0 !important;

--- a/utils/js/LangUtils.ts
+++ b/utils/js/LangUtils.ts
@@ -178,7 +178,7 @@ export function apiDeprecated(name: string, opts: APIWarnOptions = {}) {
 
     const v = opts.v ?? 'a future release',
         msg = opts.msg ? ` ${opts.msg}.` : '',
-        warn = `The use of '${name}' has been deprecated and will be removed in ${v}.${msg}`;
+        warn = `The use of '${name}' has been deprecated and will be removed in ${v}. ${msg}`;
     if (!_seenWarnings[warn]) {
         console.warn(warn);
         _seenWarnings[warn] = true;


### PR DESCRIPTION
* Added new props `favoritesSide` and `favoritesTitle`.
* Deprecated `popoverTitle` prop - use `editorTitle` instead.
* Moved "Save as Favorite" button to a new compact toolbar within the popover.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

