### PR TITLE
Add upgrade notes skill and v78-v81 upgrade guides

### DIFF
--- a/.claude/skills/xh-upgrade-notes/SKILL.md
+++ b/.claude/skills/xh-upgrade-notes/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: xh-upgrade-notes
+description: Create or update detailed upgrade notes and CHANGELOG entry for a major Hoist React release. Use when writing documentation for a new major version upgrade.
+argument-hint: [version, e.g. v79 or 79.0.0]
+disable-model-invocation: true
+---
+
+# Upgrade Notes Skill
+
+Create comprehensive, action-oriented upgrade documentation for a major Hoist React release. This
+skill produces two artifacts and validates them via dry-run simulation.
+
+**Version:** $ARGUMENTS
+
+## Phase 0: Setup
+
+1. Parse the version from `$ARGUMENTS`. Normalize to `vNN` short form and `NN.x.x` full form.
+2. Identify the **prior major version** by reading `CHANGELOG.md` to find the entry immediately
+   before the target version (e.g. if target is v79, prior is v78.x).
+3. Determine the **git tag range** for diffing: `v{prior}..v{target}` (e.g. `v78.1.4..v79.0.0`).
+   List available tags with `git tag -l 'v*'` to find exact tag names.
+4. Read [template.md](template.md) for the upgrade notes document template.
+5. Read [`docs/changelog-format.md`](../../docs/changelog-format.md) for CHANGELOG entry conventions.
+
+## Phase 1: Research
+
+Gather all information needed to write accurate documentation. Launch parallel research agents
+where possible.
+
+### 1a. Git History Analysis
+
+- Run `git diff --stat {prior_tag}..{target_tag}` to understand scope of changes.
+- Run `git log --oneline {prior_tag}..{target_tag}` to see all commits in the release.
+- Read the existing CHANGELOG entry for the target version to understand what's already documented.
+
+### 1b. Source File Analysis
+
+Read key source files that commonly change between major versions:
+
+- `package.json` — dependency versions, resolutions
+- `core/XH.ts` — singleton API, app-level getters
+- `core/HoistBase.ts` — base class lifecycle, decorators
+- `cmp/grid/` — GridModel, Column, grid infrastructure
+- `cmp/form/` — FormModel, FieldModel, FormField
+- `cmp/tab/` — TabContainerModel, TabSwitcher
+- `cmp/layout/` — layout components, LayoutProps
+- `data/` — Store, Field, Filter, Cube, View
+- `styles/` — CSS variables, SCSS mixins
+- `kit/blueprint/` — Blueprint wrappers and re-exports
+- `security/` — HoistAuthModel, auth clients
+- `desktop/cmp/dash/` — DashContainerModel, DashCanvasModel
+- `desktop/cmp/panel/` — Panel, PanelModel
+
+### 1c. Sample App Upgrade Analysis
+
+Review upgrade commits in sample applications to understand real-world app-level changes required.
+These apps are available locally (see CLAUDE.local.md for paths):
+
+- **Toolbox** (`../toolbox`) — canonical reference app, always upgraded first
+- Additional sample/customer applications listed in `CLAUDE.local.md`
+
+For each app, search git log for commits referencing the target version:
+```bash
+git -C ../toolbox log --oneline --all --grep="v{NN}" --grep="hoist" --grep="{NN}.0"
+```
+
+Read the key files from upgrade commits: `package.json`, `tsconfig.json`, `Bootstrap.ts`,
+and any files touching changed APIs.
+
+**Important:** Only reference Toolbox by name in the upgrade notes (it's the public demo app).
+Do not mention other sample or customer applications by name — use them only for research and
+abstracted patterns.
+
+### 1d. Framework Documentation
+
+If the upgrade involves a major library version change, fetch the official upgrade guide for
+reference:
+
+- **Blueprint:** `https://github.com/palantir/blueprint/wiki/Blueprint-{N}.0`
+- **AG Grid:** `https://www.ag-grid.com/react-data-grid/upgrading-to-ag-grid-{N}/`
+- **Highcharts:** `https://www.highcharts.com/blog/changelog/`
+
+## Phase 2: Write the CHANGELOG Entry
+
+### Audit the Existing Entry
+
+Read the current CHANGELOG entry for the target version. Evaluate against these criteria:
+
+- [ ] **Structure**: Uses standard emoji-prefixed section headers (💥 Breaking Changes,
+  🎁 New Features, 🐞 Bug Fixes, ⚙️ Technical, ✨ Styles, 📚 Libraries) — see
+  [`docs/changelog-format.md`](../../docs/changelog-format.md)
+- [ ] **Breaking Changes**: All required app changes are listed as individual bullets (not buried
+  in prose under Technical or other sections)
+- [ ] **Completeness**: Changes that affect behavior, APIs, or configuration are accounted for
+  (trivial formatting, internal refactors, or tooling changes can be omitted)
+- [ ] **Accuracy**: Class names, method names, file paths are correct
+- [ ] **Tense**: Past-tense, action-driven voice ("Enhanced", "Fixed", "Added") — exception:
+  developer instructions use imperative ("Update", "Adjust")
+- [ ] **Conciseness**: Each bullet is 1-2 lines; detailed instructions belong in upgrade notes
+- [ ] **Libraries section**: Present for major version bumps with `old → new` format
+
+### Write or Rewrite the Entry
+
+If the entry needs significant changes, rewrite it following the format in
+[`docs/changelog-format.md`](../../docs/changelog-format.md). Key principles:
+
+- Breaking Changes section should have a difficulty rating and list every required app change
+- Each bullet names the specific action concisely — the upgrade notes handle the detail
+- Include a link to the upgrade notes file: `docs/upgrade-notes/v{NN}-upgrade-notes.md`
+- Include a link to the relevant framework upgrade guide (if applicable)
+- Libraries section lists major dependency version bumps in `old → new` format
+
+## Phase 3: Write the Upgrade Notes
+
+Create `docs/upgrade-notes/v{NN}-upgrade-notes.md` following the template in
+[template.md](template.md).
+
+### Content Requirements
+
+Each upgrade step must include:
+
+1. **What** to change — explicit file paths from project root
+2. **Before/after** code blocks — with appropriate language tags (`typescript`, `json`, `scss`,
+   `bash`, etc.)
+3. **Search commands** — `grep -r "pattern" client-app/src/` to help developers find affected files
+4. **Why** — brief explanation of what changed and why (one sentence is usually enough)
+5. **Verification** — how to confirm the step was done correctly (where applicable)
+
+### Writing Guidelines
+
+- Be specific and concrete. Name exact files, classes, methods, and property names.
+- Use code blocks generously. Developers copy-paste from upgrade guides.
+- Before/after examples should show realistic code, not pseudocode.
+- Use element factory style in code examples (not JSX), consistent with Hoist conventions.
+- Reference Toolbox as the canonical example where helpful (it's the public demo app).
+- Do not mention sample or customer applications by name, with the exception of Toolbox.
+- Keep prose minimal between code blocks — this is a recipe, not an essay.
+- Steps should be ordered logically (build system first, then source code, then cleanup).
+- The verification checklist at the end should cover all critical functionality.
+
+### Update the docs/README.md Index
+
+Add a row to the table in `docs/README.md` for the new version.
+
+## Phase 4: Dry-Run Validation
+
+After writing both artifacts, launch an independent validation agent. This agent stress-tests
+the upgrade notes by simulating a real upgrade.
+
+### Agent Setup
+
+Launch a Task agent (subagent_type: "general-purpose") with these instructions:
+
+> You are an "App Upgrade Advisor" agent. Your job is to evaluate upgrade documentation by
+> simulating its use against a real application.
+>
+> 1. **Setup:** Check out Toolbox (at `../toolbox`) at a commit BEFORE the target hoist-react
+>    version was applied. Use `git log --oneline` to find the last commit before the upgrade.
+>    Create a temporary branch for the dry run.
+>
+> 2. **Dry run:** Working solely from the upgrade notes file at
+>    `docs/upgrade-notes/v{NN}-upgrade-notes.md` and the app's current source, walk through each
+>    step as if advising on a real upgrade. For each step, evaluate:
+>    - Is the instruction clear and unambiguous?
+>    - Does the "Before" code match what's actually in the app?
+>    - Are there files or patterns in the app not covered by the guide?
+>    - Would a developer know exactly what to do?
+>
+> 3. **Report:** Produce a structured report with:
+>    - **Gaps**: Steps or changes not covered by the guide
+>    - **Ambiguities**: Instructions that could be misinterpreted
+>    - **Inaccuracies**: Before/after examples that don't match reality
+>    - **Suggestions**: Ways to improve clarity
+>    Rate each finding as HIGH / MEDIUM / LOW priority.
+>
+> 4. **Cleanup:** Restore Toolbox to its original state (checkout original branch, delete temp
+>    branch). Do NOT leave any changes behind.
+>
+> IMPORTANT: Do NOT modify any files in the upgrade notes or CHANGELOG — only report findings.
+
+### Handling the Report
+
+Review the agent's findings. Address all HIGH and MEDIUM priority items by updating the upgrade
+notes and/or CHANGELOG entry. LOW priority items are at your discretion.
+
+## Phase 5: Finalize
+
+1. Re-read both artifacts one final time to check for consistency between the CHANGELOG entry
+   and the upgrade notes (same version numbers, same list of changes, matching links).
+2. Verify the `docs/README.md` index is updated.
+3. Present a summary to the user of what was created/changed and offer to commit.
+
+## Important Notes
+
+- This skill produces documentation — it does NOT modify application source code.
+- The CHANGELOG is a consolidated file appended to on each release. Balance completeness with
+  conciseness. The upgrade notes file is where expanded detail lives.
+- Always verify code examples against actual source files. Never guess at class names, method
+  signatures, or file paths.
+- The dry-run validation phase is critical — it catches gaps that are invisible when writing
+  documentation from the "inside out". Do not skip it.

--- a/.claude/skills/xh-upgrade-notes/template.md
+++ b/.claude/skills/xh-upgrade-notes/template.md
@@ -1,0 +1,144 @@
+# Upgrade Notes Template
+
+Use this template when creating `docs/upgrade-notes/v{NN}-upgrade-notes.md`. Replace all
+`{placeholders}` with actual values. Remove sections that don't apply, and add version-specific
+sections as needed.
+
+---
+
+```markdown
+# Hoist React v{NN} Upgrade Notes
+
+> **From:** v{PRIOR}.x → v{VERSION} | **Released:** {DATE} | **Difficulty:** {DIFFICULTY}
+
+## Overview
+
+{1-2 paragraphs describing what changed and why. Name the major framework/library changes and
+their most significant app-level impacts as a bulleted list.}
+
+The most significant app-level impacts are:
+
+- **{Impact 1}** — {brief description}
+- **{Impact 2}** — {brief description}
+- ...
+
+## Prerequisites
+
+Before starting, ensure:
+
+- [ ] **Node.js** version meets project requirements
+- [ ] **yarn** is available and working
+- [ ] **hoist-core** is upgraded to the minimum required version (if applicable)
+- [ ] {Version-specific prerequisites}
+
+## Upgrade Steps
+
+### 1. Update `package.json`
+
+Bump hoist-react and update any changed dependencies.
+
+**File:** `package.json`
+
+Before:
+```json
+"@xh/hoist": "{PRIOR_VERSION}",
+```
+
+After:
+```json
+"@xh/hoist": "{TARGET_VERSION}",
+```
+
+{Additional dependency changes, resolutions, removals.}
+
+### 2. Update `tsconfig.json` (if applicable)
+
+{Compiler option changes.}
+
+### 3. Update `Bootstrap.ts` / App Entry Point (if applicable)
+
+{Library registration changes — AG Grid modules, Highcharts imports, etc.}
+
+### 4. Update Import Paths
+
+{Import path changes — moved exports, renamed modules.}
+
+**Find affected files:**
+```bash
+grep -r "{old_import}" client-app/src/
+```
+
+### 5. Update API Usage
+
+{Component props, model configs, method renames.}
+
+Before:
+```typescript
+{existing code}
+```
+
+After:
+```typescript
+{updated code}
+```
+
+### 6. Update CSS/SCSS (if applicable)
+
+{Class renames, CSS variable changes.}
+
+**Find affected files:**
+```bash
+grep -r "{old_class}" client-app/src/
+```
+
+### 7. Clean Up Deprecated Patterns (if applicable)
+
+{Remove deprecated aliases, configs, or patterns scheduled for removal.}
+
+## Verification Checklist
+
+After completing all steps:
+
+- [ ] `yarn install` completes without errors
+- [ ] `yarn lint` passes (or only pre-existing warnings remain)
+- [ ] `npx tsc --noEmit` passes
+- [ ] Application loads without console errors
+- [ ] Grids render and function correctly (sorting, filtering, grouping)
+- [ ] Forms validate and submit correctly
+- [ ] {Version-specific verification items}
+- [ ] No deprecated patterns remain: `grep -r "{pattern}" client-app/src/`
+
+## Reference
+
+- {Link to relevant framework upgrade guide, if applicable}
+- [Toolbox on GitHub](https://github.com/xh/toolbox) — canonical example of a Hoist app
+```
+
+---
+
+## Difficulty Ratings
+
+Use one of these ratings in both the CHANGELOG Breaking Changes header and the upgrade notes
+header:
+
+| Rating | Emoji | Meaning |
+|--------|-------|---------|
+| TRIVIAL | 🎉 | Rename or simple find-replace, no functional changes |
+| LOW | 🟢 | Minor adjustments, typically < 30 min |
+| MEDIUM | 🟠 | Significant changes to build or source, typically 1-4 hours |
+| HIGH | 🔴 | Major restructuring, large-scale refactoring, multi-day effort |
+
+## Step Ordering Convention
+
+Order steps from build configuration outward to application code:
+
+1. `package.json` — version bump, dependency additions/removals, resolutions
+2. `tsconfig.json` — compiler option changes
+3. `Bootstrap.ts` / app entry point — library registration (AG Grid modules, Highcharts)
+4. Import path changes
+5. API changes — component props, model configs, method renames
+6. CSS/SCSS changes — class renames, CSS variable changes
+7. Cleanup of deprecated patterns
+
+This order lets developers build and test incrementally — the app should install and compile
+after the build system steps, then progressively fix source-level issues.

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ See [`README-ROADMAP.md`](./README-ROADMAP.md) for documentation coverage tracki
 | Understand app shell, dialogs, toasts, or theming | [`/appcontainer/`](../appcontainer/README.md) |
 | Set up builds, CI/CD, or deployment | [Build & Deploy](./build-and-deploy.md) |
 | Configure local development environment | [Development Environment](./development-environment.md) |
+| Upgrade to a new major hoist-react version | [Upgrade Notes](#upgrade-notes) |
 
 ## Package Documentation
 
@@ -109,6 +110,18 @@ for planned coverage:
 | [Development Environment](./development-environment.md) | Local development environment setup for Hoist and app developers |
 | [Compilation Notes](./compilation-notes.md) | Notes on TypeScript/Babel compilation and build tooling internals |
 
+## Upgrade Notes
+
+Step-by-step guides for upgrading applications across major hoist-react versions, with
+breaking changes, before/after code examples, and verification checklists.
+
+| Version | Released | Difficulty | Key Changes |
+|---------|----------|------------|-------------|
+| [v81](./upgrade-notes/v81-upgrade-notes.md) | _unreleased_ | 🟢 LOW | Panel CSS rename, `completeAuthAsync` return type, Blueprint `Card` → `BpCard` |
+| [v80](./upgrade-notes/v80-upgrade-notes.md) | 2026-01-27 | 🟢 LOW | FormField BEM CSS classes, `appLoadModel` → `appLoadObserver`, jQuery resolution |
+| [v79](./upgrade-notes/v79-upgrade-notes.md) | 2026-01-05 | 🟠 MEDIUM | Blueprint 5→6, `moduleResolution: "bundler"`, `loadModel` → `loadObserver` |
+| [v78](./upgrade-notes/v78-upgrade-notes.md) | 2025-11-21 | 🎉 TRIVIAL | `GridModel.setColumnState` behavior change |
+
 ## Additional Resources
 
 - [`/AGENTS.md`](../AGENTS.md) — AI coding assistant guidance: architecture patterns, coding
@@ -116,5 +129,7 @@ for planned coverage:
 - [`README-ROADMAP.md`](./README-ROADMAP.md) — Documentation coverage tracking, conventions,
   and progress notes
 - [`/CHANGELOG.md`](../CHANGELOG.md) — Version history and release notes
+- [`changelog-format.md`](./changelog-format.md) — CHANGELOG entry format conventions and
+  section headers
 - [Toolbox](https://github.com/xh/toolbox) — XH's example application showcasing hoist-react
   patterns and components

--- a/docs/changelog-format.md
+++ b/docs/changelog-format.md
@@ -1,0 +1,138 @@
+# CHANGELOG Entry Format
+
+Reference for writing and reviewing CHANGELOG entries in `CHANGELOG.md`.
+
+## Entry Structure
+
+Every major version entry should use this structure. Minor/patch releases use whichever sections
+apply.
+
+```markdown
+## {VERSION} - {YYYY-MM-DD}
+
+### 💥 Breaking Changes
+
+* {Introductory bullet with overview and link to upgrade notes}
+* {Required change 1}
+* {Required change 2}
+    * {Sub-detail if needed}
+* ...
+
+### 🎁 New Features
+
+* {Feature description}
+
+### 🐞 Bug Fixes
+
+* {Fix description}
+
+### ⚙️ Typescript API Adjustments
+
+* {Type-level change description}
+
+### ⚙️ Technical
+
+* {Internal change description}
+
+### ✨ Styles
+
+* {CSS/SCSS change description}
+
+### 📚 Libraries
+
+* {Library} `{old} → {new}`
+```
+
+## Section Headers
+
+Use these emoji-prefixed headers consistently:
+
+| Section | Header | When to Include |
+|---------|--------|-----------------|
+| Breaking Changes | `### 💥 Breaking Changes` | Required app changes exist |
+| New Features | `### 🎁 New Features` | New capabilities added |
+| Bug Fixes | `### 🐞 Bug Fixes` | Bugs fixed |
+| TS API Adjustments | `### ⚙️ Typescript API Adjustments` | Type-level changes (signatures, generics, exports) |
+| Technical | `### ⚙️ Technical` | Internal changes worth noting |
+| Styles | `### ✨ Styles` | CSS/SCSS changes, new variables, class renames |
+| Libraries | `### 📚 Libraries` | Major dependency version bumps |
+
+**Note:** TS API Adjustments and Technical share the ⚙️ emoji but are distinct sections. TS API
+Adjustments covers type signature changes that may affect app compilation but not runtime behavior.
+Technical covers internal implementation changes worth noting.
+
+## Voice and Tense
+
+- **Past tense, action-driven** for descriptions: "Enhanced", "Fixed", "Added", "Improved",
+  "Removed", "Refactored"
+- **Imperative** for developer instructions: "Update", "Adjust", "Remove", "Migrate"
+- Avoid starting bullets with "New" (prefer "Added"), "Support for" (prefer "Added support for"),
+  or present tense verbs like "Fix", "Allow", "Enable"
+
+### Examples
+
+Good:
+```markdown
+* Enhanced `GridModel` column state management to support partial updates.
+* Added support for `warning` and `info` severity in `Field.rules`.
+* Fixed regression with `Store.revert()` on stores with summary records.
+```
+
+Bad:
+```markdown
+* New support for warning severity in rules    (use "Added", not "New support for")
+* Fix to regression in Store.revert            (use "Fixed regression", not "Fix to")
+* Allow improved editing of columns            (use "Enhanced" or "Added", not "Allow")
+```
+
+## Breaking Changes Section
+
+For major versions, this section should:
+
+1. **List** every required app-level change as a separate bullet
+2. **Be specific** — name exact classes, methods, and config keys
+3. **Include** difficulty-rated sub-headers when useful (see Difficulty Ratings below)
+4. **Link** to upgrade notes when available: `docs/upgrade-notes/v{NN}-upgrade-notes.md`
+5. **Link** to relevant framework upgrade guides (e.g. Blueprint, AG Grid) when applicable
+
+Each bullet should be concise (1-2 lines). The upgrade notes file handles expanded detail with
+before/after code examples.
+
+### Difficulty Ratings
+
+When upgrade notes exist for a major version, include a difficulty rating:
+
+```markdown
+### 💥 Breaking Changes (upgrade difficulty: 🎉 TRIVIAL)
+### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW - {brief description})
+### 💥 Breaking Changes (upgrade difficulty: 🟠 MEDIUM - {brief description})
+### 💥 Breaking Changes (upgrade difficulty: 🔴 HIGH - {brief description})
+```
+
+## Libraries Section
+
+List major dependency version changes with backtick-wrapped versions:
+
+```markdown
+### 📚 Libraries
+
+* @blueprintjs/core `5.10 → 6.3`
+* react-grid-layout `1.5 → 2.1`
+* typescript `5.8 → 5.9`
+```
+
+Use abbreviated versions where the minor/patch isn't significant (e.g. `6.3` not `6.3.1`).
+
+## General Guidelines
+
+- **Positive tone**: Favor words like "Enhanced", "Improved", "Streamlined" where accurate.
+  Concisely note *why* a change is an improvement when not obvious from context (e.g.
+  "Improved shutdown handling — ensures full cleanup if the component unmounts unexpectedly").
+  Accuracy always takes precedence — bug fixes should be reported clearly as such.
+- **Conciseness**: This is a changelog, not a guide. One bullet = one change, 1-2 lines max.
+- **Specificity**: Name classes, methods, and config keys in backticks.
+- **Completeness**: Changes that modify behavior, APIs, or configuration in ways developers need
+  to know about should be accounted for. Trivial changes (formatting, internal refactors with no
+  behavioral impact, tooling updates) do not need to be included.
+- **No duplication**: Don't repeat the same change across sections. Pick the most relevant section.
+- **Punctuation**: End each bullet with a period.

--- a/docs/upgrade-notes/v78-upgrade-notes.md
+++ b/docs/upgrade-notes/v78-upgrade-notes.md
@@ -1,0 +1,78 @@
+# Hoist React v78 Upgrade Notes
+
+> **From:** v77.x → v78.0.0 | **Released:** 2025-11-21 | **Difficulty:** 🎉 TRIVIAL
+
+## Overview
+
+Hoist React v78 is a small release with only one breaking change to grid column state management.
+
+The most significant app-level impact is:
+
+- **`GridModel.setColumnState` behavior change** — the method now replaces column state wholesale
+  instead of patching. Apps relying on the previous patching behavior must switch to
+  `GridModel.applyColumnStateChanges`.
+
+## Prerequisites
+
+Before starting, ensure:
+
+- [ ] Running hoist-react v77.x
+
+## Upgrade Steps
+
+### 1. Update `package.json`
+
+Bump hoist-react to v78.
+
+**File:** `package.json`
+
+Before:
+```json
+"@xh/hoist": "~77.1.0"
+```
+
+After:
+```json
+"@xh/hoist": "~78.0.0"
+```
+
+### 2. Update `GridModel.setColumnState` Usage
+
+`GridModel.setColumnState` no longer patches existing column state — it replaces it wholesale.
+If your app passes a partial column state object expecting it to be merged with existing state,
+switch to `GridModel.applyColumnStateChanges` instead.
+
+**Find affected files:**
+```bash
+grep -r "setColumnState" client-app/src/
+```
+
+Before:
+```typescript
+// Partial update — this no longer works as a patch
+gridModel.setColumnState({visible: ['name', 'status']});
+```
+
+After:
+```typescript
+// Use applyColumnStateChanges for partial updates
+gridModel.applyColumnStateChanges({visible: ['name', 'status']});
+```
+
+If your app always passes a complete column state object to `setColumnState`, no change is needed.
+
+Note: `GridModel.cleanColumnState` is now private. This is not expected to impact applications.
+
+## Verification Checklist
+
+After completing all steps:
+
+- [ ] `yarn install` completes without errors
+- [ ] `npx tsc --noEmit` passes
+- [ ] Application loads without console errors
+- [ ] Grids with persisted or programmatically managed column state function correctly
+- [ ] Column visibility, ordering, and sizing work as expected
+
+## Reference
+
+- [Toolbox on GitHub](https://github.com/xh/toolbox) — canonical example of a Hoist app

--- a/docs/upgrade-notes/v79-upgrade-notes.md
+++ b/docs/upgrade-notes/v79-upgrade-notes.md
@@ -1,0 +1,227 @@
+# Hoist React v79 Upgrade Notes
+
+> **From:** v78.x → v79.0.0 | **Released:** 2026-01-05 | **Difficulty:** 🟠 MEDIUM
+
+## Overview
+
+Hoist React v79 upgrades Blueprint from v5 to v6 and includes several API renames. A server-side
+upgrade to hoist-core >= v35 is recommended but not strictly required.
+
+The most significant app-level impacts are:
+
+- **Blueprint 5 → 6 CSS prefix migration** — all custom CSS targeting `bp5-*` classes must change
+  to `bp6-*`
+- **`tsconfig.json` update** — `moduleResolution` must be set to `"bundler"`
+- **`loadModel` → `loadObserver` rename** — deprecated aliases remain, but apps should update
+- **`GridModel.applyColumnStateChanges` → `updateColumnState`** — renamed for clarity
+- **`TabSwitcher` / `TabContainerConfig.switcher` changes** — minor API adjustment
+- **Deprecated config removals** — `websocketsEnabled`, `popoverTitle`, `RelativeTimestamp.options`
+
+## Prerequisites
+
+Before starting, ensure:
+
+- [ ] Running hoist-react v78.x
+- [ ] hoist-core >= v35 recommended (not strictly required)
+
+## Upgrade Steps
+
+### 1. Update `package.json`
+
+Bump hoist-react. Blueprint dependencies will be updated transitively — no direct app-level
+Blueprint dependency changes are typically required.
+
+**File:** `package.json`
+
+Before:
+```json
+"@xh/hoist": "~78.1.0"
+```
+
+After:
+```json
+"@xh/hoist": "~79.0.0"
+```
+
+Run `yarn install` to pull updated transitive dependencies including Blueprint 6.
+
+### 2. Update `tsconfig.json`
+
+Set `moduleResolution` to `"bundler"`. This is required for compatibility with Blueprint 6's
+package exports.
+
+**File:** `tsconfig.json`
+
+Before:
+```json
+"moduleResolution": "node"
+```
+
+After:
+```json
+"moduleResolution": "bundler"
+```
+
+### 3. Update Blueprint CSS Prefixes
+
+Blueprint 6 changes the CSS class prefix from `bp5-` to `bp6-`. Update all custom CSS and any
+inline class references in TypeScript/TSX files.
+
+**Find affected files:**
+```bash
+grep -r "bp5-" client-app/src/
+```
+
+In SCSS files — update class selectors:
+
+Before:
+```scss
+.bp5-popover-content {
+  background-color: var(--xh-bg-alt) !important;
+}
+```
+
+After:
+```scss
+.bp6-popover-content {
+  background-color: var(--xh-bg-alt) !important;
+}
+```
+
+In TypeScript files — update inline class name strings:
+
+Before:
+```typescript
+className: `bp5-control bp5-switch bp5-inline`
+```
+
+After:
+```typescript
+className: `bp6-control bp6-switch bp6-inline`
+```
+
+Also update dark theme references:
+
+Before:
+```scss
+.xh-app.xh-dark.bp5-dark .my-widget { ... }
+```
+
+After:
+```scss
+.xh-app.xh-dark.bp6-dark .my-widget { ... }
+```
+
+See the [Blueprint 6.0 migration guide](https://github.com/palantir/blueprint/wiki/Blueprint-6.0)
+for additional details.
+
+### 4. Rename `loadModel` to `loadObserver`
+
+`LoadSupport.loadModel` has been renamed to `loadObserver` for clarity — it is a `TaskObserver`
+instance, not a `HoistModel`. The old getter remains as a deprecated alias scheduled for removal
+in v82.
+
+**Find affected files:**
+```bash
+grep -r "loadModel" client-app/src/
+```
+
+Before:
+```typescript
+const {loadModel, message, seconds} = this;
+loadModel.setMessage(message);
+
+// In component code
+mask({bind: model.loadModel})
+```
+
+After:
+```typescript
+const {loadObserver, message, seconds} = this;
+loadObserver.setMessage(message);
+
+// In component code
+mask({bind: model.loadObserver})
+```
+
+### 5. Rename `GridModel.applyColumnStateChanges` to `updateColumnState`
+
+Renamed for better symmetry with `setColumnState()`. The prior method remains as a deprecated
+alias scheduled for removal in v82.
+
+**Find affected files:**
+```bash
+grep -r "applyColumnStateChanges" client-app/src/
+```
+
+Before:
+```typescript
+gridModel.applyColumnStateChanges({visible: ['name', 'status']});
+```
+
+After:
+```typescript
+gridModel.updateColumnState({visible: ['name', 'status']});
+```
+
+### 6. Update `TabSwitcher` / `TabContainerConfig.switcher` Usage
+
+`TabContainerConfig.switcher` has been repurposed to accept a `TabSwitcherConfig` (for the model)
+rather than `TabSwitcherProps`. To pass `TabSwitcherProps` to the rendered switcher component via
+a parent `TabContainer`, use `TabContainerProps.switcher` instead.
+
+If your app imports `TabSwitcherProps` directly from its internal module path, update the import —
+it has moved to `cmp/tab/Types.ts` but remains exported from `cmp/tab/index.ts`.
+
+### 7. Tighten `LocalDate` Unit Types
+
+`LocalDate` adjustment methods now use a stricter `LocalDateUnit` type. Some less common or
+ambiguous units (e.g. `'date'` or `'d'`) are no longer accepted. Use standard units like `'day'`,
+`'month'`, `'year'`, etc.
+
+**Find affected files:**
+```bash
+grep -r "LocalDate" client-app/src/ | grep -E "\.(add|subtract|startOf|endOf)\("
+```
+
+### 8. Update `DashCanvas.rglOptions` (If Used)
+
+If your app passes `rglOptions` to `DashCanvas`, review the options for compatibility with
+`react-grid-layout` v2+. Additionally, `DashCanvasModel.containerPadding` now applies to the
+react-grid-layout div rather than the Hoist-created containing div — this may affect printing
+layouts.
+
+### 9. Remove Deprecated Configs
+
+The following previously deprecated configs have been removed:
+
+| Removed Config | Replacement |
+|---|---|
+| `AppSpec.websocketsEnabled` | Enabled by default; use `AppSpec.disableWebSockets` to opt out |
+| `GroupingChooserProps.popoverTitle` | Use `editorTitle` |
+| `RelativeTimestampProps.options` | Provide directly as top-level props |
+
+**Find affected files:**
+```bash
+grep -r "websocketsEnabled\|popoverTitle\|\.options" client-app/src/ | grep -i "timestamp\|grouping\|websocket"
+```
+
+## Verification Checklist
+
+After completing all steps:
+
+- [ ] `yarn install` completes without errors
+- [ ] `yarn lint` passes (or only pre-existing warnings remain)
+- [ ] `npx tsc --noEmit` passes
+- [ ] Application loads without console errors
+- [ ] No `bp5-` CSS classes remain: `grep -r "bp5-" client-app/src/`
+- [ ] Grids render and function correctly
+- [ ] Components using masks/loading indicators display correctly
+- [ ] Tab containers function correctly, including any dynamic tab switchers
+- [ ] DashCanvas widgets (if used) render and resize correctly
+- [ ] No deprecated patterns remain: `grep -r "loadModel\|applyColumnStateChanges\|websocketsEnabled" client-app/src/`
+
+## Reference
+
+- [Blueprint 6.0 migration guide](https://github.com/palantir/blueprint/wiki/Blueprint-6.0)
+- [Toolbox on GitHub](https://github.com/xh/toolbox) — canonical example of a Hoist app

--- a/docs/upgrade-notes/v80-upgrade-notes.md
+++ b/docs/upgrade-notes/v80-upgrade-notes.md
@@ -1,0 +1,201 @@
+# Hoist React v80 Upgrade Notes
+
+> **From:** v79.x → v80.0.0 | **Released:** 2026-01-27 | **Difficulty:** 🟢 LOW
+
+## Overview
+
+Hoist React v80 is primarily a CSS-focused release, refactoring `FormField` CSS classes to follow
+BEM conventions and completing the `loadModel` → `loadObserver` rename started in v79.
+
+The most significant app-level impacts are:
+
+- **FormField CSS class BEM refactoring** — element classes use `__` separator, modifier classes
+  use `--` separator
+- **`XH.appLoadModel` → `XH.appLoadObserver`** — completing the v79 rename
+- **Removed instance getters** — `Store.isStore`, `View.isView`, `Filter.isFilter` replaced by
+  static typeguards
+- **jQuery resolution required** — apps must add a `"jquery": "3.x"` resolution to prevent a
+  transitive dependency break
+- **`--xh-font-family` applies to inputs** — may require wider date inputs in some cases
+
+## Prerequisites
+
+Before starting, ensure:
+
+- [ ] Running hoist-react v79.x
+
+## Upgrade Steps
+
+### 1. Update `package.json`
+
+Bump hoist-react and add a `jquery` resolution to prevent the `golden-layout` transitive
+dependency from pulling in jQuery 4.x (which breaks the library).
+
+**File:** `package.json`
+
+Before:
+```json
+"@xh/hoist": "~79.0.0"
+```
+
+After:
+```json
+"@xh/hoist": "~80.0.0"
+```
+
+Add to `resolutions` (create the section if it doesn't exist):
+
+```json
+"resolutions": {
+  "jquery": "3.x"
+}
+```
+
+Run `yarn install` after making these changes.
+
+### 2. Update FormField CSS Classes
+
+FormField CSS classes have been refactored to follow BEM conventions. Element sub-components use
+`__` (double underscore) and modifier/state classes use `--` (double hyphen).
+
+**Find affected files:**
+```bash
+grep -r "xh-form-field-" client-app/src/
+```
+
+#### Element Classes (child components)
+
+| Before | After |
+|--------|-------|
+| `xh-form-field-label` | `xh-form-field__label` |
+| `xh-form-field-inner` | `xh-form-field__inner` |
+| `xh-form-field-info` | `xh-form-field__inner__info-msg` |
+| `xh-form-field-error-msg` | `xh-form-field__inner__validation-msg` |
+| `xh-form-field-error-tooltip` | `xh-form-field__validation-tooltip` |
+| `xh-form-field-required-indicator` | `xh-form-field__required-indicator` |
+| `xh-form-field-readonly-display` | `xh-form-field__readonly-display` |
+| `xh-form-field-inner--flex` | `xh-form-field__inner--flex` |
+| `xh-form-field-inner--block` | `xh-form-field__inner--block` |
+
+#### Modifier Classes (state/variant)
+
+| Before | After |
+|--------|-------|
+| `xh-form-field-required` | `xh-form-field--required` |
+| `xh-form-field-inline` | `xh-form-field--inline` |
+| `xh-form-field-minimal` | `xh-form-field--minimal` |
+| `xh-form-field-readonly` | `xh-form-field--readonly` |
+| `xh-form-field-disabled` | `xh-form-field--disabled` |
+| `xh-form-field-invalid` | `xh-form-field--invalid` |
+| `xh-form-field-{inputType}` | `xh-form-field--{inputType}` |
+
+Example — the commonly targeted label class:
+
+Before:
+```scss
+.xh-form-field .xh-form-field-label {
+  font-size: var(--xh-font-size-large-px);
+}
+```
+
+After:
+```scss
+.xh-form-field .xh-form-field__label {
+  font-size: var(--xh-font-size-large-px);
+}
+```
+
+**Consider using CSS variables instead:** v80 introduces new CSS variables for common FormField
+label customizations. These provide a cleaner alternative to class-based overrides:
+
+```scss
+.my-form-container {
+  --xh-form-field-label-text-transform: uppercase;
+  --xh-form-field-label-font-size: 0.8em;
+  --xh-form-field-label-color: var(--xh-text-color-muted);
+  --xh-form-field-label-font-weight: bold;
+}
+```
+
+See `styles/vars.scss` for the full list of `--xh-form-field-*` CSS variables.
+
+### 3. Rename `XH.appLoadModel` to `XH.appLoadObserver`
+
+Completing the `loadModel` → `loadObserver` rename started in v79. The prior getter
+`XH.appLoadModel` remains as a deprecated alias scheduled for removal in v82.
+
+**Find affected files:**
+```bash
+grep -r "appLoadModel" client-app/src/
+```
+
+Before:
+```typescript
+mask({bind: XH.appLoadModel})
+```
+
+After:
+```typescript
+mask({bind: XH.appLoadObserver})
+```
+
+Note: If you didn't update `model.loadModel` references in v79, do so now — see the
+[v79 upgrade notes](./v79-upgrade-notes.md#4-rename-loadmodel-to-loadobserver).
+
+### 4. Replace Removed Instance Getters with Static Typeguards
+
+The following instance getters have been removed:
+
+| Removed | Replacement |
+|---------|-------------|
+| `store.isStore` | `Store.isStore(store)` |
+| `view.isView` | `View.isView(view)` |
+| `filter.isFilter` | `Filter.isFilter(filter)` |
+
+**Find affected files:**
+```bash
+grep -r "\.isStore\|\.isView\|\.isFilter" client-app/src/
+```
+
+Before:
+```typescript
+if (source.isStore) { ... }
+```
+
+After:
+```typescript
+import {Store} from '@xh/hoist/data';
+if (Store.isStore(source)) { ... }
+```
+
+### 5. Review Input Sizing for Font Change
+
+The `--xh-font-family` CSS variable now applies to `input` elements (previously they used the
+browser default font). This brings inputs in line with the rest of the app but may cause some
+tightly-sized inputs (e.g. `DateInput` with narrow explicit width) to clip content.
+
+If needed, customize the input font separately:
+```scss
+:root {
+  --xh-input-font-family: 'Your Preferred Font', sans-serif;
+}
+```
+
+Or widen affected inputs to accommodate the (slightly wider) Inter font with tabular numbers.
+
+## Verification Checklist
+
+After completing all steps:
+
+- [ ] `yarn install` completes without errors
+- [ ] `yarn lint` passes (or only pre-existing warnings remain)
+- [ ] `npx tsc --noEmit` passes
+- [ ] Application loads without console errors
+- [ ] Form fields render correctly — labels, validation messages, and readonly displays
+- [ ] No old FormField CSS classes remain: `grep -r "xh-form-field-[a-z]" client-app/src/ | grep -v "xh-form-field--\|xh-form-field__"`
+- [ ] Date inputs and other tightly-sized inputs are not clipping
+- [ ] No deprecated patterns remain: `grep -r "appLoadModel\|\.isStore\b\|\.isView\b\|\.isFilter\b" client-app/src/`
+
+## Reference
+
+- [Toolbox on GitHub](https://github.com/xh/toolbox) — canonical example of a Hoist app

--- a/docs/upgrade-notes/v81-upgrade-notes.md
+++ b/docs/upgrade-notes/v81-upgrade-notes.md
@@ -1,0 +1,155 @@
+# Hoist React v81 Upgrade Notes
+
+> **From:** v80.x → v81.0.0 | **Released:** _unreleased_ | **Difficulty:** 🟢 LOW
+
+**Note:** This guide is a draft for the upcoming v81 release and may be updated before the final
+release.
+
+## Overview
+
+Hoist React v81 introduces a new `Card` component (requiring a rename of the Blueprint `Card`
+export), a Panel CSS class rename, and a signature change to `HoistAuthModel.completeAuthAsync`.
+
+The most significant app-level impacts are:
+
+- **Panel CSS class rename** — `xh-panel__content` → `xh-panel__inner`
+- **`HoistAuthModel.completeAuthAsync` return type change** — `boolean` → `IdentityInfo`
+- **Blueprint `Card` → `BpCard` rename** — `card` factory → `bpCard`
+- **Requires hoist-core >= v36.1**
+
+## Prerequisites
+
+Before starting, ensure:
+
+- [ ] Running hoist-react v80.x
+- [ ] hoist-core upgraded to >= v36.1
+
+## Upgrade Steps
+
+### 1. Update `package.json`
+
+Bump hoist-react. Ensure hoist-core is also upgraded to >= v36.1.
+
+**File:** `package.json`
+
+Before:
+```json
+"@xh/hoist": "~80.0.0"
+```
+
+After:
+```json
+"@xh/hoist": "~81.0.0"
+```
+
+### 2. Update Panel CSS Class References
+
+The CSS class on Panel's outer structural wrapper has been renamed from `xh-panel__content` to
+`xh-panel__inner`. The `xh-panel__content` class is now used on the new inner frame wrapping
+content items (the target of the new `contentBoxProps`).
+
+**Find affected files:**
+```bash
+grep -r "xh-panel__content" client-app/src/
+```
+
+Before:
+```scss
+.xh-panel__content {
+  padding: 10px;
+}
+```
+
+After:
+```scss
+.xh-panel__inner {
+  padding: 10px;
+}
+```
+
+Review each usage carefully — if you were targeting the wrapper around a Panel's content items,
+the new `xh-panel__content` class (or `Panel.contentBoxProps`) may be more appropriate than
+`xh-panel__inner`.
+
+### 3. Update `HoistAuthModel.completeAuthAsync` Return Type
+
+`HoistAuthModel.completeAuthAsync` now returns `Promise<IdentityInfo>` instead of
+`Promise<boolean>`. Similarly, `getAuthStatusFromServerAsync` and `loginWithCredentialsAsync`
+return `IdentityInfo` (or `null` if not authenticated) instead of `boolean`.
+
+**Find affected files:**
+```bash
+grep -r "completeAuthAsync" client-app/src/
+```
+
+If your app overrides `completeAuthAsync`, update its return type:
+
+Before:
+```typescript
+override async completeAuthAsync(): Promise<boolean> {
+    const authenticated = await this.myAuthProvider.checkAuth();
+    return authenticated;
+}
+```
+
+After:
+```typescript
+override async completeAuthAsync(): Promise<IdentityInfo> {
+    const result = await this.myAuthProvider.checkAuth();
+    if (!result) return null;
+    return this.getAuthStatusFromServerAsync();
+}
+```
+
+The key change: return `IdentityInfo` (from `getAuthStatusFromServerAsync()`) on success, or
+`null` on failure — instead of `true`/`false`.
+
+For apps using OAuth clients (`MsalClient`, `AuthZeroClient`), those classes have been updated
+internally to return `IdentityInfo`. Check your `AuthModel` for any intermediate handling of
+the boolean return value.
+
+### 4. Rename Blueprint `Card` to `BpCard`
+
+The Blueprint `Card` component export has been renamed to `BpCard` (and `card` factory to
+`bpCard`) to avoid collision with the new Hoist `Card` component.
+
+**Find affected files:**
+```bash
+grep -r "import.*Card.*blueprint\|from.*kit/blueprint.*Card\|\bcard(" client-app/src/
+```
+
+Before:
+```typescript
+import {Card, card} from '@xh/hoist/kit/blueprint';
+
+// In component
+card({elevation: 2, items: [...]})
+```
+
+After:
+```typescript
+import {BpCard, bpCard} from '@xh/hoist/kit/blueprint';
+
+// In component
+bpCard({elevation: 2, items: [...]})
+```
+
+Note: If your app does not directly use Blueprint's `Card` component, no change is needed.
+
+## Verification Checklist
+
+After completing all steps:
+
+- [ ] `yarn install` completes without errors
+- [ ] `yarn lint` passes (or only pre-existing warnings remain)
+- [ ] `npx tsc --noEmit` passes
+- [ ] Application loads without console errors
+- [ ] Authentication works (login/logout) — verify the auth model changes
+- [ ] Panels render correctly — check any custom CSS targeting panel structure
+- [ ] No old patterns remain: `grep -r "xh-panel__content\b" client-app/src/` (check intentional
+  uses of the new `xh-panel__content` class vs. leftover references to the old meaning)
+- [ ] Blueprint Card usages compile (if applicable)
+
+## Reference
+
+- [Toolbox on GitHub](https://github.com/xh/toolbox) — canonical example of a Hoist app


### PR DESCRIPTION
## Summary

- Ports the `xh-upgrade-notes` skill from hoist-core, adapted for hoist-react's JS/React ecosystem
- Adds `docs/changelog-format.md` as a standalone CHANGELOG conventions reference
- Produces upgrade guides for v78, v79, v80, and v81 (draft) with breaking changes, before/after code examples, search commands, and verification checklists
- Updates `docs/README.md` with a new Upgrade Notes section and index entries

## New Files

| File | Description |
|------|-------------|
| `docs/changelog-format.md` | CHANGELOG entry format conventions (7 emoji-prefixed section types) |
| `.claude/skills/xh-upgrade-notes/SKILL.md` | 5-phase skill definition (setup, research, CHANGELOG, notes, validation) |
| `.claude/skills/xh-upgrade-notes/template.md` | Upgrade notes document template with step ordering and difficulty ratings |
| `docs/upgrade-notes/v78-upgrade-notes.md` | 🎉 TRIVIAL — `GridModel.setColumnState` behavior change |
| `docs/upgrade-notes/v79-upgrade-notes.md` | 🟠 MEDIUM — Blueprint 5→6, `moduleResolution`, `loadModel` → `loadObserver` |
| `docs/upgrade-notes/v80-upgrade-notes.md` | 🟢 LOW — FormField BEM CSS classes, jQuery resolution, removed instance getters |
| `docs/upgrade-notes/v81-upgrade-notes.md` | 🟢 LOW (draft) — Panel CSS rename, `completeAuthAsync` return type, `BpCard` |

## Test plan

- [ ] Review upgrade guide content against CHANGELOG entries for accuracy
- [ ] Verify all links in `docs/README.md` resolve correctly
- [ ] Spot-check before/after code examples against Toolbox upgrade commits
- [ ] Confirm skill loads via `/xh-upgrade-notes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)