### PR TITLE
Track/Trace/Pref Service: reliable pending flush on page-hidden/unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### ⚙️ Technical
 
-* `TrackService` now flushes pending activity-tracking entries reliably when the page is hidden or unloaded, issuing the flush via `fetch({keepalive: true})` and reacting to `XH.pageState` (replacing the unreliable `beforeunload` + normal-fetch approach, which dropped the final batch on mobile and during teardown).
+* `TrackService` now flushes pending activity-tracking entries reliably when the page is hidden or
+  unloaded, issuing the flush via `fetch({keepalive: true})` and reacting to `XH.pageState`
+  (replacing less unreliable `beforeunload` + normal-fetch approach).
 
 
 ## 86.0.1 - 2026-06-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * `TrackService` now flushes pending activity-tracking entries reliably when the page is hidden or
   unloaded, issuing the flush via `fetch({keepalive: true})` and reacting to `XH.pageState`
-  (replacing less unreliable `beforeunload` + normal-fetch approach).
+  (replacing less reliable `beforeunload` + normal-fetch approach).
 
 
 ## 86.0.1 - 2026-06-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### ⚙️ Technical
 
-* `TrackService` now flushes pending activity-tracking entries reliably when the page is hidden or
-  unloaded, issuing the flush via `fetch({keepalive: true})` and reacting to `XH.pageState`
-  (replacing less reliable `beforeunload` + normal-fetch approach).
+* `TrackService`, `PrefService`, and `TraceService` now flush their pending entries reliably when
+  the page is hidden or unloaded, reacting to `XH.pageState` and issuing the flush via
+  `fetch({keepalive: true})` (replacing the less reliable `beforeunload` + normal-fetch approach).
 
 
 ## 86.0.1 - 2026-06-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* `TrackService` now flushes pending activity-tracking entries reliably when the page is hidden or unloaded, issuing the flush via `fetch({keepalive: true})` and reacting to `XH.pageState` (replacing the unreliable `beforeunload` + normal-fetch approach, which dropped the final batch on mobile and during teardown).
+
 ### 📚 Libraries
 
 * Pinned `react-draggable` to `4.5.0` - its `4.6.0` build throws on an undefined `process` global.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## 87.0.0-SNAPSHOT - unreleased
-
-### ⚙️ Technical
-
-* `TrackService`, `PrefService`, and `TraceService` now flush their pending entries reliably when
-  the page is hidden or unloaded, reacting to `XH.pageState` and issuing the flush via
-  `fetch({keepalive: true})` (replacing the less reliable `beforeunload` + normal-fetch approach).
-
 
 ## 86.0.1 - 2026-06-16
 
@@ -15,6 +7,12 @@
 
 * Fixed a circular import introduced in v86 that caused problems for apps using `@ComputeOnce`.
 * Fixed a regression to favorites icon size for `FilterChooser.`
+
+### ⚙️ Technical
+
+* `TrackService`, `PrefService`, and `TraceService` now flush their pending entries reliably when
+  the page is hidden or unloaded, reacting to `XH.pageState` and issuing the flush via
+  `fetch({keepalive: true})` (replacing the less reliable `beforeunload` + normal-fetch approach).
 
 
 ## 86.0.0 - 2026-06-12

