### PR TITLE
Upgrade react-dropzone 10.x → 15.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   [react-dropzone docs](https://react-dropzone.js.org/#section-accepting-specific-file-types)
   for the new format.
 
+### 🎁 New Features
+
+* `FileChooser` now supports a `maxFiles` prop. See [#3570](https://github.com/xh/hoist-react/issues/3570).
+
 ### 🐞 Bug Fixes
 
 * Chart right-to-left "zoom out" gesture now activates for charts configured with the modern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   `DashViewModel.icon` at runtime still see it render, but the override is no longer saved.
 * Removed the `serializeIcon()` / `deserializeIcon()` helpers from `@xh/hoist/icon`, which
   existed only to support the above.
+* `FileChooser.accept` now takes a react-dropzone `Accept` object keyed by MIME type
+  (e.g. `{'application/pdf': ['.pdf']}`) rather than an extension string or string array. See the
+  [react-dropzone docs](https://react-dropzone.js.org/#section-accepting-specific-file-types)
+  for the new format.
 
 ### 🐞 Bug Fixes
 
@@ -36,6 +40,7 @@
     * Note, applications with previously required `"jquery": "3.x"` pin in package.json
       `resolutions` should now be able to remove that pin.
 * semver `7.7 → 7.8`
+* react-dropzone `10.x → 15.x`. See breaking change note above for the `FileChooser.accept` prop.
 
 ## 85.0.0 - 2020-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@
   [react-dropzone docs](https://react-dropzone.js.org/#section-accepting-specific-file-types)
   for the new format.
 
-### 🎁 New Features
-
-* `FileChooser` now supports a `maxFiles` prop. See [#3570](https://github.com/xh/hoist-react/issues/3570).
-
 ### 🐞 Bug Fixes
 
 * Chart right-to-left "zoom out" gesture now activates for charts configured with the modern

--- a/desktop/cmp/filechooser/FileChooser.ts
+++ b/desktop/cmp/filechooser/FileChooser.ts
@@ -31,6 +31,13 @@ export interface FileChooserProps extends HoistProps<FileChooserModel>, BoxProps
      */
     enableAddMulti?: boolean;
 
+    /**
+     * Maximum number of files that can be selected. Defaults to 0 (no limit). Note that
+     * react-dropzone enforces this only on a per-drop/per-browse basis - it does not account
+     * for files already in the selection.
+     */
+    maxFiles?: number;
+
     /** Maximum accepted file size in bytes. */
     maxSize?: number;
 
@@ -70,6 +77,7 @@ export const [FileChooser, fileChooser] = hoistCmp.withFactory<FileChooserProps>
         {
             model,
             accept,
+            maxFiles,
             maxSize,
             minSize,
             targetText = 'Drag and drop files here, or click to browse...',
@@ -89,6 +97,7 @@ export const [FileChooser, fileChooser] = hoistCmp.withFactory<FileChooserProps>
             items: [
                 dropzone({
                     accept,
+                    maxFiles,
                     maxSize,
                     minSize,
                     multiple: enableAddMulti,

--- a/desktop/cmp/filechooser/FileChooser.ts
+++ b/desktop/cmp/filechooser/FileChooser.ts
@@ -6,17 +6,21 @@
  */
 import {grid} from '@xh/hoist/cmp/grid';
 import {div, hbox, input} from '@xh/hoist/cmp/layout';
-import {BoxProps, hoistCmp, HoistProps, Some, uses} from '@xh/hoist/core';
+import {BoxProps, hoistCmp, HoistProps, uses} from '@xh/hoist/core';
 import '@xh/hoist/desktop/register';
-import {dropzone} from '@xh/hoist/kit/react-dropzone';
+import {Accept, dropzone} from '@xh/hoist/kit/react-dropzone';
 import classNames from 'classnames';
 import {ReactNode} from 'react';
 import './FileChooser.scss';
 import {FileChooserModel} from './FileChooserModel';
 
 export interface FileChooserProps extends HoistProps<FileChooserModel>, BoxProps {
-    /** File type(s) to accept (e.g. `['.doc', '.docx', '.pdf']`). */
-    accept?: Some<string>;
+    /**
+     * File types to accept, keyed by MIME type with arrays of file extensions as values
+     * (e.g. `{'application/pdf': ['.pdf'], 'application/msword': ['.doc', '.docx']}`).
+     * See react-dropzone docs for details.
+     */
+    accept?: Accept;
 
     /** True (default) to allow multiple files in a single upload. */
     enableMulti?: boolean;
@@ -88,11 +92,8 @@ export const [FileChooser, fileChooser] = hoistCmp.withFactory<FileChooserProps>
                     maxSize,
                     minSize,
                     multiple: enableAddMulti,
-                    children: ({getRootProps, getInputProps, isDragActive, draggedFiles}) => {
-                        const draggedCount = draggedFiles.length,
-                            targetTxt = isDragActive
-                                ? `Drop to add ${fileNoun(draggedCount)}.`
-                                : targetText,
+                    children: ({getRootProps, getInputProps, isDragActive}) => {
+                        const targetTxt = isDragActive ? 'Drop to add files.' : targetText,
                             rejectTxt =
                                 lastRejectedCount && !isDragActive
                                     ? `Unable to accept ${fileNoun(lastRejectedCount)} for upload.`

--- a/desktop/cmp/filechooser/FileChooser.ts
+++ b/desktop/cmp/filechooser/FileChooser.ts
@@ -31,13 +31,6 @@ export interface FileChooserProps extends HoistProps<FileChooserModel>, BoxProps
      */
     enableAddMulti?: boolean;
 
-    /**
-     * Maximum number of files that can be selected. Defaults to 0 (no limit). Note that
-     * react-dropzone enforces this only on a per-drop/per-browse basis - it does not account
-     * for files already in the selection.
-     */
-    maxFiles?: number;
-
     /** Maximum accepted file size in bytes. */
     maxSize?: number;
 
@@ -77,7 +70,6 @@ export const [FileChooser, fileChooser] = hoistCmp.withFactory<FileChooserProps>
         {
             model,
             accept,
-            maxFiles,
             maxSize,
             minSize,
             targetText = 'Drag and drop files here, or click to browse...',
@@ -97,7 +89,6 @@ export const [FileChooser, fileChooser] = hoistCmp.withFactory<FileChooserProps>
             items: [
                 dropzone({
                     accept,
-                    maxFiles,
                     maxSize,
                     minSize,
                     multiple: enableAddMulti,

--- a/desktop/cmp/filechooser/FileChooserModel.ts
+++ b/desktop/cmp/filechooser/FileChooserModel.ts
@@ -9,6 +9,7 @@ import {HoistModel, managed} from '@xh/hoist/core';
 import {actionCol, calcActionColWidth} from '@xh/hoist/desktop/cmp/grid';
 import '@xh/hoist/desktop/register';
 import {Icon} from '@xh/hoist/icon';
+import {FileRejection} from '@xh/hoist/kit/react-dropzone';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {filesize} from 'filesize';
 import {find, isEmpty, uniqBy, without} from 'lodash';
@@ -118,7 +119,7 @@ export class FileChooserModel extends HoistModel {
     }
 
     @action
-    onDrop(accepted, rejected, enableMulti) {
+    onDrop(accepted: File[], rejected: readonly FileRejection[], enableMulti: boolean) {
         if (!isEmpty(accepted)) {
             if (!enableMulti) {
                 this.setSingleFile(accepted[0]);

--- a/kit/react-dropzone/index.ts
+++ b/kit/react-dropzone/index.ts
@@ -8,4 +8,5 @@ import {elementFactory} from '@xh/hoist/core';
 import Dropzone from 'react-dropzone';
 
 export {Dropzone};
+export type {Accept, FileRejection, FileWithPath} from 'react-dropzone';
 export const dropzone = elementFactory(Dropzone);

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "qs": "~6.15.0",
     "react-beautiful-dnd": "~13.1.0",
     "react-dates": "~21.8.0",
-    "react-dropzone": "~10.2.2",
+    "react-dropzone": "~15.0.0",
     "react-grid-layout": "~2.2.3",
     "react-markdown": "~10.1.0",
     "react-onsenui": "~1.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3007,7 +3007,7 @@ async-function@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
   integrity sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==
 
-attr-accept@^2.0.0:
+attr-accept@^2.2.4:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.5.tgz#d7061d958e6d4f97bf8665c68b75851a0713ab5e"
   integrity sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==
@@ -4643,12 +4643,12 @@ file-loader@~6.2.0:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-file-selector@^0.1.12:
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.19.tgz#8ecc9d069a6f544f2e4a096b64a8052e70ec8abf"
-  integrity sha512-kCWw3+Aai8Uox+5tHCNgMFaUdgidxvMnLWO6fM5sZ0hA2wlHP5/DHGF0ECe84BiB95qdJbKNEJhWKVDvMN+JDQ==
+file-selector@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-2.1.2.tgz#fe7c7ee9e550952dfbc863d73b14dc740d7de8b4"
+  integrity sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==
   dependencies:
-    tslib "^2.0.1"
+    tslib "^2.7.0"
 
 filesize@~11.0.2:
   version "11.0.17"
@@ -7325,14 +7325,14 @@ react-draggable@^4.4.6, react-draggable@^4.5.0:
     clsx "^2.1.1"
     prop-types "^15.8.1"
 
-react-dropzone@~10.2.2:
-  version "10.2.2"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-10.2.2.tgz#67b4db7459589a42c3b891a82eaf9ade7650b815"
-  integrity sha512-U5EKckXVt6IrEyhMMsgmHQiWTGLudhajPPG77KFSvgsMqNEHSyGpqWvOMc5+DhEah/vH4E1n+J5weBNLd5VtyA==
+react-dropzone@~15.0.0:
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-15.0.0.tgz#bd03c7c2b14fe4ea9db1a9c74502b85339f2e505"
+  integrity sha512-lGjYV/EoqEjEWPnmiSvH4v5IoIAwQM2W4Z1C0Q/Pw2xD0eVzKPS359BQTUMum+1fa0kH2nrKjuavmTPOGhpLPg==
   dependencies:
-    attr-accept "^2.0.0"
-    file-selector "^0.1.12"
-    prop-types "^15.7.2"
+    attr-accept "^2.2.4"
+    file-selector "^2.1.0"
+    prop-types "^15.8.1"
 
 react-fast-compare@^3.0.1:
   version "3.2.2"
@@ -8881,7 +8881,7 @@ tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.8.1:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.7.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## Summary

Replaces #4378 (dependabot major bump) with the code changes required by react-dropzone's v11–v15 breaking API changes.

- `FileChooser.accept` now takes the v14 `Accept` object form keyed by MIME type (e.g. `{'application/pdf': ['.pdf']}`) — see CHANGELOG breaking-change note.
- Drops use of removed `draggedFiles` render-prop field; drag-active message no longer includes a count.
- Types `FileChooserModel.onDrop` rejected arg as `FileRejection[]`.
- Re-exports `Accept`, `FileRejection`, `FileWithPath` from `@xh/hoist/kit/react-dropzone`.

Closes #4378.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `yarn lint` passes
- [ ] Toolbox FileChooser example: drag & drop single + multi, click-to-browse, oversize rejection, extension rejection