### PR TITLE
Cleaned up deprecated agOption `suppressMakeColumnVisibleAfterUnGroup`

### DIFF
--- a/cmp/dataview/DataView.ts
+++ b/cmp/dataview/DataView.ts
@@ -82,7 +82,7 @@ class DataViewLocalModel extends HoistModel {
         const {model} = this;
         return {
             headerHeight: 0,
-            suppressMakeColumnVisibleAfterUnGroup: true,
+            suppressGroupChangesColumnVisibility: 'suppressShowOnUngroup',
             getRowHeight: agParams => {
                 const {groupRowHeight, itemHeight} = model;
 

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -88,7 +88,7 @@ export const viewsGrid = hoistCmp.factory<GridModel>({
                 grid({
                     model,
                     agOptions: {
-                        suppressMakeColumnVisibleAfterUnGroup: true
+                        suppressGroupChangesColumnVisibility: 'suppressShowOnUngroup'
                     }
                 }),
                 div({


### PR DESCRIPTION
Changed to `suppressGroupChangesColumnVisibility: "suppressShowOnUngroup"`.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

