### PR TITLE
Fix UniqueAggregator stranding aggregate at null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   where the eager default would reformat the user's text mid-typing.
 * Fixed `GridFilter` column header values tab crashing with a duplicate-ID error when re-opened
   for a `tags`-typed field with an active filter.
+* Fixed `UniqueAggregator` permanently caching `null` on grouped cube rows after a diverge → reconverge sequence of child updates; the aggregator now falls back to a sibling re-scan when the cache could be transitioning. See [#4383](https://github.com/xh/hoist-react/issues/4383).
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@
   where the eager default would reformat the user's text mid-typing.
 * Fixed `GridFilter` column header values tab crashing with a duplicate-ID error when re-opened
   for a `tags`-typed field with an active filter.
-* Fixed `UniqueAggregator` permanently caching `null` on grouped cube rows after a diverge → reconverge sequence of child updates; the aggregator now falls back to a sibling re-scan when the cache could be transitioning. See [#4383](https://github.com/xh/hoist-react/issues/4383).
+* Fixed `UniqueAggregator` permanently caching `null` on grouped cube rows after a diverge →
+  reconverge sequence of child updates; the aggregator now falls back to a sibling re-scan when the
+  cache could be transitioning.
 
 ### ⚙️ Technical
 

--- a/data/cube/aggregate/UniqueAggregator.ts
+++ b/data/cube/aggregate/UniqueAggregator.ts
@@ -16,7 +16,8 @@ export class UniqueAggregator extends Aggregator {
     }
 
     override replace(rows, currAgg, update, context) {
-        const {newValue} = update;
-        return rows.length === 1 || isEqual(newValue, currAgg) ? newValue : null;
+        const {newValue, field} = update;
+        if (rows.length === 1 || isEqual(newValue, currAgg)) return newValue;
+        return this.aggregate(rows, field.name);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4383. `UniqueAggregator.replace` only compared `newValue` against the cached `currAgg` and never inspected siblings, so once `currAgg` flipped to `null` it stayed `null` forever — even after all children reconverged to a single value. Recovery required a full rebuild that bypassed the row cache (e.g. dimension change).

Keeps the existing O(1) fast paths and falls back to `aggregate()` when neither applies. Worst-case cost matches `aggregate()` — sibling consensus inherently requires an O(n) check for UNIQUE, so the original "optimization" wasn't saving work, just producing wrong answers.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Manual repro: cube view with `UNIQUE`-aggregated field over grouped data; drive diverge → reconverge updates on leaves and confirm aggregate cell recovers