### PR TITLE
Add contentBoxProps to mobile Panel + scrollable to desktop Panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@
   header and collapsible content.
 * Added `FormFieldSet` component for grouping `FormFields` and displaying their aggregate validation
   state.
-* Added `contentBoxProps` to `Panel`, providing direct control over the inner frame wrapping content
-  items. Use to apply padding, change flex direction, enable scrolling, or add custom classes without
-  extra wrapper elements. Matches the existing `contentBoxProps` API on `Card`.
+* Added `contentBoxProps` to desktop and mobile `Panel`, providing direct control over the inner
+  frame wrapping content items. Use to apply padding, change flex direction, enable scrolling, or
+  add custom classes without extra wrapper elements. Matches the existing `contentBoxProps` API on
+  `Card`.
+* Added `scrollable` prop to desktop `Panel`, matching the existing mobile `Panel` API. Sets
+  `overflowY: 'auto'` on the content area.
 * Layout props `padding`, `margin` (and their directional variants), and `gap` now accept a boolean
   shorthand: `true` resolves to the standard app padding CSS variable (`--xh-pad-px`, default 10px),
   `false` is treated as unset.

--- a/cmp/form/README.md
+++ b/cmp/form/README.md
@@ -573,14 +573,15 @@ formField({
 
 ### Scrollable Form Content
 
-Forms with many fields may overflow their containing Panel. Use Panel's `contentBoxProps`
-to enable scrolling — this keeps toolbars and headers fixed while the form content scrolls:
+Forms with many fields may overflow their containing Panel. Use Panel's `scrollable` prop
+to enable vertical scrolling — this keeps toolbars and headers fixed while the form content scrolls:
 
 ```typescript
 panel({
     title: 'User Profile',
     tbar: [saveButton(), resetButton()],
-    contentBoxProps: {overflow: 'auto', padding: true},
+    scrollable: true,
+    contentBoxProps: {padding: true},
     item: form({
         fieldDefaults: {inline: true},
         items: [
@@ -593,12 +594,11 @@ panel({
 })
 ```
 
-The `overflow: 'auto'` targets the inner content frame — toolbars remain fixed at the panel
-edges while form content scrolls independently. `padding: true` provides standard app spacing
-around the form without affecting toolbar alignment.
+The `scrollable` prop sets `overflowY: 'auto'` on the inner content frame — toolbars remain fixed
+at the panel edges while form content scrolls independently. `padding: true` via `contentBoxProps`
+provides standard app spacing around the form without affecting toolbar alignment.
 
-See the [Panel README](../../desktop/cmp/panel/README.md#contentboxprops) for full
-`contentBoxProps` documentation.
+See the [Panel README](../../desktop/cmp/panel/README.md#scrollable) for full documentation.
 
 ## Common Pitfalls
 

--- a/desktop/cmp/panel/Panel.ts
+++ b/desktop/cmp/panel/Panel.ts
@@ -99,6 +99,9 @@ export interface PanelProps<M extends PanelModel = PanelModel>
 
     /** Additional props to pass to the inner frame hosting child `items`. */
     contentBoxProps?: BoxProps;
+
+    /** Allow the panel content area to scroll vertically. */
+    scrollable?: boolean;
 }
 
 /**
@@ -140,6 +143,7 @@ export const [Panel, panel] = hoistCmp.withFactory<PanelProps>({
             contextMenu,
             hotkeys,
             contentBoxProps,
+            scrollable,
             children,
             ...rest
         } = nonLayoutProps;
@@ -194,6 +198,7 @@ export const [Panel, panel] = hoistCmp.withFactory<PanelProps>({
                         ...contentBoxProps,
                         className: classNames('xh-panel__content', contentBoxProps?.className),
                         flexDirection: contentBoxProps?.flexDirection ?? 'column',
+                        overflowY: scrollable ? 'auto' : contentBoxProps?.overflowY,
                         items: castArray(children)
                     }),
                     parseToolbar(bbar)

--- a/desktop/cmp/panel/README.md
+++ b/desktop/cmp/panel/README.md
@@ -84,7 +84,7 @@ panel({
     items: [leftPane(), rightPane()]
 })
 
-// Scrollable content
+// Scrollable content (via contentBoxProps)
 panel({
     title: 'Log',
     contentBoxProps: {overflow: 'auto'},
@@ -93,6 +93,21 @@ panel({
 ```
 
 This mirrors the `contentBoxProps` API available on `Card`.
+
+## scrollable
+
+The `scrollable` prop is a convenience shorthand that sets `overflowY: 'auto'` on the content
+area, keeping the header and toolbars fixed while content scrolls vertically. This is equivalent
+to `contentBoxProps: {overflowY: 'auto'}` but reads more naturally for the common case:
+
+```typescript
+// These are equivalent:
+panel({scrollable: true, item: longForm()})
+panel({contentBoxProps: {overflowY: 'auto'}, item: longForm()})
+```
+
+When both `scrollable` and `contentBoxProps.overflowY` are specified, `scrollable` takes
+precedence.
 
 ## Toolbars
 
@@ -459,6 +474,7 @@ layouts like dashboards.
 | `tbar` | `ReactNode` | Top toolbar. Array auto-wrapped in `toolbar()`. |
 | `bbar` | `ReactNode` | Bottom toolbar. Array auto-wrapped in `toolbar()`. |
 | `contentBoxProps` | `BoxProps` | Props for the inner frame wrapping content items. |
+| `scrollable` | `boolean` | Allow the panel content area to scroll vertically. |
 | `mask` | `Some<TaskObserver> \| ReactElement \| boolean \| 'onLoad'` | Mask overlay specification. |
 | `loadingIndicator` | `Some<TaskObserver> \| ReactElement \| boolean \| 'onLoad'` | Loading indicator (same forms as `mask`). |
 | `model` | `PanelModel` | Explicit PanelModel for collapse/resize. |

--- a/mobile/cmp/panel/Panel.scss
+++ b/mobile/cmp/panel/Panel.scss
@@ -1,16 +1,6 @@
 .xh-panel {
   background-color: var(--xh-panel-bg);
 
-  &__content {
-    flex: 1;
-  }
-
-  &--scrollable {
-    .xh-panel__content {
-      overflow-y: auto;
-    }
-  }
-
   .xh-panel-header {
     align-items: center;
     color: var(--xh-panel-title-text-color);


### PR DESCRIPTION
## Summary

- Adds `contentBoxProps` to mobile `Panel`, matching the desktop `Panel` API. Children are now
  wrapped in a `frame()` with the `xh-panel__content` CSS class, consistent with the desktop
  implementation.
- Adds `scrollable` prop to desktop `Panel`, matching the existing mobile `Panel` API. Sets
  `overflowY: 'auto'` on the content area as a convenience shorthand.
- Both Panels now have a consistent API surface with both `contentBoxProps` and `scrollable`.
- Updates CHANGELOG, Panel README, and Form README.

## Test plan

- [ ] Verify mobile Panel renders content correctly with default props
- [ ] Test mobile `contentBoxProps` with padding, flexDirection, and overflow
- [ ] Test mobile `scrollable` still works as before
- [ ] Test desktop `scrollable: true` enables vertical scrolling while keeping toolbars fixed
- [ ] Verify no regressions in desktop Panel contentBoxProps behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)