### PR TITLE
Add expand/collapse affordance to grouped grid column headers

### DIFF
--- a/cmp/grid/columns/Column.ts
+++ b/cmp/grid/columns/Column.ts
@@ -124,8 +124,9 @@ export interface ColumnSpec {
     headerTooltip?: string;
 
     /**
-     * True if this column header will host an expand/collapse all icon. `Column.isTreeColumn`
-     * must be enabled. Defaults to true.
+     * True if this column header can host an expand/collapse all icon. For tree grids, the icon
+     * appears on the column with `isTreeColumn` enabled. For grouped grids, the icon appears on
+     * the leftmost visible column (with this flag set to true). Defaults to true.
      */
     headerHasExpandCollapse?: boolean;
 

--- a/desktop/cmp/grid/columns/Actions.ts
+++ b/desktop/cmp/grid/columns/Actions.ts
@@ -39,6 +39,7 @@ export const actionCol: ColumnSpec = {
     sortable: false,
     resizable: false,
     filterable: false,
+    headerHasExpandCollapse: false,
     excludeFromExport: true,
     rendererIsComplex: true,
     renderer: (value, {record, column}) => {


### PR DESCRIPTION
## Summary
- Grouped grids now display an expand/collapse-all icon in the leftmost visible column header, matching existing tree grid behavior
- Icon automatically targets the first eligible visible column, reacting to column reorder, hide/show, and groupBy changes
- Opts `actionCol` out of hosting the icon via `headerHasExpandCollapse: false`

Closes #3545

## Test plan
- [ ] Grouped grid shows icon in leftmost column header
- [ ] Click icon expands/collapses all groups
- [ ] Icon state reflects majority expanded/collapsed
- [ ] Dynamic groupBy changes show/hide icon
- [ ] Column reorder moves icon to new leftmost
- [ ] Tree grid behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)