### PR TITLE
FileChooser: review-driven cleanup of model API and accept handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,13 @@
 * Redesigned `FileChooser`, moving configuration from component props to the `FileChooserModel`
   constructor config and adding a fully customizable display API.
     * Options such as `accept` and the file-size limits are now set on `FileChooserModel` rather
-      than as `FileChooser` props. `accept` continues to take file-extension strings
-      (e.g. `['.pdf', '.doc']`).
+      than as `FileChooser` props.
     * Renamed `maxSize` / `minSize` to `maxFileSize` / `minFileSize`.
     * Removed `enableMulti` / `enableAddMulti` - use `maxFiles` (set to `1` for single-file
       selection).
     * Removed `targetText` and `showFileGrid` - customize via the new `emptyDisplay` / `fileDisplay`
       content props. The default `fileDisplay` is a file grid, or a compact card with replace /
       remove actions when `maxFiles` is 1.
-    * Dropped the `enableMulti` argument from `FileChooserModel.onDrop()` and removed the
-      `lastRejectedCount` observable.
 * `DashContainerModel` no longer persists per-view `icon` in its layout state, aligning with
   `DashCanvasModel`. Icons now always come from the `DashViewSpec`. Apps that set
   `DashViewModel.icon` at runtime still see it render, but the override is no longer saved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,14 @@
   constructor config and adding a fully customizable display API.
     * Options such as `accept` and the file-size limits are now set on `FileChooserModel` rather
       than as `FileChooser` props. `accept` continues to take file-extension strings
-      (e.g. `['.pdf', '.doc']`), which the model maps to MIME types internally.
+      (e.g. `['.pdf', '.doc']`).
     * Renamed `maxSize` / `minSize` to `maxFileSize` / `minFileSize`.
     * Removed `enableMulti` / `enableAddMulti` - use `maxFiles` (set to `1` for single-file
       selection).
     * Removed `targetText` and `showFileGrid` - customize via the new `emptyDisplay` / `fileDisplay`
       content props. The default `fileDisplay` is a file grid, or a compact card with replace /
       remove actions when `maxFiles` is 1.
-    * Replaced the synchronous `FileChooserModel.onDrop()` with `onDropAsync()` and removed the
+    * Dropped the `enableMulti` argument from `FileChooserModel.onDrop()` and removed the
       `lastRejectedCount` observable.
 * `DashContainerModel` no longer persists per-view `icon` in its layout state, aligning with
   `DashCanvasModel`. Icons now always come from the `DashViewSpec`. Apps that set
@@ -35,12 +35,11 @@
 ### 🎁 New Features
 
 * `FileChooser` gained extensive new capabilities as part of its redesign: a `maxFiles` limit,
-  fully customizable `emptyDisplay` / `fileDisplay` content, async file validation via
-  `validateFilesAsync`, `onFileAccepted` / `onFileRejected` callbacks, configurable rejection
-  toasts, `maskOnDrag` / `maskOnDisabled` options, and a programmatic `openFileBrowser()` method.
-  In multi-file mode a persistent drop target sits alongside the grid - placement set via the
-  `dropTargetPlacement` prop (`left`, `top`, or `hidden`) - so users can keep adding files until
-  the limit is reached.
+  fully customizable `emptyDisplay` / `fileDisplay` content, `onFileAccepted` / `onFileRejected`
+  callbacks, configurable rejection toasts, `maskOnDrag` / `maskOnDisabled` options, and a
+  programmatic `openFileBrowser()` method. In multi-file mode a persistent drop target sits
+  alongside the grid - placement set via the `dropTargetPlacement` prop (`left`, `top`, or
+  `hidden`) - so users can keep adding files until the limit is reached.
 * Added the `Runner` API - a fluent builder (via `HoistBase.runner()`) that composes spanning,
   logging, activity tracking, metrics, and task-linking around async work and fetch calls. It
   threads a shared `CallContext` (trace + load state) across call boundaries, which fetch methods

