### PR TITLE
Fix `Store.getFieldValues()` to include null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@
   from a `DashCanvasItemState[]` array without wrapping it in a `PersistableState` object.
 * `FieldFilter` logs console warning if configured with unknown field not found in linked Store.
 
+### 🐞 Bug Fixes
+
+* Fixed `Store.getFieldValues()` to include `null` in its returned set when records contain
+  null/undefined values. Previously these were silently excluded, preventing grid column filters
+  from offering a [blank] option.
+
 ### 🤖 AI Docs + Tooling
 
 * Refactored documentation indexing to better support both MCP (LLM) and the Toolbox Docs viewer.

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -849,12 +849,12 @@ export class Store
         const ret = new Set();
         recs.forEach(rec => {
             const val = rec.get(fieldName);
-            if (!isNil(val)) {
-                if (field.type === 'tags') {
-                    val.forEach(it => ret.add(it));
-                } else {
-                    ret.add(val);
-                }
+            if (isNil(val)) {
+                ret.add(null);
+            } else if (field.type === 'tags') {
+                val.forEach(it => ret.add(it));
+            } else {
+                ret.add(val);
             }
         });
 


### PR DESCRIPTION
## Summary
- Fixed `Store.getFieldValues()` to include `null` in its returned set when records contain null/undefined values, so grid column filters can offer a [blank] option.

## Test plan
- [x] Verify grid column filters show a [blank] entry when data contains null values
- [x] Verify non-null values continue to appear as expected
- [x] Verify tags-type fields still expand correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)