### PR TITLE
Accept string/SpanConfig on FetchOptions.span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
   creation, with child spans inheriting their parent's decision. Error spans are always exported
   when `alwaysSampleErrors` is enabled. The `traceparent` header now propagates the sampling flag to
   the server.
+* `FetchOptions.span` now accepts a `string` or `SpanConfig` in addition to an existing `Span`.
+  When a string or config is provided, `FetchService` creates and manages the parent span
+  internally, simplifying a common tracing pattern for fetch calls.
 
 ### 🐞 Bug Fixes
 

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -14,7 +14,7 @@ import {
     XH
 } from '@xh/hoist/core';
 import {Exception, HoistException, TimeoutException} from '@xh/hoist/exception';
-import {formatTraceparent, Span} from '@xh/hoist/utils/telemetry';
+import {formatTraceparent, Span, SpanConfig} from '@xh/hoist/utils/telemetry';
 import {PromiseTimeoutSpec} from '@xh/hoist/promise';
 import {isLocalDate, SECONDS} from '@xh/hoist/utils/datetime';
 import {apiDeprecated, warnIf} from '@xh/hoist/utils/js';
@@ -197,6 +197,13 @@ export class FetchService extends HoistService {
     // Implementation
     //-----------------------
     private async fetchInternalAsync(opts: FetchOptions): Promise<any> {
+        // If a span spec provided create, wrap, and recurse
+        if (opts.span && !(opts.span instanceof Span)) {
+            return XH.traceService.withSpanAsync(opts.span, span =>
+                this.fetchInternalAsync({...opts, span})
+            );
+        }
+
         opts = this.withCorrelationId(opts);
 
         // Tracing - create span for this request.
@@ -425,7 +432,7 @@ export class FetchService extends HoistService {
         return traceService.createSpan({
             name: method,
             kind: 'client',
-            parent: opts.span,
+            parent: opts.span as Span,
             tags: {'http.request.method': method, 'url.path': opts.url, 'xh.source': 'hoist'},
             caller: this
         });
@@ -759,10 +766,12 @@ export interface FetchOptions {
     track?: string | TrackOptions;
 
     /**
-     * If set, the fetch span created by TraceService will be parented under this span.
-     * Use to nest fetch calls under a business-level span.
+     * Parent span for this fetch request. Use to nest fetch calls under a business-level span.
+     *
+     * Accepts an existing Span instance, a SpanConfig, or a string span name. When a SpanConfig or
+     * string is provided, FetchService will create and manage the parent span internally.
      */
-    span?: Span;
+    span?: Span | SpanConfig | string;
 
     /**
      * Distributed trace ID for this request. Set automatically by FetchService

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -427,13 +427,11 @@ export class FetchService extends HoistService {
         const method = opts.method ?? (opts.params ? 'POST' : 'GET'),
             url = this.extractUrlPath(opts.url);
 
-        if (url.endsWith('submitSpans')) return null;
-
         return traceService.createSpan({
             name: method,
             kind: 'client',
             parent: opts.span as Span,
-            tags: {'http.request.method': method, 'url.path': opts.url, 'xh.source': 'hoist'},
+            tags: {'http.request.method': method, 'url.path': url, 'xh.source': 'hoist'},
             caller: this
         });
     }
@@ -464,7 +462,7 @@ export class FetchService extends HoistService {
         }
     }
 
-    private qsFilterFn = (prefix, value) => {
+    private qsFilterFn = (_prefix: string, value: any) => {
         if (isDate(value)) return value.getTime();
         if (isLocalDate(value)) return value.isoString;
         return value;

--- a/svc/README.md
+++ b/svc/README.md
@@ -128,15 +128,16 @@ override async doLoadAsync(loadSpec: LoadSpec) {
 
 **Configuration Options:**
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `url` | string | Request URL (relative URLs appended to `XH.baseUrl`) |
-| `body` | any | Request body |
-| `params` | object | Query string parameters |
-| `headers` | object | Additional headers |
-| `timeout` | number | Timeout in ms (default 30000) |
-| `autoAbortKey` | string | Cancel previous requests with same key |
-| `loadSpec` | LoadSpec | Metadata for tracking |
+| Option | Type | Description                                                                           |
+|--------|------|---------------------------------------------------------------------------------------|
+| `url` | string | Request URL (relative URLs appended to `XH.baseUrl`)                                  |
+| `body` | any | Request body                                                                          |
+| `params` | object | Query string parameters                                                               |
+| `headers` | object | Additional headers                                                                    |
+| `timeout` | number | Timeout in ms (default 30000)                                                         |
+| `autoAbortKey` | string | Cancel previous requests with same key                                                |
+| `loadSpec` | LoadSpec | Metadata for tracking                                                                 |
+| `span` | `Span \| string \| SpanConfig` | Parent span for tracing. Accepts an existing `Span`, a `SpanConfig`, or a string name |
 
 **App-Level Defaults (`FetchService.defaults`):**
 
@@ -335,6 +336,17 @@ const result = this.withSpan({name: 'computeTotals', caller: this}, span => {
 
 // Simple string-only config
 await this.withSpanAsync('loadData', async span => { ... });
+
+// Nest a fetch call under a parent span without manual span management.
+// FetchService accepts a string, SpanConfig, or existing Span as the `span` option.
+const data = await XH.fetchJson({
+    url: 'api/portfolio',
+    span: 'loadPortfolio'
+});
+const data = await XH.fetchJson({
+    url: 'api/portfolio',
+    span: {name: 'loadPortfolio', tags: {portfolioId: id}, caller: this}
+});
 ```
 
 **SpanConfig:**

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -146,7 +146,12 @@ export class TraceService extends HoistService {
     exportSpan(span: Span) {
         if (span.sampled || (this.conf.alwaysSampleErrors && span.status === 'error')) {
             this._pending.push(span);
-            this.pushPendingBuffered();
+
+            // Queue the span, but if this is the submitSpans export itself, don't schedule
+            // another flush or we'll loop forever.
+            if (!span.tags['url.path']?.endsWith('xh/submitSpans')) {
+                this.pushPendingBuffered();
+            }
         }
     }
 
@@ -177,7 +182,7 @@ export class TraceService extends HoistService {
     //------------------
     @debounced(5 * SECONDS)
     private pushPendingBuffered() {
-        this.pushPendingAsync();
+        void this.pushPendingAsync();
     }
 
     /** Evaluate sampling rules against a span's tags. */


### PR DESCRIPTION
## Summary

* Widened `FetchOptions.span` from `Span` to `Span | SpanConfig | string`. When a string or `SpanConfig` is provided, `FetchService` creates and manages the parent span internally via `withSpanAsync`, then recurses with the realized `Span`.
* Updated `svc/README.md` with the new option in the FetchService config table and added usage examples in the TraceService section.
* Added changelog entry.
* Fixed `url.path` span tag to use the extracted path rather than the raw `opts.url`, and moved the `submitSpans` self-loop guard into `TraceService.exportSpan` so the submit span is still captured but doesn't trigger another flush.

## Test plan

- [ ] Verify fetch calls with `span: 'someName'` produce a parent span wrapping the HTTP span
- [ ] Verify fetch calls with `span: {name: '...', tags: {...}}` produce a correctly tagged parent span
- [ ] Verify fetch calls with an existing `Span` instance continue to work as before
- [ ] Verify fetch calls without `span` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)