### PR TITLE
Minor optimization to `Store.createRecords`

### DIFF
--- a/data/Store.ts
+++ b/data/Store.ts
@@ -1041,24 +1041,34 @@ export class Store extends HoistBase {
         return ret;
     }
 
-    private createRecords(rawData: PlainObject[], parent: StoreRecord, recordMap = new Map()) {
+    private createRecords(
+        rawData: PlainObject[],
+        parent: StoreRecord,
+        recordMap: Map<StoreRecordId, StoreRecord> = new Map(),
+        summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
+    ) {
         const {loadTreeData, loadTreeDataFrom} = this;
+
         rawData.forEach(raw => {
             const rec = this.createRecord(raw, parent),
                 {id} = rec;
 
             throwIf(
-                recordMap.has(id) || this.summaryRecords?.some(it => it.id === id),
+                recordMap.has(id) || summaryRecordIds.has(id),
                 `ID ${id} is not unique. Use the 'Store.idSpec' config to resolve a unique ID for each record.`
             );
 
             recordMap.set(id, rec);
 
             if (loadTreeData && raw[loadTreeDataFrom]) {
-                this.createRecords(raw[loadTreeDataFrom], rec, recordMap);
+                this.createRecords(raw[loadTreeDataFrom], rec, recordMap, summaryRecordIds);
             }
         });
         return recordMap;
+    }
+
+    private get summaryRecordIds(): Set<StoreRecordId> {
+        return new Set(this.summaryRecords?.map(it => it.id) ?? []);
     }
 
     private parseRaw(data: PlainObject): PlainObject {


### PR DESCRIPTION
- `summaryRecords` almost always empty or an array of 1-2 recs, but still seemed worth taking to a set in the hot loop.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

