### PR TITLE
Updates FetchService to handle caught exceptions with a contentType of "application/problem+json"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,24 @@
 
 ## 78.0.0-SNAPSHOT - unreleased
 
+### ⚙️ Technical
+
+* `FetchService` will recognize variants on the `application/json` content-type when processing
+  failed responses and decoding exceptions - e.g. `application/problem+json`.
+
 ## 77.1.1 - 2025-11-12
 
 ### 🎁 New Features
-*  New method `StoreRecord.getModifiedValues()` to gather edited data from a store record.
+
+* New method `StoreRecord.getModifiedValues()` to gather edited data from a store record.
 
 ### 🐞 Bug Fixes
-*  StoreRecord will no longer report `isModified` as `true` if a field has been edited and
-   then returned to its original value in a subsequent edit.
-*  Restore support for `TabModel.content` being nullable to support dynamic tab content.
-*  Remove stray context menu from appearing when clicking on column group headers and other grid
-   empty space.
+
+* StoreRecord will no longer report `isModified` as `true` if a field has been edited and
+  then returned to its original value in a subsequent edit.
+* Restore support for `TabModel.content` being nullable to support dynamic tab content.
+* Remove stray context menu from appearing when clicking on column group headers and other grid
+  empty space.
 
 ## 77.0.1 - 2025-10-29
 
@@ -41,7 +48,6 @@
 ### ⚙️ Technical
 
 * Support Grails 7 service name conventions in admin client (backward compatible)
-
 
 ## 76.2.0 - 2025-10-22
 

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -38,6 +38,12 @@ export class FetchService extends HoistService {
 
     NO_JSON_RESPONSES = [StatusCodes.NO_CONTENT, StatusCodes.RESET_CONTENT];
 
+    /**
+     * Regex applied during failed response handling to determine if contentType indicates JSON.
+     * Matches `application/json` as well as variants such as `application/problem+json`
+     */
+    JSON_CONTENT_TYPE_RE = /application\/[^+]*[+]?(json);?.*/i;
+
     private idGenerator = new ShortUniqueId({length: 16});
     private autoAborters = {};
     private _defaultHeaders: DefaultHeaders[] = [];
@@ -410,13 +416,9 @@ export class FetchService extends HoistService {
             });
         }
 
-        // Try to "smart" decode as server provided JSON Exception (with a name)
+        // Attempt to decode server-provided exception if returned as JSON.
         try {
-            const cType = headers.get('Content-Type');
-
-            // Catches application/json as well as optional JSON types, such as application/problem+json
-            const contentTypeMatcher = new RegExp(/application\/[^+]*[+]?(json);?.*/);
-            if (cType?.match(contentTypeMatcher)) {
+            if (headers.get('Content-Type')?.match(this.JSON_CONTENT_TYPE_RE)) {
                 const parsedResp = this.safeParseJson(responseText);
                 return this.createException({
                     ...defaults,


### PR DESCRIPTION
This covers a use case we are seeing in a new API for a client, where their exception payload is sent as stringified JSON, with the content type set as "application/problem+json".
This seems like a legit response type, if not often used. Its not hard to support it it here, and saves manually managing the JSON parsing of the response when it is present.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

