### PR TITLE
Add JSON Schema validation to JsonInput via AJV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,9 @@ detailed, step-by-step upgrade instructions with before/after code examples.
   hamburger menu. Set to `true` to render the current user's initials instead or provide a function
   to render a custom element for the user.
 * Added `AggregationContext` as an additional argument to `CubeField.canAggregateFn`.
+* Added `ajvSchema` and `ajvOptions` configs to JsonInputProps.
+    * `ajvSchema` - Used to validate the input JSON
+    * `ajvOptions` - Options to be passed to Ajv constructor (JSON schema validator)
 * Added `filterMatchMode` option to `ColChooserModel`, allowing customizing match to `start`,
   `startWord`, or `any`.
 * Added support for reconnecting a `View` to its associated `Cube`.
@@ -613,6 +616,7 @@ detailed, step-by-step upgrade instructions with before/after code examples.
 * @codemirror/state `6.6.0`
 * @codemirror/view `6.43.0`
 * @uiw/codemirror-theme-github `4.25.10`
+* ajv `8.17.1`
 
 ## 79.0.0 - 2026-01-05
 

--- a/desktop/cmp/input/JsonInput.ts
+++ b/desktop/cmp/input/JsonInput.ts
@@ -7,10 +7,24 @@
 import {hoistCmp} from '@xh/hoist/core';
 import '@xh/hoist/desktop/register';
 import {fmtJson} from '@xh/hoist/format';
+import Ajv, {Options, SchemaObject, ValidateFunction} from 'ajv';
 import {codeInput, CodeInputProps} from './CodeInput';
 import {jsonlint} from './impl/jsonlint.js';
 