--- a/desktop/cmp/filechooser/FileChooser.ts
+++ b/desktop/cmp/filechooser/FileChooser.ts
@@ -12,7 +12,7 @@ import {dropzone} from '@xh/hoist/kit/react-dropzone';
 import {elementFromContent, getLayoutProps} from '@xh/hoist/utils/react';
 import {FileRejection} from 'react-dropzone';
 import {FileChooserModel} from './FileChooserModel';
-import {isEmpty} from 'lodash';
+import {fromPairs, isEmpty} from 'lodash';
 import classNames from 'classnames';
 import {defaultEmptyDisplay} from './impl/DefaultEmptyDisplay';
 import {defaultFileDisplay} from './impl/DefaultFileDisplay';
@@ -88,7 +88,8 @@ export const [FileChooser, fileChooser] = hoistCmp.withFactory<FileChooserProps>
 
         return dropzone({
             ref: model.dropzoneRef,
-            accept,
+            // react-dropzone wants a {type: [extensions]} map; extensions serve as their own keys.
+            accept: accept ? fromPairs(accept.map(ext => [ext, [ext]])) : null,
             // Disable interaction (drag/click/drop) at the limit; the target shows a clear message.
             disabled: disabled || atLimit,
             maxFiles,
@@ -151,7 +152,7 @@ export const [FileChooser, fileChooser] = hoistCmp.withFactory<FileChooserProps>
                 });
             },
             onDrop: (accepted: File[], rejected: FileRejection[]) =>
-                model.onDropAsync(accepted, rejected)
+                model.onDrop(accepted, rejected)
         });
     }
 });

