### PR TITLE
Hoist telemetry enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,31 @@
 
 ## 85.0.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)
+
+* `XH.installServicesAsync()` no longer accepts the spread-args form. Callers must pass an
+  array of service classes plus the current phase's `span`:
+  ```ts
+  // before
+  await XH.installServicesAsync(MyServiceA, MyServiceB);
+  // after
+  await XH.installServicesAsync([MyServiceA, MyServiceB], span);
+  ```
+  The `span` is the one passed to your `AppModel.initAsync(span)` override. Forwarding it
+  ensures service-init spans nest under the `app-init` root.
+
 ### 🎁 New Features
 
 * Improved `withSpan`/`withSpanAsync` to always provide a non-nullable `Span`, matching the
   server-side API. Added `Span.setTag()`/`setTags()`.
-* Added `SpanConfig.source` for declaring a span's origin (recorded as the `xh.source` tag).
+* `HoistService.initAsync()` and `HoistAppModel.initAsync()` now receive a `span: Span` argument
+  so service-init spans nest under the caller's span.
+* `sampleRules` in `xhTraceConfig` now support matching against the span's name via the reserved
+  `name` key (glob-capable, same syntax as tag-value patterns). Matches addition in
+  hoist-core.
 
 ### 🐞 Bug Fixes
 
-* Fixed `FetchService` blanket-tagging every fetch span `'xh.source': 'hoist'` — spans now
-  inherit source from their parent. Hoist-internal fetches declare `source: 'hoist'` explicitly.
 * Added the `user.name` tag to all spans, matching the server-side convention.
 * Updated `HoistBase.withSpan`/`withSpanAsync` to auto-populate `caller` with `this`, ensuring
   emitted spans correctly stamp `code.namespace`.
@@ -32,6 +47,11 @@
   `--json` flag on every matching CLI subcommand.
 * Fixed a latent member-index collision bug where two exported owners sharing a simple name
   would clobber each other's `memberNames` augmentation, causing spurious symbol-search hits.
+
+### ⚙️ Technical
+
+* Improvements to the naming and tagging of hoist-created spans for consistency with hoist-core
+  and easier tag-based sampling.
 
 ## 84.0.0 - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,24 @@
 ### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW)
 
 * `XH.installServicesAsync()` no longer accepts the spread-args form. Callers must pass an
-  array of service classes plus the current phase's `span`:
+  array of service classes plus the current phase's `InitContext`:
   ```ts
   // before
   await XH.installServicesAsync(MyServiceA, MyServiceB);
   // after
-  await XH.installServicesAsync([MyServiceA, MyServiceB], span);
+  await XH.installServicesAsync([MyServiceA, MyServiceB], ctx);
   ```
-  The `span` is the one passed to your `AppModel.initAsync(span)` override. Forwarding it
+  The `ctx` is the one passed to your `AppModel.initAsync(ctx)` override. Forwarding it
   ensures service-init spans nest under the `app-init` root.
 
 ### 🎁 New Features
 
 * Improved `withSpan`/`withSpanAsync` to always provide a non-nullable `Span`, matching the
   server-side API. Added `Span.setTag()`/`setTags()`.
-* `HoistService.initAsync()` and `HoistAppModel.initAsync()` now receive a `span: Span` argument
-  so service-init spans nest under the caller's span.
+* `HoistService.initAsync()` and `HoistAppModel.initAsync()` now receive an `InitContext`
+  argument carrying the current phase's `span`, so service-init spans nest under the caller's
+  span. `InitContext` is a small wrapper (`{span}`) designed to accept additional init-time
+  context in the future without further signature churn.
 * `sampleRules` in `xhTraceConfig` now support matching against the span's name via the reserved
   `name` key (glob-capable, same syntax as tag-value patterns). Matches addition in
   hoist-core.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@
 
 * Improved `withSpan`/`withSpanAsync` to always provide a non-nullable `Span`, matching the
   server-side API. Added `Span.setTag()`/`setTags()`.
+* Added `SpanConfig.source` for declaring a span's origin (recorded as the `xh.source` tag).
 
 ### 🐞 Bug Fixes
 
+* Fixed `FetchService` blanket-tagging every fetch span `'xh.source': 'hoist'` — spans now
+  inherit source from their parent. Hoist-internal fetches declare `source: 'hoist'` explicitly.
 * Added the `user.name` tag to all spans, matching the server-side convention.
 * Updated `HoistBase.withSpan`/`withSpanAsync` to auto-populate `caller` with `this`, ensuring
   emitted spans correctly stamp `code.namespace`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,18 +21,20 @@
 * Improved `withSpan`/`withSpanAsync` to always provide a non-nullable `Span`, matching the
   server-side API. Added `Span.setTag()`/`setTags()`.
 * `HoistService.initAsync()` and `HoistAppModel.initAsync()` now receive an `InitContext`
-  argument carrying the current phase's `span`, so service-init spans nest under the caller's
-  span. `InitContext` is a small wrapper (`{span}`) designed to accept additional init-time
-  context in the future without further signature churn.
+  argument carrying the current phase's `span`, so service init spans can nest under the caller's
+  span.
 * `sampleRules` in `xhTraceConfig` now support matching against the span's name via the reserved
-  `name` key (glob-capable, same syntax as tag-value patterns). Matches addition in
-  hoist-core.
+  `name` key (same syntax as tag-value patterns). Matches addition in hoist-core.
+* Added the `user.name` tag to all spans.  New `xh.impersonating` tag on spans shows impersonated
+  user, if any.
+* Improved, properly nested spans for app loading: `xh.client.load`, `xh.client.hoistInit`, and
+  `xh.client.appInit`.
 
 ### 🐞 Bug Fixes
 
-* Added the `user.name` tag to all spans, matching the server-side convention.
 * Updated `HoistBase.withSpan`/`withSpanAsync` to auto-populate `caller` with `this`, ensuring
   emitted spans correctly stamp `code.namespace`.