-export type JsonInputProps = CodeInputProps;
+export interface JsonInputProps extends CodeInputProps {
+    /**
+     * JSON Schema object used to validate the input JSON. Accepts any valid JSON Schema keywords
+     * supported by AJV, such as `type`, `properties`, `required`, and `additionalProperties`.
+     * @see https://ajv.js.org/json-schema.html
+     */
+    ajvSchema?: SchemaObject;
+
+    /**
+     * Configuration object with any properties supported by the AJV API.
+     * @sees https://ajv.js.org/options.html
+     */
+    ajvOptions?: Options;
+}
 
 /**
  * Code-editor style input for editing and validating JSON, powered by CodeMirror.
@@ -19,11 +33,13 @@ export const [JsonInput, jsonInput] = hoistCmp.withFactory<JsonInputProps>({
     displayName: 'JsonInput',
     className: 'xh-json-input',
     render(props, ref) {
+        const {ajvSchema, ajvOptions, ...rest} = props;
+
         return codeInput({
-            linter,
+            linter: jsonLinterWrapper(ajvSchema, ajvOptions),
             formatter: fmtJson,
             language: 'json',
-            ...props,
+            ...rest,
             ref
         });
     }
@@ -31,12 +47,38 @@ export const [JsonInput, jsonInput] = hoistCmp.withFactory<JsonInputProps>({
 (JsonInput as any).hasLayoutSupport = true;
 
 //----------------------
-// Implementation
+// JSON Linter helper
 //----------------------
-function linter(text: string) {
-    const annotations: any[] = [];
-    if (!text) return annotations;
+function jsonLinterWrapper(ajvSchema?: SchemaObject, ajvOptions?: Options) {
+    // No schema → only use JSONLint
+    if (!ajvSchema) {
+        return (text: string) => {
+            const annotations: any[] = [];
+            if (!text) return annotations;
+            runJsonLint(text, annotations);
+            return annotations;
+        };
+    }
 
+    const ajv = new Ajv(ajvOptions),
+        validate = ajv.compile(ajvSchema);
+
+    return (text: string) => {
+        const annotations: any[] = [];
+
+        if (!text.trim()) return annotations;
+
+        runJsonLint(text, annotations);
+        if (annotations.length) return annotations;
+
+        runAjvValidation(text, validate, annotations);
+
+        return annotations;
+    };
+}
+
+/** Run JSONLint and append errors to annotations */
+function runJsonLint(text: string, annotations: any[]) {
     jsonlint.parseError = (message, hash) => {
         const {first_line, first_column, last_line, last_column} = hash.loc;
         annotations.push({
@@ -50,11 +92,62 @@ function linter(text: string) {
     try {
         jsonlint.parse(text);
     } catch (ignored) {}
-
-    return annotations;
 }
 
-/** Convert line/col (1-based line, 0-based col) to absolute string index. */
+/** Run AJV schema validation and append errors to annotations */
+function runAjvValidation(text: string, validate: ValidateFunction, annotations: any[]) {
+    let data: any;
+    try {
+        data = JSON.parse(text);
+    } catch (ignored) {
+        return;
+    }
+
+    const valid = validate(data);
+    if (valid || !validate.errors) return;
+
+    validate.errors.forEach(err => {
+        const {from, to} = getErrorPosition(err, text),
+            message = formatAjvMessage(err);
+
+        annotations.push({from, to, message, severity: 'error'});
+    });
+}
+
+/** Determine text positions for AJV error highlighting */
+function getErrorPosition(err: any, text: string): {from: number; to: number} {
+    let from = 0,
+        to = 0,
+        key: string;
+
+    if (err.keyword === 'additionalProperties' && err.params?.additionalProperty) {
+        key = err.params.additionalProperty;
+    } else {
+        const parts = (err.instancePath || '').split('/').filter(Boolean);
+        key = parts[parts.length - 1];
+    }
+
+    if (key) {
+        const idx = text.indexOf(`"${key}"`);
+        if (idx >= 0) {
+            from = idx;
+            to = idx + key.length + 2;
+        }
+    }
+
+    return {from, to};
+}
+
+/** Format AJV error messages nicely */
+function formatAjvMessage(err: any): string {
+    const path = err.instancePath || '(root)';
+    if (err.keyword === 'additionalProperties' && err.params?.additionalProperty) {
+        return `Unexpected property "${err.params.additionalProperty}"`;
+    }
+    return `${path} ${err.message}`;
+}
+
+/** Convert line/col to string index */
 function indexFromLineCol(text: string, line: number, col: number): number {
     const lines = text.split('\n');
     let idx = 0;

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@seznam/compose-react-refs": "~1.0.5",
     "@uiw/codemirror-theme-github": "~4.25.10",
+    "ajv": "~8.17.1",
     "classnames": "~2.5.1",
     "clipboard-copy": "~4.0.1",
     "commander": "^14.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3311,6 +3311,16 @@ ajv@^8.0.0, ajv@^8.0.1, ajv@^8.17.1, ajv@^8.9.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
 
+ajv@~8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+
 ajv@~8.18.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.18.0.tgz#8864186b6738d003eb3a933172bb3833e10cefbc"


### PR DESCRIPTION
## Summary

Adds optional schema validation to `JsonInput` via AJV. Split out of #4116 (CodeMirror v6 migration) so each PR has a focused scope.

- New props on `JsonInput`:
  - `ajvSchema` — JSON Schema object passed to AJV for content validation
  - `ajvOptions` — options forwarded to the AJV constructor
- When `ajvSchema` is provided, validation errors are surfaced as CodeMirror lint annotations alongside the existing jsonlint syntax checks. Error highlights point at the offending property in the source text.
- When `ajvSchema` is omitted, behavior is unchanged from the v6 baseline (jsonlint-only).
- New direct dep: `ajv ~8.17.1`.

## Known limitations / follow-ups

- The AJV validator is currently rebuilt on every `JsonInput` render (`new Ajv()` + `ajv.compile()`). Consumers passing a stable schema reference still pay this cost. Worth memoizing.
- Error positioning uses `text.indexOf(\`\"key\"\`)`, which finds the first occurrence of the property name. If the same key appears in multiple objects, the highlight can land on the wrong one.

Both are acceptable for a first cut but worth tracking.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `yarn lint` clean
- [ ] Manual smoke: JsonInput without `ajvSchema` lints syntax errors as before
- [ ] Manual smoke: JsonInput with an `ajvSchema` flags schema violations (missing required props, type mismatches, `additionalProperties: false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)