### PR TITLE
Preserve persisted Panel Sizing when `defaultCollapsed`

### DIFF
--- a/desktop/cmp/panel/PanelModel.ts
+++ b/desktop/cmp/panel/PanelModel.ts
@@ -292,13 +292,14 @@ export class PanelModel extends HoistModel implements Persistable<PanelPersistSt
     setCollapsed(collapsed: boolean) {
         throwIf(collapsed && !this.collapsible, 'Panel does not support collapsing.');
 
-        // When opening we never want to shrink -- in that degenerate case restore default size.
-        // Can happen when no min height and title bar, and user has sized panel to be very small.
+        // When opening a rendered collapsed panel we never want to shrink it -- in that degenerate
+        // case restore default size. Can happen when no min height and title bar, and user has
+        // sized panel to be very small.
         if (this.collapsed && !collapsed) {
             const el = this._resizeRef?.current,
                 currSize = this.vertical ? el?.offsetHeight : el?.offsetWidth,
                 {size} = this;
-            if (isNil(currSize) || isNil(size) || (isNumber(size) && size < currSize)) {
+            if (!isNil(currSize) && (isNil(size) || (isNumber(size) && size < currSize))) {
                 this.size = this.defaultSize;
             }
         }


### PR DESCRIPTION
Make workaround for very small collapsed panel more narrowly target to already rendered panels.

Avoid whacking perfectly good sizes for panels that are 'defaultCollapsed' and just getting initialized.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

