### PR TITLE
Fix localStorage.removeItem bug in BaseOAuthClient

### DIFF
--- a/security/BaseOAuthClient.ts
+++ b/security/BaseOAuthClient.ts
@@ -379,7 +379,10 @@ export abstract class BaseOAuthClient<
     }
 
     protected setLocalStorage(key: string, value: any) {
-        if (value == null) window.localStorage.removeItem(value);
+        if (value == null) {
+            window.localStorage.removeItem(key);
+            return;
+        }
         if (isObject(value)) value = JSON.stringify(value);
         window.localStorage.setItem(key, value);
     }


### PR DESCRIPTION
## Description
Fixed a bug in the `setLocalStorage` method where `localStorage.removeItem()` was being called with the wrong parameter. The method was passing `value` instead of `key`, causing the removal operation to fail when attempting to clear null values from storage.

## Changes
- Fixed `setLocalStorage` to pass the correct `key` parameter to `localStorage.removeItem()`
- Added early return after removal to avoid unnecessary subsequent operations

## Checklist
- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

## Test Plan
This is a straightforward bug fix. Existing unit tests for the `setLocalStorage` method should verify the correct behavior when `value` is null.

https://claude.ai/code/session_01P8MhNMadpeKqbZG5poGpci