### PR TITLE
Use BEM more consistently for new validation modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@
       so there is no deprecated alias. Any app usages should swap to `XH.appLoadObserver`.
     * Removed additional references to deprecated `loadModel` within Hoist itself.
 * Removed the following instance getters - use new static typeguards instead:
-  * `Store.isStore`
-  * `View.isView`
-  * `Filter.isFilter`
+    * `Store.isStore`
+    * `View.isView`
+    * `Filter.isFilter`
+
+### 🎁 New Features
+
+* Enhanced `Field.rules` to support `warning` and `info` severity. Useful for non-blocking
+  validation scenarios, such as providing guidance to users without preventing form submission.
 
 ### ⚙️ Typescript API Adjustments
 
@@ -22,6 +27,15 @@
   `View` implement these interfaces, meaning no changes are required for apps, but it is now
   possible to use these models with other, alternate implementations if needed.
 * Added new static typeguard methods on `Store`, `View`, and `Filter` + subclasses.
+* Removed `RecordErrorMap` + reorganized validation types (not expected to impact most apps).
+
+### ✨ Styles
+
+* Updated + added validation-related input and form-field CSS classes and variables to account for
+  new `info` and `warning` validation levels.
+    * ⚠️Pre-existing `xh-input-invalid` and `xh-form-field-invalid` CSS classes have been updated to
+      better follow BEM conventions with `--` modifier. They are now `xh-input--invalid` and
+      `xh-form-field--invalid`.
 
 ## 79.0.0 - 2026-01-05
 
@@ -54,8 +68,6 @@ this release, but is not strictly required.
   `react-grid-layout` v2+ (not common).
 * Modified `DashCanvasModel.containerPadding` to apply to the `react-grid-layout` div created by the
   library, instead of the Hoist-created containing div. This may affect printing layouts.
-* Enhanced `Field.rules` to support `warning` and `info` severity. Useful for non-blocking
-  validation scenarios, such as providing guidance to users without preventing form submission.
 
 ### 🎁 New Features
 
@@ -89,10 +101,6 @@ this release, but is not strictly required.
   and restored by the browser).
 * Introduced opt-in `Grid` performance optimizations on an experimental basis with
   `GridExperimentalFlags.deltaSort` and `GridExperimentalFlags.disableScrollOptimization`
-
-### ⚙️ Typescript API Adjustments
-
-* Removed `RecordErrorMap`/reorganized validation types (not expected to impact most applications).
 
 ### 📚 Libraries
 