+* Fixes to built-in fetch CLIENT span:  install `http.response.status_code` and `url.full` tags.
 * Fixed downstream app type-check failures on hoist-react asset imports by adding triple-slash
   references to `assets.d.ts` from the files that import PNGs. The ambient declarations were
   not reachable from consumer tsconfigs with narrower `include` patterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
   await XH.installServicesAsync([MyServiceA, MyServiceB], ctx);
   ```
   The `ctx` is the one passed to your `AppModel.initAsync(ctx)` override. Forwarding it
-  ensures service-init spans nest under the `app-init` root.
+  ensures service-init spans nest under the current phase's root span (e.g. `xh.client.appInit`
+  for app-level services, `xh.client.hoistInit` for Hoist-internal services).
 
 ### 🎁 New Features
 

--- a/admin/AppModel.ts
+++ b/admin/AppModel.ts
@@ -7,8 +7,7 @@
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {TabConfig, TabContainerModel} from '@xh/hoist/cmp/tab';
 import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
-import {HoistAppModel, XH} from '@xh/hoist/core';
-import {Span} from '@xh/hoist/utils/telemetry';
+import {HoistAppModel, InitContext, XH} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {without} from 'lodash';
 import {Route} from 'router5';
@@ -45,9 +44,9 @@ export class AppModel extends HoistAppModel {
         GridModel.defaults.autosizeMode = 'managed';
     }
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         await this.initViewManagerModelsAsync();
-        await super.initAsync(span);
+        await super.initAsync(ctx);
     }
 
     override getRoutes(): Route[] {

--- a/admin/AppModel.ts
+++ b/admin/AppModel.ts
@@ -8,6 +8,7 @@ import {GridModel} from '@xh/hoist/cmp/grid';
 import {TabConfig, TabContainerModel} from '@xh/hoist/cmp/tab';
 import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
 import {HoistAppModel, XH} from '@xh/hoist/core';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {Icon} from '@xh/hoist/icon';
 import {without} from 'lodash';
 import {Route} from 'router5';
@@ -44,9 +45,9 @@ export class AppModel extends HoistAppModel {
         GridModel.defaults.autosizeMode = 'managed';
     }
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         await this.initViewManagerModelsAsync();
-        await super.initAsync();
+        await super.initAsync(span);
     }
 
     override getRoutes(): Route[] {

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -279,6 +279,7 @@ export class AppContainerModel extends HoistModel {
                         [EnvironmentService, ConfigService, PrefService, JsonBlobService],
                         hoistInitSpan
                     );
+                    XH.traceService.noteConfigAvailable();
 
                     await installServicesAsync([TrackService], hoistInitSpan);
                     await installServicesAsync(

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -142,8 +142,6 @@ export class AppContainerModel extends HoistModel {
      * Triggers initial authentication and initialization of Hoist and application.
      */
     async initAsync() {
-        this.setAppState('PRE_AUTH');
-
         // Avoid bug where "Discarded" browser tabs can re-init an old version (see #3574)
         if (window.document['wasDiscarded']) {
             XH.reloadApp();
@@ -154,62 +152,34 @@ export class AppContainerModel extends HoistModel {
         if (this.initCalled) return;
         this.initCalled = true;
 
-        const {appSpec} = this,
-            {isPhone, isTablet, isDesktop} = this.userAgentModel,
-            {isMobileApp} = appSpec;
-
-        // Add xh css classes to power Hoist CSS selectors.
-        document.body.classList.add(
-            ...compact([
-                'xh-app',
-                isMobileApp ? 'xh-mobile' : 'xh-standard',
-                isDesktop ? 'xh-desktop' : null,
-                isPhone ? 'xh-phone' : null,
-                isTablet ? 'xh-tablet' : null
-            ])
-        );
-
-        if (isMobileApp) {
-            // Disable browser context menu on long-press, used to show (app) context menus and as an
-            // alternate gesture for tree grid drill-own.
-            window.addEventListener('contextmenu', e => e.preventDefault(), {capture: true});
-
-            // Spec viewport-fit=cover to allow use of safe-area-inset envs for mobile styling
-            // (e.g. `env(safe-area-inset-top)`). This allows us to avoid overlap with OS-level
-            // controls like the iOS tab switcher, as well as to more easily set the background
-            // color of the (effectively) unusable portions of the screen via
-            this.setViewportContent(this.getViewportContent() + ', viewport-fit=cover');
-
-            // Temporarily set maximum-scale=1 on orientation change to force reset Safari iOS
-            // zoom level, and then remove to restore user zooming. This is a workaround for a bug
-            // where Safari full-screen re-zooms on orientation change if user has *ever* zoomed.
-            window.addEventListener(
-                'orientationchange',
-                () => {
-                    const content = this.getViewportContent();
-                    this.setViewportContent(content + ', maximum-scale=1');
-                    setTimeout(() => this.setViewportContent(content), 0);
-                },
-                false
-            );
-        }
-
         try {
-            await installServicesAsync([FetchService]);
+            // Install TraceService first so booting traceable; it will defer sampling and export until config available
+            await installServicesAsync([TraceService], null);
 
-            // Check auth, locking out, or showing login if possible
-            this.setAppState('AUTHENTICATING');
-            XH.authModel = createSingleton(appSpec.authModelClass);
-            const identity = await XH.authModel.completeAuthAsync();
-            if (identity) {
-                await this.completeInitAsync(identity);
-            } else {
-                throwIf(
-                    !appSpec.enableLoginForm,
-                    'Unable to complete required authentication (SSO/Auth failure).'
+            await this.withSpanAsync({name: 'xh.app-load'}, async appLoadSpan => {
+                this.addGlobalListenersAndCss();
+                await installServicesAsync([FetchService], appLoadSpan);
+
+                // Check auth, falling through to interactive login if SSO returns no identity.
+                this.setAppState('AUTHENTICATING');
+                XH.authModel = createSingleton(this.appSpec.authModelClass);
+                let identity = await this.withSpanAsync(
+                    {name: 'xh.auth', parent: appLoadSpan},
+                    () => XH.authModel.completeAuthAsync()
                 );
-                this.setAppState('LOGIN_REQUIRED');
-            }
+                if (!identity) {
+                    throwIf(
+                        !this.appSpec.enableLoginForm,
+                        'Unable to complete required authentication (SSO/Auth failure).'
+                    );
+                    this.setAppState('LOGIN_REQUIRED');
+                    identity = await this.withSpanAsync(
+                        {name: 'xh.login', parent: appLoadSpan},
+                        () => this.awaitInteractiveLoginAsync()
+                    );
+                }
+                await this.completeInitAsync(identity, appLoadSpan);
+            });
         } catch (e) {
             this.setAppState('LOAD_FAILED');
             XH.handleException(e, {requireReload: true});
@@ -218,84 +188,12 @@ export class AppContainerModel extends HoistModel {
     }
 
     /**
-     * Complete initialization. Called after the client has confirmed that the user is generally
-     * authenticated and known to the server (regardless of application roles at this point).
+     * Called by {@link LoginPanelModel} on successful credential submission to resume startup.
+     * @internal
      */
-    @action
-    async completeInitAsync(identity: IdentityInfo) {
-        try {
-            // Install identity and check roles
-            await installServicesAsync(IdentityService);
-            XH.identityService.initIdentity(identity);
-            if (!this.appStateModel.checkAccess()) {
-                this.setAppState('ACCESS_DENIED');
-                return;
-            }
-
-            // Complete initialization process
-            this.setAppState('INITIALIZING_HOIST');
-            await installServicesAsync([LocalStorageService, SessionStorageService]);
-            await installServicesAsync([
-                EnvironmentService,
-                ConfigService,
-                PrefService,
-                JsonBlobService
-            ]);
-            await installServicesAsync([TrackService, TraceService]);
-
-            await installServicesAsync([
-                AlertBannerService,
-                AutoRefreshService,
-                ChangelogService,
-                ClientHealthService,
-                IdleService,
-                InspectorService,
-                GridAutosizeService,
-                GridExportService,
-                WebSocketService
-            ]);
-
-            // init all models other than Router
-            const models = [
-                this.appLoadObserver,
-                this.appStateModel,
-                this.pageStateModel,
-                this.routerModel,
-                this.aboutDialogModel,
-                this.changelogDialogModel,
-                this.exceptionDialogModel,
-                this.feedbackDialogModel,
-                this.impersonationBarModel,
-                this.optionsDialogModel,
-                this.bannerSourceModel,
-                this.messageSourceModel,
-                this.toastSourceModel,
-                this.refreshContextModel,
-                this.sizingModeModel,
-                this.viewportSizeModel,
-                this.themeModel,
-                this.userAgentModel
-            ];
-            models.forEach((m: any) => m.init?.());
-
-            this.bindInitSequenceToAppLoadObserver();
-
-            this.setDocTitle();
-
-            // Delay to workaround hot-reload styling issues in dev.
-            await wait(XH.isDevelopmentMode ? 300 : 1);
-
-            this.setAppState('INITIALIZING_APP');
-            this.appModel = createSingleton(this.appSpec.modelClass);
-            await this.appModel.initAsync();
-            this.startRouter();
-            this.startOptionsDialog();
-            this.setAppState('RUNNING');
-            this.emitAppLoadSpans();
-        } catch (e) {
-            this.setAppState('LOAD_FAILED');
-            XH.handleException(e, {requireReload: true});
-        }
+    completeInteractiveLogin(identity: IdentityInfo) {
+        this.interactiveLoginDeferred?.resolve(identity);
+        this.interactiveLoginDeferred = null;
     }
 
     /**
@@ -344,50 +242,146 @@ export class AppContainerModel extends HoistModel {
     //----------------------------
     // Implementation
     //-----------------------------
-    /**
-     * Construct these post-load with lower level api.
-     * TraceService not yet ready, and code path spread across multiple methods.
-     */
-    private emitAppLoadSpans() {
-        const svc = XH.traceService;
-        if (!svc.enabled) return;
+    private interactiveLoginDeferred: {
+        resolve: (identity: IdentityInfo) => void;
+        reject: (err: unknown) => void;
+    } = null;
 
-        const {loadStarted, timings} = this.appStateModel,
-            loginWait = timings.LOGIN_REQUIRED ?? 0;
+    private awaitInteractiveLoginAsync(): Promise<IdentityInfo> {
+        return new Promise((resolve, reject) => {
+            this.interactiveLoginDeferred = {resolve, reject};
+        });
+    }
 
-        // Build root app-load span with child spans from timing data.
-        // Timings record cumulative ms per state — reconstruct start/end times sequentially.
-        let startTime = loadStarted;
-
-        const emit = (name: string, duration: number, parent?: Span): Span => {
-            const span = svc.createSpan({name, parent, startTime, source: 'hoist'});
-            if (span) {
-                span.endTime = startTime + duration;
-                span.status = 'ok';
-                svc.exportSpan(span);
+    @action
+    private async completeInitAsync(identity: IdentityInfo, appLoadSpan: Span) {
+        try {
+            // Install identity and check roles
+            await installServicesAsync(IdentityService, appLoadSpan);
+            XH.identityService.initIdentity(identity);
+            if (!this.appStateModel.checkAccess()) {
+                this.setAppState('ACCESS_DENIED');
+                return;
             }
-            return span;
-        };
 
-        const root = emit('app-load', Date.now() - loadStarted - loginWait);
-        if (!root) return;
+            // Hoist init phase - all service inits nest under a `hoist-init` span. Sampling for
+            // any spans created before ConfigService loads (FetchService, auth, early storage
+            // installs, etc.) is resolved mid-phase, immediately after ConfigService init.
+            this.setAppState('INITIALIZING_HOIST');
+            await this.withSpanAsync(
+                {name: 'xh.hoist-init', parent: appLoadSpan},
+                async hoistInitSpan => {
+                    await installServicesAsync(
+                        [LocalStorageService, SessionStorageService],
+                        hoistInitSpan
+                    );
+                    await installServicesAsync(
+                        [EnvironmentService, ConfigService, PrefService, JsonBlobService],
+                        hoistInitSpan
+                    );
 
-        let dur: number;
+                    await installServicesAsync([TrackService], hoistInitSpan);
+                    await installServicesAsync(
+                        [
+                            AlertBannerService,
+                            AutoRefreshService,
+                            ChangelogService,
+                            ClientHealthService,
+                            IdleService,
+                            InspectorService,
+                            GridAutosizeService,
+                            GridExportService,
+                            WebSocketService
+                        ],
+                        hoistInitSpan
+                    );
 
-        dur = timings.PRE_AUTH ?? 0;
-        emit('pre-auth', dur, root);
-        startTime += dur;
+                    // init all models other than Router
+                    const models = [
+                        this.appLoadObserver,
+                        this.appStateModel,
+                        this.pageStateModel,
+                        this.routerModel,
+                        this.aboutDialogModel,
+                        this.changelogDialogModel,
+                        this.exceptionDialogModel,
+                        this.feedbackDialogModel,
+                        this.impersonationBarModel,
+                        this.optionsDialogModel,
+                        this.bannerSourceModel,
+                        this.messageSourceModel,
+                        this.toastSourceModel,
+                        this.refreshContextModel,
+                        this.sizingModeModel,
+                        this.viewportSizeModel,
+                        this.themeModel,
+                        this.userAgentModel
+                    ];
+                    models.forEach((m: any) => m.init?.());
 
-        dur = timings.AUTHENTICATING ?? 0;
-        emit('auth', dur, root);
-        startTime += dur + loginWait;
+                    this.bindInitSequenceToAppLoadObserver();
+                    this.setDocTitle();
 
-        dur = timings.INITIALIZING_HOIST ?? 0;
-        emit('hoist-init', dur, root);
-        startTime += dur;
+                    // Delay to workaround hot-reload styling issues in dev.
+                    await wait(XH.isDevelopmentMode ? 300 : 1);
+                }
+            );
 
-        dur = timings.INITIALIZING_APP ?? 0;
-        emit('app-init', dur, root);
+            // App init phase
+            this.setAppState('INITIALIZING_APP');
+            this.appModel = createSingleton(this.appSpec.modelClass);
+            await this.withSpanAsync({name: 'xh.app-init', parent: appLoadSpan}, span =>
+                this.appModel.initAsync(span)
+            );
+
+            this.startRouter();
+            this.startOptionsDialog();
+            this.setAppState('RUNNING');
+        } catch (e) {
+            this.setAppState('LOAD_FAILED');
+            XH.handleException(e, {requireReload: true});
+        }
+    }
+
+    private addGlobalListenersAndCss() {
+        const {isPhone, isTablet, isDesktop} = this.userAgentModel,
+            {isMobileApp} = this.appSpec;
+
+        // Add xh css classes to power Hoist CSS selectors.
+        document.body.classList.add(
+            ...compact([
+                'xh-app',
+                isMobileApp ? 'xh-mobile' : 'xh-standard',
+                isDesktop ? 'xh-desktop' : null,
+                isPhone ? 'xh-phone' : null,
+                isTablet ? 'xh-tablet' : null
+            ])
+        );
+
+        if (isMobileApp) {
+            // Disable browser context menu on long-press, used to show (app) context menus and as an
+            // alternate gesture for tree grid drill-own.
+            window.addEventListener('contextmenu', e => e.preventDefault(), {capture: true});
+
+            // Spec viewport-fit=cover to allow use of safe-area-inset envs for mobile styling
+            // (e.g. `env(safe-area-inset-top)`). This allows us to avoid overlap with OS-level
+            // controls like the iOS tab switcher, as well as to more easily set the background
+            // color of the (effectively) unusable portions of the screen via
+            this.setViewportContent(this.getViewportContent() + ', viewport-fit=cover');
+
+            // Temporarily set maximum-scale=1 on orientation change to force reset Safari iOS
+            // zoom level, and then remove to restore user zooming. This is a workaround for a bug
+            // where Safari full-screen re-zooms on orientation change if user has *ever* zoomed.
+            window.addEventListener(
+                'orientationchange',
+                () => {
+                    const content = this.getViewportContent();
+                    this.setViewportContent(content + ', maximum-scale=1');
+                    setTimeout(() => this.setViewportContent(content), 0);
+                },
+                false
+            );
+        }
     }
 
     private setDocTitle() {

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -157,7 +157,7 @@ export class AppContainerModel extends HoistModel {
             // Install TraceService first so booting traceable; it will defer sampling and export until config available
             await installServicesAsync([TraceService], {span: null});
 
-            await this.withSpanAsync({name: 'xh.client.app-load'}, async appLoadSpan => {
+            await this.withSpanAsync({name: 'xh.client.load'}, async appLoadSpan => {
                 this.addGlobalListenersAndCss();
                 await installServicesAsync([FetchService], {span: appLoadSpan});
 
@@ -175,7 +175,7 @@ export class AppContainerModel extends HoistModel {
                     );
                     this.setAppState('LOGIN_REQUIRED');
                     identity = await this.withSpanAsync(
-                        {name: 'xh.client.login', parent: appLoadSpan},
+                        {name: 'xh.client.interactiveLogin', parent: appLoadSpan},
                         () => this.awaitInteractiveLoginAsync()
                     );
                 }
@@ -254,6 +254,10 @@ export class AppContainerModel extends HoistModel {
         });
     }
 
+    /**
+     * Complete initialization. Called after the client has confirmed that the user is generally
+     * authenticated and known to the server (regardless of application roles at this point).
+     */
     @action
     private async completeInitAsync(identity: IdentityInfo, appLoadSpan: Span) {
         try {
@@ -265,12 +269,10 @@ export class AppContainerModel extends HoistModel {
                 return;
             }
 
-            // Hoist init phase - all service inits nest under a `hoist-init` span. Sampling for
-            // any spans created before ConfigService loads (FetchService, auth, early storage
-            // installs, etc.) is resolved mid-phase, immediately after ConfigService init.
+            // Hoist init phase
             this.setAppState('INITIALIZING_HOIST');
             await this.withSpanAsync(
-                {name: 'xh.client.hoist-init', parent: appLoadSpan},
+                {name: 'xh.client.hoistInit', parent: appLoadSpan},
                 async hoistInitSpan => {
                     const hoistInitCtx: InitContext = {span: hoistInitSpan};
                     await installServicesAsync(
@@ -333,7 +335,7 @@ export class AppContainerModel extends HoistModel {
             // App init phase
             this.setAppState('INITIALIZING_APP');
             this.appModel = createSingleton(this.appSpec.modelClass);
-            await this.withSpanAsync({name: 'xh.client.app-init', parent: appLoadSpan}, span =>
+            await this.withSpanAsync({name: 'xh.client.appInit', parent: appLoadSpan}, span =>
                 this.appModel.initAsync({span})
             );
 

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -156,7 +156,7 @@ export class AppContainerModel extends HoistModel {
             // Install TraceService first so booting traceable; it will defer sampling and export until config available
             await installServicesAsync([TraceService], null);
 
-            await this.withSpanAsync({name: 'xh.app-load'}, async appLoadSpan => {
+            await this.withSpanAsync({name: 'xh.client.app-load'}, async appLoadSpan => {
                 this.addGlobalListenersAndCss();
                 await installServicesAsync([FetchService], appLoadSpan);
 
@@ -164,7 +164,7 @@ export class AppContainerModel extends HoistModel {
                 this.setAppState('AUTHENTICATING');
                 XH.authModel = createSingleton(this.appSpec.authModelClass);
                 let identity = await this.withSpanAsync(
-                    {name: 'xh.auth', parent: appLoadSpan},
+                    {name: 'xh.client.auth', parent: appLoadSpan},
                     () => XH.authModel.completeAuthAsync()
                 );
                 if (!identity) {
@@ -174,7 +174,7 @@ export class AppContainerModel extends HoistModel {
                     );
                     this.setAppState('LOGIN_REQUIRED');
                     identity = await this.withSpanAsync(
-                        {name: 'xh.login', parent: appLoadSpan},
+                        {name: 'xh.client.login', parent: appLoadSpan},
                         () => this.awaitInteractiveLoginAsync()
                     );
                 }
@@ -269,7 +269,7 @@ export class AppContainerModel extends HoistModel {
             // installs, etc.) is resolved mid-phase, immediately after ConfigService init.
             this.setAppState('INITIALIZING_HOIST');
             await this.withSpanAsync(
-                {name: 'xh.hoist-init', parent: appLoadSpan},
+                {name: 'xh.client.hoist-init', parent: appLoadSpan},
                 async hoistInitSpan => {
                     await installServicesAsync(
                         [LocalStorageService, SessionStorageService],
@@ -331,7 +331,7 @@ export class AppContainerModel extends HoistModel {
             // App init phase
             this.setAppState('INITIALIZING_APP');
             this.appModel = createSingleton(this.appSpec.modelClass);
-            await this.withSpanAsync({name: 'xh.app-init', parent: appLoadSpan}, span =>
+            await this.withSpanAsync({name: 'xh.client.app-init', parent: appLoadSpan}, span =>
                 this.appModel.initAsync(span)
             );
 

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -11,6 +11,7 @@ import {
     HoistAppModel,
     HoistModel,
     IdentityInfo,
+    InitContext,
     managed,
     RootRefreshContextModel,
     TaskObserver,
@@ -154,11 +155,11 @@ export class AppContainerModel extends HoistModel {
 
         try {
             // Install TraceService first so booting traceable; it will defer sampling and export until config available
-            await installServicesAsync([TraceService], null);
+            await installServicesAsync([TraceService], {span: null});
 
             await this.withSpanAsync({name: 'xh.client.app-load'}, async appLoadSpan => {
                 this.addGlobalListenersAndCss();
-                await installServicesAsync([FetchService], appLoadSpan);
+                await installServicesAsync([FetchService], {span: appLoadSpan});
 
                 // Check auth, falling through to interactive login if SSO returns no identity.
                 this.setAppState('AUTHENTICATING');
@@ -257,7 +258,7 @@ export class AppContainerModel extends HoistModel {
     private async completeInitAsync(identity: IdentityInfo, appLoadSpan: Span) {
         try {
             // Install identity and check roles
-            await installServicesAsync(IdentityService, appLoadSpan);
+            await installServicesAsync(IdentityService, {span: appLoadSpan});
             XH.identityService.initIdentity(identity);
             if (!this.appStateModel.checkAccess()) {
                 this.setAppState('ACCESS_DENIED');
@@ -271,17 +272,18 @@ export class AppContainerModel extends HoistModel {
             await this.withSpanAsync(
                 {name: 'xh.client.hoist-init', parent: appLoadSpan},
                 async hoistInitSpan => {
+                    const hoistInitCtx: InitContext = {span: hoistInitSpan};
                     await installServicesAsync(
                         [LocalStorageService, SessionStorageService],
-                        hoistInitSpan
+                        hoistInitCtx
                     );
                     await installServicesAsync(
                         [EnvironmentService, ConfigService, PrefService, JsonBlobService],
-                        hoistInitSpan
+                        hoistInitCtx
                     );
                     XH.traceService.noteConfigAvailable();
 
-                    await installServicesAsync([TrackService], hoistInitSpan);
+                    await installServicesAsync([TrackService], hoistInitCtx);
                     await installServicesAsync(
                         [
                             AlertBannerService,
@@ -294,7 +296,7 @@ export class AppContainerModel extends HoistModel {
                             GridExportService,
                             WebSocketService
                         ],
-                        hoistInitSpan
+                        hoistInitCtx
                     );
 
                     // init all models other than Router
@@ -332,7 +334,7 @@ export class AppContainerModel extends HoistModel {
             this.setAppState('INITIALIZING_APP');
             this.appModel = createSingleton(this.appSpec.modelClass);
             await this.withSpanAsync({name: 'xh.client.app-init', parent: appLoadSpan}, span =>
-                this.appModel.initAsync(span)
+                this.appModel.initAsync({span})
             );
 
             this.startRouter();

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -360,7 +360,7 @@ export class AppContainerModel extends HoistModel {
         let startTime = loadStarted;
 
         const emit = (name: string, duration: number, parent?: Span): Span => {
-            const span = svc.createSpan({name, parent, startTime, tags: {'xh.source': 'hoist'}});
+            const span = svc.createSpan({name, parent, startTime, source: 'hoist'});
             if (span) {
                 span.endTime = startTime + duration;
                 span.status = 'ok';

--- a/appcontainer/login/LoginPanelModel.ts
+++ b/appcontainer/login/LoginPanelModel.ts
@@ -48,7 +48,7 @@ export class LoginPanelModel extends HoistModel {
 
             if (identity) {
                 this.warning = '';
-                await XH.appContainerModel.completeInitAsync(identity);
+                XH.appContainerModel.completeInteractiveLogin(identity);
             } else {
                 this.warning = 'Login incorrect.';
             }

--- a/cmp/viewmanager/DataAccess.ts
+++ b/cmp/viewmanager/DataAccess.ts
@@ -33,7 +33,8 @@ export class DataAccess<T> {
         try {
             const ret = await XH.fetchJson({
                 url: 'xhView/allData',
-                params: {type, viewInstance: instance}
+                params: {type, viewInstance: instance},
+                span: {name: 'getAllViews', source: 'hoist', caller: this}
             });
             return {
                 views: ret.views.map(v => new ViewInfo(v, this.model)),
@@ -52,7 +53,11 @@ export class DataAccess<T> {
         const {model} = this;
         if (!token) return View.createDefault(model);
         try {
-            const raw = await XH.fetchJson({url: 'xhView/get', params: {token}});
+            const raw = await XH.fetchJson({
+                url: 'xhView/get',
+                params: {token},
+                span: {name: 'getView', source: 'hoist', caller: this}
+            });
             return View.fromBlob(raw, model);
         } catch (e) {
             throw XH.exception({message: `Unable to fetch view with token ${token}`, cause: e});
@@ -65,7 +70,8 @@ export class DataAccess<T> {
         try {
             const raw = await XH.postJson({
                 url: 'xhView/create',
-                body: {type: model.type, ...spec}
+                body: {type: model.type, ...spec},
+                span: {name: 'createView', source: 'hoist', caller: this}
             });
             return View.fromBlob(raw, model);
         } catch (e) {
@@ -80,7 +86,8 @@ export class DataAccess<T> {
             const raw = await XH.postJson({
                 url: 'xhView/updateInfo',
                 params: {token: view.token},
-                body: updates
+                body: updates,
+                span: {name: 'updateViewInfo', source: 'hoist', caller: this}
             });
             return View.fromBlob(raw, this.model);
         } catch (e) {
@@ -95,7 +102,8 @@ export class DataAccess<T> {
             const raw = await XH.postJson({
                 url: 'xhView/updateValue',
                 params: {token: view.token},
-                body: value
+                body: value,
+                span: {name: 'updateViewValue', source: 'hoist', caller: this}
             });
             return View.fromBlob(raw, this.model);
         } catch (e) {
@@ -111,7 +119,8 @@ export class DataAccess<T> {
         try {
             await XH.postJson({
                 url: 'xhView/delete',
-                params: {tokens: map(views, 'token').join(',')}
+                params: {tokens: map(views, 'token').join(',')},
+                span: {name: 'deleteViews', source: 'hoist', caller: this}
             });
         } catch (e) {
             throw XH.exception({
@@ -129,7 +138,8 @@ export class DataAccess<T> {
         return XH.postJson({
             url: 'xhView/updateState',
             params: {type, viewInstance: instance},
-            body: update
+            body: update,
+            span: {name: 'updateViewState', source: 'hoist', caller: this}
         });
     }
 

--- a/cmp/viewmanager/DataAccess.ts
+++ b/cmp/viewmanager/DataAccess.ts
@@ -34,7 +34,7 @@ export class DataAccess<T> {
             const ret = await XH.fetchJson({
                 url: 'xhView/allData',
                 params: {type, viewInstance: instance},
-                span: {name: 'getAllViews', source: 'hoist', caller: this}
+                span: {name: 'xh.getAllViews', caller: this}
             });
             return {
                 views: ret.views.map(v => new ViewInfo(v, this.model)),
@@ -56,7 +56,7 @@ export class DataAccess<T> {
             const raw = await XH.fetchJson({
                 url: 'xhView/get',
                 params: {token},
-                span: {name: 'getView', source: 'hoist', caller: this}
+                span: {name: 'xh.getView', caller: this}
             });
             return View.fromBlob(raw, model);
         } catch (e) {
@@ -71,7 +71,7 @@ export class DataAccess<T> {
             const raw = await XH.postJson({
                 url: 'xhView/create',
                 body: {type: model.type, ...spec},
-                span: {name: 'createView', source: 'hoist', caller: this}
+                span: {name: 'xh.createView', caller: this}
             });
             return View.fromBlob(raw, model);
         } catch (e) {
@@ -87,7 +87,7 @@ export class DataAccess<T> {
                 url: 'xhView/updateInfo',
                 params: {token: view.token},
                 body: updates,
-                span: {name: 'updateViewInfo', source: 'hoist', caller: this}
+                span: {name: 'xh.updateViewInfo', caller: this}
             });
             return View.fromBlob(raw, this.model);
         } catch (e) {
@@ -103,7 +103,7 @@ export class DataAccess<T> {
                 url: 'xhView/updateValue',
                 params: {token: view.token},
                 body: value,
-                span: {name: 'updateViewValue', source: 'hoist', caller: this}
+                span: {name: 'xh.updateViewValue', caller: this}
             });
             return View.fromBlob(raw, this.model);
         } catch (e) {
@@ -120,7 +120,7 @@ export class DataAccess<T> {
             await XH.postJson({
                 url: 'xhView/delete',
                 params: {tokens: map(views, 'token').join(',')},
-                span: {name: 'deleteViews', source: 'hoist', caller: this}
+                span: {name: 'xh.deleteViews', caller: this}
             });
         } catch (e) {
             throw XH.exception({
@@ -139,7 +139,7 @@ export class DataAccess<T> {
             url: 'xhView/updateState',
             params: {type, viewInstance: instance},
             body: update,
-            span: {name: 'updateViewState', source: 'hoist', caller: this}
+            span: {name: 'xh.updateViewState', caller: this}
         });
     }
 

--- a/cmp/viewmanager/DataAccess.ts
+++ b/cmp/viewmanager/DataAccess.ts
@@ -34,7 +34,7 @@ export class DataAccess<T> {
             const ret = await XH.fetchJson({
                 url: 'xhView/allData',
                 params: {type, viewInstance: instance},
-                span: {name: 'xh.client.getAllViews', caller: this}
+                span: {name: 'xh.client.view.getAll', caller: this}
             });
             return {
                 views: ret.views.map(v => new ViewInfo(v, this.model)),
@@ -56,7 +56,7 @@ export class DataAccess<T> {
             const raw = await XH.fetchJson({
                 url: 'xhView/get',
                 params: {token},
-                span: {name: 'xh.client.getView', caller: this}
+                span: {name: 'xh.client.view.get', caller: this}
             });
             return View.fromBlob(raw, model);
         } catch (e) {
@@ -71,7 +71,7 @@ export class DataAccess<T> {
             const raw = await XH.postJson({
                 url: 'xhView/create',
                 body: {type: model.type, ...spec},
-                span: {name: 'xh.client.createView', caller: this}
+                span: {name: 'xh.client.view.create', caller: this}
             });
             return View.fromBlob(raw, model);
         } catch (e) {
@@ -87,7 +87,7 @@ export class DataAccess<T> {
                 url: 'xhView/updateInfo',
                 params: {token: view.token},
                 body: updates,
-                span: {name: 'xh.client.updateViewInfo', caller: this}
+                span: {name: 'xh.client.view.updateInfo', caller: this}
             });
             return View.fromBlob(raw, this.model);
         } catch (e) {
@@ -103,7 +103,7 @@ export class DataAccess<T> {
                 url: 'xhView/updateValue',
                 params: {token: view.token},
                 body: value,
-                span: {name: 'xh.client.updateViewValue', caller: this}
+                span: {name: 'xh.client.view.updateValue', caller: this}
             });
             return View.fromBlob(raw, this.model);
         } catch (e) {
@@ -120,7 +120,7 @@ export class DataAccess<T> {
             await XH.postJson({
                 url: 'xhView/delete',
                 params: {tokens: map(views, 'token').join(',')},
-                span: {name: 'xh.client.deleteViews', caller: this}
+                span: {name: 'xh.client.view.delete', caller: this}
             });
         } catch (e) {
             throw XH.exception({
@@ -139,7 +139,7 @@ export class DataAccess<T> {
             url: 'xhView/updateState',
             params: {type, viewInstance: instance},
             body: update,
-            span: {name: 'xh.client.updateViewState', caller: this}
+            span: {name: 'xh.client.view.updateState', caller: this}
         });
     }
 

--- a/cmp/viewmanager/DataAccess.ts
+++ b/cmp/viewmanager/DataAccess.ts
@@ -34,7 +34,7 @@ export class DataAccess<T> {
             const ret = await XH.fetchJson({
                 url: 'xhView/allData',
                 params: {type, viewInstance: instance},
-                span: {name: 'xh.getAllViews', caller: this}
+                span: {name: 'xh.client.getAllViews', caller: this}
             });
             return {
                 views: ret.views.map(v => new ViewInfo(v, this.model)),
@@ -56,7 +56,7 @@ export class DataAccess<T> {
             const raw = await XH.fetchJson({
                 url: 'xhView/get',
                 params: {token},
-                span: {name: 'xh.getView', caller: this}
+                span: {name: 'xh.client.getView', caller: this}
             });
             return View.fromBlob(raw, model);
         } catch (e) {
@@ -71,7 +71,7 @@ export class DataAccess<T> {
             const raw = await XH.postJson({
                 url: 'xhView/create',
                 body: {type: model.type, ...spec},
-                span: {name: 'xh.createView', caller: this}
+                span: {name: 'xh.client.createView', caller: this}
             });
             return View.fromBlob(raw, model);
         } catch (e) {
@@ -87,7 +87,7 @@ export class DataAccess<T> {
                 url: 'xhView/updateInfo',
                 params: {token: view.token},
                 body: updates,
-                span: {name: 'xh.updateViewInfo', caller: this}
+                span: {name: 'xh.client.updateViewInfo', caller: this}
             });
             return View.fromBlob(raw, this.model);
         } catch (e) {
@@ -103,7 +103,7 @@ export class DataAccess<T> {
                 url: 'xhView/updateValue',
                 params: {token: view.token},
                 body: value,
-                span: {name: 'xh.updateViewValue', caller: this}
+                span: {name: 'xh.client.updateViewValue', caller: this}
             });
             return View.fromBlob(raw, this.model);
         } catch (e) {
@@ -120,7 +120,7 @@ export class DataAccess<T> {
             await XH.postJson({
                 url: 'xhView/delete',
                 params: {tokens: map(views, 'token').join(',')},
-                span: {name: 'xh.deleteViews', caller: this}
+                span: {name: 'xh.client.deleteViews', caller: this}
             });
         } catch (e) {
             throw XH.exception({
@@ -139,7 +139,7 @@ export class DataAccess<T> {
             url: 'xhView/updateState',
             params: {type, viewInstance: instance},
             body: update,
-            span: {name: 'xh.updateViewState', caller: this}
+            span: {name: 'xh.client.updateViewState', caller: this}
         });
     }
 

--- a/core/HoistAppModel.ts
+++ b/core/HoistAppModel.ts
@@ -5,8 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {webSocketIndicator} from '@xh/hoist/cmp/websocket';
-import {AppOptionSpec, HoistModel, Thunkable} from './';
-import {Span} from '@xh/hoist/utils/telemetry';
+import {AppOptionSpec, HoistModel, InitContext, Thunkable} from './';
 import {Route} from 'router5';
 import {ReactNode} from 'react';
 /**
@@ -32,13 +31,14 @@ export class HoistAppModel extends HoistModel {
      * has mounted. Use to trigger initialization of the app and any app-specific services.
      *
      * Applications will typically use this method to install and initialize app-specific
-     * services using one or more phased calls to XH.installServicesAsync(). Pass `span`
+     * services using one or more phased calls to XH.installServicesAsync(). Pass `ctx`
      * along to those calls to nest service init under the `app-init` root span.
      *
-     * @param span - the `app-init` root span. Use as the `parent` of any spans created
-     *      directly here, and pass to `XH.installServicesAsync()` to nest service inits.
+     * @param ctx - init context for the `app-init` phase. Use `ctx.span` as the `parent`
+     *      of any spans created directly here, and forward `ctx` to `XH.installServicesAsync()`
+     *      to nest service inits.
      */
-    async initAsync(span: Span) {}
+    async initAsync(ctx: InitContext) {}
 
     /**
      * Should the version bar be shown in this application?.

--- a/core/HoistAppModel.ts
+++ b/core/HoistAppModel.ts
@@ -32,11 +32,9 @@ export class HoistAppModel extends HoistModel {
      *
      * Applications will typically use this method to install and initialize app-specific
      * services using one or more phased calls to XH.installServicesAsync(). Pass `ctx`
-     * along to those calls to nest service init under the `app-init` root span.
+     * along to those calls to nest service init appropriately within the app loading telemetry.
      *
-     * @param ctx - init context for the `app-init` phase. Use `ctx.span` as the `parent`
-     *      of any spans created directly here, and forward `ctx` to `XH.installServicesAsync()`
-     *      to nest service inits.
+     * @param ctx - init context
      */
     async initAsync(ctx: InitContext) {}
 

--- a/core/HoistAppModel.ts
+++ b/core/HoistAppModel.ts
@@ -6,6 +6,7 @@
  */
 import {webSocketIndicator} from '@xh/hoist/cmp/websocket';
 import {AppOptionSpec, HoistModel, Thunkable} from './';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {Route} from 'router5';
 import {ReactNode} from 'react';
 /**
@@ -31,9 +32,13 @@ export class HoistAppModel extends HoistModel {
      * has mounted. Use to trigger initialization of the app and any app-specific services.
      *
      * Applications will typically use this method to install and initialize app-specific
-     * services using one or more phased calls to XH.installServicesAsync().
+     * services using one or more phased calls to XH.installServicesAsync(). Pass `span`
+     * along to those calls to nest service init under the `app-init` root span.
+     *
+     * @param span - the `app-init` root span. Use as the `parent` of any spans created
+     *      directly here, and pass to `XH.installServicesAsync()` to nest service inits.
      */
-    async initAsync() {}
+    async initAsync(span: Span) {}
 
     /**
      * Should the version bar be shown in this application?.

--- a/core/HoistService.ts
+++ b/core/HoistService.ts
@@ -65,9 +65,7 @@ export class HoistService extends HoistBase implements Loadable {
      * Throwing an exception from this method will typically block startup.
      * Service writers should take care to stifle and manage all non-fatal exceptions.
      *
-     * @param ctx - init context for the current phase. Use `ctx.span` as the `parent` of any
-     *      spans created here so init activity nests under the phase root in the resulting trace.
-     *      Forward `ctx` to any `XH.installServicesAsync()` calls.
+     * @param ctx - init context
      */
     async initAsync(ctx: InitContext): Promise<void> {}
 

--- a/core/HoistService.ts
+++ b/core/HoistService.ts
@@ -6,6 +6,7 @@
  */
 import {HoistBase, managed, LoadSupport, LoadSpec, Loadable, PlainObject, TaskObserver} from './';
 import {apiDeprecated} from '@xh/hoist/utils/js';
+import {Span} from '@xh/hoist/utils/telemetry';
 
 /**
  * Core superclass for Services in Hoist. Services are special classes used in both Hoist and
@@ -55,8 +56,12 @@ export class HoistService extends HoistBase implements Loadable {
      * Called by framework or application to initialize before application startup.
      * Throwing an exception from this method will typically block startup.
      * Service writers should take care to stifle and manage all non-fatal exceptions.
+     *
+     * @param span - root span for the current init phase (e.g. `hoist-init`, `app-init`).
+     *      Pass as the `parent` of any spans created by this method so init activity nests
+     *      under the phase root in the resulting trace.
      */
-    async initAsync(): Promise<void> {}
+    async initAsync(span: Span): Promise<void> {}
 
     /**
      * Provides optional support for Hoist's approach to managed loading.

--- a/core/HoistService.ts
+++ b/core/HoistService.ts
@@ -4,9 +4,17 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistBase, managed, LoadSupport, LoadSpec, Loadable, PlainObject, TaskObserver} from './';
+import {
+    HoistBase,
+    InitContext,
+    managed,
+    LoadSupport,
+    LoadSpec,
+    Loadable,
+    PlainObject,
+    TaskObserver
+} from './';
 import {apiDeprecated} from '@xh/hoist/utils/js';
-import {Span} from '@xh/hoist/utils/telemetry';
 
 /**
  * Core superclass for Services in Hoist. Services are special classes used in both Hoist and
@@ -57,11 +65,11 @@ export class HoistService extends HoistBase implements Loadable {
      * Throwing an exception from this method will typically block startup.
      * Service writers should take care to stifle and manage all non-fatal exceptions.
      *
-     * @param span - root span for the current init phase (e.g. `hoist-init`, `app-init`).
-     *      Pass as the `parent` of any spans created by this method so init activity nests
-     *      under the phase root in the resulting trace.
+     * @param ctx - init context for the current phase. Use `ctx.span` as the `parent` of any
+     *      spans created here so init activity nests under the phase root in the resulting trace.
+     *      Forward `ctx` to any `XH.installServicesAsync()` calls.
      */
-    async initAsync(span: Span): Promise<void> {}
+    async initAsync(ctx: InitContext): Promise<void> {}
 
     /**
      * Provides optional support for Hoist's approach to managed loading.

--- a/core/XH.ts
+++ b/core/XH.ts
@@ -60,6 +60,7 @@ import {
     PlainObject,
     ReloadAppOptions,
     SizingMode,
+    Some,
     TaskObserver,
     Theme,
     ToastSpec,
@@ -67,6 +68,7 @@ import {
 } from './';
 import {installServicesAsync} from './impl/InstallServices';
 import {instanceManager} from './impl/InstanceManager';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {HoistModel, ModelSelector, RefreshContextModel} from './model';
 
 export const MIN_HOIST_CORE_VERSION = '31.2';
@@ -770,10 +772,13 @@ export class XHApi {
      * Applications must choose a unique name of the form xxxService to avoid naming collisions.
      * If naming collisions are detected, an error will be thrown.
      *
-     * @param serviceClasses - classes extending HoistService
+     * @param serviceClasses - one or more classes extending HoistService.
+     * @param span - root span for the current init phase (typically the `span` passed to
+     *      `AppModel.initAsync()`). Forwarded to each service's `initAsync()` so spans created
+     *      during init nest under this phase root.
      */
-    async installServicesAsync(...serviceClasses: HoistServiceClass[]) {
-        return installServicesAsync(serviceClasses);
+    async installServicesAsync(serviceClasses: Some<HoistServiceClass>, span: Span): Promise<void> {
+        return installServicesAsync(serviceClasses, span);
     }
 
     /**

--- a/core/XH.ts
+++ b/core/XH.ts
@@ -54,6 +54,7 @@ import {
     HoistAppModel,
     HoistService,
     HoistServiceClass,
+    InitContext,
     HoistUser,
     MessageSpec,
     PageState,
@@ -68,7 +69,6 @@ import {
 } from './';
 import {installServicesAsync} from './impl/InstallServices';
 import {instanceManager} from './impl/InstanceManager';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {HoistModel, ModelSelector, RefreshContextModel} from './model';
 
 export const MIN_HOIST_CORE_VERSION = '31.2';
@@ -773,12 +773,15 @@ export class XHApi {
      * If naming collisions are detected, an error will be thrown.
      *
      * @param serviceClasses - one or more classes extending HoistService.
-     * @param span - root span for the current init phase (typically the `span` passed to
+     * @param ctx - init context for the current phase (typically the `ctx` passed to
      *      `AppModel.initAsync()`). Forwarded to each service's `initAsync()` so spans created
-     *      during init nest under this phase root.
+     *      during init nest under this phase's root span.
      */
-    async installServicesAsync(serviceClasses: Some<HoistServiceClass>, span: Span): Promise<void> {
-        return installServicesAsync(serviceClasses, span);
+    async installServicesAsync(
+        serviceClasses: Some<HoistServiceClass>,
+        ctx: InitContext
+    ): Promise<void> {
+        return installServicesAsync(serviceClasses, ctx);
     }
 
     /**

--- a/core/impl/InstallServices.ts
+++ b/core/impl/InstallServices.ts
@@ -7,12 +7,14 @@
 import {HoistService, HoistServiceClass, Some, XH} from '@xh/hoist/core';
 import {instanceManager} from '@xh/hoist/core/impl/InstanceManager';
 import {createSingleton, throwIf} from '@xh/hoist/utils/js';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {camelCase, castArray} from 'lodash';
 
 /**
  * Install HoistServices on XH.
  *
  * @param serviceClasses - Classes extending HoistService
+ * @param span - root span for the current init phase.
  *
  * This method will create, initialize, and install the services classes listed on XH.
  * All services will be initialized concurrently. To guarantee execution order of service
@@ -25,13 +27,13 @@ import {camelCase, castArray} from 'lodash';
  *
  * @internal - apps should use {@link XH.installServicesAsync} instead.
  */
-export async function installServicesAsync(serviceClasses: Some<HoistServiceClass>) {
+export async function installServicesAsync(serviceClasses: Some<HoistServiceClass>, span: Span) {
     serviceClasses = castArray(serviceClasses);
     const notSvc = serviceClasses.find((it: any) => !it.isHoistService);
     throwIf(notSvc, `Cannot initialize ${notSvc?.name} - does not extend HoistService`);
 
     const svcs = serviceClasses.map(c => createSingleton(c));
-    await initServicesInternalAsync(svcs);
+    await initServicesInternalAsync(svcs, span);
 
     svcs.forEach(svc => {
         const clazz = svc.constructor,
@@ -47,9 +49,9 @@ export async function installServicesAsync(serviceClasses: Some<HoistServiceClas
     });
 }
 
-async function initServicesInternalAsync(svcs: HoistService[]) {
+async function initServicesInternalAsync(svcs: HoistService[], span: Span) {
     const promises = svcs.map(it => {
-        return it.withDebug(`Initializing`, () => it.initAsync());
+        return it.withDebug(`Initializing`, () => it.initAsync(span));
     });
 
     const results: any[] = await Promise.allSettled(promises),

--- a/core/impl/InstallServices.ts
+++ b/core/impl/InstallServices.ts
@@ -4,17 +4,16 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, HoistServiceClass, Some, XH} from '@xh/hoist/core';
+import {HoistService, HoistServiceClass, InitContext, Some, XH} from '@xh/hoist/core';
 import {instanceManager} from '@xh/hoist/core/impl/InstanceManager';
 import {createSingleton, throwIf} from '@xh/hoist/utils/js';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {camelCase, castArray} from 'lodash';
 
 /**
  * Install HoistServices on XH.
  *
  * @param serviceClasses - Classes extending HoistService
- * @param span - root span for the current init phase.
+ * @param ctx - init context for the current phase.
  *
  * This method will create, initialize, and install the services classes listed on XH.
  * All services will be initialized concurrently. To guarantee execution order of service
@@ -27,13 +26,16 @@ import {camelCase, castArray} from 'lodash';
  *
  * @internal - apps should use {@link XH.installServicesAsync} instead.
  */
-export async function installServicesAsync(serviceClasses: Some<HoistServiceClass>, span: Span) {
+export async function installServicesAsync(
+    serviceClasses: Some<HoistServiceClass>,
+    ctx: InitContext
+) {
     serviceClasses = castArray(serviceClasses);
     const notSvc = serviceClasses.find((it: any) => !it.isHoistService);
     throwIf(notSvc, `Cannot initialize ${notSvc?.name} - does not extend HoistService`);
 
     const svcs = serviceClasses.map(c => createSingleton(c));
-    await initServicesInternalAsync(svcs, span);
+    await initServicesInternalAsync(svcs, ctx);
 
     svcs.forEach(svc => {
         const clazz = svc.constructor,
@@ -49,9 +51,9 @@ export async function installServicesAsync(serviceClasses: Some<HoistServiceClas
     });
 }
 
-async function initServicesInternalAsync(svcs: HoistService[], span: Span) {
+async function initServicesInternalAsync(svcs: HoistService[], ctx: InitContext) {
     const promises = svcs.map(it => {
-        return it.withDebug(`Initializing`, () => it.initAsync(span));
+        return it.withDebug(`Initializing`, () => it.initAsync(ctx));
     });
 
     const results: any[] = await Promise.allSettled(promises),

--- a/core/index.ts
+++ b/core/index.ts
@@ -13,7 +13,6 @@ export * from './load';
 
 export * from './model';
 export * from './HoistService';
-export * from './InitContext';
 
 export * from './AppSpec';
 export * from './HoistProps';

--- a/core/index.ts
+++ b/core/index.ts
@@ -13,6 +13,7 @@ export * from './load';
 
 export * from './model';
 export * from './HoistService';
+export * from './InitContext';
 
 export * from './AppSpec';
 export * from './HoistProps';

--- a/core/types/Interfaces.ts
+++ b/core/types/Interfaces.ts
@@ -56,7 +56,7 @@ export interface IdentityInfo {
  * `ctx.span` as the `parent` for any new spans created during init.
  */
 export interface InitContext {
-    /** Root span for the current init phase (e.g. `xh.client.appLoad`). */
+    /** Root span for the current init phase (e.g. `xh.client.hoistInit`, `xh.client.appInit`). */
     span: Span;
 }
 

--- a/core/types/Interfaces.ts
+++ b/core/types/Interfaces.ts
@@ -7,10 +7,23 @@
 
 import {BaseFieldConfig} from '@xh/hoist/cmp/form/field/BaseFieldModel';
 import {RuleLike} from '@xh/hoist/data';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {isString} from 'lodash';
 import {isValidElement, MouseEvent, ReactElement, ReactNode} from 'react';
 import {LoadSpec, LoadSpecConfig} from '../load';
 import {Intent, PlainObject, Thunkable} from './Types';
+
+/**
+ * Context passed to `HoistService.initAsync()` and `HoistAppModel.initAsync()`, and forwarded
+ * via `XH.installServicesAsync()` to nest service-init activity under the current phase.
+ *
+ * Apps should pass `ctx` through unchanged to `XH.installServicesAsync()` calls, and use
+ * `ctx.span` as the `parent` for any new spans created during init.
+ */
+export interface InitContext {
+    /** Root span for the current init phase (e.g. `xh.client.hoist-init`, `xh.client.app-init`). */
+    span: Span;
+}
 
 /**
  * A user of the application, as loaded from the server.

--- a/core/types/Interfaces.ts
+++ b/core/types/Interfaces.ts
@@ -14,18 +14,6 @@ import {LoadSpec, LoadSpecConfig} from '../load';
 import {Intent, PlainObject, Thunkable} from './Types';
 
 /**
- * Context passed to `HoistService.initAsync()` and `HoistAppModel.initAsync()`, and forwarded
- * via `XH.installServicesAsync()` to nest service-init activity under the current phase.
- *
- * Apps should pass `ctx` through unchanged to `XH.installServicesAsync()` calls, and use
- * `ctx.span` as the `parent` for any new spans created during init.
- */
-export interface InitContext {
-    /** Root span for the current init phase (e.g. `xh.client.hoist-init`, `xh.client.app-init`). */
-    span: Span;
-}
-
-/**
  * A user of the application, as loaded from the server.
  *
  * Note that instances of this class may contain other custom properties serialize by an
@@ -58,6 +46,18 @@ export interface IdentityInfo {
      * will be different during impersonation.
      */
     apparentUser: HoistUser;
+}
+
+/**
+ * Context passed to `HoistService.initAsync()` and `HoistAppModel.initAsync()`, and forwarded
+ * via `XH.installServicesAsync()` to nest service-init activity under the current phase.
+ *
+ * Apps should pass `ctx` through unchanged to `XH.installServicesAsync()` calls, and use
+ * `ctx.span` as the `parent` for any new spans created during init.
+ */
+export interface InitContext {
+    /** Root span for the current init phase (e.g. `xh.client.appLoad`). */
+    span: Span;
 }
 
 /**

--- a/docs/planning/trace/prompt.md
+++ b/docs/planning/trace/prompt.md
@@ -245,18 +245,18 @@ Automatic spans representing the app bootstrap, broken into phases that map dire
 `AppStateModel`'s existing state transitions:
 
 ```
