### PR TITLE
Normalize `parseFilter` return to `null` w/false/empty value

### DIFF
--- a/data/filter/Utils.ts
+++ b/data/filter/Utils.ts
@@ -5,24 +5,21 @@
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
 
-import {castArray, flatMap, groupBy, isArray, isFunction} from 'lodash';
-
-import {FieldFilterSpec, FilterLike} from './Types';
-import {Filter} from './Filter';
-import {FieldFilter} from './FieldFilter';
-import {FunctionFilter} from './FunctionFilter';
-import {CompoundFilter} from './CompoundFilter';
 import {Some} from '@xh/hoist/core';
+import {CompoundFilter, FunctionFilter} from '@xh/hoist/data';
+import {castArray, flatMap, groupBy, isArray, isFunction} from 'lodash';
+import {FieldFilter} from './FieldFilter';
+import {Filter} from './Filter';
+import {FieldFilterSpec, FilterLike} from './Types';
 
 /**
  * Parse a filter from an object or array representation.
  *
  * @param spec - one or more filters or specs to create one.
  *      * An existing Filter instance will be returned directly as-is.
- *      * A null value will also be returned as-is. A null filter represents no filter at all,
- *        or the equivalent of a filter that always passes every record.
+ *      * Null/undefined or empty array will return `null`, representing no filter.
  *      * A raw Function will be converted to a `FunctionFilter` with key 'default'.
- *      * Arrays will be converted to a `CompoundFilter` with a default 'AND' operator.
+ *      * Non-empty arrays will return a `CompoundFilter` with a default 'AND' operator.
  *      * Config objects will be returned as an appropriate concrete `Filter` subclass based on
  *        their properties.
  *
@@ -32,7 +29,8 @@ export function parseFilter(spec: FilterLike): Filter {
     let s = spec as any;
 
     // Degenerate cases
-    if (!s || s instanceof Filter) return s as Filter;
+    if (s instanceof Filter) return s as Filter;
+    if (!s || (isArray(s) && s.length === 0)) return null;
 
     // Normalize special forms
     if (isFunction(s)) s = {key: 'default', testFn: s};


### PR DESCRIPTION
- Previous `parseFilter` handling would allow an `undefined` input to pass through, which would then throw within `FilterChooserModel.setValue()` which does a check on `f === null` within its `validateFilter()`.
- The parser now normalizes falsy inputs and also empty arrays to `null`.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