--- a/cmp/input/HoistInput.scss
+++ b/cmp/input/HoistInput.scss
@@ -6,19 +6,19 @@
  */
 
 .xh-input {
-  &.xh-input-invalid {
+  &.xh-input--invalid {
     input {
       border: var(--xh-form-field-invalid-border);
     }
   }
 
-  &.xh-input-warning {
+  &.xh-input--warning {
     input {
       border: var(--xh-form-field-warning-border);
     }
   }
 
-  &.xh-input-info {
+  &.xh-input--info {
     input {
       border: var(--xh-form-field-info-border);
     }

--- a/cmp/input/HoistInputModel.ts
+++ b/cmp/input/HoistInputModel.ts
@@ -338,6 +338,7 @@ export function useHoistInputModel(
 
     const field = inputModel.getField(),
         severityToDisplay = field?.validationDisplayed && maxSeverity(field?.validationResults),
+        displayInvalid = severityToDisplay === 'error',
         disabledClass = props.disabled ? 'xh-input-disabled' : null;
 
     return component({
@@ -346,8 +347,8 @@ export function useHoistInputModel(
         ref: inputModel.domRef,
         className: classNames(
             'xh-input',
-            severityToDisplay &&
-                `xh-input-${severityToDisplay === 'error' ? 'invalid' : severityToDisplay}`,
+            severityToDisplay && `xh-input--${severityToDisplay}`,
+            displayInvalid && 'xh-input--invalid',
             disabledClass,
             props.className
         )

--- a/desktop/cmp/form/FormField.scss
+++ b/desktop/cmp/form/FormField.scss
@@ -48,9 +48,7 @@
   }
 
   .xh-form-field-info,
-  .xh-form-field-error-msg,
-  .xh-form-field-warning-msg,
-  .xh-form-field-info-msg {
+  &__validation-msg {
     font-size: var(--xh-font-size-small-px);
     line-height: calc(var(--xh-font-size-small-px) + var(--xh-pad-px));
     white-space: nowrap;
@@ -58,16 +56,18 @@
     overflow: hidden;
   }
 
-  .xh-form-field-error-msg {
-    color: var(--xh-red);
-  }
+  &__validation-msg {
+    &--error {
+      color: var(--xh-form-field-invalid-color);
+    }
 
-  .xh-form-field-warning-msg {
-    color: var(--xh-orange);
-  }
+    &--info {
+      color: var(--xh-form-field-info-color);
+    }
 
-  .xh-form-field-info-msg {
-    color: var(--xh-blue);
+    &--warning {
+      color: var(--xh-form-field-warning-color);
+    }
   }
 
   &.xh-form-field-inline {
@@ -95,9 +95,7 @@
       }
     }
 
-    .xh-form-field-error-msg,
-    .xh-form-field-warning-msg,
-    .xh-form-field-info-msg {
+    .xh-form-field__validation-msg {
       display: none;
     }
 
@@ -113,7 +111,7 @@
     }
   }
 
-  &.xh-form-field-invalid:not(.xh-form-field-readonly) {
+  &.xh-form-field--invalid:not(.xh-form-field-readonly) {
     .xh-check-box span {
       box-shadow: var(--xh-form-field-invalid-box-shadow) !important;
     }
@@ -131,7 +129,7 @@
     }
 
     .xh-text-input > svg {
-      color: var(--xh-intent-danger);
+      color: var(--xh-form-field-invalid-color);
     }
 
     .xh-text-area.textarea {
@@ -139,7 +137,7 @@
     }
   }
 
-  &.xh-form-field-warning:not(.xh-form-field-readonly) {
+  &.xh-form-field--warning:not(.xh-form-field-readonly) {
     .xh-check-box span {
       box-shadow: var(--xh-form-field-warning-box-shadow) !important;
     }
@@ -157,7 +155,7 @@
     }
 
     .xh-text-input > svg {
-      color: var(--xh-intent-warning);
+      color: var(--xh-form-field-warning-color);
     }
 
     .xh-text-area.textarea {
@@ -165,7 +163,7 @@
     }
   }
 
-  &.xh-form-field-info:not(.xh-form-field-readonly) {
+  &.xh-form-field--info:not(.xh-form-field-readonly) {
     .xh-check-box span {
       box-shadow: var(--xh-form-field-info-box-shadow) !important;
     }
@@ -183,7 +181,7 @@
     }
 
     .xh-text-input > svg {
-      color: var(--xh-intent-primary);
+      color: var(--xh-form-field-info-color);
     }
 
     .xh-text-area.textarea {
@@ -192,7 +190,7 @@
   }
 }
 
-ul.xh-form-field-error-tooltip {
+ul.xh-form-field__validation-tooltip {
   margin: 0;
   padding: 0 1em 0 2em;
 }
@@ -210,9 +208,7 @@ ul.xh-form-field-error-tooltip {
     align-items: center;
   }
 
-  .xh-form-field-error-msg,
-  .xh-form-field-warning-msg,
-  .xh-form-field-info-msg {
+  .xh-form-field__validation-msg {
     margin: 0 var(--xh-pad-px);
   }
 }

--- a/desktop/cmp/form/FormField.ts
+++ b/desktop/cmp/form/FormField.ts
@@ -126,6 +126,7 @@ export const [FormField, formField] = hoistCmp.withFactory<FormFieldProps>({
             severityToDisplay = model?.validationDisplayed
                 ? maxSeverity(model.validationResults)
                 : null,
+            displayInvalid = severityToDisplay === 'error',
             validationResultsToDisplay = severityToDisplay
                 ? model.validationResults.filter(v => v.severity === severityToDisplay)
                 : [],
@@ -172,10 +173,11 @@ export const [FormField, formField] = hoistCmp.withFactory<FormFieldProps>({
         if (minimal) classes.push('xh-form-field-minimal');
         if (readonly) classes.push('xh-form-field-readonly');
         if (disabled) classes.push('xh-form-field-disabled');
-        if (severityToDisplay)
-            classes.push(
-                `xh-form-field-${severityToDisplay === 'error' ? 'invalid' : severityToDisplay}`
-            );
+
+        if (severityToDisplay) {
+            classes.push(`xh-form-field--${severityToDisplay}`);
+            if (displayInvalid) classes.push('xh-form-field--invalid');
+        }
 
         const testId = getFormFieldTestId(props, formContext, model?.name);
         useOnMount(() => instanceManager.registerModelWithTestId(testId, model));
@@ -206,8 +208,8 @@ export const [FormField, formField] = hoistCmp.withFactory<FormFieldProps>({
                 item: childEl,
                 className: classNames(
                     'xh-input',
-                    severityToDisplay &&
-                        `xh-input-${severityToDisplay === 'error' ? 'invalid' : severityToDisplay}`
+                    severityToDisplay && `xh-input--${severityToDisplay}`,
+                    displayInvalid && 'xh-input--invalid'
                 ),
                 targetTagName:
                     !blockChildren.includes(childElementName) || childWidth ? 'span' : 'div',
@@ -251,7 +253,7 @@ export const [FormField, formField] = hoistCmp.withFactory<FormFieldProps>({
                         tooltip({
                             omit: minimal || !severityToDisplay,
                             openOnTargetFocus: false,
-                            className: `xh-form-field-${severityToDisplay}-msg`,
+                            className: `xh-form-field__validation-msg xh-form-field__validation-msg--${severityToDisplay}`,
                             item: first(validationResultsToDisplay)?.message,
                             content: getValidationTooltipContent(
                                 validationResultsToDisplay
@@ -335,7 +337,6 @@ const editableChild = hoistCmp.factory<FieldModel>({
 //--------------------------------
 // Helper Functions
 //---------------------------------
-
 export function defaultReadonlyRenderer(value: any): ReactNode {
     if (isLocalDate(value)) return fmtDate(value);
     if (isDate(value)) return fmtDateTime(value);
@@ -386,7 +387,7 @@ function getValidationTooltipContent(validationResults: ValidationResult[]): Rea
     } else {
         const severity = first(validationResults).severity;
         return ul({
-            className: `xh-form-field-${severity}-tooltip`,
+            className: `xh-form-field__validation-tooltip xh-form-field__validation-tooltip--${severity}`,
             items: validationResults.map((it, idx) => li({key: idx, item: it.message}))
         });
     }

--- a/desktop/cmp/input/CodeInput.scss
+++ b/desktop/cmp/input/CodeInput.scss
@@ -29,19 +29,19 @@
 .xh-code-input {
   height: 100px;
 
-  &.xh-input-invalid {
+  &.xh-input--invalid {
     div.CodeMirror {
       border: var(--xh-form-field-invalid-border);
     }
   }
 
-  &.xh-input-warning {
+  &.xh-input--warning {
     div.CodeMirror {
       border: var(--xh-form-field-warning-border);
     }
   }
 
-  &.xh-input-info {
+  &.xh-input--info {
     div.CodeMirror {
       border: var(--xh-form-field-info-border);
     }

--- a/desktop/cmp/input/RadioInput.scss
+++ b/desktop/cmp/input/RadioInput.scss
@@ -10,23 +10,23 @@
     margin-right: var(--xh-pad-double-px);
   }
 
-  &.xh-input-invalid,
-  &.xh-input-warning,
-  &.xh-input-info {
+  &.xh-input--invalid,
+  &.xh-input--warning,
+  &.xh-input--info {
     .xh-radio-input-option .bp6-control-indicator::before {
       margin: -1px;
     }
   }
 
-  &.xh-input-invalid .xh-radio-input-option .bp6-control-indicator {
+  &.xh-input--invalid .xh-radio-input-option .bp6-control-indicator {
     border: var(--xh-form-field-invalid-border);
   }
 
-  &.xh-input-warning .xh-radio-input-option .bp6-control-indicator {
+  &.xh-input--warning .xh-radio-input-option .bp6-control-indicator {
     border: var(--xh-form-field-warning-border);
   }
 
-  &.xh-input-info .xh-radio-input-option .bp6-control-indicator {
+  &.xh-input--info .xh-radio-input-option .bp6-control-indicator {
     border: var(--xh-form-field-info-border);
   }
 }

--- a/desktop/cmp/input/SwitchInput.scss
+++ b/desktop/cmp/input/SwitchInput.scss
@@ -5,28 +5,30 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 
-.xh-switch-input.xh-input-invalid,
-.xh-switch-input.xh-input-warning,
-.xh-switch-input.xh-input-info {
-  .bp6-control-indicator::before {
-    margin: 1px;
+.xh-switch-input {
+  &.xh-input--invalid,
+  &.xh-input--warning,
+  &.xh-input--info {
+    .bp6-control-indicator::before {
+      margin: 1px;
+    }
   }
-}
 
-.xh-switch-input.xh-input-invalid {
-  .bp6-control-indicator {
-    border: var(--xh-form-field-invalid-border);
+  &.xh-input--invalid {
+    .bp6-control-indicator {
+      border: var(--xh-form-field-invalid-border);
+    }
   }
-}
 
-.xh-switch-input.xh-input-warning {
-  .bp6-control-indicator {
-    border: var(--xh-form-field-warning-border);
+  &.xh-input--warning {
+    .bp6-control-indicator {
+      border: var(--xh-form-field-warning-border);
+    }
   }
-}
 
-.xh-switch-input.xh-input-info {
-  .bp6-control-indicator {
-    border: var(--xh-form-field-info-border);
+  &.xh-input--info {
+    .bp6-control-indicator {
+      border: var(--xh-form-field-info-border);
+    }
   }
 }

--- a/desktop/cmp/input/TextArea.scss
+++ b/desktop/cmp/input/TextArea.scss
@@ -12,15 +12,15 @@
   // Suppress resize handles added by browser - we want to manage the size more closely.
   resize: none;
 
-  &.xh-input-invalid {
+  &.xh-input--invalid {
     border: var(--xh-form-field-invalid-border);
   }
 
-  &.xh-input-warning {
+  &.xh-input--warning {
     border: var(--xh-form-field-warning-border);
   }
 
-  &.xh-input-info {
+  &.xh-input--info {
     border: var(--xh-form-field-info-border);
   }
 }

--- a/kit/onsen/styles.scss
+++ b/kit/onsen/styles.scss
@@ -24,19 +24,19 @@
     border: var(--xh-border-solid);
     border-radius: var(--xh-border-radius-px);
 
-    &:not(.xh-input-invalid):not(.xh-input-warning):not(.xh-input-info):focus-within {
+    &:not(.xh-input--invalid):not(.xh-input--warning):not(.xh-input--info):focus-within {
       border-color: var(--xh-focus-outline-color);
     }
 
-    &.xh-input-invalid {
+    &.xh-input--invalid {
       border: var(--xh-form-field-invalid-border);
     }
 
-    &.xh-input-warning {
+    &.xh-input--warning {
       border: var(--xh-form-field-warning-border);
     }
 
-    &.xh-input-info {
+    &.xh-input--info {
       border: var(--xh-form-field-info-border);
     }
   }

--- a/mobile/cmp/form/FormField.scss
+++ b/mobile/cmp/form/FormField.scss
@@ -22,10 +22,7 @@
   }
 
   .xh-form-field-info,
-  .xh-form-field-error-msg,
-  .xh-form-field-pending-msg,
-  .xh-form-field-warning-msg,
-  .xh-form-field-info-msg {
+  &__validation-msg {
     font-size: var(--xh-font-size-small-px);
     line-height: calc(var(--xh-font-size-small-px) + var(--xh-pad-px));
     color: var(--xh-text-color-muted);
@@ -34,34 +31,34 @@
     overflow: hidden;
   }
 
-  .xh-form-field-error-msg {
-    color: var(--xh-red);
+  &__validation-msg {
+    &--error {
+      color: var(--xh-form-field-invalid-color);
+    }
+
+    &--info {
+      color: var(--xh-form-field-info-color);
+    }
+
+    &--warning {
+      color: var(--xh-form-field-warning-color);
+    }
   }
 
-  .xh-form-field-warning-msg {
-    color: var(--xh-orange);
+  &--invalid .xh-form-field-label {
+    color: var(--xh-form-field-invalid-color);
   }
 
-  .xh-form-field-info-msg {
-    color: var(--xh-blue);
+  &--warning .xh-form-field-label {
+    color: var(--xh-form-field-warning-color);
   }
 
-  &.xh-form-field-invalid .xh-form-field-label {
-    color: var(--xh-red);
-  }
-
-  &.xh-form-field-warning .xh-form-field-label {
-    color: var(--xh-orange);
-  }
-
-  &.xh-form-field-info .xh-form-field-label {
-    color: var(--xh-blue);
+  &--info .xh-form-field-label {
+    color: var(--xh-form-field-info-color);
   }
 
   &.xh-form-field-readonly {
-    .xh-form-field-error-msg,
-    .xh-form-field-warning-msg,
-    .xh-form-field-info-msg {
+    .xh-form-field__validation-msg {
       display: none;
     }
 

--- a/mobile/cmp/form/FormField.ts
+++ b/mobile/cmp/form/FormField.ts
@@ -69,6 +69,7 @@ export const [FormField, formField] = hoistCmp.withFactory<FormFieldProps>({
             severityToDisplay = model?.validationDisplayed
                 ? maxSeverity(model.validationResults)
                 : null,
+            displayInvalid = severityToDisplay === 'error',
             validationResultsToDisplay = severityToDisplay
                 ? model.validationResults.filter(v => v.severity === severityToDisplay)
                 : [],
@@ -104,10 +105,10 @@ export const [FormField, formField] = hoistCmp.withFactory<FormFieldProps>({
         if (minimal) classes.push('xh-form-field-minimal');
         if (readonly) classes.push('xh-form-field-readonly');
         if (disabled) classes.push('xh-form-field-disabled');
-        if (severityToDisplay)
-            classes.push(
-                `xh-form-field-${severityToDisplay === 'error' ? 'invalid' : severityToDisplay}`
-            );
+        if (severityToDisplay) {
+            classes.push(`xh-form-field--${severityToDisplay}`);
+            if (displayInvalid) classes.push('xh-form-field--invalid');
+        }
 
         let childEl =
             readonly || !child
@@ -147,12 +148,12 @@ export const [FormField, formField] = hoistCmp.withFactory<FormFieldProps>({
                         }),
                         div({
                             omit: minimal || !isPending || !severityToDisplay,
-                            className: 'xh-form-field-pending-msg',
+                            className: `xh-form-field__validation-msg xh-form-field__validation-msg--pending`,
                             item: 'Validating...'
                         }),
                         div({
                             omit: minimal || !severityToDisplay,
-                            className: `xh-form-field-${severityToDisplay}-msg`,
+                            className: `xh-form-field__validation-msg xh-form-field__validation-msg--${severityToDisplay}`,
                             item: first(validationResultsToDisplay)?.message
                         })
                     ]

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -404,31 +404,35 @@ body {
   //------------------------
   // Form Fields
   //------------------------
-  --xh-form-field-box-shadow-color-top: var(--form-field-box-shadow-color-top, #{mc-trans('blue-grey', '100', 0.15)});
-  --xh-form-field-box-shadow-color-bottom: var(--form-field-box-shadow-color-bottom, #{mc-trans('blue-grey', '100', 0.2)});
-  --xh-form-field-box-shadow: var(--form-field-box-shadow, #{inset 0 0 0 1px var(--xh-form-field-box-shadow-color-top), inset 0 1px 1px var(--xh-form-field-box-shadow-color-bottom)});
-  --xh-form-field-focused-border-color: var(--form-field-focused-border-color, var(--xh-focus-outline-color));
-  --xh-form-field-focused-box-shadow: var(--form-field-focused-box-shadow, #{inset 0 0 0 1px var(--xh-form-field-focused-border-color), inset 0 1px 1px var(--xh-form-field-focused-border-color)});
-  --xh-form-field-invalid-border-color: var(--form-field-invalid-border-color, var(--xh-intent-danger));
-  --xh-form-field-invalid-box-shadow: var(--form-field-invalid-border-color, #{inset 0 0 0 1px var(--xh-form-field-invalid-border-color), inset 0 1px 1px var(--xh-form-field-invalid-border-color)});
-  --xh-form-field-invalid-border-width: var(--form-field-invalid-border-width, 1);
-  --xh-form-field-invalid-border-width-px: calc(var(--xh-form-field-invalid-border-width) * 1px);
-  --xh-form-field-invalid-border: #{(var(--xh-form-field-invalid-border-width-px) solid var(--xh-form-field-invalid-border-color))};
-  --xh-form-field-invalid-message-text-color: var(--form-field-invalid-message-text-color, var(--xh-intent-danger));
   --xh-form-field-margin-bottom: var(--form-field-margin-bottom, 0);
   --xh-form-field-margin-right: var(--form-field-margin-right, 0);
-  --xh-form-field-warning-border-color: var(--form-field-warning-border-color, var(--xh-intent-warning));
-  --xh-form-field-warning-box-shadow: var(--form-field-warning-border-color, #{inset 0 0 0 1px var(--xh-form-field-warning-border-color), inset 0 1px 1px var(--xh-form-field-warning-border-color)});
-  --xh-form-field-warning-border-width: var(--form-field-warning-border-width, 1);
-  --xh-form-field-warning-border-width-px: calc(var(--xh-form-field-warning-border-width) * 1px);
-  --xh-form-field-warning-border: #{(var(--xh-form-field-warning-border-width-px) solid var(--xh-form-field-warning-border-color))};
-  --xh-form-field-warning-message-text-color: var(--form-field-warning-message-text-color, var(--xh-intent-warning));
+
+  --xh-form-field-box-shadow: var(--form-field-box-shadow, #{inset 0 0 0 1px var(--xh-form-field-box-shadow-color-top), inset 0 1px 1px var(--xh-form-field-box-shadow-color-bottom)});
+  --xh-form-field-box-shadow-color-bottom: var(--form-field-box-shadow-color-bottom, #{mc-trans('blue-grey', '100', 0.2)});
+  --xh-form-field-box-shadow-color-top: var(--form-field-box-shadow-color-top, #{mc-trans('blue-grey', '100', 0.15)});
+  --xh-form-field-focused-border-color: var(--form-field-focused-border-color, var(--xh-focus-outline-color));
+  --xh-form-field-focused-box-shadow: var(--form-field-focused-box-shadow, #{inset 0 0 0 1px var(--xh-form-field-focused-border-color), inset 0 1px 1px var(--xh-form-field-focused-border-color)});
+
+  --xh-form-field-info-border: #{(var(--xh-form-field-info-border-width-px) solid var(--xh-form-field-info-border-color))};
   --xh-form-field-info-border-color: var(--form-field-info-border-color, var(--xh-intent-primary));
-  --xh-form-field-info-box-shadow: var(--form-field-info-border-color, #{inset 0 0 0 1px var(--xh-form-field-info-border-color), inset 0 1px 1px var(--xh-form-field-info-border-color)});
   --xh-form-field-info-border-width: var(--form-field-info-border-width, 1);
   --xh-form-field-info-border-width-px: calc(var(--xh-form-field-info-border-width) * 1px);
-  --xh-form-field-info-border: #{(var(--xh-form-field-info-border-width-px) solid var(--xh-form-field-info-border-color))};
-  --xh-form-field-info-message-text-color: var(--form-field-info-message-text-color, var(--xh-intent-primary));
+  --xh-form-field-info-box-shadow: var(--form-field-info-border-color, #{inset 0 0 0 1px var(--xh-form-field-info-border-color), inset 0 1px 1px var(--xh-form-field-info-border-color)});
+  --xh-form-field-info-color: var(--form-field-info-color, var(--xh-intent-primary));
+
+  --xh-form-field-invalid-border: #{(var(--xh-form-field-invalid-border-width-px) solid var(--xh-form-field-invalid-border-color))};
+  --xh-form-field-invalid-border-color: var(--form-field-invalid-border-color, var(--xh-intent-danger));
+  --xh-form-field-invalid-border-width: var(--form-field-invalid-border-width, 1);
+  --xh-form-field-invalid-border-width-px: calc(var(--xh-form-field-invalid-border-width) * 1px);
+  --xh-form-field-invalid-box-shadow: var(--form-field-invalid-border-color, #{inset 0 0 0 1px var(--xh-form-field-invalid-border-color), inset 0 1px 1px var(--xh-form-field-invalid-border-color)});
+  --xh-form-field-invalid-color: var(--form-field-invalid-color, var(--xh-intent-danger));
+
+  --xh-form-field-warning-border: #{(var(--xh-form-field-warning-border-width-px) solid var(--xh-form-field-warning-border-color))};
+  --xh-form-field-warning-border-color: var(--form-field-warning-border-color, var(--xh-intent-warning));
+  --xh-form-field-warning-border-width: var(--form-field-warning-border-width, 1);
+  --xh-form-field-warning-border-width-px: calc(var(--xh-form-field-warning-border-width) * 1px);
+  --xh-form-field-warning-box-shadow: var(--form-field-warning-border-color, #{inset 0 0 0 1px var(--xh-form-field-warning-border-color), inset 0 1px 1px var(--xh-form-field-warning-border-color)});
+  --xh-form-field-warning-color: var(--form-field-warning-color, var(--xh-intent-warning));
 
   &.xh-dark {
     --xh-form-field-box-shadow-color-top: var(--form-field-box-shadow-color-top, #{mc-trans('blue-grey', '800', 0.15)});


### PR DESCRIPTION
- Use `--` modifier when appending to validation-related classes.
- Remove some remaining direct uses of the intents or colors in favor of the new per-level CSS vars.
- Define additional base classes for validation messages.
- Fixup changelog to note updates under correct version.
