### PR TITLE
Bug fixes and ergonomic improvements to TraceService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 85.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* Improved `withSpan`/`withSpanAsync` to always provide a non-nullable `Span`, matching the
+  server-side API. Added `Span.setTag()`/`setTags()`.
+
+### 🐞 Bug Fixes
+
+* `TraceService` now includes the `user.name` tag on all spans, matching the server-side
+  convention.
+* `HoistBase.withSpan`/`withSpanAsync` now auto-populate `caller` with `this`, so emitted spans
+  correctly stamp `code.namespace`.
+
 ## 84.0.0 - 2026-04-15
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)

--- a/core/HoistBase.ts
+++ b/core/HoistBase.ts
@@ -115,11 +115,11 @@ export abstract class HoistBase {
     }
 
     withSpan<T>(config: string | SpanConfig, fn: (span: Span) => T): T {
-        return XH.traceService.withSpan(config, fn);
+        return XH.traceService.withSpan(this.enhanceSpanConfig(config), fn);
     }
 
     withSpanAsync<T>(config: string | SpanConfig, fn: (span: Span) => Promise<T>): Promise<T> {
-        return XH.traceService.withSpanAsync(config, fn);
+        return XH.traceService.withSpanAsync(this.enhanceSpanConfig(config), fn);
     }
 
     /**
@@ -313,6 +313,13 @@ export abstract class HoistBase {
         this.disposers.forEach(f => f());
         this.managedInstances.forEach(i => XH.safeDestroy(i));
         this['_xhManagedProperties']?.forEach(p => XH.safeDestroy(this[p]));
+    }
+
+    //------------------
+    // Implementation
+    //------------------
+    private enhanceSpanConfig(config: string | SpanConfig): SpanConfig {
+        return isString(config) ? {name: config, caller: this} : {caller: this, ...config};
     }
 }
 

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -198,7 +198,7 @@ export class FetchService extends HoistService {
     //-----------------------
     private async fetchInternalAsync(opts: FetchOptions): Promise<any> {
         // If a span spec provided create, wrap, and recurse
-        if (opts.span && !(opts.span instanceof Span)) {
+        if (XH.traceService.enabled && opts.span && !(opts.span instanceof Span)) {
             return XH.traceService.withSpanAsync(opts.span, span =>
                 this.fetchInternalAsync({...opts, span})
             );

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -17,8 +17,9 @@ import {Span, SpanConfig} from '@xh/hoist/utils/telemetry';
  * headers on outgoing requests so server-side spans nest under client spans, producing
  * end-to-end traces from user interaction through server processing and back.
  *
- * Controlled by the `xhTraceConfig` soft config. When disabled (the default), all
- * span-creation methods are no-ops - the wrapped function still executes normally.
+ * Controlled by the `xhTraceConfig` soft config. When disabled (the default), spans are
+ * still created and passed to wrapped functions, but are flagged as unsampled and never
+ * exported - callers can interact with the span without null checks.
  *
  * Completed spans are batched and exported to the Hoist server endpoint `xh/submitSpans`,
  * which relays them to the configured collector.
@@ -65,8 +66,6 @@ export class TraceService extends HoistService {
      */
     override withSpan<T>(config: string | SpanConfig, fn: (span: Span) => T): T {
         const span = this.createSpan(config);
-        if (!span) return fn(null);
-
         try {
             const result = fn(span);
             span.end('ok');
@@ -92,8 +91,6 @@ export class TraceService extends HoistService {
         fn: (span: Span) => Promise<T>
     ): Promise<T> {
         const span = this.createSpan(config);
-        if (!span) return fn(null);
-
         try {
             const result = await fn(span);
             span.end('ok');
@@ -108,7 +105,8 @@ export class TraceService extends HoistService {
     }
 
     /**
-     * Create a new span, or return null if tracing is disabled.
+     * Create a new span. Always returns a span - when tracing is disabled the returned span
+     * is flagged unsampled and will never be exported, so callers can interact with it safely.
      * Inherits the parent's `source` tag if not specified.
      *
      * Sampling rules from `xhTraceConfig.sampleRules` are evaluated against the span's tags
@@ -119,9 +117,9 @@ export class TraceService extends HoistService {
      * @param config - span name string, or a SpanConfig with name and optional tags.
      */
     createSpan(config: string | SpanConfig): Span {
-        if (!this.enabled) return null;
-
         const ret: SpanConfig = isString(config) ? {name: config} : {...config};
+
+        if (!this.enabled) return new Span({...ret, sampled: false});
 
         // Apply default tags.
         ret.tags = {
@@ -129,6 +127,7 @@ export class TraceService extends HoistService {
             'xh.loadId': XH.loadId,
             'xh.tabId': XH.tabId,
             'xh.source': ret.parent?.tags?.['xh.source'] ?? 'app',
+            'user.name': XH.getUsername(),
             ...(ret.caller ? {'code.namespace': parseNameSource(ret.caller)} : {}),
             ...ret.tags
         };
@@ -144,6 +143,7 @@ export class TraceService extends HoistService {
     //------------------
     /** Submit a completed span for export. */
     exportSpan(span: Span) {
+        if (!this.enabled) return;
         if (span.sampled || (this.conf.alwaysSampleErrors && span.status === 'error')) {
             this._pending.push(span);
 

--- a/utils/telemetry/Span.ts
+++ b/utils/telemetry/Span.ts
@@ -63,6 +63,16 @@ export class Span {
         this.status = status;
     }
 
+    /** Set a single tag on this span. */
+    setTag(key: string, value: any) {
+        this.tags[key] = value;
+    }
+
+    /** Merge the given tags onto this span. */
+    setTags(tags: PlainObject) {
+        Object.assign(this.tags, tags);
+    }
+
     /** Record an error event on this span and stamp traceId onto the error if not already set. */
     recordError(error: unknown) {
         const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

- `withSpan`/`withSpanAsync` now always provide a non-nullable `Span` to the wrapped fn, matching the server-side API. When tracing is disabled, the span is flagged unsampled and never exported - callers can interact with it without null checks.
- `HoistBase.withSpan`/`withSpanAsync` auto-populate `caller` with `this`, so emitted spans correctly stamp `code.namespace`.
- `TraceService` now includes the `user.name` tag on all spans, matching the server-side convention.
- Added `Span.setTag()`/`setTags()` helpers.

## Test plan

- [ ] Verify spans emitted from `HoistBase` subclasses carry correct `code.namespace`
- [ ] Confirm `user.name` tag appears on exported spans
- [ ] Verify `withSpan`/`withSpanAsync` callbacks receive a usable span when tracing is disabled