### PR TITLE
Fix race condition in FilterChooserModel.updateSelectValueAndBind

### DIFF
--- a/cmp/filter/FilterChooserModel.ts
+++ b/cmp/filter/FilterChooserModel.ts
@@ -610,11 +610,23 @@ export class FilterChooserModel extends HoistModel {
     }
 
     /**
-     * Update the select value and bind the filter to the bound model. Runs asynchronously after
-     * selectOptions are set to ensure the component is ready to render the tags correctly.
+     * Update the select value and bind the filter to the bound model. The outbound sync to the
+     * bind target runs synchronously to avoid race conditions during persistence restoration
+     * (e.g. ViewManager). The selectValue update is deferred to ensure selectOptions are set
+     * and the component is ready to render the tags correctly.
      */
     private updateSelectValueAndBind(displayFilters = this.toDisplayFilters(this.value)) {
         const {bind, value} = this;
+
+        // Outbound sync: replace the FieldFilter portion of the bind target's filter with
+        // this model's value, preserving any FunctionFilters installed by other components
+        // (e.g. StoreFilterField). Done synchronously to ensure the bind target is updated
+        // before any deferred reactions (e.g. inbound sync) can observe stale state.
+        if (bind) {
+            const filter = appendFilter(bind.filter?.removeFieldFilters(), value);
+            bind.setFilter(filter);
+        }
+
         wait()
             .thenAction(() => {
                 // No-op if we've already re-entered this method by the time this async routine runs.
@@ -629,14 +641,6 @@ export class FilterChooserModel extends HoistModel {
                         return isFinite(idx) && idx > -1 ? idx : displayFilters.length;
                     }
                 );
-
-                // Outbound sync: replace the FieldFilter portion of the bind target's
-                // filter with this model's value, preserving any FunctionFilters
-                // installed by other components (e.g. StoreFilterField).
-                if (bind) {
-                    const filter = appendFilter(bind.filter?.removeFieldFilters(), value);
-                    bind.setFilter(filter);
-                }
             })
             .linkTo(this.filterTask);
     }


### PR DESCRIPTION
 ## Summary
  - Moved the outbound `bind.setFilter()` call in
  `FilterChooserModel.updateSelectValueAndBind` to run synchronously instead of being
   deferred behind a `wait()` microtask
  - Fixes persisted filter values being silently dropped when a ViewManager restores
  a view alongside other providers that trigger reactions on the same bind target
  - The `wait()` is retained for the `selectValue` UI update (its actual purpose)

  ## Problem
  When `ViewManagerModel.loadViewAsync` restores a view, all persistence providers
  push state in a single MobX action. `FilterChooserModel` set `this.value`
  synchronously but deferred `bind.setFilter()` behind a `wait()`. Before that
  microtask resolved, the action completed, other reactions fired and changed
  `bind.filter`, the inbound sync reaction overwrote `this.value`, and the staleness
  guard in the `wait()` callback bailed out — permanently losing the restored filter.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [ ] Caught up with `develop` branch as of last change.
- [ ] Added CHANGELOG entry, or determined not required.
- [ ] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [ ] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [ ] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

