### PR TITLE
Enhance errors produced by Promise.track 

### DIFF
--- a/core/exception/Exception.ts
+++ b/core/exception/Exception.ts
@@ -210,7 +210,7 @@ export class Exception {
 
     private static createInternal(attributes: PlainObject, baseError?: Error) {
         const {message, ...rest} = attributes;
-        return Object.assign(
+        const ret = Object.assign(
             baseError ?? new Error(message),
             {
                 isRoutine: false,
@@ -218,6 +218,11 @@ export class Exception {
             },
             rest
         ) as HoistException;
+
+        // statuses of 0, 4XX, 5XX are server errors, so stack irrelevant and potentially misleading
+        if (ret.stack == null || /^[045]/.test(ret.httpStatus)) delete ret.stack;
+
+        return ret;
     }
 }
 

--- a/core/exception/ExceptionHandler.ts
+++ b/core/exception/ExceptionHandler.ts
@@ -185,8 +185,7 @@ export class ExceptionHandler {
     async logOnServerAsync(options: ExceptionHandlerLoggingOptions): Promise<boolean> {
         const {exception, userAlerted, userMessage} = options;
         try {
-            const error = this.stringifyErrorSafely(exception),
-                username = XH.getUsername();
+            const username = XH.getUsername();
 
             if (!username) {
                 logWarn('Error report cannot be submitted to UI server - user unknown', this);
@@ -194,7 +193,7 @@ export class ExceptionHandler {
             }
 
             const data: PlainObject = {
-                error: JSON.parse(error),
+                error: this.sanitizeException(exception),
                 userAlerted
             };
             if (userMessage) data.userMessage = stripTags(userMessage);
@@ -216,8 +215,16 @@ export class ExceptionHandler {
     }
 
     /**
-     * Serialize an error object safely for submission to server, or user display.
-     * This method will avoid circular references and will trim the depth of the object.
+     * Sanitize an exception for submission to server. This method will avoid circular references
+     * trim the depth of the object, and redact sensitive info (e.g. passwords).
+     */
+    sanitizeException(exception: HoistException): PlainObject {
+        return JSON.parse(this.stringifyErrorSafely(exception));
+    }
+
+    /**
+     * Serialize an error object safely for user display.  This method will avoid circular
+     * references, trim the depth of the object, and redact sensitive info (e.g. passwords).
      */
     stringifyErrorSafely(exception: HoistException): string {
         try {
@@ -287,8 +294,6 @@ export class ExceptionHandler {
             this.hideParams(e, opts);
         }
 
-        this.cleanStack(e);
-
         return {e, opts};
     }
 
@@ -340,12 +345,6 @@ export class ExceptionHandler {
 
     private sessionMismatch(e: HoistException): boolean {
         return e.name === 'SessionMismatchException';
-    }
-
-    private cleanStack(e: HoistException) {
-        // statuses of 0, 4XX, 5XX are server errors, so the javascript stack
-        // is irrelevant and potentially misleading
-        if (/^[045]/.test(e.httpStatus)) delete e.stack;
     }
 
     private cloneAndTrim(obj, depth = 5) {


### PR DESCRIPTION
So it has been bothering me for a while that our Track Messages coming from Promise.track() do not include the underlying exception.  I realized there is no reason we could not post the exception side by side with any underlying data the applications was otherwise including.  Keeping any existing app-specified data together and pushing it to an internal data key.

Other changes here are just to support that change by easing our ability to get a properly sanitized exception in Promise.track for submission to the server.


Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

