### PR TITLE
Trace ergonomics: ObservedRun builder replaces withSpan/withSpanAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ app-load span changes in this release.
   the upgrade notes cover the mechanical changes and recommended ways to forward `ctx.span`
   into init-time fetch and async work.
 
+* `HoistBase.withSpan()` / `withSpanAsync()` have been removed in favor of the new
+  `HoistBase.span()` builder. Replace `this.withSpanAsync(cfg, fn)` with
+  `this.span(cfg).run(fn)`. The underlying `XH.traceService.withSpan()` API remains for
+  advanced use - now a single async method (the prior sync `withSpan` and async
+  `withSpanAsync` on `TraceService` have been merged).
 * `TraceService` no longer supports the `alwaysSampleErrors` flag, which was deemed inappropriate
   for head-based sampling. This change is consistent with a similar update in hoist-core v39. Apps
   requiring full visibility into error spans for a particular set of errors should ensure they
@@ -33,8 +38,12 @@ app-load span changes in this release.
 
 ### 🎁 New Features
 
-* Improved `withSpan`/`withSpanAsync` to always provide a non-nullable `Span`, matching the
-  server-side API. Added `Span.setTag()`/`setTags()`.
+* Added `HoistBase.observe()` / `HoistBase.span()` - a composable builder
+  ({@link ObservedRun}) that wraps a function with a span and/or `withInfo`/`withDebug`
+  logging in a single call, e.g. `this.span('loadPortfolio').logInfo('Loading').run(fn)`.
+  Replaces the prior `withSpan`/`withSpanAsync` helpers on `HoistBase` (see Breaking Changes).
+* Added `Span.setTag()`/`setTags()`.  Span passed to spanned functions is now non-nullable,
+  matching the server-side API.
 * `HoistService.initAsync()` and `HoistAppModel.initAsync()` now receive an `InitContext`
   argument carrying the current phase's `span`, so service init spans can nest under the caller's
   span.

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -157,15 +157,14 @@ export class AppContainerModel extends HoistModel {
             // Install TraceService first so booting traceable; it will defer sampling and export until config available
             await installServicesAsync([TraceService], {span: null});
 
-            await this.withSpanAsync({name: 'xh.client.load'}, async appLoadSpan => {
+            await this.span({name: 'xh.client.load'}).run(async appLoadSpan => {
                 this.addGlobalListenersAndCss();
                 await installServicesAsync([FetchService], {span: appLoadSpan});
 
                 // Check auth, falling through to interactive login if SSO returns no identity.
                 this.setAppState('AUTHENTICATING');
                 XH.authModel = createSingleton(this.appSpec.authModelClass);
-                let identity = await this.withSpanAsync(
-                    {name: 'xh.client.auth', parent: appLoadSpan},
+                let identity = await this.span({name: 'xh.client.auth', parent: appLoadSpan}).run(
                     () => XH.authModel.completeAuthAsync()
                 );
                 if (!identity) {
@@ -174,10 +173,10 @@ export class AppContainerModel extends HoistModel {
                         'Unable to complete required authentication (SSO/Auth failure).'
                     );
                     this.setAppState('LOGIN_REQUIRED');
-                    identity = await this.withSpanAsync(
-                        {name: 'xh.client.interactiveLogin', parent: appLoadSpan},
-                        () => this.awaitInteractiveLoginAsync()
-                    );
+                    identity = await this.span({
+                        name: 'xh.client.interactiveLogin',
+                        parent: appLoadSpan
+                    }).run(() => this.awaitInteractiveLoginAsync());
                 }
                 await this.completeInitAsync(identity, appLoadSpan);
             });
@@ -271,8 +270,7 @@ export class AppContainerModel extends HoistModel {
 
             // Hoist init phase
             this.setAppState('INITIALIZING_HOIST');
-            await this.withSpanAsync(
-                {name: 'xh.client.hoistInit', parent: appLoadSpan},
+            await this.span({name: 'xh.client.hoistInit', parent: appLoadSpan}).run(
                 async hoistInitSpan => {
                     const hoistInitCtx: InitContext = {span: hoistInitSpan};
                     await installServicesAsync(
@@ -335,7 +333,7 @@ export class AppContainerModel extends HoistModel {
             // App init phase
             this.setAppState('INITIALIZING_APP');
             this.appModel = createSingleton(this.appSpec.modelClass);
-            await this.withSpanAsync({name: 'xh.client.appInit', parent: appLoadSpan}, span =>
+            await this.span({name: 'xh.client.appInit', parent: appLoadSpan}).run(span =>
                 this.appModel.initAsync({span})
             );
 

--- a/core/HoistBase.ts
+++ b/core/HoistBase.ts
@@ -23,7 +23,7 @@ import {
     withDebug,
     withInfo
 } from '@xh/hoist/utils/js';
-import {Span, SpanConfig} from '@xh/hoist/utils/telemetry';
+import {ObservedRun, SpanConfig} from '@xh/hoist/utils/telemetry';
 import {
     debounce as lodashDebounce,
     isFunction,
@@ -116,12 +116,14 @@ export abstract class HoistBase {
         return withDebug<T>(messages, fn, this);
     }
 
-    withSpan<T>(config: string | SpanConfig, fn: (span: Span) => T): T {
-        return XH.traceService.withSpan(this.enhanceSpanConfig(config), fn);
+    /** Create an {@link ObservedRun} builder with this object as the caller. */
+    observe(): ObservedRun {
+        return ObservedRun.observe(this);
     }
 
-    withSpanAsync<T>(config: string | SpanConfig, fn: (span: Span) => Promise<T>): Promise<T> {
-        return XH.traceService.withSpanAsync(this.enhanceSpanConfig(config), fn);
+    /** Create an {@link ObservedRun} builder with an initial span and this object as the caller. */
+    span(config: string | SpanConfig): ObservedRun {
+        return this.observe().span(config);
     }
 
     /**
@@ -315,13 +317,6 @@ export abstract class HoistBase {
         this.disposers.forEach(f => f());
         this.managedInstances.forEach(i => XH.safeDestroy(i));
         this['_xhManagedProperties']?.forEach(p => XH.safeDestroy(this[p]));
-    }
-
-    //------------------
-    // Implementation
-    //------------------
-    private enhanceSpanConfig(config: string | SpanConfig): SpanConfig {
-        return isString(config) ? {name: config, caller: this} : {caller: this, ...config};
     }
 }
 

--- a/docs/upgrade-notes/v85-upgrade-notes.md
+++ b/docs/upgrade-notes/v85-upgrade-notes.md
@@ -207,16 +207,16 @@ override async initAsync(ctx: InitContext) {
 After (named child span wrapping a group of calls):
 ```typescript
 override async initAsync(ctx: InitContext) {
-    await this.withSpanAsync({name: 'loadPortfolioRefData', parent: ctx.span}, async () => {
+    await this.span({name: 'loadPortfolioRefData', parent: ctx.span}).run(async () => {
         this.lookups = await XH.fetchJson({url: 'portfolio/lookups'});
         this.symbols = await XH.fetchJson({url: 'portfolio/symbols'});
     });
 }
 ```
 
-The `withSpanAsync` form is useful when init does several related calls — the wrapper span
+The `span().run()` form is useful when init does several related calls — the wrapper span
 rolls them up into one phase in the timeline, and individual fetches nest beneath it
-automatically via the `FetchService` span. `HoistBase.withSpanAsync()` auto-populates `caller`
+automatically via the `FetchService` span. `HoistBase.span()` auto-populates `caller`
 with `this`, so the emitted span correctly carries `code.namespace`.
 
 #### 5b. Pass `ctx.span` through to `AppModel` initialization work
@@ -230,7 +230,7 @@ override async initAsync(ctx: InitContext) {
     await super.initAsync(ctx);
     await XH.installServicesAsync([LookupService, EventService], ctx);
 
-    await this.withSpanAsync({name: 'loadInitialClientData', parent: ctx.span}, async () => {
+    await this.span({name: 'loadInitialClientData', parent: ctx.span}).run(async () => {
         await this.lookupService.loadAsync();
     });
 }
@@ -302,4 +302,4 @@ After completing all steps:
 - [`/svc/README.md`](../../svc/README.md) — reference for `TraceService`, `FetchService`, and the
   `FetchOptions.span` API used in Step 5.
 - [`/core/README.md`](../../core/README.md) — reference for `HoistService`, `HoistAppModel`, and
-  the `HoistBase.withSpanAsync()` helper used in Step 5.
+  the `HoistBase.span()` builder used in Step 5.

--- a/promise/Promise.ts
+++ b/promise/Promise.ts
@@ -258,7 +258,7 @@ const enhancePromise = promisePrototype => {
         },
 
         span<T>(config: SpanConfig | string): Promise<T> {
-            return XH.traceService.withSpanAsync(config, () => this) as Promise<T>;
+            return XH.traceService.withSpan(config, () => this) as Promise<T>;
         },
 
         tap<T>(onFulfillment: (value: T) => any): Promise<T> {

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -199,15 +199,15 @@ export class FetchService extends HoistService {
     private async fetchInternalAsync(opts: FetchOptions): Promise<any> {
         // 1) If a convenience span spec provided, resolve to an outer Span and recurse.
         if (opts.span && !(opts.span instanceof Span)) {
-            // Use the global withSpanAsync -- don't want to tag with this as the caller.
-            return XH.traceService.withSpanAsync(opts.span, span =>
+            // Use the global withSpan -- don't want to tag with this as the caller.
+            return XH.traceService.withSpan(opts.span, span =>
                 this.fetchInternalAsync({...opts, span})
             );
         }
 
         // 2) Apply appropriate tracing and correlation to the core work.
         opts = this.withCorrelationId(opts);
-        let ret = this.withSpanAsync(this.createSpanConfig(opts), span => {
+        let ret = this.span(this.createSpanConfig(opts)).run(span => {
             opts = {...opts, traceId: span.traceId};
 
             // Core promise - chained with header resolution to ensure that work is included in overall tracked time.

--- a/svc/README.md
+++ b/svc/README.md
@@ -322,19 +322,20 @@ decision. The `traceparent` header propagates the sampling flag to the server. S
 hoist-core tracing documentation for full sampling configuration details.
 
 ```typescript
-// Wrap an async operation in a span (from any HoistBase subclass)
-await this.withSpanAsync({name: 'loadPortfolio', caller: this}, async span => {
+// Wrap an async operation in a span (from any HoistBase subclass).
+// `caller` is auto-populated from `this`.
+await this.span({name: 'loadPortfolio'}).run(async span => {
     const positions = await this.loadPositionsAsync();
     this.setPositions(positions);
 });
 
-// Wrap a sync operation
-const result = this.withSpan({name: 'computeTotals', caller: this}, span => {
-    return this.computeTotals();
-});
-
 // Simple string-only config
-await this.withSpanAsync('loadData', async span => { ... });
+await this.span('loadData').run(async span => { ... });
+
+// Compose with logging - times completion via withInfo/withDebug as appropriate.
+await this.span('loadPortfolio').logInfo('Loading portfolio').run(async span => {
+    ...
+});
 
 // Nest a fetch call under a parent span without manual span management.
 // FetchService accepts a string, SpanConfig, or existing Span as the `span` option.

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -62,38 +62,13 @@ export class TraceService extends HoistService {
     // Span Lifecycle
     //------------------
     /**
-     * Create a span wrapping a synchronous operation.
-     * Automatically handles timing, error recording, and export.
-     *
-     * @param config - span name string, or a SpanConfig with name and optional tags.
-     * @param fn - the function to wrap.
-     */
-    override withSpan<T>(config: string | SpanConfig, fn: (span: Span) => T): T {
-        const span = this.createSpan(config);
-        try {
-            const result = fn(span);
-            span.end();
-            return result;
-        } catch (e) {
-            span.recordException(e);
-            span.end();
-            throw e;
-        } finally {
-            this.exportSpan(span);
-        }
-    }
-
-    /**
      * Create a span wrapping an async operation.
      * Automatically handles timing, error recording, and export.
      *
      * @param config - span name string, or a SpanConfig with name and optional tags.
      * @param fn - the async function to wrap.
      */
-    override async withSpanAsync<T>(
-        config: string | SpanConfig,
-        fn: (span: Span) => Promise<T>
-    ): Promise<T> {
+    async withSpan<T>(config: string | SpanConfig, fn: (span: Span) => Promise<T>): Promise<T> {
         const span = this.createSpan(config);
         try {
             const result = await fn(span);

--- a/utils/telemetry/ObservedRun.ts
+++ b/utils/telemetry/ObservedRun.ts
@@ -1,0 +1,105 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {Some, XH} from '@xh/hoist/core';
+import {getLogLevel, NameSource, withDebug, withInfo} from '@xh/hoist/utils/js';
+import {isString} from 'lodash';
+import {Span, SpanConfig} from './Span';
+
+/**
+ * Composable builder for wrapping a function with tracing and logging.
+ *
+ * Each concern is opt-in via dedicated builder methods, then executed with {@link run}. The
+ * function is wrapped according to the precedence below, regardless of the order the methods
+ * are called in:
+ *      span → log → user fn.
+ *
+ * ```typescript
+ * observe(this)
+ *     .span({name: 'processOrder', tags: {orderId}})
+ *     .logInfo('Processing order')
+ *     .run(() => {
+ *         // business logic
+ *     });
+ * ```
+ *
+ * When both {@link logInfo} and {@link logDebug} are configured, the finer level is selected at
+ * run time: debug if the current log level permits, otherwise info.
+ *
+ * @see HoistBase#observe - convenience factory for service/model callers.
+ */
+export class ObservedRun {
+    private caller: NameSource;
+    private infoMsgs: Some<unknown> = null;
+    private debugMsgs: Some<unknown> = null;
+    private spanConfig: SpanConfig = null;
+
+    /**
+     * Create an ObservedRun with the given caller.
+     *
+     * @param caller - object owning the observed work, typically a Hoist service or model. Used as
+     *     the logging context for {@link logInfo} / {@link logDebug} and as the span
+     *     `code.namespace` tag. May be omitted for anonymous usage.
+     */
+    static observe(caller?: NameSource): ObservedRun {
+        return new ObservedRun(caller);
+    }
+
+    private constructor(caller?: NameSource) {
+        this.caller = caller;
+    }
+
+    //---------------------------
+    // Log configuration
+    //---------------------------
+    /** Time and log completion at info level via {@link withInfo}. */
+    logInfo(msgs: Some<unknown>): this {
+        this.infoMsgs = msgs;
+        return this;
+    }
+
+    /** Time and log completion at debug level via {@link withDebug}. */
+    logDebug(msgs: Some<unknown>): this {
+        this.debugMsgs = msgs;
+        return this;
+    }
+
+    //---------------------------
+    // Span configuration
+    //---------------------------
+    /** Configure a trace span. Caller is auto-populated from the {@link observe} caller. */
+    span(config: string | SpanConfig): this {
+        const cfg: SpanConfig = isString(config) ? {name: config} : {...config};
+        if (this.caller && !cfg.caller) cfg.caller = this.caller;
+        this.spanConfig = cfg;
+        return this;
+    }
+
+    //---------------------------
+    // Terminal
+    //---------------------------
+    /** Execute an async fn with all configured observability. */
+    run<T>(fn: (span?: Span) => Promise<T>): Promise<T> {
+        return this.wrapSpan(span => Promise.resolve(this.wrapLog(() => fn(span))));
+    }
+
+    //------------------------------------------------------
+    // Implementation
+    //------------------------------------------------------
+    private wrapSpan<T>(fn: (span?: Span) => Promise<T>): Promise<T> {
+        return this.spanConfig ? XH.traceService.withSpan(this.spanConfig, fn) : fn(undefined);
+    }
+
+    private wrapLog<T>(fn: () => T): T {
+        if (this.debugMsgs != null && getLogLevel() === 'debug') {
+            return withDebug<T>(this.debugMsgs, fn, this.caller);
+        }
+        if (this.infoMsgs != null) {
+            return withInfo<T>(this.infoMsgs, fn, this.caller);
+        }
+        return fn();
+    }
+}

--- a/utils/telemetry/index.ts
+++ b/utils/telemetry/index.ts
@@ -4,4 +4,5 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
+export * from './ObservedRun';
 export * from './Span';


### PR DESCRIPTION
## Summary

Replaces `HoistBase.withSpan()` / `withSpanAsync()` with a composable `ObservedRun` builder accessed via `HoistBase.observe()` / `HoistBase.span()`, and merges `TraceService.withSpan` / `withSpanAsync` into a single async `withSpan`.

## Changes

- Added `utils/telemetry/ObservedRun` - composable builder wrapping a fn with span + `withInfo`/`withDebug` logging in one call (`this.span('loadX').logInfo('Loading').run(fn)`).
- Added `HoistBase.observe()` and `HoistBase.span()`; removed `HoistBase.withSpan()` / `withSpanAsync()`.
- `TraceService`: merged sync `withSpan` and async `withSpanAsync` into a single async `withSpan`.
- Migrated callers: `AppContainerModel`, `FetchService`, `Promise.span`.
- Updated `CHANGELOG.md`, `svc/README.md`, and `v85-upgrade-notes.md` to reflect the new API.

## Test plan

- [ ] Verify `xh.client.load` and child spans (auth, hoistInit, appInit) export correctly on app boot
- [ ] Verify `FetchService` spans still nest under caller-supplied parent spans
- [ ] Verify `Promise.span()` chain still records spans