### PR TITLE
Preserve router5-plugin-browser augmentation in emitted .d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Fixed downstream TypeScript error `Property 'buildUrl' does not exist on type 'Router'`
+  (and similarly for `matchUrl`, `replaceHistoryState`, `lastKnownState`)
+  when consuming the published `@xh/hoist` declaration output. The `router5-plugin-browser` module
+  augmentation was being stripped from `RouterModel.d.ts` because its only import was a value-only
+  default that `tsc` removes when emitting declarations; a side-effect import now preserves it.
+
 ## 86.0.1 - 2026-06-16
 
 ### 🐞 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,7 @@
 
 ### 🐞 Bug Fixes
 
-* Fixed downstream TypeScript error `Property 'buildUrl' does not exist on type 'Router'`
-  (and similarly for `matchUrl`, `replaceHistoryState`, `lastKnownState`)
-  when consuming the published `@xh/hoist` declaration output. The `router5-plugin-browser` module
-  augmentation was being stripped from `RouterModel.d.ts` because its only import was a value-only
-  default that `tsc` removes when emitting declarations; a side-effect import now preserves it.
+* Ensure publication of `router5-plugin-browser` TS module augmentation.
 
 ## 86.0.1 - 2026-06-16
 

--- a/appcontainer/RouterModel.ts
+++ b/appcontainer/RouterModel.ts
@@ -9,10 +9,9 @@ import {action, observable, makeObservable} from '@xh/hoist/mobx';
 import {mergeDeep} from '@xh/hoist/utils/js';
 import {isOmitted} from '@xh/hoist/utils/impl';
 import {createRouter, Router, State} from 'router5';
-// Side-effect import preserved in emitted .d.ts so downstream consumers pick up
-// router5-plugin-browser's Router augmentation (buildUrl, matchUrl, etc.).
-import 'router5-plugin-browser';
 import browserPlugin from 'router5-plugin-browser';
+// Required so downstream consumers pick up Router TS augmentation (buildUrl, etc.).
+import 'router5-plugin-browser';
 
 /**
  * Top-level model for managing application routing in Hoist.

--- a/appcontainer/RouterModel.ts
+++ b/appcontainer/RouterModel.ts
@@ -9,6 +9,9 @@ import {action, observable, makeObservable} from '@xh/hoist/mobx';
 import {mergeDeep} from '@xh/hoist/utils/js';
 import {isOmitted} from '@xh/hoist/utils/impl';
 import {createRouter, Router, State} from 'router5';
+// Side-effect import preserved in emitted .d.ts so downstream consumers pick up
+// router5-plugin-browser's Router augmentation (buildUrl, matchUrl, etc.).
+import 'router5-plugin-browser';
 import browserPlugin from 'router5-plugin-browser';
 
 /**


### PR DESCRIPTION
## Summary

- Downstream apps consuming the published `@xh/hoist` types got `TS2339: Property 'buildUrl' does not exist on type 'Router'` (and similarly for `matchUrl`, `replaceHistoryState`, `lastKnownState`).
- Root cause: `RouterModel.ts` imported `router5-plugin-browser` only as a default value, so `tsc` stripped it from the emitted `.d.ts` and the plugin's `declare module 'router5/types/types/router'` augmentation never reached consumers.
- Added a side-effect `import 'router5-plugin-browser';` (alongside the existing default import) so the augmentation flows through to the published declaration output.

Fixes #4431.

## Test plan

- [x] Build hoist-react (`rm -rf build/types tsconfig.tsbuildinfo && tsc --build`) and confirm `build/types/appcontainer/RouterModel.d.ts` now contains `import 'router5-plugin-browser';`.
- [x] Confirm a downstream `XH.router.buildUrl(...)` call type-checks against the rebuilt output.
- [ ] CI green.