-[app-load]                          ← root span, _xhLoadTimestamp → RUNNING
-  ├─ [pre-auth]                     ← PRE_AUTH → AUTHENTICATED (includes SSO redirects)
-  ├─ [hoist-init]                   ← core Hoist service installation
-  └─ [app-init]                     ← AppModel.initAsync() (app service installation + setup)
+[appLoad]                           ← root span, _xhLoadTimestamp → RUNNING
+  ├─ [preAuth]                      ← PRE_AUTH → AUTHENTICATED (includes SSO redirects)
+  ├─ [hoistInit]                    ← core Hoist service installation
+  └─ [appInit]                      ← AppModel.initAsync() (app service installation + setup)
 ```
 
-- **`app-load`:** Root span from `window._xhLoadTimestamp` through `AppState.RUNNING`,
+- **`appLoad`:** Root span from `window._xhLoadTimestamp` through `AppState.RUNNING`,
   capturing the full bootstrap duration.
-- **`pre-auth`:** Time spent in authentication, including any SSO redirects or login flows.
+- **`preAuth`:** Time spent in authentication, including any SSO redirects or login flows.
   This can dominate load time and is valuable to isolate.
-- **`hoist-init`:** Core Hoist service installation — framework overhead.
-- **`app-init`:** `AppModel.initAsync()` — app-level service installation and setup.
+- **`hoistInit`:** Core Hoist service installation — framework overhead.
+- **`appInit`:** `AppModel.initAsync()` — app-level service installation and setup.
 
 All tagged `source: 'hoist'`.
 

--- a/promise/Promise.ts
+++ b/promise/Promise.ts
@@ -98,7 +98,7 @@ declare global {
          * Wrap this promise in a tracing span. The span starts when `.span()` is called
          * and ends when the promise settles (resolves or rejects).
          *
-         * @param config - span name string, or a SpanConfig.
+         * @param config - SpanConfig, or simply a span name.
          */
         span(config: SpanConfig | string): Promise<T>;
     }

--- a/promise/Promise.ts
+++ b/promise/Promise.ts
@@ -258,24 +258,7 @@ const enhancePromise = promisePrototype => {
         },
 
         span<T>(config: SpanConfig | string): Promise<T> {
-            const svc = XH.traceService,
-                span = svc?.createSpan(config);
-
-            if (!span) return this;
-
-            return this.then(
-                (v: T) => {
-                    span.end('ok');
-                    return v;
-                },
-                (e: unknown) => {
-                    span.recordError(e);
-                    span.end('error');
-                    throw e;
-                }
-            ).finally(() => {
-                svc.exportSpan(span);
-            });
+            return XH.traceService.withSpanAsync(config, () => this) as Promise<T>;
         },
 
         tap<T>(onFulfillment: (value: T) => any): Promise<T> {

--- a/svc/AutoRefreshService.ts
+++ b/svc/AutoRefreshService.ts
@@ -4,11 +4,10 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, managed, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, managed, XH} from '@xh/hoist/core';
 import {Timer} from '@xh/hoist/utils/async';
 import {olderThan, ONE_SECOND, SECONDS} from '@xh/hoist/utils/datetime';
 import {withDefault} from '@xh/hoist/utils/js';
-import {Span} from '@xh/hoist/utils/telemetry';
 
 /**
  * Service to triggers an app-wide auto-refresh (if enabled, on a configurable interval) via the
@@ -45,7 +44,7 @@ export class AutoRefreshService extends HoistService {
         return withDefault(conf[XH.clientAppCode], -1);
     }
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         this.initTime = Date.now();
 
         this.timer = Timer.create({

--- a/svc/AutoRefreshService.ts
+++ b/svc/AutoRefreshService.ts
@@ -8,6 +8,7 @@ import {HoistService, managed, XH} from '@xh/hoist/core';
 import {Timer} from '@xh/hoist/utils/async';
 import {olderThan, ONE_SECOND, SECONDS} from '@xh/hoist/utils/datetime';
 import {withDefault} from '@xh/hoist/utils/js';
+import {Span} from '@xh/hoist/utils/telemetry';
 
 /**
  * Service to triggers an app-wide auto-refresh (if enabled, on a configurable interval) via the
@@ -44,7 +45,7 @@ export class AutoRefreshService extends HoistService {
         return withDefault(conf[XH.clientAppCode], -1);
     }
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         this.initTime = Date.now();
 
         this.timer = Timer.create({

--- a/svc/ChangelogService.ts
+++ b/svc/ChangelogService.ts
@@ -9,6 +9,7 @@ import {HoistService, XH} from '@xh/hoist/core';
 import jsonFromMarkdown from '@xh/app-changelog.json';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {checkMinVersion} from '@xh/hoist/utils/js';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {isEmpty, forOwn, includes} from 'lodash';
 
 /**
@@ -82,7 +83,7 @@ export class ChangelogService extends HoistService {
         makeObservable(this);
     }
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         this.changelog = !isEmpty(jsonFromMarkdown?.versions)
             ? jsonFromMarkdown
             : {title: null, versions: []};

--- a/svc/ChangelogService.ts
+++ b/svc/ChangelogService.ts
@@ -4,12 +4,11 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, XH} from '@xh/hoist/core';
 // @ts-ignore
 import jsonFromMarkdown from '@xh/app-changelog.json';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {checkMinVersion} from '@xh/hoist/utils/js';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {isEmpty, forOwn, includes} from 'lodash';
 
 /**
@@ -83,7 +82,7 @@ export class ChangelogService extends HoistService {
         makeObservable(this);
     }
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         this.changelog = !isEmpty(jsonFromMarkdown?.versions)
             ? jsonFromMarkdown
             : {title: null, versions: []};

--- a/svc/ClientHealthService.ts
+++ b/svc/ClientHealthService.ts
@@ -8,6 +8,7 @@ import {HoistService, PageState, PlainObject, TrackOptions, XH} from '@xh/hoist/
 import {WebSocketTelemetry} from '@xh/hoist/svc/WebSocketService';
 import {Timer} from '@xh/hoist/utils/async';
 import {MINUTES} from '@xh/hoist/utils/datetime';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {withFormattedTimestamps} from '@xh/hoist/format';
 import {pick, round} from 'lodash';
 
@@ -24,7 +25,7 @@ export class ClientHealthService extends HoistService {
 
     private sources: Map<string, () => any> = new Map();
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         const {clientHealthReport} = XH.trackService.conf;
         Timer.create({
             runFn: () => this.sendReportInternal(),

--- a/svc/ClientHealthService.ts
+++ b/svc/ClientHealthService.ts
@@ -4,11 +4,10 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, PageState, PlainObject, TrackOptions, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, PageState, PlainObject, TrackOptions, XH} from '@xh/hoist/core';
 import {WebSocketTelemetry} from '@xh/hoist/svc/WebSocketService';
 import {Timer} from '@xh/hoist/utils/async';
 import {MINUTES} from '@xh/hoist/utils/datetime';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {withFormattedTimestamps} from '@xh/hoist/format';
 import {pick, round} from 'lodash';
 
@@ -25,7 +24,7 @@ export class ClientHealthService extends HoistService {
 
     private sources: Map<string, () => any> = new Map();
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         const {clientHealthReport} = XH.trackService.conf;
         Timer.create({
             runFn: () => this.sendReportInternal(),

--- a/svc/ConfigService.ts
+++ b/svc/ConfigService.ts
@@ -6,6 +6,7 @@
  */
 import {HoistService, XH} from '@xh/hoist/core';
 import {deepFreeze, throwIf} from '@xh/hoist/utils/js';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {keys} from 'lodash';
 
 /**
@@ -28,12 +29,10 @@ export class ConfigService extends HoistService {
 
     private _data = {};
 
-    override async initAsync() {
-        this._data = await XH.fetchJson({
-            url: 'xh/getConfig',
-            span: {name: 'getConfig', source: 'hoist', caller: this}
-        });
+    override async initAsync(span: Span) {
+        this._data = await XH.fetchJson({url: 'xh/getConfig', span});
         deepFreeze(this._data);
+        XH.traceService.noteConfigAvailable();
     }
 
     /**

--- a/svc/ConfigService.ts
+++ b/svc/ConfigService.ts
@@ -29,7 +29,10 @@ export class ConfigService extends HoistService {
     private _data = {};
 
     override async initAsync() {
-        this._data = await XH.fetchJson({url: 'xh/getConfig'});
+        this._data = await XH.fetchJson({
+            url: 'xh/getConfig',
+            span: {name: 'getConfig', source: 'hoist', caller: this}
+        });
         deepFreeze(this._data);
     }
 

--- a/svc/ConfigService.ts
+++ b/svc/ConfigService.ts
@@ -29,7 +29,10 @@ export class ConfigService extends HoistService {
     private _data = {};
 
     override async initAsync(ctx: InitContext) {
-        this._data = await XH.fetchJson({url: 'xh/getConfig', span: ctx.span});
+        this._data = await XH.fetchJson({
+            url: 'xh/getConfig',
+            span: {name: 'xh.client.config.get', parent: ctx.span, caller: this}
+        });
         deepFreeze(this._data);
     }
 

--- a/svc/ConfigService.ts
+++ b/svc/ConfigService.ts
@@ -4,9 +4,8 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, XH} from '@xh/hoist/core';
 import {deepFreeze, throwIf} from '@xh/hoist/utils/js';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {keys} from 'lodash';
 
 /**
@@ -29,8 +28,8 @@ export class ConfigService extends HoistService {
 
     private _data = {};
 
-    override async initAsync(span: Span) {
-        this._data = await XH.fetchJson({url: 'xh/getConfig', span});
+    override async initAsync(ctx: InitContext) {
+        this._data = await XH.fetchJson({url: 'xh/getConfig', span: ctx.span});
         deepFreeze(this._data);
     }
 

--- a/svc/ConfigService.ts
+++ b/svc/ConfigService.ts
@@ -32,7 +32,6 @@ export class ConfigService extends HoistService {
     override async initAsync(span: Span) {
         this._data = await XH.fetchJson({url: 'xh/getConfig', span});
         deepFreeze(this._data);
-        XH.traceService.noteConfigAvailable();
     }
 
     /**

--- a/svc/EnvironmentService.ts
+++ b/svc/EnvironmentService.ts
@@ -51,7 +51,8 @@ export class EnvironmentService extends HoistService {
 
     override async initAsync() {
         const {pollConfig, instanceName, alertBanner, ...serverEnv} = await XH.fetchJson({
-                url: 'xh/environment'
+                url: 'xh/environment',
+                span: {name: 'getEnvironment', source: 'hoist', caller: this}
             }),
             clientTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'Unknown',
             clientTimeZoneOffset = new Date().getTimezoneOffset() * -1 * MINUTES;
@@ -114,9 +115,12 @@ export class EnvironmentService extends HoistService {
      * @internal - not for app use. Called by `pollTimer` and as needed by Hoist code.
      */
     async pollServerAsync() {
-        let data;
+        let data: any;
         try {
-            data = await XH.fetchJson({url: 'xh/environmentPoll'});
+            data = await XH.fetchJson({
+                url: 'xh/environmentPoll',
+                span: {name: 'envPoll', source: 'hoist', caller: this}
+            });
         } catch (e) {
             this.logError('Error polling server environment', e);
             return;

--- a/svc/EnvironmentService.ts
+++ b/svc/EnvironmentService.ts
@@ -120,7 +120,7 @@ export class EnvironmentService extends HoistService {
         try {
             data = await XH.fetchJson({
                 url: 'xh/environmentPoll',
-                span: {name: 'xh.envPoll', caller: this}
+                span: {name: 'xh.client.envPoll', caller: this}
             });
         } catch (e) {
             this.logError('Error polling server environment', e);

--- a/svc/EnvironmentService.ts
+++ b/svc/EnvironmentService.ts
@@ -5,14 +5,13 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import bpPkg from '@blueprintjs/core/package.json';
-import {HoistService, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, XH} from '@xh/hoist/core';
 import {agGridVersion} from '@xh/hoist/kit/ag-grid';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import hoistPkg from '@xh/hoist/package.json';
 import {Timer} from '@xh/hoist/utils/async';
 import {MINUTES, SECONDS} from '@xh/hoist/utils/datetime';
 import {checkMinVersion, deepFreeze, throwIf} from '@xh/hoist/utils/js';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {defaults, isFinite} from 'lodash';
 import mobxPkg from 'mobx/package.json';
 import {version as reactVersion} from 'react';
@@ -50,10 +49,10 @@ export class EnvironmentService extends HoistService {
     private pollConfig: PollConfig;
     private pollTimer: Timer;
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         const {pollConfig, instanceName, alertBanner, ...serverEnv} = await XH.fetchJson({
                 url: 'xh/environment',
-                span
+                span: ctx.span
             }),
             clientTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'Unknown',
             clientTimeZoneOffset = new Date().getTimezoneOffset() * -1 * MINUTES;

--- a/svc/EnvironmentService.ts
+++ b/svc/EnvironmentService.ts
@@ -109,7 +109,7 @@ export class EnvironmentService extends HoistService {
     }
 
     /**
-     * Update critical environment information from server, including current app version + build,
+     * Update critical environment information from the server, including current app version + build,
      * upgrade prompt mode, and alert banner.
      *
      * @internal - not for app use. Called by `pollTimer` and as needed by Hoist code.

--- a/svc/EnvironmentService.ts
+++ b/svc/EnvironmentService.ts
@@ -12,6 +12,7 @@ import hoistPkg from '@xh/hoist/package.json';
 import {Timer} from '@xh/hoist/utils/async';
 import {MINUTES, SECONDS} from '@xh/hoist/utils/datetime';
 import {checkMinVersion, deepFreeze, throwIf} from '@xh/hoist/utils/js';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {defaults, isFinite} from 'lodash';
 import mobxPkg from 'mobx/package.json';
 import {version as reactVersion} from 'react';
@@ -49,10 +50,10 @@ export class EnvironmentService extends HoistService {
     private pollConfig: PollConfig;
     private pollTimer: Timer;
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         const {pollConfig, instanceName, alertBanner, ...serverEnv} = await XH.fetchJson({
                 url: 'xh/environment',
-                span: {name: 'getEnvironment', source: 'hoist', caller: this}
+                span
             }),
             clientTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'Unknown',
             clientTimeZoneOffset = new Date().getTimezoneOffset() * -1 * MINUTES;
@@ -119,7 +120,7 @@ export class EnvironmentService extends HoistService {
         try {
             data = await XH.fetchJson({
                 url: 'xh/environmentPoll',
-                span: {name: 'envPoll', source: 'hoist', caller: this}
+                span: {name: 'xh.envPoll', caller: this}
             });
         } catch (e) {
             this.logError('Error polling server environment', e);

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -84,17 +84,17 @@ export class FetchService extends HoistService {
     }
 
     /**
-     * Promise handlers to be executed before fufilling or rejecting returned Promise.
+     * Promise handlers to be executed before fulfilling or rejecting returned Promise.
      *
      * Use the `onRejected` handler for apps requiring common handling for particular exceptions.
-     * Useful for recognizing 401s (i.e. session end), or wrapping, logging, or enhancing exceptions.
+     * Useful for recognizing 401s (i.e., session end), or wrapping, logging, or enhancing exceptions.
      * The simplest onRejected handler will simply rethrow the passed exception, or a wrapped version of it.
      * Such handlers may also return `never()` to prevent further processing of the request -- this
-     * is useful, i.e. if the handler is going to redirect the entire app, or otherwise end normal
+     * is useful, i.e., if the handler is going to redirect the entire app, or otherwise end normal
      * app processing.  Rejected handlers may also be able to retry and return valid results via
      * another call to fetch.
      *
-     * Use the `onFulfilled` hander for enhancing, tracking, or even rejecting "successful" returns.
+     * Use the `onFulfilled` handler for enhancing, tracking, or even rejecting "successful" returns.
      * For example, a handler of this form could be used to transform a 200 response returned by
      * an API with an "error" flag into a proper client-side exception.
      */
@@ -209,6 +209,8 @@ export class FetchService extends HoistService {
         opts = this.withCorrelationId(opts);
         let ret = this.withSpanAsync(this.createSpanConfig(opts), span => {
             opts = {...opts, traceId: span.traceId};
+
+            // Core promise - chained with header resolution to ensure that work is included in overall tracked time.
             return this.withResolvedHeadersAsync(opts, span).then(opts =>
                 this.managedFetchAsync(opts, span)
             );

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -431,7 +431,7 @@ export class FetchService extends HoistService {
             name: method,
             kind: 'client',
             parent: opts.span as Span,
-            tags: {'http.request.method': method, 'url.path': url, 'xh.source': 'hoist'},
+            tags: {'http.request.method': method, 'url.path': url},
             caller: this
         });
     }

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -349,11 +349,8 @@ export class FetchService extends HoistService {
         aborter: AbortController
     ): Promise<Response> {
         // 1) Prepare URL
-        let {url, method, headers, body, params} = opts,
-            isRelativeUrl = !url.startsWith('/') && !url.includes('//');
-        if (isRelativeUrl) {
-            url = XH.baseUrl + url;
-        }
+        let {url, method, headers, body, params} = opts;
+        url = this.resolveUrl(url);
 
         // 2) Prepare options for fetch API
         const fetchOpts: RequestInit = {
@@ -420,18 +417,33 @@ export class FetchService extends HoistService {
             tags: {
                 'xh.source': 'hoist',
                 'http.request.method': method,
-                'url.path': this.extractUrlPath(opts.url)
+                'url.full': this.buildFullUrl(opts.url)
             }
         };
     }
 
-    private extractUrlPath(url: string): string {
+    /** Prefix relative URLs with {@link XH.baseUrl}; leave absolute/root-relative URLs as-is. */
+    private resolveUrl(url: string): string {
         if (!url) return '';
+        const isRelative = !url.startsWith('/') && !url.includes('//');
+        return isRelative ? XH.baseUrl + url : url;
+    }
+
+    private buildFullUrl(url: string): string {
+        const raw = this.resolveUrl(url);
+        if (!raw) return '';
+
         try {
-            if (url.includes('//')) return new URL(url).pathname;
-            return url.split('?')[0];
-        } catch (e) {
-            return url.split('?')[0];
+            const parsed = new URL(raw, window.location.origin);
+            // Redact values of query params that commonly carry secrets.
+            const sensitive =
+                /^(token|access_token|id_token|password|pwd|secret|api[_-]?key|auth|session|sig|signature)$/i;
+            for (const key of Array.from(parsed.searchParams.keys())) {
+                if (sensitive.test(key)) parsed.searchParams.set(key, 'REDACTED');
+            }
+            return parsed.toString();
+        } catch {
+            return raw;
         }
     }
 

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -197,50 +197,39 @@ export class FetchService extends HoistService {
     // Implementation
     //-----------------------
     private async fetchInternalAsync(opts: FetchOptions): Promise<any> {
-        // If a span spec provided create, wrap, and recurse
-        if (XH.traceService?.enabled && opts.span && !(opts.span instanceof Span)) {
+        // 1) If a convenience span spec provided, resolve to an outer Span and recurse.
+        if (opts.span && !(opts.span instanceof Span)) {
+            // Use the global withSpanAsync -- don't want to tag with this as the caller.
             return XH.traceService.withSpanAsync(opts.span, span =>
                 this.fetchInternalAsync({...opts, span})
             );
         }
 
+        // 2) Apply appropriate tracing and correlation to the core work.
         opts = this.withCorrelationId(opts);
+        let ret = this.withSpanAsync(this.createSpanConfig(opts), span => {
+            opts = {...opts, traceId: span.traceId};
+            return this.withResolvedHeadersAsync(opts, span).then(opts =>
+                this.managedFetchAsync(opts, span)
+            );
+        });
 
-        // Tracing - create span for this request.
-        const span = this.startFetchSpan(opts);
-        if (span) opts = {...opts, traceId: span.traceId};
-
-        // Core Promise - chained with header resolution to ensure that work is included in overall tracked time.
-        let ret = this.withResolvedHeadersAsync(opts, span).then(opts =>
-            this.managedFetchAsync(opts)
-        );
-
-        // Apply tracking
-        const {correlationId, loadSpec, track} = opts;
-        if (track) {
+        // 3) Apply tracking
+        if (opts.track) {
+            const {correlationId, loadSpec, track} = opts;
             const trackOptions: TrackOptions = isString(track) ? {message: track} : track;
             warnIf(
                 trackOptions.correlationId || trackOptions.loadSpec,
                 'Neither Correlation ID nor LoadSpec should be set in `FetchOptions.track`. Use `FetchOptions` top-level properties instead.'
             );
-            ret = ret.track({...trackOptions, correlationId: correlationId as string, loadSpec});
+            ret = ret.track({
+                ...trackOptions,
+                correlationId: correlationId as string,
+                loadSpec
+            });
         }
 
-        // Tracing - end span on completion or failure.
-        if (span) {
-            ret = ret.then(
-                value => {
-                    this.endFetchSpan(span, value);
-                    return value;
-                },
-                cause => {
-                    this.endFetchSpan(span, null, cause);
-                    throw cause;
-                }
-            );
-        }
-
-        // Apply interceptors
+        // 4) Apply interceptors - run after span has ended and exported.
         for (const interceptor of this._interceptors) {
             ret = ret.then(
                 value => interceptor.onFulfilled(opts, value),
@@ -309,7 +298,7 @@ export class FetchService extends HoistService {
         return {...opts, method, headers};
     }
 
-    private async managedFetchAsync(opts: FetchOptions): Promise<any> {
+    private async managedFetchAsync(opts: FetchOptions, span: Span): Promise<any> {
         // Prepare auto-aborter
         const {autoAborters, defaultTimeout} = this,
             {autoAbortKey, timeout = defaultTimeout} = opts,
@@ -323,7 +312,10 @@ export class FetchService extends HoistService {
 
         try {
             return await this.abortableFetchAsync(opts, aborter)
-                .then(opts.asJson ? r => this.parseJsonAsync(opts, r) : null)
+                .then(r => {
+                    span.setTag('http.response.status_code', r.status);
+                    return opts.asJson ? this.parseJsonAsync(opts, r) : r;
+                })
                 .timeout(timeout);
         } catch (e) {
             if (e.isTimeout) {
@@ -417,39 +409,18 @@ export class FetchService extends HoistService {
         }
     }
 
-    //------------------
-    // Tracing
-    //------------------
-    private startFetchSpan(opts: FetchOptions): Span {
-        const traceService = XH.traceService;
-        if (!traceService?.enabled) return null;
-
-        const method = opts.method ?? (opts.params ? 'POST' : 'GET'),
-            url = this.extractUrlPath(opts.url);
-
-        return traceService.createSpan({
+    private createSpanConfig(opts: FetchOptions): SpanConfig {
+        const method = opts.method ?? (opts.params ? 'POST' : 'GET');
+        return {
             name: method,
             kind: 'client',
             parent: opts.span as Span,
-            tags: {'xh.source': 'hoist', 'http.request.method': method, 'url.path': url},
-            caller: this
-        });
-    }
-
-    private endFetchSpan(span: Span, value?: any, error?: unknown) {
-        if (!span) return;
-
-        if (value?.status != null) {
-            span.tags['http.response.status_code'] = value.status;
-        }
-
-        if (error) {
-            span.recordError(error);
-            span.end('error');
-        } else {
-            span.end('ok');
-        }
-        XH.traceService.exportSpan(span);
+            tags: {
+                'xh.source': 'hoist',
+                'http.request.method': method,
+                'url.path': this.extractUrlPath(opts.url)
+            }
+        };
     }
 
     private extractUrlPath(url: string): string {

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -431,7 +431,7 @@ export class FetchService extends HoistService {
             name: method,
             kind: 'client',
             parent: opts.span as Span,
-            tags: {'http.request.method': method, 'url.path': url},
+            tags: {'xh.source': 'hoist', 'http.request.method': method, 'url.path': url},
             caller: this
         });
     }

--- a/svc/IdentityService.ts
+++ b/svc/IdentityService.ts
@@ -102,7 +102,7 @@ export class IdentityService extends HoistService {
             params: {
                 username: username
             },
-            span: {name: 'impersonate', source: 'hoist', caller: this}
+            span: {name: 'xh.impersonate', caller: this}
         });
         XH.reloadApp();
     }
@@ -113,7 +113,7 @@ export class IdentityService extends HoistService {
             await XH.prefService?.pushPendingAsync();
             await XH.fetchJson({
                 url: 'xh/endImpersonate',
-                span: {name: 'endImpersonate', source: 'hoist', caller: this}
+                span: {name: 'xh.endImpersonate', caller: this}
             });
             XH.reloadApp();
         } catch (e) {

--- a/svc/IdentityService.ts
+++ b/svc/IdentityService.ts
@@ -102,7 +102,7 @@ export class IdentityService extends HoistService {
             params: {
                 username: username
             },
-            span: {name: 'xh.impersonate', caller: this}
+            span: {name: 'xh.client.impersonate', caller: this}
         });
         XH.reloadApp();
     }
@@ -113,7 +113,7 @@ export class IdentityService extends HoistService {
             await XH.prefService?.pushPendingAsync();
             await XH.fetchJson({
                 url: 'xh/endImpersonate',
-                span: {name: 'xh.endImpersonate', caller: this}
+                span: {name: 'xh.client.endImpersonate', caller: this}
             });
             XH.reloadApp();
         } catch (e) {

--- a/svc/IdentityService.ts
+++ b/svc/IdentityService.ts
@@ -102,7 +102,7 @@ export class IdentityService extends HoistService {
             params: {
                 username: username
             },
-            span: {name: 'xh.client.impersonate', caller: this}
+            span: {name: 'xh.client.identity.impersonate', caller: this}
         });
         XH.reloadApp();
     }
@@ -113,7 +113,7 @@ export class IdentityService extends HoistService {
             await XH.prefService?.pushPendingAsync();
             await XH.fetchJson({
                 url: 'xh/endImpersonate',
-                span: {name: 'xh.client.endImpersonate', caller: this}
+                span: {name: 'xh.client.identity.endImpersonate', caller: this}
             });
             XH.reloadApp();
         } catch (e) {

--- a/svc/IdentityService.ts
+++ b/svc/IdentityService.ts
@@ -101,7 +101,8 @@ export class IdentityService extends HoistService {
             url: 'xh/impersonate',
             params: {
                 username: username
-            }
+            },
+            span: {name: 'impersonate', source: 'hoist', caller: this}
         });
         XH.reloadApp();
     }
@@ -110,7 +111,10 @@ export class IdentityService extends HoistService {
     async endImpersonateAsync() {
         try {
             await XH.prefService?.pushPendingAsync();
-            await XH.fetchJson({url: 'xh/endImpersonate'});
+            await XH.fetchJson({
+                url: 'xh/endImpersonate',
+                span: {name: 'endImpersonate', source: 'hoist', caller: this}
+            });
             XH.reloadApp();
         } catch (e) {
             XH.handleException(e, {message: 'Failed to end impersonation'});

--- a/svc/InspectorService.ts
+++ b/svc/InspectorService.ts
@@ -11,6 +11,7 @@ import {wait} from '@xh/hoist/promise';
 import {Timer} from '@xh/hoist/utils/async';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {instanceManager} from '@xh/hoist/core/impl/InstanceManager';
+import {Span} from '@xh/hoist/utils/telemetry';
 
 /**
  * Developer/Admin focused service to provide additional processing and stats related to the
@@ -68,7 +69,7 @@ export class InspectorService extends HoistService {
         makeObservable(this);
     }
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         // Ensure deactivated if not enabled - active could be persisted to true.
         if (!this.enabled) {
             this.deactivate();

--- a/svc/InspectorService.ts
+++ b/svc/InspectorService.ts
@@ -4,14 +4,13 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, managed, persist, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, managed, persist, XH} from '@xh/hoist/core';
 import {Store} from '@xh/hoist/data';
 import {action, bindable, makeObservable, observable} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 import {Timer} from '@xh/hoist/utils/async';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {instanceManager} from '@xh/hoist/core/impl/InstanceManager';
-import {Span} from '@xh/hoist/utils/telemetry';
 
 /**
  * Developer/Admin focused service to provide additional processing and stats related to the
@@ -69,7 +68,7 @@ export class InspectorService extends HoistService {
         makeObservable(this);
     }
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         // Ensure deactivated if not enabled - active could be persisted to true.
         if (!this.enabled) {
             this.deactivate();

--- a/svc/PrefService.ts
+++ b/svc/PrefService.ts
@@ -128,7 +128,7 @@ export class PrefService extends HoistService {
             params: {
                 clientUsername: XH.getUsername()
             },
-            span: {name: 'xh.client.setPrefs', caller: this}
+            span: {name: 'xh.client.prefs.set', caller: this}
         });
     }
 
@@ -144,7 +144,7 @@ export class PrefService extends HoistService {
         const data = await XH.fetchJson({
             url: 'xh/getPrefs',
             params: {clientUsername: XH.getUsername()},
-            span
+            span: {name: 'xh.client.prefs.get', parent: span, caller: this}
         });
         forEach(data, v => {
             deepFreeze(v.value);

--- a/svc/PrefService.ts
+++ b/svc/PrefService.ts
@@ -128,7 +128,7 @@ export class PrefService extends HoistService {
             params: {
                 clientUsername: XH.getUsername()
             },
-            span: {name: 'xh.setPrefs', caller: this}
+            span: {name: 'xh.client.setPrefs', caller: this}
         });
     }
 

--- a/svc/PrefService.ts
+++ b/svc/PrefService.ts
@@ -126,7 +126,8 @@ export class PrefService extends HoistService {
             body: updates,
             params: {
                 clientUsername: XH.getUsername()
-            }
+            },
+            span: {name: 'setPrefs', source: 'hoist', caller: this}
         });
     }
 
@@ -141,7 +142,8 @@ export class PrefService extends HoistService {
     private async loadPrefsAsync() {
         const data = await XH.fetchJson({
             url: 'xh/getPrefs',
-            params: {clientUsername: XH.getUsername()}
+            params: {clientUsername: XH.getUsername()},
+            span: {name: 'getPrefs', source: 'hoist', caller: this}
         });
         forEach(data, v => {
             deepFreeze(v.value);

--- a/svc/PrefService.ts
+++ b/svc/PrefService.ts
@@ -7,6 +7,7 @@
 import {HoistService, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {debounced, deepFreeze, throwIf} from '@xh/hoist/utils/js';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {cloneDeep, forEach, isEmpty, isEqual} from 'lodash';
 
 /**
@@ -31,9 +32,9 @@ export class PrefService extends HoistService {
     private _data = {};
     private _updates = {};
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         window.addEventListener('beforeunload', () => this.pushPendingAsync());
-        return this.loadPrefsAsync();
+        return this.loadPrefsAsync(span);
     }
 
     /**
@@ -127,7 +128,7 @@ export class PrefService extends HoistService {
             params: {
                 clientUsername: XH.getUsername()
             },
-            span: {name: 'setPrefs', source: 'hoist', caller: this}
+            span: {name: 'xh.setPrefs', caller: this}
         });
     }
 
@@ -139,11 +140,11 @@ export class PrefService extends HoistService {
         this.pushPendingAsync();
     }
 
-    private async loadPrefsAsync() {
+    private async loadPrefsAsync(span: Span) {
         const data = await XH.fetchJson({
             url: 'xh/getPrefs',
             params: {clientUsername: XH.getUsername()},
-            span: {name: 'getPrefs', source: 'hoist', caller: this}
+            span
         });
         forEach(data, v => {
             deepFreeze(v.value);

--- a/svc/PrefService.ts
+++ b/svc/PrefService.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {debounced, deepFreeze, throwIf} from '@xh/hoist/utils/js';
 import {Span} from '@xh/hoist/utils/telemetry';
@@ -32,9 +32,9 @@ export class PrefService extends HoistService {
     private _data = {};
     private _updates = {};
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         window.addEventListener('beforeunload', () => this.pushPendingAsync());
-        return this.loadPrefsAsync(span);
+        return this.loadPrefsAsync(ctx.span);
     }
 
     /**

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, PlainObject, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, PlainObject, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {debounced, parseNameSource} from '@xh/hoist/utils/js';
 import {every, forEach, groupBy, isEmpty, isString} from 'lodash';
@@ -48,7 +48,7 @@ export class TraceService extends HoistService {
     //------------------
     // Initialization
     //------------------
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         window.addEventListener('beforeunload', () => this.pushPendingAsync());
     }
 

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -43,6 +43,7 @@ export class TraceService extends HoistService {
      * its "deferred" branch.
      */
     private _pendingConfig: Span[] = [];
+    private conf: TraceConfig = {enabled: false};
 
     //------------------
     // Initialization
@@ -54,14 +55,6 @@ export class TraceService extends HoistService {
     //------------------
     // Configuration
     //------------------
-    /** Parsed tracing config from server soft-config */
-    get conf(): TraceConfig {
-        return {
-            enabled: false,
-            ...(XH.configService?.get('xhTraceConfig', {}) ?? {})
-        };
-    }
-
     /** Is tracing currently enabled? */
     get enabled(): boolean {
         return this.conf.enabled;
@@ -117,6 +110,9 @@ export class TraceService extends HoistService {
         }
     }
 
+    //------------------
+    // Implementation
+    //------------------
     /**
      * Create a new span. Always returns a span - when tracing is disabled the returned span
      * is flagged unsampled and will never be exported, so callers can interact with it safely.
@@ -133,7 +129,7 @@ export class TraceService extends HoistService {
      *
      * @param config - span name string, or a SpanConfig with name and optional tags.
      */
-    createSpan(config: string | SpanConfig): Span {
+    private createSpan(config: string | SpanConfig): Span {
         const ret: SpanConfig = isString(config) ? {name: config} : {...config};
 
         // Apply default tags - safe to call even before identity is resolved (getUsername is null).
@@ -162,7 +158,7 @@ export class TraceService extends HoistService {
      * Submit a completed span for export. Spans whose sampling is still undecided are held
      * for {@link noteConfigAvailable}; sampled spans are queued and flushed on a debounced timer.
      */
-    exportSpan(span: Span) {
+    private exportSpan(span: Span) {
         // Defer - decision will be made once xhTraceConfig is loaded.
         if (span.sampled === null) return;
         if (!this.enabled) return;
@@ -181,7 +177,7 @@ export class TraceService extends HoistService {
      * Push all pending spans to the server.
      * Called on debounced interval and on page unload.
      */
-    async pushPendingAsync() {
+    private async pushPendingAsync() {
         const spans = this._pending;
         if (isEmpty(spans)) return;
 
@@ -199,9 +195,6 @@ export class TraceService extends HoistService {
         }
     }
 
-    //------------------
-    // Implementation
-    //------------------
     /**
      * Called by {@link ConfigService} once `xhTraceConfig` has loaded. Applies sampling
      * decisions to all spans created during early startup and held in the pendingConfig
@@ -214,6 +207,7 @@ export class TraceService extends HoistService {
      * @internal - for framework use only.
      */
     noteConfigAvailable() {
+        this.conf = {enabled: false, ...XH.configService.get('xhTraceConfig', {})};
         const pending = this._pendingConfig;
         this._pendingConfig = null;
 

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -126,7 +126,7 @@ export class TraceService extends HoistService {
             'xh.clientApp': XH.clientAppCode,
             'xh.loadId': XH.loadId,
             'xh.tabId': XH.tabId,
-            'xh.source': ret.parent?.tags?.['xh.source'] ?? 'app',
+            'xh.source': ret.source ?? ret.parent?.tags?.['xh.source'] ?? 'app',
             'user.name': XH.getUsername(),
             ...(ret.caller ? {'code.namespace': parseNameSource(ret.caller)} : {}),
             ...ret.tags

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, InitContext, PlainObject, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {debounced, parseNameSource} from '@xh/hoist/utils/js';
 import {every, forEach, groupBy, isEmpty, isString} from 'lodash';
@@ -18,15 +18,15 @@ import {Span, SpanConfig} from '@xh/hoist/utils/telemetry';
  * end-to-end traces from user interaction through server processing and back.
  *
  * Controlled by the `xhTraceConfig` soft config. When disabled (the default), spans are
- * still created and passed to wrapped functions, but are flagged as unsampled and never
+ * still created and passed to wrapped functions but are flagged as unsampled and never
  * exported - callers can interact with the span without null checks.
  *
- * To support tracing from the earliest moments of app startup, this service is installed
+ * To support tracing from the earliest moments of app startup this service is installed
  * before any other, well before Config can be loaded. Spans created during that
  * window are marked with `sampled === null` (decision deferred) and held in a pending bucket.
- * Once config arrives, {@link noteConfigAvailable} walks the bucket, and applies sampling rules
- * per-trace.  Outbound `traceparent` headers send `00` while undecided so server-side spans don't
- * sample without a client decision.
+ * Once config arrives, {@link noteConfigAvailable} the service walks the bucket, and applies
+ * sampling rules per-trace.  Outbound `traceparent` headers send `00` in the undetermined state
+ * so server-side spans don't sample without a client decision.
  *
  * Completed spans are batched and exported to the Hoist server endpoint `xh/submitSpans`,
  * which relays them to the configured collector.
@@ -37,13 +37,11 @@ export class TraceService extends HoistService {
     /** Spans whose sampling has been decided and are queued for export. */
     private _pending: Span[] = [];
 
-    /**
-     * Spans created before sampling config is loaded - held here until {@link noteConfigAvailable}
-     * resolves them. Nulled out once config is available, which also gates `shouldSample` out of
-     * its "deferred" branch.
-     */
-    private _pendingConfig: Span[] = [];
-    private conf: TraceConfig = {enabled: false};
+    /** Config. Will be loaded when available. */
+    private conf: TraceConfig = null;
+
+    /** Spans created before config available. */
+    private _preConfigSpans: Span[] = [];
 
     //------------------
     // Initialization
@@ -57,7 +55,7 @@ export class TraceService extends HoistService {
     //------------------
     /** Is tracing currently enabled? */
     get enabled(): boolean {
-        return this.conf.enabled;
+        return this.conf?.enabled ?? false;
     }
 
     //------------------
@@ -143,11 +141,17 @@ export class TraceService extends HoistService {
             ...ret.tags
         };
 
-        // Sampling: children inherit; roots evaluate rules.
-        ret.sampled = ret.parent ? ret.parent.sampled : this.shouldSample(ret.name, ret.tags);
-
         const span = new Span(ret);
-        if (span.sampled === null) this._pendingConfig?.push(span);
+
+        // Handle sampling for roots. If config available compute, otherwise defer
+        if (span.sampled === null) {
+            if (this.conf) {
+                span.sampled = this.shouldSample(span);
+            } else {
+                this._preConfigSpans.push(span);
+            }
+        }
+
         return span;
     }
 
@@ -159,14 +163,12 @@ export class TraceService extends HoistService {
      * for {@link noteConfigAvailable}; sampled spans are queued and flushed on a debounced timer.
      */
     private exportSpan(span: Span) {
-        // Defer - decision will be made once xhTraceConfig is loaded.
-        if (span.sampled === null) return;
-        if (!this.enabled) return;
+        if (!this.enabled || span.sampled === null) return; // defer until config is loaded.
+
         if (span.sampled || (this.conf.alwaysSampleErrors && span.status === 'error')) {
             this._pending.push(span);
 
-            // Queue the span, but if this is the submitSpans export itself, don't schedule
-            // another flush or we'll loop forever.
+            // Queue the push unless its submitSpans export itself (avoid looping).
             if (!span.tags['url.path']?.endsWith('xh/submitSpans')) {
                 this.pushPendingBuffered();
             }
@@ -208,20 +210,19 @@ export class TraceService extends HoistService {
      */
     noteConfigAvailable() {
         this.conf = {enabled: false, ...XH.configService.get('xhTraceConfig', {})};
-        const pending = this._pendingConfig;
-        this._pendingConfig = null;
 
         // Group by traceId so we can resolve sampling once at root. Re-export any spans that
         // have already ended - their own finally-block `exportSpan` early-returned on null.
         // Spans still in flight will export correctly when they end.
-        forEach(groupBy(pending, 'traceId'), spans => {
-            const root = spans.find(s => !s.parentSpanId) ?? spans[0],
-                decision = this.shouldSample(root.name, root.tags);
+        forEach(groupBy(this._preConfigSpans, 'traceId'), spans => {
+            const rootSampled = this.shouldSample(spans.find(s => !s.parent) ?? spans[0]);
             spans.forEach(s => {
-                s.sampled = decision;
+                s.sampled = rootSampled;
                 if (s.endTime) this.exportSpan(s);
             });
         });
+
+        this._preConfigSpans = null;
     }
 
     @debounced(5 * SECONDS)
@@ -230,26 +231,28 @@ export class TraceService extends HoistService {
     }
 
     /**
-     * Resolve a root-span sampling decision: returns `null` to defer until config is loaded,
-     * `false` when tracing is disabled, or a probabilistic decision from `sampleRules`. Rules
+     * Resolve a root-span sampling decision: a probabilistic decision from `sampleRules`. Rules
      * match on tag keys; the reserved key `name` matches the span's name (glob-capable, same
      * syntax as tag-value patterns).
      */
-    private shouldSample(name: string, tags: PlainObject): boolean | null {
-        if (this._pendingConfig) return null;
+    private shouldSample(span: Span): boolean {
         if (!this.enabled) return false;
         try {
-            return Math.random() < this.getSampleRate(name, tags);
+            return Math.random() < this.getSampleRate(span);
         } catch (e) {
             this.logError('Failed to compute sample rate', e);
             return false;
         }
     }
 
-    private getSampleRate(name: string, tags: PlainObject): number {
+    private getSampleRate(span: Span): number {
         const {conf} = this;
         for (const rule of conf.sampleRules ?? []) {
-            if (every(rule.match, (v, k) => this.matchesValue(k === 'name' ? name : tags[k], v))) {
+            if (
+                every(rule.match, (v, k) =>
+                    this.matchesValue(k === 'name' ? span.name : span.tags[k], v)
+                )
+            ) {
                 return rule.sampleRate;
             }
         }

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -7,7 +7,7 @@
 import {HoistService, InitContext, PlainObject, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {debounced, parseNameSource} from '@xh/hoist/utils/js';
-import {every, forEach, groupBy, isEmpty, isString} from 'lodash';
+import {every, forEach, groupBy, isEmpty, isString, omitBy} from 'lodash';
 import {Span, SpanConfig} from '@xh/hoist/utils/telemetry';
 
 /**
@@ -116,7 +116,8 @@ export class TraceService extends HoistService {
      * is flagged unsampled and will never be exported, so callers can interact with it safely.
      *
      * The `xh.source` tag defaults to `'hoist'` for spans whose name starts with `'xh.'` and
-     * `'app'` otherwise. Callers may override via `tags`.
+     * `'app'` otherwise. Callers may override all tag values, including setting to null to prevent
+     *  any default tag from being applied.
      *
      * Sampling rules from `xhTraceConfig.sampleRules` are evaluated against the span's tags
      * at creation time (head-based). Child spans inherit their parent's sampling decision.
@@ -131,6 +132,7 @@ export class TraceService extends HoistService {
         const ret: SpanConfig = isString(config) ? {name: config} : {...config};
 
         // Apply default tags - safe to call even before identity is resolved (getUsername is null).
+        // Remove nulls they are used in this API to just prevent defaults
         ret.tags = {
             'xh.clientApp': XH.clientAppCode,
             'xh.loadId': XH.loadId,
@@ -140,6 +142,7 @@ export class TraceService extends HoistService {
             ...this.identityTags(),
             ...ret.tags
         };
+        ret.tags = omitBy(ret.tags, v => v == null);
 
         const span = new Span(ret);
 

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -7,7 +7,7 @@
 import {HoistService, PlainObject, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {debounced, parseNameSource} from '@xh/hoist/utils/js';
-import {every, isEmpty, isString} from 'lodash';
+import {every, forEach, groupBy, isEmpty, isString} from 'lodash';
 import {Span, SpanConfig} from '@xh/hoist/utils/telemetry';
 
 /**
@@ -21,31 +21,44 @@ import {Span, SpanConfig} from '@xh/hoist/utils/telemetry';
  * still created and passed to wrapped functions, but are flagged as unsampled and never
  * exported - callers can interact with the span without null checks.
  *
+ * To support tracing from the earliest moments of app startup, this service is installed
+ * before any other, well before Config can be loaded. Spans created during that
+ * window are marked with `sampled === null` (decision deferred) and held in a pending bucket.
+ * Once config arrives, {@link noteConfigAvailable} walks the bucket, and applies sampling rules
+ * per-trace.  Outbound `traceparent` headers send `00` while undecided so server-side spans don't
+ * sample without a client decision.
+ *
  * Completed spans are batched and exported to the Hoist server endpoint `xh/submitSpans`,
  * which relays them to the configured collector.
- *
  */
 export class TraceService extends HoistService {
     static instance: TraceService;
 
+    /** Spans whose sampling has been decided and are queued for export. */
     private _pending: Span[] = [];
+
+    /**
+     * Spans created before sampling config is loaded - held here until {@link noteConfigAvailable}
+     * resolves them. Nulled out once config is available, which also gates `shouldSample` out of
+     * its "deferred" branch.
+     */
+    private _pendingConfig: Span[] = [];
 
     //------------------
     // Initialization
     //------------------
-    override async initAsync() {
-        if (!this.enabled) return;
+    override async initAsync(span: Span) {
         window.addEventListener('beforeunload', () => this.pushPendingAsync());
     }
 
     //------------------
     // Configuration
     //------------------
-    /** Parsed tracing config from server soft-config. */
+    /** Parsed tracing config from server soft-config */
     get conf(): TraceConfig {
         return {
             enabled: false,
-            ...XH.getConf('xhTraceConfig', {})
+            ...(XH.configService?.get('xhTraceConfig', {}) ?? {})
         };
     }
 
@@ -107,42 +120,51 @@ export class TraceService extends HoistService {
     /**
      * Create a new span. Always returns a span - when tracing is disabled the returned span
      * is flagged unsampled and will never be exported, so callers can interact with it safely.
-     * Inherits the parent's `source` tag if not specified.
+     *
+     * The `xh.source` tag defaults to `'hoist'` for spans whose name starts with `'xh.'` and
+     * `'app'` otherwise. Callers may override via `tags`.
      *
      * Sampling rules from `xhTraceConfig.sampleRules` are evaluated against the span's tags
      * at creation time (head-based). Child spans inherit their parent's sampling decision.
-     * Unsampled spans may still be exported if they end in error and `alwaysSampleErrors` is
-     * enabled — see {@link exportSpan}.
+     * Spans created before `xhTraceConfig` is loaded (during early app startup) are marked
+     * `sampled === null` and parked in a pending bucket; {@link noteConfigAvailable} decides their
+     * fate once config arrives. Unsampled spans may still be exported if they end in error and
+     * `alwaysSampleErrors` is enabled - see {@link exportSpan}.
      *
      * @param config - span name string, or a SpanConfig with name and optional tags.
      */
     createSpan(config: string | SpanConfig): Span {
         const ret: SpanConfig = isString(config) ? {name: config} : {...config};
 
-        if (!this.enabled) return new Span({...ret, sampled: false});
-
-        // Apply default tags.
+        // Apply default tags - safe to call even before identity is resolved (getUsername is null).
         ret.tags = {
             'xh.clientApp': XH.clientAppCode,
             'xh.loadId': XH.loadId,
             'xh.tabId': XH.tabId,
-            'xh.source': ret.source ?? ret.parent?.tags?.['xh.source'] ?? 'app',
+            'xh.source': ret.name.startsWith('xh.') ? 'hoist' : 'app',
             'user.name': XH.getUsername(),
             ...(ret.caller ? {'code.namespace': parseNameSource(ret.caller)} : {}),
             ...ret.tags
         };
 
-        // Sampling: children inherit parent decision; root spans evaluate rules.
-        ret.sampled = ret.parent ? ret.parent.sampled : this.shouldSample(ret.tags);
+        // Sampling: children inherit; roots evaluate rules.
+        ret.sampled = ret.parent ? ret.parent.sampled : this.shouldSample(ret.name, ret.tags);
 
-        return new Span(ret);
+        const span = new Span(ret);
+        if (span.sampled === null) this._pendingConfig?.push(span);
+        return span;
     }
 
     //------------------
     // Span Export
     //------------------
-    /** Submit a completed span for export. */
+    /**
+     * Submit a completed span for export. Spans whose sampling is still undecided are held
+     * for {@link noteConfigAvailable}; sampled spans are queued and flushed on a debounced timer.
+     */
     exportSpan(span: Span) {
+        // Defer - decision will be made once xhTraceConfig is loaded.
+        if (span.sampled === null) return;
         if (!this.enabled) return;
         if (span.sampled || (this.conf.alwaysSampleErrors && span.status === 'error')) {
             this._pending.push(span);
@@ -180,25 +202,60 @@ export class TraceService extends HoistService {
     //------------------
     // Implementation
     //------------------
+    /**
+     * Called by {@link ConfigService} once `xhTraceConfig` has loaded. Applies sampling
+     * decisions to all spans created during early startup and held in the pendingConfig
+     * bucket.
+     *
+     * For each trace represented in the pending bucket: the root span (or oldest-known
+     * ancestor) is evaluated against the sampling rules, and the decision is propagated
+     * to every span in that trace. Sampled, ended spans are exported at this time.
+     *
+     * @internal - for framework use only.
+     */
+    noteConfigAvailable() {
+        const pending = this._pendingConfig;
+        this._pendingConfig = null;
+
+        // Group by traceId so we can resolve sampling once at root. Re-export any spans that
+        // have already ended - their own finally-block `exportSpan` early-returned on null.
+        // Spans still in flight will export correctly when they end.
+        forEach(groupBy(pending, 'traceId'), spans => {
+            const root = spans.find(s => !s.parentSpanId) ?? spans[0],
+                decision = this.shouldSample(root.name, root.tags);
+            spans.forEach(s => {
+                s.sampled = decision;
+                if (s.endTime) this.exportSpan(s);
+            });
+        });
+    }
+
     @debounced(5 * SECONDS)
     private pushPendingBuffered() {
         void this.pushPendingAsync();
     }
 
-    /** Evaluate sampling rules against a span's tags. */
-    private shouldSample(tags: PlainObject): boolean {
+    /**
+     * Resolve a root-span sampling decision: returns `null` to defer until config is loaded,
+     * `false` when tracing is disabled, or a probabilistic decision from `sampleRules`. Rules
+     * match on tag keys; the reserved key `name` matches the span's name (glob-capable, same
+     * syntax as tag-value patterns).
+     */
+    private shouldSample(name: string, tags: PlainObject): boolean | null {
+        if (this._pendingConfig) return null;
+        if (!this.enabled) return false;
         try {
-            return Math.random() < this.getSampleRate(tags);
+            return Math.random() < this.getSampleRate(name, tags);
         } catch (e) {
             this.logError('Failed to compute sample rate', e);
             return false;
         }
     }
 
-    private getSampleRate(tags: PlainObject): number {
+    private getSampleRate(name: string, tags: PlainObject): number {
         const {conf} = this;
         for (const rule of conf.sampleRules ?? []) {
-            if (every(rule.match, (v, k) => this.matchesValue(tags[k], v))) {
+            if (every(rule.match, (v, k) => this.matchesValue(k === 'name' ? name : tags[k], v))) {
                 return rule.sampleRate;
             }
         }

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, InitContext, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, PlainObject, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {debounced, parseNameSource} from '@xh/hoist/utils/js';
 import {every, forEach, groupBy, isEmpty, isString} from 'lodash';
@@ -136,8 +136,8 @@ export class TraceService extends HoistService {
             'xh.loadId': XH.loadId,
             'xh.tabId': XH.tabId,
             'xh.source': ret.name.startsWith('xh.') ? 'hoist' : 'app',
-            'user.name': XH.getUsername(),
             ...(ret.caller ? {'code.namespace': parseNameSource(ret.caller)} : {}),
+            ...this.identityTags(),
             ...ret.tags
         };
 
@@ -146,7 +146,7 @@ export class TraceService extends HoistService {
         // Handle sampling for roots. If config available compute, otherwise defer
         if (span.sampled === null) {
             if (this.conf) {
-                span.sampled = this.shouldSample(span);
+                span.sampled = this.computeSampled(span);
             } else {
                 this._preConfigSpans.push(span);
             }
@@ -215,7 +215,14 @@ export class TraceService extends HoistService {
         // have already ended - their own finally-block `exportSpan` early-returned on null.
         // Spans still in flight will export correctly when they end.
         forEach(groupBy(this._preConfigSpans, 'traceId'), spans => {
-            const rootSampled = this.shouldSample(spans.find(s => !s.parent) ?? spans[0]);
+            // record the now available identity
+            const tags = this.identityTags();
+            spans.forEach(s => {
+                s.setTags(tags);
+            });
+
+            // sample and export as needed
+            const rootSampled = this.computeSampled(spans.find(s => !s.parent) ?? spans[0]);
             spans.forEach(s => {
                 s.sampled = rootSampled;
                 if (s.endTime) this.exportSpan(s);
@@ -235,7 +242,7 @@ export class TraceService extends HoistService {
      * match on tag keys; the reserved key `name` matches the span's name (glob-capable, same
      * syntax as tag-value patterns).
      */
-    private shouldSample(span: Span): boolean {
+    private computeSampled(span: Span): boolean {
         if (!this.enabled) return false;
         try {
             return Math.random() < this.getSampleRate(span);
@@ -274,6 +281,16 @@ export class TraceService extends HoistService {
         if (startsWithWild) return actual.endsWith(core);
         if (endsWithWild) return actual.startsWith(core);
         return actual === pattern;
+    }
+
+    private identityTags(): PlainObject {
+        if (!XH.identityService) return {};
+        const {authUsername, username} = XH.identityService,
+            ret: PlainObject = {'user.name': authUsername};
+        if (username != authUsername) {
+            ret['xh.impersonating'] = username;
+        }
+        return ret;
     }
 }
 

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -282,12 +282,12 @@ export class TraceService extends HoistService {
 
 interface TraceConfig {
     enabled: boolean;
-    sampleRules?: SamplingRule[];
+    sampleRules?: SampleRule[];
     sampleRate?: number;
     alwaysSampleErrors?: boolean;
 }
 
-interface SamplingRule {
+interface SampleRule {
     match: Record<string, string>;
     sampleRate: number;
 }

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -103,7 +103,7 @@ export class TrackService extends HoistService {
             url: 'xh/track',
             body: {entries: pending},
             params: {clientUsername: XH.getUsername()},
-            span: {name: 'xh.client.trackPush', caller: this}
+            span: {name: 'xh.client.track.push', caller: this}
         });
     }
 

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -4,11 +4,10 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, PlainObject, TrackOptions, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, PlainObject, TrackOptions, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {isOmitted} from '@xh/hoist/utils/impl';
 import {debounced, stripTags, withDefault} from '@xh/hoist/utils/js';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {isEmpty, isNil, isString} from 'lodash';
 
 /**
@@ -22,7 +21,7 @@ export class TrackService extends HoistService {
     private oncePerSessionSent = new Map();
     private pending: PlainObject[] = [];
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         window.addEventListener('beforeunload', () => this.pushPendingAsync());
     }
 

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -104,7 +104,7 @@ export class TrackService extends HoistService {
             url: 'xh/track',
             body: {entries: pending},
             params: {clientUsername: XH.getUsername()},
-            span: {name: 'xh.trackPush', caller: this}
+            span: {name: 'xh.client.trackPush', caller: this}
         });
     }
 

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -8,6 +8,7 @@ import {HoistService, PlainObject, TrackOptions, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {isOmitted} from '@xh/hoist/utils/impl';
 import {debounced, stripTags, withDefault} from '@xh/hoist/utils/js';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {isEmpty, isNil, isString} from 'lodash';
 
 /**
@@ -21,7 +22,7 @@ export class TrackService extends HoistService {
     private oncePerSessionSent = new Map();
     private pending: PlainObject[] = [];
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         window.addEventListener('beforeunload', () => this.pushPendingAsync());
     }
 
@@ -103,7 +104,7 @@ export class TrackService extends HoistService {
             url: 'xh/track',
             body: {entries: pending},
             params: {clientUsername: XH.getUsername()},
-            span: {name: 'trackPush', source: 'hoist', caller: this}
+            span: {name: 'xh.trackPush', caller: this}
         });
     }
 

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -102,7 +102,8 @@ export class TrackService extends HoistService {
         await XH.fetchService.postJson({
             url: 'xh/track',
             body: {entries: pending},
-            params: {clientUsername: XH.getUsername()}
+            params: {clientUsername: XH.getUsername()},
+            span: {name: 'trackPush', source: 'hoist', caller: this}
         });
     }
 

--- a/svc/WebSocketService.ts
+++ b/svc/WebSocketService.ts
@@ -10,6 +10,7 @@ import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {Timer} from '@xh/hoist/utils/async';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {throwIf} from '@xh/hoist/utils/js';
+import {Span} from '@xh/hoist/utils/telemetry';
 import {find, pull} from 'lodash';
 
 /**
@@ -84,7 +85,7 @@ export class WebSocketService extends HoistService {
         makeObservable(this);
     }
 
-    override async initAsync() {
+    override async initAsync(span: Span) {
         if (!this.enabled) return;
 
         const {environmentService} = XH;

--- a/svc/WebSocketService.ts
+++ b/svc/WebSocketService.ts
@@ -4,13 +4,12 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, PlainObject, XH} from '@xh/hoist/core';
+import {HoistService, InitContext, PlainObject, XH} from '@xh/hoist/core';
 import {withFormattedTimestamps} from '@xh/hoist/format';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {Timer} from '@xh/hoist/utils/async';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {throwIf} from '@xh/hoist/utils/js';
-import {Span} from '@xh/hoist/utils/telemetry';
 import {find, pull} from 'lodash';
 
 /**
@@ -85,7 +84,7 @@ export class WebSocketService extends HoistService {
         makeObservable(this);
     }
 
-    override async initAsync(span: Span) {
+    override async initAsync(ctx: InitContext) {
         if (!this.enabled) return;
 
         const {environmentService} = XH;

--- a/utils/telemetry/Span.ts
+++ b/utils/telemetry/Span.ts
@@ -118,6 +118,12 @@ export interface SpanConfig {
     startTime?: number;
     caller?: NameSource;
     sampled?: boolean;
+
+    /**
+     * Origin of this span - recorded as the `xh.source` tag. When omitted, inherits from the
+     * parent span, defaulting to `'app'` for roots.
+     */
+    source?: string;
 }
 
 export interface SpanEvent {

--- a/utils/telemetry/Span.ts
+++ b/utils/telemetry/Span.ts
@@ -42,8 +42,15 @@ export class Span {
     tags: PlainObject;
     events: SpanEvent[] = [];
 
-    /** Whether this span was selected by client-side sampling rules. */
-    sampled: boolean;
+    /**
+     * Tri-state sampling decision:
+     * - `true`: span is sampled and will be exported.
+     * - `false`: span is not sampled and will be dropped (unless `alwaysSampleErrors` and error).
+     * - `null`: decision deferred (e.g. created before {@link TraceService} sampling config is
+     *   loaded). Resolved later by {@link TraceService}; outbound `traceparent` headers send `00`
+     *   while undecided so server-side spans don't sample without a client decision.
+     */
+    sampled: boolean | null;
 
     constructor(config: SpanConfig) {
         const parent = config.parent;
@@ -54,7 +61,7 @@ export class Span {
         this.kind = config.kind ?? 'internal';
         this.startTime = config.startTime ?? Date.now();
         this.tags = {...config.tags};
-        this.sampled = config.sampled ?? true;
+        this.sampled = config.sampled ?? null;
     }
 
     /** End this span, recording status and computing duration. */
@@ -118,12 +125,6 @@ export interface SpanConfig {
     startTime?: number;
     caller?: NameSource;
     sampled?: boolean;
-
-    /**
-     * Origin of this span - recorded as the `xh.source` tag. When omitted, inherits from the
-     * parent span, defaulting to `'app'` for roots.
-     */
-    source?: string;
 }
 
 export interface SpanEvent {
@@ -136,15 +137,17 @@ export type SpanKind = 'internal' | 'client' | 'server' | 'producer' | 'consumer
 export type SpanStatus = 'ok' | 'error' | 'unset';
 
 /**
- * Format a W3C traceparent header value.
+ * Format a W3C traceparent header value. An undecided sampling state (`null`) is sent as `00`
+ * (not sampled) so the server doesn't make its own sampling decision in the absence of a client
+ * one - those server-side spans would be unparented from the client's perspective.
  * @see https://www.w3.org/TR/trace-context/#traceparent-header
  */
 export function formatTraceparent(
     traceId: string,
     spanId: string,
-    sampled: boolean = true
+    sampled: boolean | null = true
 ): string {
-    return `00-${traceId}-${spanId}-${sampled ? '01' : '00'}`;
+    return `00-${traceId}-${spanId}-${sampled === true ? '01' : '00'}`;
 }
 
 /** Generate a 32-hex-char (128-bit) trace ID. */

--- a/utils/telemetry/Span.ts
+++ b/utils/telemetry/Span.ts
@@ -13,6 +13,8 @@ import {NameSource} from '@xh/hoist/utils/js';
  * Produces W3C-compatible trace and span IDs without requiring the full
  * OpenTelemetry SDK. Completed spans are exported to the Hoist server,
  * which relays them to the configured collector.
+ *
+ * @internal
  */
 export class Span {
     /** 32 hex chars (128-bit). */
@@ -21,8 +23,8 @@ export class Span {
     /** 16 hex chars (64-bit). */
     spanId: string;
 
-    /** 16 hex chars, or null for root spans. */
-    parentSpanId: string;
+    /** Parent span, or null for root spans. */
+    parent: Span;
 
     name: string;
 
@@ -53,15 +55,15 @@ export class Span {
     sampled: boolean | null;
 
     constructor(config: SpanConfig) {
-        const parent = config.parent;
-        this.traceId = parent?.traceId ?? genTraceId();
+        const {parent} = config;
+        this.parent = config.parent;
         this.spanId = genSpanId();
-        this.parentSpanId = parent?.spanId ?? null;
         this.name = config.name;
         this.kind = config.kind ?? 'internal';
         this.startTime = config.startTime ?? Date.now();
-        this.tags = {...config.tags};
-        this.sampled = config.sampled ?? null;
+        this.tags = config.tags;
+        this.traceId = parent?.traceId ?? genTraceId();
+        this.sampled = config.sampled ?? parent?.sampled ?? null;
     }
 
     /** End this span, recording status and computing duration. */
@@ -96,7 +98,7 @@ export class Span {
         return {
             traceId: this.traceId,
             spanId: this.spanId,
-            parentSpanId: this.parentSpanId,
+            parentSpanId: this.parent?.spanId ?? null,
             name: this.name,
             kind: this.kind,
             startTime: this.startTime,


### PR DESCRIPTION
## Summary

- `HoistService.initAsync()` and `HoistAppModel.initAsync()` now receive a `span: Span` so service-init spans nest under `app-init`
- `XH.installServicesAsync()` takes `(classes[], span)` (breaking — see CHANGELOG for before/after)
- `withSpan`/`withSpanAsync` always provide a non-nullable `Span`, matching the server-side API; added `Span.setTag()`/`setTags()`
- `FetchService` refactored to use `withSpanAsync` instead of hand-rolled span creation/export; incidentally fixes a latent bug where `http.response.status_code` was read from the parsed JSON body (not the `Response`) when `asJson` was set
- `Promise.span()` now a one-liner that delegates to `withSpanAsync`, letting `TraceService.createSpan`/`exportSpan` go private
- `sampleRules` in `xhTraceConfig` now support matching the span `name` (glob-capable)

See CHANGELOG for full list including tag/naming consistency improvements.

## Test plan

- [ ] Verify `app-init` root span captures service init spans as children
- [ ] Check fetch spans export correctly with `http.response.status_code` tag for both raw and `asJson` responses
- [ ] Confirm `sampleRules` with a `name` matcher route correctly
- [ ] Smoke-test Toolbox with `xhTraceConfig.enabled: true`