### PR TITLE
Add suppressStackTrace and includeStartMessages to Log Levels admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 84.0.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)
+
+* Requires `hoist-core >= 38.0`.
+
+### ⚙️ Technical
+
+* Added `suppressStackTrace` and `includeStartMessages` fields to the Log Levels admin panel,
+  supporting the new hoist-core per-logger logging behavior overrides.
+
 ## 83.0.2 - 2026-03-30
 
 ### ⚙️ Technical

--- a/admin/tabs/cluster/instances/logs/levels/LogLevelDialogModel.ts
+++ b/admin/tabs/cluster/instances/logs/levels/LogLevelDialogModel.ts
@@ -62,15 +62,13 @@ export class LogLevelDialogModel extends HoistModel {
                     {name: 'level', type: 'string', displayName: 'Override', lookupName: 'levels'},
                     {
                         name: 'suppressStackTrace',
-                        type: 'auto',
-                        displayName: 'Suppress Stack',
-                        lookupName: 'suppressStackTraces'
+                        type: 'bool',
+                        displayName: 'Suppress Stack'
                     },
                     {
                         name: 'includeStartMessages',
-                        type: 'auto',
-                        displayName: 'Start Msgs',
-                        lookupName: 'includeStartMessages'
+                        type: 'bool',
+                        displayName: 'Start Msgs'
                     },
                     {name: 'defaultLevel', type: 'string', displayName: 'Initial', editable: false},
                     {
@@ -90,8 +88,8 @@ export class LogLevelDialogModel extends HoistModel {
                 {field: 'defaultLevel', width: 110},
                 {field: 'level', width: 110},
                 {field: 'effectiveLevel', width: 110},
-                {field: 'suppressStackTrace', width: 120, renderer: boolFlagRenderer},
-                {field: 'includeStartMessages', width: 120, renderer: boolFlagRenderer},
+                {field: 'suppressStackTrace', width: 120},
+                {field: 'includeStartMessages', width: 120},
                 Col.lastUpdated,
                 Col.lastUpdatedBy
             ],
@@ -101,15 +99,11 @@ export class LogLevelDialogModel extends HoistModel {
                     formField: {
                         item: textInput({
                             placeholder: 'com.myapp.MyClassWithLogging (or partial path)'
-                        })
+                        }),
+                        info: 'Hint - leave in place with no values set below to easily adjust again later.'
                     }
                 },
-                {
-                    field: 'level',
-                    formField: {
-                        info: 'Hint - clear to leave at default while keeping record in place to adjust again later.'
-                    }
-                },
+                {field: 'level'},
                 {field: 'suppressStackTrace'},
                 {field: 'includeStartMessages'},
                 {field: 'lastUpdated'},
@@ -117,8 +111,4 @@ export class LogLevelDialogModel extends HoistModel {
             ]
         });
     }
-}
-
-function boolFlagRenderer(v: any): string {
-    return v == null ? 'None' : String(v);
 }

--- a/admin/tabs/cluster/instances/logs/levels/LogLevelDialogModel.ts
+++ b/admin/tabs/cluster/instances/logs/levels/LogLevelDialogModel.ts
@@ -60,6 +60,18 @@ export class LogLevelDialogModel extends HoistModel {
                         required: true
                     },
                     {name: 'level', type: 'string', displayName: 'Override', lookupName: 'levels'},
+                    {
+                        name: 'suppressStackTrace',
+                        type: 'auto',
+                        displayName: 'Suppress Stack',
+                        lookupName: 'suppressStackTraces'
+                    },
+                    {
+                        name: 'includeStartMessages',
+                        type: 'auto',
+                        displayName: 'Start Msgs',
+                        lookupName: 'includeStartMessages'
+                    },
                     {name: 'defaultLevel', type: 'string', displayName: 'Initial', editable: false},
                     {
                         name: 'effectiveLevel',
@@ -78,6 +90,8 @@ export class LogLevelDialogModel extends HoistModel {
                 {field: 'defaultLevel', width: 110},
                 {field: 'level', width: 110},
                 {field: 'effectiveLevel', width: 110},
+                {field: 'suppressStackTrace', width: 120, renderer: boolFlagRenderer},
+                {field: 'includeStartMessages', width: 120, renderer: boolFlagRenderer},
                 Col.lastUpdated,
                 Col.lastUpdatedBy
             ],
@@ -96,9 +110,15 @@ export class LogLevelDialogModel extends HoistModel {
                         info: 'Hint - clear to leave at default while keeping record in place to adjust again later.'
                     }
                 },
+                {field: 'suppressStackTrace'},
+                {field: 'includeStartMessages'},
                 {field: 'lastUpdated'},
                 {field: 'lastUpdatedBy'}
             ]
         });
     }
+}
+
+function boolFlagRenderer(v: any): string {
+    return v == null ? 'None' : String(v);
 }


### PR DESCRIPTION
## Summary
- Added `suppressStackTrace` and `includeStartMessages` fields to the Log Levels admin dialog.
- Fields use `type: 'bool'` with nullable support, displaying as checkboxes in the grid and editor.
- Requires `hoist-core >= 38.0`.

## Test plan
- [x] Verify new columns appear in the Log Levels dialog grid
- [ ] Verify fields are editable in the add/edit form
- [ ] Verify null/true/false values round-trip correctly with hoist-core

🤖 Generated with [Claude Code](https://claude.com/claude-code)