### PR TITLE
Add `XH.logLevel` for dynamic logging severity and reduced console use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,21 @@
   or disruptive action.
 * Updated grid column filters to apply on `Enter` / dismiss on `Esc` and tweaked the filter popup
   toolbar for clarity.
-* Hoist's client-side logging utilities are now governed by the new `XH.logLevel` property, defining
-  a logging severity threshold for the app.  Set at 'info' by default, this prevents memory and
-  performance impacts of verbose logging on level 'debug'.  This level can be changed at runtime
-  for troubleshooting. See docstrings in 'LogUtils.ts' for more info.
 
 ### 🐞 Bug Fixes
 
 * Handled an edge-case `ViewManager` bug where `enableDefault` changed to `false` after some user
   state had already been persisted w/users pointed at in-code default view. The manager now calls
   its configured `initialViewSpec` function as expected in this case.
-
-* `XH.restoreDefaultsAsync` will now clear basic view state.  Views themselves will be preserved.
-  Requires hoist-core v31.2
+* `XH.restoreDefaultsAsync` will now clear basic ViewManager state, notably last active view. User
+  views themselves will be preserved. Requires `hoist-core >= 31.2`.
 
 ### ⚙️ Technical
 
+* Hoist's client-side logging utilities are now governed by the new `XH.logLevel` property, defining
+  a logging severity threshold for the app. Default level is 'info', preventing memory usage and
+  performance impacts from verbose logging on level 'debug'. This level can be changed at runtime
+  for troubleshooting. See documentation within `LogUtils.ts` for more info.
 * Added control to trigger browser GC from app footer. Useful for troubleshooting memory issues.
   Requires running chromium-based browser via e.g. `start chrome --js-flags="--expose-gc`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,17 @@
   or disruptive action.
 * Updated grid column filters to apply on `Enter` / dismiss on `Esc` and tweaked the filter popup
   toolbar for clarity.
+* Hoist's client-side logging utilities are now governed by the new `XH.logLevel` property, defining
+  a logging severity threshold for the app.  Set at 'info' by default, this prevents memory and
+  performance impacts of verbose logging on level 'debug'.  This level can be changed at runtime
+  for troubleshooting. See docstrings in 'LogUtils.ts' for more info.
 
 ### 🐞 Bug Fixes
 
 * Handled an edge-case `ViewManager` bug where `enableDefault` changed to `false` after some user
   state had already been persisted w/users pointed at in-code default view. The manager now calls
   its configured `initialViewSpec` function as expected in this case.
-  
+
 * `XH.restoreDefaultsAsync` will now clear basic view state.  Views themselves will be preserved.
   Requires hoist-core v31.2
 

--- a/cmp/grid/impl/Utils.ts
+++ b/cmp/grid/impl/Utils.ts
@@ -6,6 +6,7 @@
  */
 import {Column, ColumnGroup, ColumnRenderer, GroupRowRenderer} from '@xh/hoist/cmp/grid';
 import {HeaderClassParams} from '@xh/hoist/kit/ag-grid';
+import {logWarn} from '@xh/hoist/utils/js';
 import {castArray, isFunction} from 'lodash';
 
 /** @internal */
@@ -18,7 +19,7 @@ export function managedRenderer<T extends ColumnRenderer | GroupRowRenderer>(
         try {
             return fn.apply(null, arguments);
         } catch (e) {
-            console.warn(`Renderer for '${identifier}' has thrown an error`, e);
+            logWarn([`Renderer for '${identifier}' has thrown an error`, e]);
             return '#ERROR';
         }
     } as unknown as T;

--- a/core/HoistComponent.ts
+++ b/core/HoistComponent.ts
@@ -25,7 +25,7 @@ import {
     formatSelector,
     HoistModel
 } from './model';
-import {throwIf, warnIf, withDefault} from '@xh/hoist/utils/js';
+import {logError, throwIf, warnIf, withDefault} from '@xh/hoist/utils/js';
 import {getLayoutProps, useOnMount, useOnUnmount} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {isFunction, isPlainObject, isObject} from 'lodash';
