### PR TITLE
Properly added commitOnChange to dateInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 ### 🐞 Bug Fixes
 * Chart right-to-left "zoom out" gesture now activates for charts configured with the modern
   `chart.zooming.type = 'x'` Highcharts option, in addition to the legacy `chart.zoomType = 'x'`.
-* Desktop `DateInput` no longer eagerly commits typed values on the keystroke that completes an
-  exact-format match - it now waits for blur, Enter, or picker selection, consistent with
-  `TextInput` and other Hoist inputs. Adds a new `commitOnChange` prop (default `false`) for
-  callers who want the prior eager behavior.
+* Desktop `DateInput` now supports a `commitOnChange` prop (default `true`). Set to `false` to
+  defer parsing and value commit until blur, Enter, or picker selection. Useful when configuring
+  `parseStrings` such that one format is a prefix of another (e.g. `MM/DD/YY` and `MM/DD/YYYY`),
+  where the eager default would reformat the user's text mid-typing.
 
 ## 85.0.0 - 2020-04-30
 

--- a/desktop/cmp/input/DateInput.ts
+++ b/desktop/cmp/input/DateInput.ts
@@ -31,7 +31,7 @@ import './DateInput.scss';
 export interface DateInputProps extends HoistProps, LayoutProps, HoistInputProps {
     value?: Date | LocalDate;
 
-    /** True to commit eagerly whenever typed input parses to a new valid date. Default false. */
+    /** True to commit eagerly whenever typed input parses to a new valid date. Default true. */
     commitOnChange?: boolean;
 
     /** Props passed to ReactDayPicker component, as per DayPicker docs. */
@@ -214,7 +214,7 @@ class DateInputModel extends HoistInputModel {
     }
 
     override get commitOnChange() {
-        return withDefault(this.componentProps.commitOnChange, false);
+        return withDefault(this.componentProps.commitOnChange, true);
     }
 
     constructor() {
@@ -297,6 +297,8 @@ class DateInputModel extends HoistInputModel {
     };
 
     onInputChange = value => {
+        // Skip mid-typing parses to avoid reformatting in-progress text via formatDate.
+        if (!this.commitOnChange) return;
         if (!value && !trim(value)) this.onDateChange(null);
         const date = this.parseDate(value, true);
         if (date) this.onDateChange(date);


### PR DESCRIPTION
- Fixed the proper bug (needed another line of code).
- Set default behavior to (commitOnChange: true) to make default non-breaking.

Small toolbox addition used to test this: https://github.com/xh/toolbox/pull/849

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

