### PR TITLE
Stop persisting per-view icon in DashContainer state (#4320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,12 @@
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)
 
 * `DashContainerModel` no longer persists per-view `icon` in its layout state, aligning with
-  `DashCanvasModel`. Icons are now sourced exclusively from the `DashViewSpec` on every load,
-  avoiding stale icons when a viewSpec is updated in code. Apps that set `DashViewModel.icon` at
-  runtime can still do so - the override still drives tab header rendering via the existing
-  reaction, it just no longer round-trips through persisted state. For dynamic icons, drive them
-  from a reaction on observable state (see the "Dynamic Titles" pattern in the dash README).
-* Removed the `serializeIcon()` and `deserializeIcon()` helpers from `@xh/hoist/icon`. These were
-  used internally by the previous `DashContainer` icon persistence path and had no other
-  framework consumers. Apps that reference them directly should inline the equivalent logic
-  (`pickBy(iconEl.props)` to serialize, `Icon.icon(json)` to restore).
+  `DashCanvasModel`. Icons now always come from the `DashViewSpec`. Apps that set
+  `DashViewModel.icon` at runtime still see it render, but the override is no longer saved -
+  drive dynamic icons from a reaction on observable state.
+* Removed the `serializeIcon()` / `deserializeIcon()` helpers from `@xh/hoist/icon`, which
+  existed only to support the above. Apps still needing this can use `pickBy(iconEl.props)` and
+  `Icon.icon(json)` respectively.
 
 ### 🎁 New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   convention.
 * `HoistBase.withSpan`/`withSpanAsync` now auto-populate `caller` with `this`, so emitted spans
   correctly stamp `code.namespace`.
+* `DashContainerModel` no longer persists per-view `icon` in its layout state. Icons are now sourced
+  exclusively from the `DashViewSpec`, matching `DashCanvasModel` behavior and avoiding stale icons
+  when a viewSpec is updated in code. Apps that set `DashViewModel.icon` at runtime can still do so,
+  but the override is no longer written to persisted state - drive dynamic icons from a reaction on
+  observable state instead.
 
 ### 🤖 AI Docs + Tooling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 85.0.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)
+
+* `DashContainerModel` no longer persists per-view `icon` in its layout state, aligning with
+  `DashCanvasModel`. Icons are now sourced exclusively from the `DashViewSpec` on every load,
+  avoiding stale icons when a viewSpec is updated in code. Apps that set `DashViewModel.icon` at
+  runtime can still do so - the override still drives tab header rendering via the existing
+  reaction, it just no longer round-trips through persisted state. For dynamic icons, drive them
+  from a reaction on observable state (see the "Dynamic Titles" pattern in the dash README).
+* Removed the `serializeIcon()` and `deserializeIcon()` helpers from `@xh/hoist/icon`. These were
+  used internally by the previous `DashContainer` icon persistence path and had no other
+  framework consumers. Apps that reference them directly should inline the equivalent logic
+  (`pickBy(iconEl.props)` to serialize, `Icon.icon(json)` to restore).
+
 ### 🎁 New Features
 
 * Improved `withSpan`/`withSpanAsync` to always provide a non-nullable `Span`, matching the
@@ -13,11 +26,6 @@
   convention.
 * `HoistBase.withSpan`/`withSpanAsync` now auto-populate `caller` with `this`, so emitted spans
   correctly stamp `code.namespace`.
-* `DashContainerModel` no longer persists per-view `icon` in its layout state. Icons are now sourced
-  exclusively from the `DashViewSpec`, matching `DashCanvasModel` behavior and avoiding stale icons
-  when a viewSpec is updated in code. Apps that set `DashViewModel.icon` at runtime can still do so,
-  but the override is no longer written to persisted state - drive dynamic icons from a reaction on
-  observable state instead.
 
 ### 🤖 AI Docs + Tooling
 

--- a/desktop/cmp/dash/container/DashContainerModel.ts
+++ b/desktop/cmp/dash/container/DashContainerModel.ts
@@ -17,7 +17,7 @@ import {
     XH
 } from '@xh/hoist/core';
 import {DashContainerViewModel} from '@xh/hoist/desktop/cmp/dash/container/DashContainerViewModel';