--- a/desktop/cmp/filechooser/FileChooserModel.ts
+++ b/desktop/cmp/filechooser/FileChooserModel.ts
@@ -16,7 +16,7 @@ import {ReactElement, ReactNode} from 'react';
 import {DropzoneRef} from 'react-dropzone';
 
 export interface FileChooserConfig {
-    /** File extension(s) to accept, e.g. `['.doc', '.docx', '.pdf']` (MIME types not supported). */
+    /** File extension(s) to accept, e.g. `['.doc', '.docx', '.pdf']` */
     accept?: Some<string>;
 
     /** Maximum number of overall files that can be added. Defaults to null (no limit). */

--- a/desktop/cmp/filechooser/FileChooserModel.ts
+++ b/desktop/cmp/filechooser/FileChooserModel.ts
@@ -11,7 +11,7 @@ import {FileRejection} from '@xh/hoist/kit/react-dropzone';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {pluralize, withDefault} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
-import {castArray, concat, filter, isEmpty, keys, fromPairs, map, uniqBy} from 'lodash';
+import {castArray, concat, filter, isEmpty, keys, fromPairs, map, sortBy, uniqBy} from 'lodash';
 import {ReactElement, ReactNode} from 'react';
 import {DropzoneRef} from 'react-dropzone';
 
@@ -100,7 +100,7 @@ export class FileChooserModel extends HoistModel {
         super();
         makeObservable(this);
 
-        this.accept = isEmpty(config.accept) ? null : castArray(config.accept);
+        this.accept = isEmpty(config.accept) ? null : sortBy(castArray(config.accept));
         this.maxFiles = config.maxFiles;
         this.maxFileSize = config.maxFileSize;
         this.minFileSize = config.minFileSize;

--- a/desktop/cmp/filechooser/FileChooserModel.ts
+++ b/desktop/cmp/filechooser/FileChooserModel.ts
@@ -11,13 +11,12 @@ import {FileRejection} from '@xh/hoist/kit/react-dropzone';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {pluralize, withDefault} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
-import {castArray, concat, filter, isEmpty, keys, fromPairs, map, uniqBy, isFunction} from 'lodash';
-import mime from 'mime';
+import {castArray, concat, filter, isEmpty, keys, fromPairs, map, uniqBy} from 'lodash';
 import {ReactElement, ReactNode} from 'react';
 import {DropzoneRef} from 'react-dropzone';
 
 export interface FileChooserConfig {
-    /** File type(s) to accept (e.g. `['.doc', '.docx', '.pdf']`). */
+    /** File extension(s) to accept, e.g. `['.doc', '.docx', '.pdf']` (MIME types not supported). */
     accept?: Some<string>;
 
     /** Maximum number of overall files that can be added. Defaults to null (no limit). */
@@ -28,12 +27,6 @@ export interface FileChooserConfig {
 
     /** Minimum accepted file size in bytes. Defaults to null (no limit). */
     minFileSize?: number;
-
-    /**
-     * Callback executed on drop event. Used for additional file validation outside of file type
-     * and size prior to updating the model's file state.
-     */
-    validateFilesAsync?: (accepted: File[]) => Promise<File[]>;
 
     /** Callback executed on drop event, invoked when files are accepted. */
     onFileAccepted?: (accepted: File[]) => void;
@@ -77,8 +70,8 @@ export interface FileChooserConfig {
 /**
  * Model managing file selection state for a {@link FileChooser} component.
  *
- * Tracks selected files, supports add/remove/clear operations, and de-duplicates by filename.
- * Includes a managed GridModel to display selected files with name and size columns.
+ * Tracks selected files and supports add/remove/clear operations. De-duplicates by filename, with
+ * a newly added file taking precedence over any existing file of the same name.
  */
 export class FileChooserModel extends HoistModel {
     @observable.ref
@@ -87,7 +80,7 @@ export class FileChooserModel extends HoistModel {
     @observable
     disabled: boolean;
 
-    readonly accept: Record<string, string[]>;
+    readonly accept: string[];
     readonly maxFiles: number;
     readonly maxFileSize: number;
     readonly minFileSize: number;
@@ -98,7 +91,6 @@ export class FileChooserModel extends HoistModel {
 
     dropzoneRef = createObservableRef<DropzoneRef>();
 
-    private readonly validateFilesAsync: (accepted: File[]) => Promise<File[]>;
     private readonly onFileAccepted: (accepted: File[]) => void;
     private readonly onFileRejected: (rejected: FileRejection[]) => void;
     private readonly rejectToastMessage: (rejectedFiles: FileRejection[]) => ReactNode;
@@ -108,11 +100,10 @@ export class FileChooserModel extends HoistModel {
         super();
         makeObservable(this);
 
-        this.accept = this.getMimesByExt(config.accept);
+        this.accept = isEmpty(config.accept) ? null : castArray(config.accept);
         this.maxFiles = config.maxFiles;
         this.maxFileSize = config.maxFileSize;
         this.minFileSize = config.minFileSize;
-        this.validateFilesAsync = config.validateFilesAsync;
         this.onFileAccepted = config.onFileAccepted;
         this.onFileRejected = config.onFileRejected;
         this.rejectToastMessage = withDefault(config.rejectToastMessage, this.defaultRejectMessage);
@@ -129,12 +120,13 @@ export class FileChooserModel extends HoistModel {
     }
 
     /**
-     * Add files to the selection. Files will be de-duplicated by name, with a newly added file
-     * taking precedence over any existing file with the same name.
+     * Add files to the selection.
+     *
+     * Respects the `maxFiles` limit but does NOT enforce the `accept` / file-size constraints
+     * (those are applied only on drop/browse) - use with care.
      */
-    @action
     addFiles(files: Some<File>) {
-        this.files = uniqBy(concat(files, this.files), 'name');
+        this.addFilesInternal(files);
     }
 
     /** Remove a single file from the current selection. */
@@ -152,52 +144,53 @@ export class FileChooserModel extends HoistModel {
     //------------------------
     // Event Handlers
     //------------------------
-    async onDropAsync(accepted: File[], rejected: Partial<FileRejection[]>) {
-        const {files, maxFiles, rejectToastMessage, validateFilesAsync} = this,
-            // In single-file mode, a lone valid file replaces the current selection rather than
-            // being rejected for exceeding the limit.
-            isReplace = maxFiles === 1 && accepted.length === 1;
+    onDrop(accepted: File[], rejected: FileRejection[]) {
+        const {maxFiles, rejectToastMessage} = this;
 
-        if (!isReplace && maxFiles != null && files.length + accepted.length > maxFiles) {
-            XH.warningToast(
-                maxFiles === 1
-                    ? 'Only one file allowed for upload.'
-                    : `File limit of ${maxFiles} exceeded.`
-            );
-            return;
+        if (!isEmpty(rejected)) {
+            if (this.rejectToastSpec) {
+                XH.toast({...this.rejectToastSpec, message: rejectToastMessage(rejected)});
+            }
+            this.onFileRejected?.(rejected);
         }
 
-        if (rejected.length && this.rejectToastSpec) {
-            XH.toast({...this.rejectToastSpec, message: rejectToastMessage(rejected)});
+        if (!isEmpty(accepted)) {
+            // In single-file mode, replace the current selection with the incoming file.
+            if (maxFiles === 1 && accepted.length === 1) this.clear();
+
+            if (this.addFilesInternal(accepted)) {
+                this.onFileAccepted?.(accepted);
+            }
         }
-
-        if (isFunction(validateFilesAsync) && !isEmpty(accepted)) {
-            accepted = await validateFilesAsync(accepted);
-        }
-
-        // Clear first only when a valid replacement survived validation, so a rejected
-        // replacement does not wipe out the existing selection.
-        if (isReplace && !isEmpty(accepted)) this.clear();
-        this.addFiles(accepted);
-
-        this.onFileAccepted?.(accepted);
-        this.onFileRejected?.(rejected);
     }
 
     //------------------------
     // Implementation
     //------------------------
-    private getMimesByExt(extensions: Some<string>): Record<string, string[]> {
-        if (isEmpty(extensions)) return null;
+    // De-dupe by name, then enforce `maxFiles` on the result. Warns and no-ops if exceeded;
+    // returns true if the selection was updated.
+    @action
+    private addFilesInternal(files: Some<File>): boolean {
+        const {maxFiles} = this,
+            deduped = uniqBy(concat(files, this.files), 'name');
 
-        extensions = castArray(extensions);
-        return fromPairs(extensions.map(ext => [mime.getType(ext), [ext]]));
+        if (maxFiles != null && deduped.length > maxFiles) {
+            XH.warningToast(
+                maxFiles === 1
+                    ? 'Only one file allowed for upload.'
+                    : `File limit of ${maxFiles} exceeded.`
+            );
+            return false;
+        }
+
+        this.files = deduped;
+        return true;
     }
 
     private defaultRejectMessage(rejections: FileRejection[]): ReactElement {
         // 1) Map rejected files to error messages
         const errorsByFile = fromPairs(
-            map(rejections, ({file, errors}) => [file.handle.name, map(errors, 'message')])
+            map(rejections, ({file, errors}) => [file.name, map(errors, 'message')])
         );
 
         // 2) List files with bulleted error messages

--- a/desktop/cmp/filechooser/impl/DefaultEmptyDisplay.ts
+++ b/desktop/cmp/filechooser/impl/DefaultEmptyDisplay.ts
@@ -1,9 +1,9 @@
 import {div, placeholder} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
-import {FileChooserModel} from '@xh/hoist/desktop/cmp/filechooser';
+import {FileChooserModel} from '../FileChooserModel';
 import {Icon} from '@xh/hoist/icon';
 import {filesize} from 'filesize';
-import {flatten, isEmpty, uniq, values} from 'lodash';
+import {isEmpty, uniq} from 'lodash';
 import './DefaultEmptyDisplay.scss';
 
 const DEFAULT_PROMPT = 'Drag and drop files here, or click to browse.';
@@ -33,7 +33,7 @@ const emptyHint = hoistCmp.factory({
 
         let hint = emptyDisplayHint;
         if (hint === undefined) {
-            const exts = accept ? uniq(flatten(values(accept))) : [],
+            const exts = accept ? uniq(accept) : [],
                 parts: string[] = [];
 
             if (!isEmpty(exts)) {

--- a/desktop/cmp/filechooser/impl/DefaultFileDisplayModel.ts
+++ b/desktop/cmp/filechooser/impl/DefaultFileDisplayModel.ts
@@ -1,6 +1,6 @@
 import {fileExtCol, GridModel} from '@xh/hoist/cmp/grid';
 import {HoistModel, lookup, managed, ReactionSpec} from '@xh/hoist/core';
-import {FileChooserModel} from '@xh/hoist/desktop/cmp/filechooser';
+import {FileChooserModel} from '../FileChooserModel';
 import {actionCol, calcActionColWidth} from '@xh/hoist/desktop/cmp/grid';
 import {Icon} from '@xh/hoist/icon';
 import {makeObservable} from '@xh/hoist/mobx';

--- a/desktop/cmp/filechooser/impl/MultiDropTarget.ts
+++ b/desktop/cmp/filechooser/impl/MultiDropTarget.ts
@@ -1,6 +1,6 @@
 import {div, placeholder} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
-import {FileChooserModel} from '@xh/hoist/desktop/cmp/filechooser';
+import {FileChooserModel} from '../FileChooserModel';
 import {Icon} from '@xh/hoist/icon';
 
 /**

--- a/desktop/cmp/filechooser/impl/SingleFileDisplay.ts
+++ b/desktop/cmp/filechooser/impl/SingleFileDisplay.ts
@@ -1,7 +1,7 @@
 import {div, placeholder} from '@xh/hoist/cmp/layout';
 import {hoistCmp, uses} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
-import {FileChooserModel} from '@xh/hoist/desktop/cmp/filechooser';
+import {FileChooserModel} from '../FileChooserModel';
 import {Icon} from '@xh/hoist/icon';
 import {filesize} from 'filesize';
 import {MouseEvent} from 'react';

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "jwt-decode": "~4.0.0",
     "lodash": "~4.18.0",
     "lodash-inflection": "~1.5.0",
-    "mime": "^4.1.0",
     "mobx": "~6.15.0",
     "mobx-react-lite": "~4.1.0",
     "moment": "~2.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6987,11 +6987,6 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-4.1.0.tgz#ec55df7aa21832a36d44f0bbee5c04639b27802f"
-  integrity sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==
-
 mimic-function@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"


### PR DESCRIPTION
Follow-up to the FileChooser redesign (#4385), addressing code-review feedback. Targets `upgradeDropzone` so the diff is just these refinements.

### Changes
- **Reject-message crash fix** — use `file.name` instead of the optional `file.handle.name`. `handle` is only populated on the drag-drop path in secure-context Chromium; it's `undefined` on click-to-browse and in Firefox/Safari, where the default reject toast would otherwise throw.
- **Dropped `validateFilesAsync`** — and reverted the async `onDropAsync` back to a synchronous `onDrop` (the validation hook was its only `await`). Also corrected the `rejected` param type from `Partial<FileRejection[]>` to `FileRejection[]`.
- **`addFilesInternal` shared add path** — de-dupes by name, then enforces `maxFiles` on the *de-duped* result, so re-adding an already-selected file isn't double-counted. Public `addFiles` now respects the limit (and is documented as not enforcing `accept`/file-size, which only the dropzone applies).
- **Simplified `accept`** — removed the `mime` dependency and the extension→MIME mapping (the source of the same-MIME-collapse and `'null'`-key bugs). The model stores extensions directly; the react-dropzone `{type: [exts]}` map is built on the fly in the component. Documented as extensions-only.
- **Import cycle** — impl files now import `FileChooserModel` relatively instead of via the package barrel.
- Updated class doc and CHANGELOG to match.

### Notes
- `accept` is intentionally extensions-only; MIME/wildcard support can be added later as a non-breaking change if needed.
- `tsc` clean; pre-commit prettier/eslint/tsc hooks pass.