### PR TITLE
Renamed `GridModel.applyColumnStateChanges()` to `updateColumnState()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 79.0.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes
+
+* Renamed `GridModel.applyColumnStateChanges()` to `updateColumnState()` for clarity and better
+  symmetry with `setColumnState()`. The prior method remains as an alias but is now deprecated and
+  scheduled for removal in v82.
+
 ### 🐞 Bug Fixes
 
 * Defaulted Highcharts font to Hoist default (--xh-font-family)

--- a/desktop/cmp/grid/impl/colchooser/ColChooserModel.ts
+++ b/desktop/cmp/grid/impl/colchooser/ColChooserModel.ts
@@ -95,7 +95,7 @@ export class ColChooserModel extends HoistModel {
             }
         });
 
-        gridModel.applyColumnStateChanges(colChanges);
+        gridModel.updateColumnState(colChanges);
         if (autosizeOnCommit && colChanges.length) gridModel.autosizeAsync({showMask: true});
     }
 

--- a/mobile/cmp/grid/impl/ColChooserModel.ts
+++ b/mobile/cmp/grid/impl/ColChooserModel.ts
@@ -132,7 +132,7 @@ export class ColChooserModel extends HoistModel {
             return {colId, hidden, pinned};
         });
 
-        gridModel.applyColumnStateChanges(colChanges);
+        gridModel.updateColumnState(colChanges);
         if (autosizeOnCommit) gridModel.autosizeAsync({showMask: true});
     }
 

--- a/svc/GridAutosizeService.ts
+++ b/svc/GridAutosizeService.ts
@@ -79,7 +79,7 @@ export class GridAutosizeService extends HoistService {
 
         runInAction(() => {
             // Apply calculated widths to grid.
-            gridModel.applyColumnStateChanges(requiredWidths);
+            gridModel.updateColumnState(requiredWidths);
             this.logDebug(
                 `Auto-sized ${requiredWidths.length} columns`,
                 `${records.length} records`
@@ -94,7 +94,7 @@ export class GridAutosizeService extends HoistService {
                     fillMode,
                     asManuallySized
                 );
-                gridModel.applyColumnStateChanges(fillWidths);
+                gridModel.updateColumnState(fillWidths);
                 this.logDebug(`Auto-sized ${fillWidths.length} columns using fillMode`);
             }
         });


### PR DESCRIPTION
- For clarity and better symmetry with `setColumnState()`.
- The prior method remains as an alias but is now deprecated and scheduled for removal in v82.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

