### PR TITLE
Fix for a react error thrown when Blueprint menus include nested child items

### DIFF
--- a/core/types/Interfaces.ts
+++ b/core/types/Interfaces.ts
@@ -342,9 +342,6 @@ export interface MenuItem<T = MenuToken, C = MenuContext> {
 
     /** True to skip this item. May be set dynamically via prepareFn. Alias for hidden.  */
     omit?: Thunkable<boolean>;
-
-    /** Needed when rendering nested child menu items */
-    key?: string;
 }
 
 /**

--- a/utils/impl/MenuItems.ts
+++ b/utils/impl/MenuItems.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {isMenuItem, MenuItemLike, XH} from '@xh/hoist/core';
+import {ElementSpec, isMenuItem, MenuItemLike} from '@xh/hoist/core';
 import {menuDivider, menuItem} from '@xh/hoist/kit/blueprint';
 import {MenuItemProps} from '@blueprintjs/core';
 import {wait} from '@xh/hoist/promise';
@@ -43,9 +43,8 @@ export function parseMenuItems(items: MenuItemLike[]): ReactNode[] {
             const {actionFn} = item;
 
             // Create menuItem from config
-            const cfg: MenuItemProps & {key?: string} = {
+            const cfg: ElementSpec<MenuItemProps> = {
                 text: item.text,
-                key: item.key ?? XH.genId(),
                 icon: item.icon,
                 intent: item.intent,
                 className: item.className,
@@ -55,7 +54,7 @@ export function parseMenuItems(items: MenuItemLike[]): ReactNode[] {
 
             // Recursively parse any submenus
             if (!isEmpty(item.items)) {
-                cfg.children = parseMenuItems(item.items);
+                cfg.items = parseMenuItems(item.items);
                 cfg.popoverProps = {openOnTargetFocus: false};
             }
 


### PR DESCRIPTION
I found this error when implementing a new nested navigation menu in Dash. As soon as the pop over menu was shown, a console error would appear complaining about missing keys on menu items.
<img width="2180" height="1457" alt="Screenshot 2026-01-06 at 2 38 34 PM" src="https://github.com/user-attachments/assets/a2b860fe-f316-4fc6-bbaf-c88bc12b8592" />

The error would not appear unless menu items were present which themselves were parent items to show flyout child items.
I tried adding a key to each item (parent and child), but this did not fix the issue, and when inspecting the elements before render, I could see that no key was present.

I found the issue in our Hoist "parseMenuItems" method - which takes a list of menu option config objects, and converts them into Blueprint MenuItem components. This did not have "key" in its list of props it would accept then pass into the MenuItem from blueprint.

I found the same error in Toolbox, and confirmed the error was present even before the recent Blueprint 6.0 update.
<img width="1031" height="786" alt="Screenshot 2026-01-06 at 2 50 15 PM" src="https://github.com/user-attachments/assets/7f78c30c-6234-4edd-a5df-10e2050e891c" />

In the above case, it was the same error text output, but an easier fix.
https://github.com/xh/toolbox/blob/develop/client-app/src/desktop/tabs/panels/BasicPanel.tsx#L94-L96
Here we are not using the "parseMenuItems" method, but we ARE neglecting to provide a key to the "menuItem" listings for these nested children. So this toolbox error could be fixed with just the added key.

However, I wanted a recreate the error from Dash, so I create https://github.com/xh/toolbox/compare/bp-menu-child-item-parsing?expand=1 to update this menu code to use "parseMenuItems", and confirm that the added key would work when using this method to generate a menu.


Hoist P/R Checklist
-------------------
- [ ] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [ ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

