### PR TITLE
Allow use of window.gc() for troubleshooting, without opening console.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Added new `extraConfirmText`, `extraConfirmLabel` properties to `MessageOptions`.  Use this option
   to require the specified text to be re-typed by a user when confirming a potentially destructive or disruptive action.
 
+### ⚙️ Technical
+* Provide support for triggering browser GC during development. Useful for troubleshooting memory
+  consumption issues.  Requires running chromium-based browser with flag, e.g.
+  "start chrome --js-flags="--expose-gc"
+
 ## 75.0.1 - 2025-08-11
 
 ### 🎁 New Features

--- a/desktop/appcontainer/VersionBar.ts
+++ b/desktop/appcontainer/VersionBar.ts
@@ -53,7 +53,7 @@ export const versionBar = hoistCmp.factory({
                     title: 'Open Admin Console',
                     onClick: () => XH.appContainerModel.openAdmin()
                 }),
-                // Force GC, available when V8/chromium run with --js-flags="--expose-gc"
+                // Force GC, available via V8/chromium and "start chrome --js-flags="--expose-gc"
                 Icon.memory({
                     omit: !window['gc'],
                     title: 'Force GC',


### PR DESCRIPTION
Not strictly necessary, but was finding this very useful to force GC during memory troubleshooting without having to open chrome developer tools.  I think its harmless -- unless you start chrome up with the flag you will never see it

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

