### PR TITLE
Fix View connection logic

### DIFF
--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -155,6 +155,11 @@ export class Cube extends HoistBase {
         return this.store.empty;
     }
 
+    /** Timestamp (ms) of when the Cube data was last updated */
+    get lastUpdated(): number {
+        return this.store.lastUpdated;
+    }
+
     /** Count of currently connected, auto-updating Views. */
     get connectedViewCount(): number {
         return this._connectedViews.size;
@@ -234,7 +239,7 @@ export class Cube extends HoistBase {
         this._connectedViews.add(view);
 
         // If the view is not up-to-date with the current cube data, then reload the view
-        if (view.info !== this.info) {
+        if (view.cubeDataUpdated !== this.lastUpdated) {
             view.noteCubeLoaded();
         }
     }

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -95,6 +95,10 @@ export class View
     @observable.ref
     info: PlainObject = null;
 
+    /** Timestamp (ms) of when the cube data was last changed at the time of the last View update */
+    @observable
+    cubeDataUpdated: number;
+
     /** Timestamp (ms) of the last time this view's data was changed. */
     @observable
     lastUpdated: number;
@@ -184,6 +188,7 @@ export class View
 
         if (oldCube !== newCube) {
             this.info = null;
+            this.cubeDataUpdated = null;
             this._rowCache.clear();
 
             if (oldCube.viewIsConnected(this)) {
@@ -251,6 +256,7 @@ export class View
             this.dataOnlyUpdate(simpleUpdates);
         } else {
             this.info = this.cube.info;
+            this.cubeDataUpdated = this.cube.lastUpdated;
         }
     }
 
@@ -309,6 +315,7 @@ export class View
         const {_leafMap, _rowDatas} = this;
         this.result = {rows: _rowDatas, leafMap: _leafMap};
         this.info = this.cube.info;
+        this.cubeDataUpdated = this.cube.lastUpdated;
         this.lastUpdated = Date.now();
     }
 


### PR DESCRIPTION
Don't depend on the Cube info for determining when a View update is required upon connecting to a Cube, as it is intended for application use only, and may not be used/updated at all.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