@@ -285,11 +285,11 @@ function wrapWithModel(render: RenderFn, cfg: Config): RenderFn {
 
         // 2) Validate
         if (!model && !spec.optional && spec instanceof UsesSpec) {
-            console.error(`
-                Failed to find model with selector '${formatSelector(spec.selector)}' for
-                component '${cfg.displayName}'. Ensure the proper model is available via context, or
-                specify explicitly using the 'model' prop.
-            `);
+            logError(
+                `Failed to find model with selector '${formatSelector(spec.selector)}'. Ensure the
+                proper model is available via context, or specify using the 'model' prop.`,
+                cfg.displayName
+            );
             return cmpErrDisplay({...getLayoutProps(props), item: 'No model found'});
         }
 
@@ -408,10 +408,11 @@ function lookupModel(props: HoistProps, modelLookup: ModelLookup, cfg: Config): 
     // 2) props - instance
     if (model) {
         if (!model.isHoistModel || !model.matchesSelector(selector, true)) {
-            console.error(
-                `Incorrect model passed to '${cfg.displayName}'.
+            logError(
+                `Incorrect model passed.
                 Expected: ${formatSelector(selector)}
-                Received: ${model.constructor.name}`
+                Received: ${model.constructor.name}`,
+                cfg.displayName
             );
             model = null;
         }

--- a/core/XH.ts
+++ b/core/XH.ts
@@ -370,7 +370,7 @@ export class XHApi {
     }
 
     /**
-     * Adjust severity level of logging for lifetime of page or browser tab session.
+     * Adjust severity threshold for app.
      *
      * Call this method from the console to adjust the log level for troubleshooting.
      */

--- a/core/XH.ts
+++ b/core/XH.ts
@@ -362,17 +362,18 @@ export class XHApi {
     }
 
     /**
-     * Logging severity threshold for app.  Messages with less severity will be ignored.
-     * Default 'info'.
+     * Current minimum severity for Hoist log utils (default 'info').
+     * Messages logged via managed Hoist log utils with lower severity will be ignored.
      */
     get logLevel(): LogLevel {
         return getLogLevel();
     }
 
     /**
-     * Adjust severity threshold for app.
+     * Set the minimum severity for Hoist log utils until the page is refreshed. Optionally persist
+     * this adjustment to sessionStorage to maintain for the lifetime of the browser tab.
      *
-     * Call this method from the console to adjust the log level for troubleshooting.
+     * Hint: call this method from the console to adjust your app's log level while troubleshooting.
      */
     setLogLevel(level: LogLevel, persistInSessionStorage: boolean = false) {
         setLogLevel(level, persistInSessionStorage);

--- a/core/XH.ts
+++ b/core/XH.ts
@@ -31,6 +31,7 @@ import {
     WebSocketService,
     ClientHealthService
 } from '@xh/hoist/svc';
+import {getLogLevel, setLogLevel, LogLevel} from '@xh/hoist/utils/js';
 import {camelCase, flatten, isString, uniqueId} from 'lodash';
 import {Router, State} from 'router5';
 import {CancelFn} from 'router5/types/types/base';
@@ -358,6 +359,23 @@ export class XHApi {
     async logoutAsync(): Promise<void> {
         await this.authModel?.logoutAsync();
         this.reloadApp();
+    }
+
+    /**
+     * Logging severity threshold for app.  Messages with less severity will be ignored.
+     * Default 'info'.
+     */
+    get logLevel(): LogLevel {
+        return getLogLevel();
+    }
+
+    /**
+     * Adjust severity level of logging for lifetime of page or browser tab session.
+     *
+     * Call this method from the console to adjust the log level for troubleshooting.
+     */
+    setLogLevel(level: LogLevel, persistInSessionStorage: boolean = false) {
+        setLogLevel(level, persistInSessionStorage);
     }
 
     //----------------------

--- a/core/exception/ExceptionHandler.ts
+++ b/core/exception/ExceptionHandler.ts
@@ -312,7 +312,7 @@ export class ExceptionHandler {
     }
 
     private logException(e: HoistException, opts: ExceptionHandlerOptions) {
-        return opts.showAsError ? console.error(opts.message, e) : console.debug(opts.message);
+        return opts.showAsError ? logError([opts.message, e], this) : logDebug(opts.message, this);
     }
 
     private parseOptions(

--- a/core/load/LoadSupport.ts
+++ b/core/load/LoadSupport.ts
@@ -135,7 +135,7 @@ export async function loadAllAsync(objs: Loadable[], loadSpec?: LoadSpec | any) 
         ret = await Promise.allSettled(promises);
 
     ret.filter(it => it.status === 'rejected').forEach((err: any) =>
-        console.error('Failed to Load Object', err.reason)
+        logError(['Failed to Load Object', err.reason])
     );
 
     return ret;

--- a/data/filter/Utils.ts
+++ b/data/filter/Utils.ts
@@ -7,6 +7,7 @@
 
 import {Some} from '@xh/hoist/core';
 import {CompoundFilter, FunctionFilter} from '@xh/hoist/data';
+import {logError} from '@xh/hoist/utils/js';
 import {castArray, flatMap, groupBy, isArray, isFunction} from 'lodash';
 import {FieldFilter} from './FieldFilter';
 import {Filter} from './Filter';
@@ -55,7 +56,7 @@ export function parseFilter(spec: FilterLike): Filter {
         }
     }
 
-    console.error('Unable to identify filter type:', s);
+    logError(['Unable to identify filter type:', s]);
     return null;
 }
 

--- a/desktop/cmp/dash/container/impl/DashContainerUtils.ts
+++ b/desktop/cmp/dash/container/impl/DashContainerUtils.ts
@@ -7,7 +7,7 @@
 import {PlainObject} from '@xh/hoist/core';
 import {DashContainerModel} from '@xh/hoist/desktop/cmp/dash';
 import {serializeIcon} from '@xh/hoist/icon';
-import {throwIf} from '@xh/hoist/utils/js';
+import {logDebug, throwIf} from '@xh/hoist/utils/js';
 import {isArray, isEmpty, isFinite, isNil, isPlainObject, isString, round} from 'lodash';
 import {DashContainerViewSpec} from '../DashContainerViewSpec';
 import GoldenLayout, {ContentItem} from 'golden-layout';
@@ -119,8 +119,9 @@ function convertStateToGLInner(items = [], viewSpecs = [], containerSize, contai
             const viewSpec = viewSpecs.find(v => v.id === item.id);
 
             if (!viewSpec) {
-                console.debug(
-                    `Attempted to load non-existent or omitted view from state: ${item.id}`
+                logDebug(
+                    `Attempted to load non-existent or omitted view from state: ${item.id}`,
+                    'DashContainer'
                 );
                 return null;
             }

--- a/inspector/instances/InstancesModel.ts
+++ b/inspector/instances/InstancesModel.ts
@@ -130,7 +130,7 @@ export class InstancesModel extends HoistModel {
             instance = this.getInstance(xhId);
 
         if (!instance) {
-            console.warn(`Instance with xhId ${xhId} no longer alive - cannot be logged`);
+            this.logWarn(`Instance with xhId ${xhId} no longer alive - cannot be logged`);
         } else {
             console.log(`[${xhId}]`, instance);
             XH.toast({
@@ -147,7 +147,7 @@ export class InstancesModel extends HoistModel {
             instance = this.getInstance(instanceXhId);
 
         if (!instance) {
-            console.warn(`Instance ${instanceDisplayName} no longer alive - cannot be logged`);
+            this.logWarn(`Instance ${instanceDisplayName} no longer alive - cannot be logged`);
         } else {
             console.log(`[${instanceDisplayName}].${property}`, instance[property]);
             XH.toast({

--- a/kit/ag-grid/index.ts
+++ b/kit/ag-grid/index.ts
@@ -5,7 +5,7 @@
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
 
-import {checkVersion} from '@xh/hoist/utils/js/VersionUtils';
+import {checkVersion, logError} from '@xh/hoist/utils/js';
 
 /**
  * The exports below are ag-Grid components provided at runtime by applications.
@@ -57,7 +57,7 @@ const MAX_VERSION = '31.*.*';
  */
 export function installAgGrid(ComponentReactWrapper, version: string) {
     if (!checkVersion(version, MIN_VERSION, MAX_VERSION)) {
-        console.error(
+        logError(
             `This version of Hoist requires an ag-Grid version between ${MIN_VERSION} and ` +
                 `${MAX_VERSION}. Version ${version} detected. ag-Grid will be unavailable.`
         );

--- a/kit/highcharts/index.ts
+++ b/kit/highcharts/index.ts
@@ -5,7 +5,7 @@
  * Copyright © 2025 Extremely Heavy Industries Inc.
  */
 
-import {checkVersion} from '@xh/hoist/utils/js/VersionUtils';
+import {checkVersion, logError} from '@xh/hoist/utils/js';
 
 export let Highcharts = null;
 
@@ -19,7 +19,7 @@ const MAX_VERSION = '11.*.*';
 export function installHighcharts(HighchartsImpl) {
     const {version} = HighchartsImpl;
     if (!checkVersion(version, MIN_VERSION, MAX_VERSION)) {
-        console.error(
+        logError(
             `This version of Hoist requires a Highcharts version between ${MIN_VERSION} and ` +
                 `${MAX_VERSION}. Version ${version} detected. Highcharts will be unavailable.`
         );

--- a/promise/Promise.ts
+++ b/promise/Promise.ts
@@ -17,6 +17,7 @@ import {
 } from '@xh/hoist/core';
 import {action} from '@xh/hoist/mobx';
 import {olderThan, SECONDS} from '@xh/hoist/utils/datetime';
+import {logWarn} from '@xh/hoist/utils/js';
 import {castArray, isFunction, isNumber, isString} from 'lodash';
 
 /**
@@ -311,9 +312,7 @@ enhancePromise(Promise.prototype);
 // @see https://github.com/xh/hoist-react/issues/1411
 const asyncFnReturn = (async () => {})();
 if (!(asyncFnReturn instanceof Promise)) {
-    console.debug(
-        '"Native" Promise return detected as return from async function - enhancing prototype'
-    );
+    logWarn('"Native" Promise return detected as return from async function - enhancing prototype');
 
     // @ts-ignore
     enhancePromise(asyncFnReturn.__proto__);

--- a/promise/Promise.ts
+++ b/promise/Promise.ts
@@ -17,7 +17,6 @@ import {
 } from '@xh/hoist/core';
 import {action} from '@xh/hoist/mobx';
 import {olderThan, SECONDS} from '@xh/hoist/utils/datetime';
-import {logWarn} from '@xh/hoist/utils/js';
 import {castArray, isFunction, isNumber, isString} from 'lodash';
 
 /**
@@ -306,14 +305,3 @@ const enhancePromise = promisePrototype => {
 
 // Enhance canonical Promises.
 enhancePromise(Promise.prototype);
-
-// MS Edge returns a "native Promise" from async functions that won't get the enhancements above.
-// Check to see if we're in such an environment and enhance that prototype as well.
-// @see https://github.com/xh/hoist-react/issues/1411
-const asyncFnReturn = (async () => {})();
-if (!(asyncFnReturn instanceof Promise)) {
-    logWarn('"Native" Promise return detected as return from async function - enhancing prototype');
-
-    // @ts-ignore
-    enhancePromise(asyncFnReturn.__proto__);
-}

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -261,7 +261,7 @@ export class FetchService extends HoistService {
         const {correlationIdHeaderKey} = this;
         if (opts.correlationId) {
             if (headers[correlationIdHeaderKey]) {
-                console.warn(
+                this.logWarn(
                     `Header ${correlationIdHeaderKey} value already set within FetchOptions.`
                 );
             } else {

--- a/utils/js/LangUtils.ts
+++ b/utils/js/LangUtils.ts
@@ -6,7 +6,7 @@
  */
 import {PlainObject, Thunkable} from '@xh/hoist/core';
 import {Exception} from '@xh/hoist/core/exception/Exception';
-import {LogSource, logWarn, logError} from '@xh/hoist/utils/js';
+import {LogSource, logWarn, logError} from '@xh/hoist/utils/js/LogUtils';
 import {
     flatMap,
     forOwn,

--- a/utils/js/LangUtils.ts
+++ b/utils/js/LangUtils.ts
@@ -6,7 +6,7 @@
  */
 import {PlainObject, Thunkable} from '@xh/hoist/core';
 import {Exception} from '@xh/hoist/core/exception/Exception';
-import {LogSource, logWarn} from '@xh/hoist/utils/js/LogUtils';
+import {LogSource, logWarn, logError} from '@xh/hoist/utils/js';
 import {
     flatMap,
     forOwn,
@@ -131,7 +131,7 @@ export function throwIf(condition: any, message: unknown) {
  */
 export function warnIf(condition: any, message: any) {
     if (condition) {
-        console.warn(message);
+        logWarn(message);
     }
 }
 
@@ -140,7 +140,7 @@ export function warnIf(condition: any, message: any) {
  */
 export function errorIf(condition: any, message: any) {
     if (condition) {
-        console.error(message);
+        logError(message);
     }
 }
 

--- a/utils/js/LogUtils.ts
+++ b/utils/js/LogUtils.ts
@@ -10,11 +10,12 @@ import store from 'store2';
 import {intersperse} from './LangUtils';
 
 /**
- * Utility functions providing managed, structured logging to hoist apps.  Essentially a wrapper
- * around the browser console supporting logging levels, timing, and miscellaneous hoist
- * display conventions.
+ * Utility functions providing managed, structured logging to Hoist apps.
  *
- * Objects extending HoistBase need not import these functions directly, as they are available
+ * Essentially a wrapper around the browser console supporting logging levels, timing, and
+ * miscellaneous Hoist display conventions.
+ *
+ * Objects extending `HoistBase` need not import these functions directly, as they are available
  * via delegates on `HoistBase`.
  *
  * Hoist sets its minimum severity level to 'info' by default.  This prevents performance or
@@ -29,23 +30,27 @@ export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
 export type LogSource = string | {displayName: string} | {constructor: {name: string}};
 
 /**
- * Severity threshold for app.  Messages with less severity will be ignored. Default 'info'.
- * @internal Applications should typically use `XH.logLevel` instead.
+ * Current minimum severity for Hoist log utils (default 'info').
+ * Messages logged via managed Hoist log utils with lower severity will be ignored.
+ *
+ * @internal - use public `XH.logLevel`.
  */
 export function getLogLevel() {
     return _logLevel;
 }
 
 /**
- * Adjust severity level of logging for lifetime of page or browser tab.
+ * Set the minimum severity for Hoist log utils until the page is refreshed. Optionally persist
+ * this adjustment to sessionStorage to maintain for the lifetime of the browser tab.
  *
- * Call this method from the console to adjust the log level for troubleshooting.
- * @internal Applications should typically use `XH.setLogLevel()` instead.
+ * @internal - use public `XH.setLogLevel()`.
  */
 export function setLogLevel(level: LogLevel, persistInSessionStorage: boolean = false) {
     level = level.toLowerCase() as LogLevel;
-    if (!['error', 'warn', 'info', 'debug'].includes(level)) {
-        console.error(`Invalid value for log level: '${level}'`);
+
+    const validLevels = ['error', 'warn', 'info', 'debug'];
+    if (!validLevels.includes(level)) {
+        console.error(`Ignored invalid log level '${level}' - must be one of ${validLevels}`);
         return;
     }
     _logLevel = level;


### PR DESCRIPTION
Started with moving toward a client-side XH.LogService, which had some nice properties for code organization, but ultimately the complexity around not having it available to  use for *early* framework logging, made me discard the idea.

Also explored some server-side configuration discussed by ATM-- but decided to hold off on that for this version.  We can always revisit (and if we added, at that point, a service might make sense).

Also, unrelated -- removed one obsolete bit of Promise code for Edge that was bothering me, and I think is now safe to remove.



Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

