### PR TITLE
Admin Servers tab auto-selects primary instance on first load

### DIFF
--- a/admin/tabs/cluster/instances/InstancesTabModel.ts
+++ b/admin/tabs/cluster/instances/InstancesTabModel.ts
@@ -71,7 +71,10 @@ export class InstancesTabModel extends HoistModel {
             usedPctMax: row.memory?.usedPctMax
         }));
         gridModel.loadData(data);
-        await gridModel.preSelectFirstAsync();
+        if (!gridModel.hasSelection) {
+            const primary = gridModel.store.records.find(r => r.data.isPrimary);
+            await (primary ? gridModel.selectAsync(primary) : gridModel.selectFirstAsync());
+        }
     }
 
     constructor() {


### PR DESCRIPTION
## Summary

- Admin Console's Servers tab now auto-selects the primary instance on first load, instead of whichever record happens to sort first. The primary is the most useful default and best orients the admin viewer in multi-instance scenarios.
- Existing user selections are preserved across refreshes via a `!hasSelection` guard. Falls back to first record if no primary is present.

Closes #4315

## Test plan

- [ ] Load the Admin Console Servers tab in a multi-instance deployment - confirm the primary instance is auto-selected
- [ ] Select a non-primary instance and wait for auto-refresh - confirm selection is preserved
- [ ] Load in a single-instance deployment - confirm that instance is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)