### PR TITLE
Add new `ClipboardButton.errorMessage` prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 * Deprecated the `RelativeTimestamp.options` prop - all the same options are now top-level props.
 * Added new `GroupingChooserModel.sortDimensions` config. Set to `false` to respect the order in
   which `dimensions` are provided to the model.
+* Added new `ClipboardButton.errorMessage` prop to customize or suppress a toast alert if the copy
+  operation fails. Set to `false` to fail silently (the behavior prior to this change).
 
 ### 🐞 Bug Fixes
 

--- a/desktop/cmp/clipboard/ClipboardButton.ts
+++ b/desktop/cmp/clipboard/ClipboardButton.ts
@@ -10,10 +10,18 @@ import '@xh/hoist/desktop/register';
 import {Icon} from '@xh/hoist/icon';
 import {withDefault} from '@xh/hoist/utils/js';
 import copy from 'clipboard-copy';
+import {isString} from 'lodash';
 
 export interface ClipboardButtonProps extends ButtonProps {
     /** Function returning the text to copy. May be async. */
     getCopyText: () => string | Promise<string>;
+
+    /**
+     * Message to be displayed in a toast should the copy operation fail, or `true` (default) to
+     * show a toast-based alert from `XH.handleException`. Spec `false` to fail silently.
+     */
+    errorMessage?: string | boolean;
+
     /** Message to be displayed in a toast when copy is complete. */
     successMessage?: string;
 }
@@ -24,24 +32,35 @@ export interface ClipboardButtonProps extends ButtonProps {
 export const [ClipboardButton, clipboardButton] = hoistCmp.withFactory<ClipboardButtonProps>({
     displayName: 'ClipboardButton',
     model: false,
+
     render(props) {
-        let {icon, onClick, text, getCopyText, successMessage, ...rest} = props;
+        let {icon, onClick, text, getCopyText, errorMessage, successMessage, ...rest} = props;
+        errorMessage = withDefault(props.errorMessage, true);
 
         if (!onClick) {
             onClick = async () => {
-                const {successMessage, getCopyText} = props;
-
                 try {
                     const text = await getCopyText();
                     await copy(text);
                     if (successMessage) {
                         XH.toast({
-                            message: successMessage,
-                            icon: Icon.clipboard()
+                            icon: Icon.clipboard(),
+                            message: successMessage
                         });
                     }
                 } catch (e) {
-                    XH.handleException(e, {showAlert: false});
+                    if (isString(errorMessage)) {
+                        XH.dangerToast({
+                            icon: Icon.clipboard(),
+                            message: errorMessage
+                        });
+                    } else {
+                        XH.handleException(e, {
+                            title: 'Error copying to clipboard',
+                            showAlert: !!errorMessage,
+                            alertType: 'toast'
+                        });
+                    }
                 }
             };
         }


### PR DESCRIPTION
- Fixes #4049
- Enable toast alert via `handleException` by default, if not suppressed via the new prop. This is a change in behavior but seems like a better default.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