-import {convertIconToHtml, deserializeIcon, ResolvedIconProps} from '@xh/hoist/icon';
+import {convertIconToHtml, ResolvedIconProps} from '@xh/hoist/icon';
 import {GoldenLayout} from '@xh/hoist/kit/golden-layout';
 import {action, bindable, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
@@ -665,8 +665,6 @@ export class DashContainerModel
         viewSpecs.forEach(viewSpec => {
             ret.registerComponent(viewSpec.id, data => {
                 const {viewModelId, title, viewState} = data;
-                let icon = data.icon;
-                if (icon) icon = deserializeIcon(icon);
 
                 let model = this.viewModels.find(it => it.id === viewModelId);
                 if (model) {
@@ -675,7 +673,6 @@ export class DashContainerModel
                     model = new DashContainerViewModel({
                         id: viewModelId,
                         viewSpec,
-                        icon,
                         title,
                         viewState,
                         containerModel: this

--- a/desktop/cmp/dash/container/impl/DashContainerUtils.ts
+++ b/desktop/cmp/dash/container/impl/DashContainerUtils.ts
@@ -6,7 +6,6 @@
  */
 import {PlainObject} from '@xh/hoist/core';
 import {DashContainerModel} from '@xh/hoist/desktop/cmp/dash';
-import {serializeIcon} from '@xh/hoist/icon';
 import {logWarn, throwIf} from '@xh/hoist/utils/js';
 import {isArray, isEmpty, isFinite, isNil, isPlainObject, isString, round} from 'lodash';
 import {DashContainerViewSpec} from '../DashContainerViewSpec';
@@ -50,7 +49,6 @@ function convertGLToStateInner(
                 viewModel = dashContainerModel.getViewModel(viewModelId),
                 view = {type: 'view', viewModelId, id: viewSpecId} as PlainObject;
 
-            if (viewModel.icon !== viewSpec.icon) view.icon = serializeIcon(viewModel.icon);
             if (viewModel.title !== viewSpec.title) view.title = viewModel.title;
             if (!isEmpty(viewModel.viewState)) view.state = viewModel.viewState;
 
@@ -130,7 +128,6 @@ function convertStateToGLInner(items = [], viewSpecs = [], containerSize, contai
 
             const ret = goldenLayoutConfig(viewSpec, item.viewModelId);
 
-            if (!isNil(item.icon)) ret.icon = item.icon;
             if (!isNil(item.title)) ret.title = item.title;
             if (isPlainObject(item.state)) ret.state = item.state;
             if (isFinite(width)) ret.width = width;

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,7 +123,7 @@ Cross-cutting documentation that spans multiple packages:
 
 | Package | Description | Key Topics |
 |---------|-------------|------------|
-| [`/icon/`](../icon/README.md) | Factory-based icon system wrapping FontAwesome Pro | Icon singleton, IconProps, intent coloring, size variants, asHtml, fileIcon, serializeIcon, Spinner, SpinnerProps |
+| [`/icon/`](../icon/README.md) | Factory-based icon system wrapping FontAwesome Pro | Icon singleton, IconProps, intent coloring, size variants, asHtml, fileIcon, Spinner, SpinnerProps |
 | [`/security/`](../security/README.md) | OAuth 2.0 client abstraction for Auth0 and Microsoft Entra ID (MSAL) | BaseOAuthClient, AuthZeroClient, MsalClient, Token, AccessTokenSpec, auto-refresh, re-login |
 | [`/kit/`](../kit/README.md) | Centralized wrappers for third-party libraries used by Hoist | installAgGrid, installHighcharts, Blueprint, Onsen, GoldenLayout, react-select, version constraints |
 | [`/inspector/`](../inspector/README.md) | Built-in developer tool for real-time inspection of Hoist instances and memory | InspectorPanel, StatsModel, InstancesModel, property watchlist, model leak detection |

--- a/icon/Icon.ts
+++ b/icon/Icon.ts
@@ -10,7 +10,7 @@ import {div} from '@xh/hoist/cmp/layout';
 import {HoistProps, Intent, Thunkable} from '@xh/hoist/core';
 import {throwIf} from '@xh/hoist/utils/js';
 import classNames from 'classnames';
-import {last, pickBy, split, toLower} from 'lodash';
+import {last, split, toLower} from 'lodash';
 import {ReactElement} from 'react';
 import {iconCmp} from './impl/IconCmp';
 import {enhanceFaClasses, iconHtml} from './impl/IconHtml';
@@ -957,33 +957,6 @@ export function convertIconToHtml(iconElem: ReactElement): string {
         'Icon not provided, or not created by a Hoist Icon factory - cannot convert to HTML/SVG.'
     );
     return iconHtml(iconElem.props as ResolvedIconProps);
-}
-
-/**
- * Serialize an icon into a JSON format with relevant props for persistence.
- *
- * @param iconElem - React element representing a Hoist Icon component.
- *      Must be created by Hoist's built-in Icon factories.
- * @returns JSON representation of icon.
- */
-export function serializeIcon(iconElem: ReactElement): any {
-    throwIf(
-        !(iconElem?.type as any)?.isHoistComponent,
-        'Icon not provided, or not created by a Hoist Icon factory - cannot serialize.'
-    );
-
-    return pickBy(iconElem.props as ResolvedIconProps);
-}
-
-/**
- * Deserialize an icon - the inverse operation of {@link serializeIcon}.
- *
- * @param iconDef - JSON  representation of icon, produced by serializeIcon.
- * @returns React element representing a Hoist Icon component.
- *      This is the form of element created by Hoist's built-in Icon class factories.
- */
-export function deserializeIcon(iconDef: any): ReactElement | string {
-    return Icon.icon(iconDef);
 }
 
 //-----------------------------

--- a/icon/README.md
+++ b/icon/README.md
@@ -28,7 +28,6 @@ curated set of FA Pro icons and provides:
   automatically, ensuring consistent spacing in menus, buttons, and toolbars
 - **HTML mode** — Render as raw SVG strings for non-React contexts (e.g. Highcharts tooltips)
 - **File-type icons** — `Icon.fileIcon({filename})` maps extensions to appropriate icons
-- **Serialization** — `serializeIcon()`/`deserializeIcon()` for persisting icon config as JSON
 
 ## Architecture
 
@@ -239,22 +238,6 @@ else that accepts an icon element.
 | `asHtml`    | `boolean`            | Return raw SVG string instead of React element                                                                 |
 | `className` | `string`             | Additional CSS class(es)                                                                                       |
 | `omit`      | `Thunkable<boolean>` | Skip rendering this icon when true                                                                             |
-
-## Serialization
-
-`serializeIcon()` and `deserializeIcon()` support persisting icon configuration as JSON, for apps
-that need to save and restore an icon selection:
-
-```typescript
-import {serializeIcon, deserializeIcon} from '@xh/hoist/icon';
-
-const iconEl = Icon.check({intent: 'success'});
-const json = serializeIcon(iconEl);  // {iconName: 'check', prefix: 'far', ...}
-const restored = deserializeIcon(json);  // equivalent React element
-```
-
-Both functions require that the icon element was created by Hoist's `Icon` factories — they will
-throw if passed an arbitrary React element.
 
 ## Common Pitfalls
 

--- a/icon/README.md
+++ b/icon/README.md
@@ -28,8 +28,7 @@ curated set of FA Pro icons and provides:
   automatically, ensuring consistent spacing in menus, buttons, and toolbars
 - **HTML mode** — Render as raw SVG strings for non-React contexts (e.g. Highcharts tooltips)
 - **File-type icons** — `Icon.fileIcon({filename})` maps extensions to appropriate icons
-- **Serialization** — `serializeIcon()`/`deserializeIcon()` for persisting icon config (used by
-  DashContainer to save/restore widget icons in layout state)
+- **Serialization** — `serializeIcon()`/`deserializeIcon()` for persisting icon config as JSON
 
 ## Architecture
 
@@ -243,8 +242,8 @@ else that accepts an icon element.
 
 ## Serialization
 
-`serializeIcon()` and `deserializeIcon()` support persisting icon configuration as JSON. This is
-used by DashContainerModel to save/restore widget icons as part of persisted layout state:
+`serializeIcon()` and `deserializeIcon()` support persisting icon configuration as JSON, for apps
+that need to save and restore an icon selection:
 
 ```typescript
 import {serializeIcon, deserializeIcon} from '@xh/hoist/icon';
@@ -318,5 +317,3 @@ with Hoist by default.
   via static defaults on the `Spinner` class
 - [`/desktop/`](../desktop/README.md) — Desktop components use icons extensively in buttons,
   toolbars, menus, and grid columns
-- [`/desktop/cmp/dash/`](../desktop/cmp/dash/README.md) — DashContainer uses icon serialization
-  to persist widget icons in saved layout state


### PR DESCRIPTION
Closes #4320.

## Summary

Removes per-view `icon` persistence from `DashContainerModel` layout state, and drops the `serializeIcon` / `deserializeIcon` helpers that existed to support it. Icons now come from the `DashViewSpec` on every load, matching `DashCanvasModel` and avoiding stale icons after a viewSpec is updated in code.

Marked breaking since the serialize/deserialize helpers are public exports, though the blast radius is small - no consumers in the framework or any of the sample apps.

## What changed

- `desktop/cmp/dash/container/impl/DashContainerUtils.ts` - removed the `icon` write in `convertGLToState` and the matching read in `convertStateToGL`.
- `desktop/cmp/dash/container/DashContainerModel.ts` - removed the `deserializeIcon` handling in the GoldenLayout `registerComponent` callback. The computed `viewState` getter still tracks `icon`, so an app-driven change to `DashViewModel.icon` still triggers the tab-header redraw at runtime - the override just no longer round-trips through persisted state.
- `icon/Icon.ts` - removed the `serializeIcon()` / `deserializeIcon()` exports. Apps that need the equivalent can use `pickBy(iconEl.props)` and `Icon.icon(json)`.
- `icon/README.md` and `docs/README.md` - removed references to the dropped helpers.
- `CHANGELOG.md` - breaking change entry under `85.0.0-SNAPSHOT` with 🟢 LOW upgrade difficulty.

## Why

Reviewing the code around #4320 surfaced an asymmetry: `DashContainerModel` persisted widget icons, while `DashCanvasModel` did not. Tracing the history, the icon persistence path came in alongside the tab-rename feature (#1558), which pulled `title` and `icon` out of the generic `viewState` bag so that user-driven title renames could be saved without colliding with app-defined keys. At the time, `title` and `icon` were treated as a pair - and the `icon` half of that pair carried forward by analogy.

In practice the two have different profiles:

- `title` has a first-class user action (double-click to rename), so persisting user-entered values is load-bearing.
- `icon` has no user-facing UI. It is part of the widget's identity and belongs on the `DashViewSpec`. Persisting an earlier snapshot means that if an app updates the spec icon in code, users see the old icon until they clear their layout.

`DashCanvasModel`, written later, landed without icon persistence and has served apps well that way. Removing the DashContainer half aligns the two dash types, reduces state surface area, and removes a quiet source of drift between code and persisted state. With that internal user gone, the `serializeIcon` / `deserializeIcon` helpers were stranded and could be dropped from the public API as well.

## Impact on apps

- Apps that set `DashViewModel.icon` imperatively at runtime can still do so - the override drives the tab-header render via the existing reactivity. What changes is that the override is not written to persisted state, so a reload will show the viewSpec icon again. The recommended pattern for dynamic icons (and the one documented for dynamic titles in the dash README) is to drive them from a reaction on observable app state.
- Apps that import `serializeIcon` / `deserializeIcon` from `@xh/hoist/icon` will need to inline the equivalent logic. A grep across Toolbox, Jobsite, DirectLend, and Veracity found no direct consumers.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Lint / prettier clean via pre-commit hooks
- [ ] Smoke-test a DashContainer layout in Toolbox: add/rename/remove views, reload, confirm icons render from viewSpec and titles still persist

Hoist P/R Checklist
-------------------

- [x] Caught up with \`develop\` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added \`breaking-change\` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required. (Dash is desktop-only.)
- [ ] Created Toolbox branch / PR, or determined not required.