--- a/svc/PrefService.ts
+++ b/svc/PrefService.ts
@@ -34,7 +34,16 @@ export class PrefService extends HoistService {
     private _updates = {};
 
     override async initAsync(ctx: InitContext) {
-        window.addEventListener('beforeunload', () => this.pushPendingAsync());
+        // Flush reliably on page teardown: pageState fires synchronously while the page is still
+        // alive, and `keepalive` carries the request across unload.
+        this.addReaction({
+            track: () => XH.pageState,
+            run: state => {
+                if (state === 'hidden' || state === 'frozen' || state === 'terminated') {
+                    this.pushPendingInternalAsync(true);
+                }
+            }
+        });
         return this.loadPrefsAsync(ctx);
     }
 
@@ -117,22 +126,7 @@ export class PrefService extends HoistService {
      * changes and option and then immediately hits a (browser) refresh.
      */
     async pushPendingAsync() {
-        const updates = this._updates;
-        if (isEmpty(updates)) return;
-
-        await this.runner()
-            .span('set')
-            .run(async ctx => {
-                this._updates = {};
-                await XH.postJson(
-                    {
-                        url: 'xh/setPrefs',
-                        body: updates,
-                        params: {clientUsername: XH.getUsername()}
-                    },
-                    ctx
-                );
-            });
+        return this.pushPendingInternalAsync();
     }
 
     //-------------------
@@ -140,7 +134,35 @@ export class PrefService extends HoistService {
     //-------------------
     @debounced(5 * SECONDS)
     private pushPendingBuffered() {
-        this.pushPendingAsync();
+        return this.pushPendingInternalAsync();
+    }
+
+    /**
+     * Flush the queue of pending preference updates to the server.
+     * @param keepalive - issue the request with `fetch({keepalive: true})` so it survives a page
+     *      teardown. Used by the page-unload flush; not for normal use, as keepalive requests are
+     *      subject to a 64KB body cap.
+     */
+    private async pushPendingInternalAsync(keepalive: boolean = false) {
+        const updates = this._updates;
+        if (isEmpty(updates)) return;
+
+        // Clear synchronously with the capture, so overlapping flushes cannot post twice.
+        this._updates = {};
+
+        await this.runner()
+            .span('set')
+            .run(ctx =>
+                XH.postJson(
+                    {
+                        url: 'xh/setPrefs',
+                        body: updates,
+                        params: {clientUsername: XH.getUsername()},
+                        fetchOpts: keepalive ? {keepalive: true} : undefined
+                    },
+                    ctx
+                )
+            );
     }
 
     private async loadPrefsAsync(ctx: CallContextLike) {

--- a/svc/PrefService.ts
+++ b/svc/PrefService.ts
@@ -8,6 +8,7 @@ import {CallContextLike, HoistService, InitContext, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {debounced, deepFreeze, throwIf} from '@xh/hoist/utils/js';
 import {cloneDeep, forEach, isEmpty, isEqual} from 'lodash';
+import {terminationSafePostJson} from './impl/Fetch';
 
 /**
  * Service to read and set user-specific preference values.
@@ -34,14 +35,11 @@ export class PrefService extends HoistService {
     private _updates = {};
 
     override async initAsync(ctx: InitContext) {
-        // Flush reliably on page teardown: pageState fires synchronously while the page is still
-        // alive, and `keepalive` carries the request across unload.
+        // Flush on page teardown while the page is still alive.
         this.addReaction({
             track: () => XH.pageState,
-            run: state => {
-                if (state === 'hidden' || state === 'frozen' || state === 'terminated') {
-                    this.pushPendingInternalAsync(true);
-                }
+            run: () => {
+                if (!XH.pageIsVisible) this.pushPendingAsync();
             }
         });
         return this.loadPrefsAsync(ctx);
@@ -121,29 +119,12 @@ export class PrefService extends HoistService {
     }
 
     /**
-     * Push any pending buffered updates to persist newly set values to server.
-     * Called automatically by this app on page unload to avoid dropping changes when e.g. a user
-     * changes and option and then immediately hits a (browser) refresh.
+     * Push any pending buffered updates to persist newly set values to the server.
+     *
+     * Not typically called by applications.  Called automatically by the framework after changes
+     * and when page is hidden/terminated.
      */
     async pushPendingAsync() {
-        return this.pushPendingInternalAsync();
-    }
-
-    //-------------------
-    //  Implementation
-    //-------------------
-    @debounced(5 * SECONDS)
-    private pushPendingBuffered() {
-        return this.pushPendingInternalAsync();
-    }
-
-    /**
-     * Flush the queue of pending preference updates to the server.
-     * @param keepalive - issue the request with `fetch({keepalive: true})` so it survives a page
-     *      teardown. Used by the page-unload flush; not for normal use, as keepalive requests are
-     *      subject to a 64KB body cap.
-     */
-    private async pushPendingInternalAsync(keepalive: boolean = false) {
         const updates = this._updates;
         if (isEmpty(updates)) return;
 
@@ -153,16 +134,23 @@ export class PrefService extends HoistService {
         await this.runner()
             .span('set')
             .run(ctx =>
-                XH.postJson(
+                terminationSafePostJson(
                     {
                         url: 'xh/setPrefs',
                         body: updates,
-                        params: {clientUsername: XH.getUsername()},
-                        fetchOpts: keepalive ? {keepalive: true} : undefined
+                        params: {clientUsername: XH.getUsername()}
                     },
                     ctx
                 )
             );
+    }
+
+    //-------------------
+    //  Implementation
+    //-------------------
+    @debounced(5 * SECONDS)
+    private pushPendingBuffered() {
+        void this.pushPendingAsync();
     }
 
     private async loadPrefsAsync(ctx: CallContextLike) {

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -8,6 +8,7 @@ import {HoistService, PlainObject, XH, Span, FullSpanConfig} from '@xh/hoist/cor
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {debounced, parseNameSource} from '@xh/hoist/utils/js';
 import {every, forEach, groupBy, isEmpty, isString, omitBy, takeRight} from 'lodash';
+import {terminationSafePostJson} from './impl/Fetch';
 
 /**
  * Client-side distributed tracing service for Hoist applications.
@@ -49,14 +50,11 @@ export class TraceService extends HoistService {
     // Initialization
     //------------------
     override async initAsync() {
-        // Flush reliably on page teardown: pageState fires synchronously while the page is still
-        // alive, and `keepalive` carries the request across unload.
+        // Flush on page teardown while the page is still alive.
         this.addReaction({
             track: () => XH.pageState,
-            run: state => {
-                if (state === 'hidden' || state === 'frozen' || state === 'terminated') {
-                    this.pushPendingInternalAsync(true);
-                }
+            run: () => {
+                if (!XH.pageIsVisible) this.pushPendingInternalAsync();
             }
         });
     }
@@ -216,26 +214,20 @@ export class TraceService extends HoistService {
         void this.pushPendingInternalAsync();
     }
 
-    /**
-     * Flush all pending spans to the server.
-     * @param keepalive - issue the request with `fetch({keepalive: true})` so it survives a page
-     *      teardown. Used by the page-unload flush; not for normal use, as keepalive requests are
-     *      subject to a 64KB body cap.
-     */
-    private async pushPendingInternalAsync(keepalive: boolean = false) {
+    /** Flush all pending spans to the server. */
+    private async pushPendingInternalAsync() {
         const spans = this._pending;
         if (isEmpty(spans)) return;
 
         // Clear synchronously with the capture, so overlapping flushes cannot post twice.
         this._pending = [];
         try {
-            await XH.postJson({
+            await terminationSafePostJson({
                 url: 'xh/submitSpans',
                 body: spans.map(s => s.toJSON()),
                 params: {
                     clientUsername: XH.getUsername()
-                },
-                fetchOpts: keepalive ? {keepalive: true} : undefined
+                }
             });
         } catch (e) {
             if (isRetryableError(e)) {

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -4,10 +4,10 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, InitContext, PlainObject, XH, Span, FullSpanConfig} from '@xh/hoist/core';
+import {HoistService, PlainObject, XH, Span, FullSpanConfig} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {debounced, parseNameSource} from '@xh/hoist/utils/js';
-import {every, forEach, groupBy, isEmpty, isString, omitBy} from 'lodash';
+import {every, forEach, groupBy, isEmpty, isString, omitBy, takeRight} from 'lodash';
 
 /**
  * Client-side distributed tracing service for Hoist applications.
@@ -48,8 +48,17 @@ export class TraceService extends HoistService {
     //------------------
     // Initialization
     //------------------
-    override async initAsync(ctx: InitContext) {
-        window.addEventListener('beforeunload', () => this.pushPendingAsync());
+    override async initAsync() {
+        // Flush reliably on page teardown: pageState fires synchronously while the page is still
+        // alive, and `keepalive` carries the request across unload.
+        this.addReaction({
+            track: () => XH.pageState,
+            run: state => {
+                if (state === 'hidden' || state === 'frozen' || state === 'terminated') {
+                    this.pushPendingInternalAsync(true);
+                }
+            }
+        });
     }
 
     //------------------
@@ -159,44 +168,11 @@ export class TraceService extends HoistService {
     }
 
     /**
-     * Push all pending spans to the server.
-     * Called on debounced interval and on page unload.
+     * Flush the queue of pending spans to the server.
+     * @internal - apps should generally allow this service to manage w/its internal debounce.
      */
     async pushPendingAsync() {
-        const spans = this._pending;
-        if (isEmpty(spans)) return;
-
-        this._pending = [];
-        try {
-            await XH.postJson({
-                url: 'xh/submitSpans',
-                body: spans.map(s => s.toJSON()),
-                params: {
-                    clientUsername: XH.getUsername()
-                }
-            });
-        } catch (e) {
-            if (isRetryableError(e)) {
-                // Transient failure - re-queue the batch (ahead of newer spans) to retry on the
-                // next flush, then bound the buffer in case the outage is prolonged.
-                this._pending = [...spans, ...this._pending];
-                this.enforceCap();
-                this.logError('Failed to push spans - will retry on next flush', e);
-            } else {
-                // Permanent (client-side) rejection - drop the batch so it can't deadlock the
-                // pipe (e.g. a session mismatch or oversized payload would fail forever).
-                this.logError('Server rejected span batch - dropping', e);
-            }
-        }
-    }
-
-    /** Bound the pending buffer, silently dropping oldest spans (failed pushes are logged). */
-    private enforceCap() {
-        const {_pending} = this,
-            {MAX_PENDING} = TraceService;
-        if (_pending.length > MAX_PENDING) {
-            _pending.splice(0, _pending.length - MAX_PENDING);
-        }
+        return this.pushPendingInternalAsync();
     }
 
     /**
@@ -237,7 +213,51 @@ export class TraceService extends HoistService {
 
     @debounced(5 * SECONDS)
     private pushPendingBuffered() {
-        void this.pushPendingAsync();
+        void this.pushPendingInternalAsync();
+    }
+
+    /**
+     * Flush all pending spans to the server.
+     * @param keepalive - issue the request with `fetch({keepalive: true})` so it survives a page
+     *      teardown. Used by the page-unload flush; not for normal use, as keepalive requests are
+     *      subject to a 64KB body cap.
+     */
+    private async pushPendingInternalAsync(keepalive: boolean = false) {
+        const spans = this._pending;
+        if (isEmpty(spans)) return;
+
+        // Clear synchronously with the capture, so overlapping flushes cannot post twice.
+        this._pending = [];
+        try {
+            await XH.postJson({
+                url: 'xh/submitSpans',
+                body: spans.map(s => s.toJSON()),
+                params: {
+                    clientUsername: XH.getUsername()
+                },
+                fetchOpts: keepalive ? {keepalive: true} : undefined
+            });
+        } catch (e) {
+            if (isRetryableError(e)) {
+                // Transient failure - re-queue the batch (ahead of newer spans) to retry on the
+                // next flush, then bound the buffer in case the outage is prolonged.
+                this._pending = [...spans, ...this._pending];
+                this.enforceCap();
+                this.logError('Failed to push spans - will retry on next flush', e);
+            } else {
+                // Permanent (client-side) rejection - drop the batch so it can't deadlock the
+                // pipe (e.g. a session mismatch or oversized payload would fail forever).
+                this.logError('Server rejected span batch - dropping', e);
+            }
+        }
+    }
+
+    /** Bound the pending buffer, silently dropping oldest spans (failed pushes are logged). */
+    private enforceCap() {
+        const {MAX_PENDING} = TraceService;
+        if (this._pending.length > MAX_PENDING) {
+            this._pending = takeRight(this._pending, MAX_PENDING);
+        }
     }
 
     /**

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -9,6 +9,7 @@ import {SECONDS} from '@xh/hoist/utils/datetime';
 import {isOmitted} from '@xh/hoist/utils/impl';
 import {debounced, stripTags, withDefault} from '@xh/hoist/utils/js';
 import {isEmpty, isNil, isString} from 'lodash';
+import {terminationSafePostJson} from './impl/Fetch';
 
 /**
  * Primary service for tracking any activity that an application's admins want to track.
@@ -24,14 +25,11 @@ export class TrackService extends HoistService {
     private pending: PlainObject[] = [];
 
     override async initAsync() {
-        // Flush reliably on page teardown: pageState fires synchronously while the page is still
-        // alive, and `keepalive` carries the request across unload.
+        // Flush on page teardown while the page is still alive
         this.addReaction({
             track: () => XH.pageState,
-            run: state => {
-                if (state === 'hidden' || state === 'frozen' || state === 'terminated') {
-                    this.pushPendingInternalAsync(true);
-                }
+            run: () => {
+                if (!XH.pageIsVisible) this.pushPendingAsync();
             }
         });
     }
@@ -103,27 +101,11 @@ export class TrackService extends HoistService {
 
     /**
      * Flush the queue of pending activity tracking messages to the server.
-     * @internal - apps should generally allow this service to manage w/its internal debounce.
+     *
+     * Not typically called by applications.  Called automatically by the framework via a
+     * debounce and when the page is hidden/terminated.
      */
     async pushPendingAsync() {
-        return this.pushPendingInternalAsync();
-    }
-
-    //------------------
-    // Implementation
-    //------------------
-    @debounced(10 * SECONDS)
-    private pushPendingBuffered() {
-        return this.pushPendingInternalAsync();
-    }
-
-    /**
-     * Flush the queue of pending activity tracking messages to the server.
-     * @param keepalive - issue the request with `fetch({keepalive: true})` so it survives a page
-     *      teardown. Used by the page-hidden/unload flush; not for normal use, as keepalive
-     *      requests are subject to a 64KB body cap.
-     */
-    private async pushPendingInternalAsync(keepalive: boolean = false) {
         const {pending} = this;
         if (isEmpty(pending)) return;
 
@@ -133,16 +115,23 @@ export class TrackService extends HoistService {
         await this.runner()
             .span('push')
             .run(ctx =>
-                XH.postJson(
+                terminationSafePostJson(
                     {
                         url: 'xh/track',
                         body: {entries: pending},
-                        params: {clientUsername: XH.getUsername()},
-                        fetchOpts: keepalive ? {keepalive: true} : undefined
+                        params: {clientUsername: XH.getUsername()}
                     },
                     ctx
                 )
             );
+    }
+
+    //------------------
+    // Implementation
+    //------------------
+    @debounced(10 * SECONDS)
+    private pushPendingBuffered() {
+        void this.pushPendingAsync();
     }
 
     private toServerJson(options: TrackOptions): PlainObject {

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -116,11 +116,14 @@ export class TrackService extends HoistService {
         const {pending} = this;
         if (isEmpty(pending)) return;
 
+        // Clear synchronously with the capture, before any `await`,
+        // so overlapping flushes cannot post the same entries twice.
+        this.pending = [];
+
         await this.runner()
             .span('push')
-            .run(async ctx => {
-                this.pending = [];
-                await XH.postJson(
+            .run(ctx =>
+                XH.postJson(
                     {
                         url: 'xh/track',
                         body: {entries: pending},
@@ -128,8 +131,8 @@ export class TrackService extends HoistService {
                         fetchOpts: opts?.keepalive ? {keepalive: true} : undefined
                     },
                     ctx
-                );
-            });
+                )
+            );
     }
 
     //------------------

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -26,9 +26,7 @@ export class TrackService extends HoistService {
     override async initAsync() {
         // Reliably flush pending entries when the page is hidden or unloaded. PageState transitions
         // synchronously within its DOM handlers, so this (non-delayed) reaction fires while the page
-        // is still alive, and `keepalive` carries the issued request across teardown - unlike the
-        // prior `beforeunload` + normal-fetch approach, which the browser cancelled mid-teardown and
-        // which never fired at all for discarded mobile tabs.
+        // is still alive, and `keepalive` carries the issued request across teardown.
         this.addReaction({
             track: () => XH.pageState,
             run: state => {

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -24,14 +24,13 @@ export class TrackService extends HoistService {
     private pending: PlainObject[] = [];
 
     override async initAsync() {
-        // Reliably flush pending entries when the page is hidden or unloaded. PageState transitions
-        // synchronously within its DOM handlers, so this (non-delayed) reaction fires while the page
-        // is still alive, and `keepalive` carries the issued request across teardown.
+        // Flush reliably on page teardown: pageState fires synchronously while the page is still
+        // alive, and `keepalive` carries the request across unload.
         this.addReaction({
             track: () => XH.pageState,
             run: state => {
                 if (state === 'hidden' || state === 'frozen' || state === 'terminated') {
-                    this.pushPendingAsync({keepalive: true});
+                    this.pushPendingInternalAsync(true);
                 }
             }
         });
@@ -104,18 +103,31 @@ export class TrackService extends HoistService {
 
     /**
      * Flush the queue of pending activity tracking messages to the server.
-     * @param opts - flush options.
-     *      `keepalive` - issue the request with `fetch({keepalive: true})` so it survives a page
-     *      teardown. Used by the page-hidden/unload flush; not for normal use, as keepalive requests
-     *      are subject to a 64KB body cap.
      * @internal - apps should generally allow this service to manage w/its internal debounce.
      */
-    async pushPendingAsync(opts?: {keepalive?: boolean}) {
+    async pushPendingAsync() {
+        return this.pushPendingInternalAsync();
+    }
+
+    //------------------
+    // Implementation
+    //------------------
+    @debounced(10 * SECONDS)
+    private pushPendingBuffered() {
+        return this.pushPendingInternalAsync();
+    }
+
+    /**
+     * Flush the queue of pending activity tracking messages to the server.
+     * @param keepalive - issue the request with `fetch({keepalive: true})` so it survives a page
+     *      teardown. Used by the page-hidden/unload flush; not for normal use, as keepalive
+     *      requests are subject to a 64KB body cap.
+     */
+    private async pushPendingInternalAsync(keepalive: boolean = false) {
         const {pending} = this;
         if (isEmpty(pending)) return;
 
-        // Clear synchronously with the capture, before any `await`,
-        // so overlapping flushes cannot post the same entries twice.
+        // Clear synchronously with the capture, so overlapping flushes cannot post twice.
         this.pending = [];
 
         await this.runner()
@@ -126,19 +138,11 @@ export class TrackService extends HoistService {
                         url: 'xh/track',
                         body: {entries: pending},
                         params: {clientUsername: XH.getUsername()},
-                        fetchOpts: opts?.keepalive ? {keepalive: true} : undefined
+                        fetchOpts: keepalive ? {keepalive: true} : undefined
                     },
                     ctx
                 )
             );
-    }
-
-    //------------------
-    // Implementation
-    //------------------
-    @debounced(10 * SECONDS)
-    private pushPendingBuffered() {
-        this.pushPendingAsync();
     }
 
     private toServerJson(options: TrackOptions): PlainObject {

--- a/svc/TrackService.ts
+++ b/svc/TrackService.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistService, InitContext, PlainObject, TrackOptions, XH} from '@xh/hoist/core';
+import {HoistService, PlainObject, TrackOptions, XH} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {isOmitted} from '@xh/hoist/utils/impl';
 import {debounced, stripTags, withDefault} from '@xh/hoist/utils/js';
@@ -23,8 +23,20 @@ export class TrackService extends HoistService {
     private oncePerSessionSent = new Map();
     private pending: PlainObject[] = [];
 
-    override async initAsync(ctx: InitContext) {
-        window.addEventListener('beforeunload', () => this.pushPendingAsync());
+    override async initAsync() {
+        // Reliably flush pending entries when the page is hidden or unloaded. PageState transitions
+        // synchronously within its DOM handlers, so this (non-delayed) reaction fires while the page
+        // is still alive, and `keepalive` carries the issued request across teardown - unlike the
+        // prior `beforeunload` + normal-fetch approach, which the browser cancelled mid-teardown and
+        // which never fired at all for discarded mobile tabs.
+        this.addReaction({
+            track: () => XH.pageState,
+            run: state => {
+                if (state === 'hidden' || state === 'frozen' || state === 'terminated') {
+                    this.pushPendingAsync({keepalive: true});
+                }
+            }
+        });
     }
 
     get conf(): ActivityTrackingConfig {
@@ -94,9 +106,13 @@ export class TrackService extends HoistService {
 
     /**
      * Flush the queue of pending activity tracking messages to the server.
+     * @param opts - flush options.
+     *      `keepalive` - issue the request with `fetch({keepalive: true})` so it survives a page
+     *      teardown. Used by the page-hidden/unload flush; not for normal use, as keepalive requests
+     *      are subject to a 64KB body cap.
      * @internal - apps should generally allow this service to manage w/its internal debounce.
      */
-    async pushPendingAsync() {
+    async pushPendingAsync(opts?: {keepalive?: boolean}) {
         const {pending} = this;
         if (isEmpty(pending)) return;
 
@@ -108,7 +124,8 @@ export class TrackService extends HoistService {
                     {
                         url: 'xh/track',
                         body: {entries: pending},
-                        params: {clientUsername: XH.getUsername()}
+                        params: {clientUsername: XH.getUsername()},
+                        fetchOpts: opts?.keepalive ? {keepalive: true} : undefined
                     },
                     ctx
                 );

--- a/svc/impl/Fetch.ts
+++ b/svc/impl/Fetch.ts
@@ -1,0 +1,33 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {CallContextLike, XH} from '@xh/hoist/core';
+import type {FetchOptions} from '../FetchService';
+
+/**
+ * Post a JSON body, using `fetch({keepalive: true})` when the page is no longer visible so the
+ * request can survive teardown (e.g. a flush as `XH.pageState` goes `hidden`/`frozen`/`terminated`).
+ *
+ * Keepalive bodies share a single browser-wide 64KB budget; if exceeded the request is never sent
+ * and we retry once uncapped (without keepalive), which still completes while the page is alive (the
+ * common `hidden` case). Real server errors are re-thrown, not re-posted.
+ *
+ * @internal
+ */
+export async function terminationSafePostJson(
+    opts: FetchOptions,
+    ctx?: CallContextLike
+): Promise<any> {
+    if (XH.pageIsVisible) return XH.postJson(opts, ctx);
+
+    try {
+        return await XH.postJson({...opts, fetchOpts: {...opts.fetchOpts, keepalive: true}}, ctx);
+    } catch (e: any) {
+        // Retry uncapped if keepalive was never sent (over-budget); re-throw real server errors.
+        if (e.isServerUnavailable) return XH.postJson(opts, ctx);
+        throw e;
+    }
+}


### PR DESCRIPTION
Activity-tracking, preference, and trace-span entries queued just before a page closes were being dropped. `TrackService`, `PrefService`, and `TraceService` each flushed on `beforeunload` with a normal `fetch`, which the browser cancels mid-teardown - and `beforeunload` never fires at all for discarded (e.g. mobile) tabs. This switches all three to flush on `XH.pageState` transitions, routed through a shared `terminationSafePostJson` helper that issues the flush via `fetch({keepalive: true})` when the page is no longer visible, so the final batch actually lands.

### Changes
- New shared helper `terminationSafePostJson` (`svc/impl/Fetch.ts`): posts normally while the page is visible, and with `keepalive: true` once `XH.pageState` has gone `hidden`/`frozen`/`terminated`. Keepalive bodies share a browser-wide ~64KB budget; if exceeded the request is never sent, so the helper retries once uncapped (without keepalive) - which still completes in the common, still-alive `hidden` case. Real server errors are re-thrown, not retried.
- `TrackService`, `PrefService`, and `TraceService`: replaced the `beforeunload` listener with a reaction to `XH.pageState` becoming non-visible. `hidden` is the last reliable callback in the page lifecycle (incl. mobile discard) and fires while the page is still alive.
- Moved each service's pending-queue clear to run synchronously with the capture (before any `await`), so the page-hidden flush and the existing debounced flush can't race and double-post the same entries.
- `TraceService`: extracted the flush into `pushPendingInternalAsync`; it now retries on transient/5xx errors (re-queue ahead of newer spans, bounded by `MAX_PENDING`) and drops only on permanent client-side (4xx) rejections such as session-mismatch or oversized payload.

### Notes for reviewer
- keepalive is used only for the page-hidden/unload flush, never the normal debounced path.
- Track/Pref flushes are best-effort: the queue is cleared optimistically, so a failed flush drops that batch. Considered and rejected clear-on-success (double-post risk) and restore-on-failure (poison-pill risk). Trace layers transient-retry on top, since spans flush frequently and a brief 5xx shouldn't lose a batch.
