### PR TITLE
Add mobile SegmentedControl input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Added a mobile `SegmentedControl` input - the mobile counterpart to the desktop component, with a
   matching `options`-driven API for selecting a single value from a set of mutually exclusive
   choices. Built on Hoist's mobile `Button` (no Blueprint dependency).
+    * The shared `SegmentedControlOption` option types now export from `@xh/hoist/cmp/input` rather
+      than the desktop `SegmentedControl` module; update any direct type imports.
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* Added a mobile `SegmentedControl` input - the mobile counterpart to the desktop component, with a
+  matching `options`-driven API for selecting a single value from a set of mutually exclusive
+  choices. Built on Hoist's mobile `Button` (no Blueprint dependency).
+
 ### 🐞 Bug Fixes
 
 * Ensure publication of `router5-plugin-browser` TS module augmentation.

--- a/cmp/input/SegmentedControlOption.ts
+++ b/cmp/input/SegmentedControlOption.ts
@@ -1,0 +1,61 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {Intent} from '@xh/hoist/core';
+import {LocalDate} from '@xh/hoist/utils/datetime';
+import {ReactElement} from 'react';
+
+/** Primitive value types supported as a SegmentedControl option value/label. */
+export type OptionPrimitive = string | number | boolean | LocalDate;
+
+/**
+ * Option for a SegmentedControl, shared by the desktop and mobile implementations.
+ */
+export interface SegmentedControlOption {
+    /** Value for this option. */
+    value: OptionPrimitive;
+
+    /** Display label. Defaults to `value.toString()` if omitted. */
+    label?: string;
+
+    /** Icon element, displayed before the label. */
+    icon?: ReactElement;
+
+    /** True to disable this individual option. */
+    disabled?: boolean;
+
+    /**
+     * Visual intent for this option - rendered as a solid fill when selected and as a subtle
+     * text-color hint when not (e.g. to flag a destructive choice). Overrides any control-level
+     * `intent` default. Defaults to the control's `intent`.
+     */
+    intent?: Intent;
+}
+
+/**
+ * Variant of SegmentedControlOption for representing a null/"no value" selection.
+ * Label is required to force use case to override default js 'null' toString rendering.
+ */
+export interface SegmentedControlNullOption {
+    /** Null value for this option. */
+    value: null;
+
+    /** Display label - required for null options. */
+    label: string;
+
+    /** Icon element, displayed before the label. */
+    icon?: ReactElement;
+
+    /** True to disable this individual option. */
+    disabled?: boolean;
+
+    /**
+     * Visual intent for this option - rendered as a solid fill when selected and as a subtle
+     * text-color hint when not (e.g. to flag a destructive choice). Overrides any control-level
+     * `intent` default. Defaults to the control's `intent`.
+     */
+    intent?: Intent;
+}

--- a/cmp/input/index.ts
+++ b/cmp/input/index.ts
@@ -1,2 +1,3 @@
 export * from './HoistInputModel';
 export * from './HoistInputProps';
+export * from './SegmentedControlOption';

--- a/desktop/cmp/input/SegmentedControl.ts
+++ b/desktop/cmp/input/SegmentedControl.ts
@@ -23,8 +23,6 @@ import classNames from 'classnames';
 import {filter, isObject} from 'lodash';
 import './SegmentedControl.scss';
 
-export type {OptionPrimitive, SegmentedControlOption, SegmentedControlNullOption};
-
 export interface SegmentedControlProps extends HoistProps, HoistInputProps {
     /** True to render in a compact mode with reduced sizing for space-constrained contexts. */
     compact?: boolean;

--- a/mobile/cmp/input/SegmentedControl.scss
+++ b/mobile/cmp/input/SegmentedControl.scss
@@ -66,28 +66,6 @@
       flex: 1 1 0;
     }
 
-    // Scrollable mode - when the options cannot all fit, scroll the tray horizontally rather than
-    // truncating labels. Options size to their content and never shrink, so the row overflows and
-    // scrolls; in fill mode they still grow to fill the width when there is room to spare.
-    &.xh-segmented-control--scrollable {
-      overflow-x: auto;
-      // Hide the scrollbar for a clean, native-feeling swipe (content is discoverable by dragging).
-      scrollbar-width: none;
-      -webkit-overflow-scrolling: touch;
-
-      &::-webkit-scrollbar {
-        display: none;
-      }
-
-      .xh-button.xh-segmented-control-option {
-        flex: 0 0 auto;
-      }
-
-      &.xh-segmented-control--fill .xh-button.xh-segmented-control-option {
-        flex: 1 0 auto;
-      }
-    }
-
     // Outlined mode - border around the tray with no inner background fill.
     &.xh-segmented-control--outlined {
       background-color: transparent;

--- a/mobile/cmp/input/SegmentedControl.scss
+++ b/mobile/cmp/input/SegmentedControl.scss
@@ -20,9 +20,25 @@
     // the tray background shows through and our segmented text color applies.
     .xh-button.xh-segmented-control-option {
       flex: 0 0 auto;
+      // Allow the button to shrink below its content width so the label can ellipsis-truncate
+      // (flex items default to min-width: auto, which forces overflow / hard clipping instead).
+      min-width: 0;
       border-radius: var(--xh-segmented-control-border-radius-px);
       background-color: transparent;
       color: var(--xh-segmented-control-text-color);
+
+      // Keep icons at full size - only the label gives way when space is tight.
+      > svg {
+        flex: 0 0 auto;
+      }
+    }
+
+    // Label - truncate with an ellipsis when its segment is too narrow to fit the full text.
+    .xh-segmented-control-option__label {
+      overflow: hidden;
+      min-width: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     // Selected option - a solid tile standing out from the tray.

--- a/mobile/cmp/input/SegmentedControl.scss
+++ b/mobile/cmp/input/SegmentedControl.scss
@@ -66,6 +66,28 @@
       flex: 1 1 0;
     }
 
+    // Scrollable mode - when the options cannot all fit, scroll the tray horizontally rather than
+    // truncating labels. Options size to their content and never shrink, so the row overflows and
+    // scrolls; in fill mode they still grow to fill the width when there is room to spare.
+    &.xh-segmented-control--scrollable {
+      overflow-x: auto;
+      // Hide the scrollbar for a clean, native-feeling swipe (content is discoverable by dragging).
+      scrollbar-width: none;
+      -webkit-overflow-scrolling: touch;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+
+      .xh-button.xh-segmented-control-option {
+        flex: 0 0 auto;
+      }
+
+      &.xh-segmented-control--fill .xh-button.xh-segmented-control-option {
+        flex: 1 0 auto;
+      }
+    }
+
     // Outlined mode - border around the tray with no inner background fill.
     &.xh-segmented-control--outlined {
       background-color: transparent;

--- a/mobile/cmp/input/SegmentedControl.scss
+++ b/mobile/cmp/input/SegmentedControl.scss
@@ -61,9 +61,12 @@
       }
     }
 
-    // Fill mode (default) - distribute options equally across the available width.
+    // Fill mode (default) - options grow to fill the available width. Basis is `auto` (content)
+    // rather than 0 so each option keeps at least its content width and only the leftover space
+    // is shared out - a wider label is not starved into truncation by narrower siblings. Options
+    // still shrink + ellipsis (see below) when the set genuinely cannot fit.
     &.xh-segmented-control--fill .xh-button.xh-segmented-control-option {
-      flex: 1 1 0;
+      flex: 1 1 auto;
     }
 
     // Outlined mode - border around the tray with no inner background fill.

--- a/mobile/cmp/input/SegmentedControl.scss
+++ b/mobile/cmp/input/SegmentedControl.scss
@@ -70,6 +70,18 @@
     &.xh-segmented-control--outlined {
       background-color: transparent;
       border: 1px solid var(--xh-border-color);
+
+      // Reserve border space on every option so selecting one does not shift the row. The
+      // transparent tray offers no recessed backdrop to set a filled tile against, so indicate
+      // selection with a ring instead - currentColor keeps it in step with the option's
+      // text / intent color.
+      .xh-button.xh-segmented-control-option {
+        border: 1px solid transparent;
+      }
+
+      .xh-button.xh-segmented-control-option--selected {
+        border-color: currentColor;
+      }
     }
 
     @each $intent in (primary, success, warning, danger) {

--- a/mobile/cmp/input/SegmentedControl.scss
+++ b/mobile/cmp/input/SegmentedControl.scss
@@ -1,0 +1,78 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+
+// Scoped under .xh-app to win specificity over the .xh-app-scoped mobile Button styles.
+.xh-app {
+  .xh-segmented-control {
+    // The tray - a recessed container the selected option rises out of.
+    display: flex;
+    align-items: stretch;
+    background-color: var(--xh-segmented-control-bg);
+    border-radius: var(--xh-segmented-control-border-radius-px);
+    padding: var(--xh-segmented-control-pad-px);
+    gap: var(--xh-segmented-control-pad-px);
+
+    // Options - buttons receding into the tray by default. Override the minimal Button base so
+    // the tray background shows through and our segmented text color applies.
+    .xh-button.xh-segmented-control-option {
+      flex: 0 0 auto;
+      border-radius: var(--xh-segmented-control-border-radius-px);
+      background-color: transparent;
+      color: var(--xh-segmented-control-text-color);
+    }
+
+    // Selected option - a solid tile standing out from the tray.
+    .xh-button.xh-segmented-control-option--selected {
+      background-color: var(--xh-segmented-control-selected-bg);
+      color: var(--xh-segmented-control-selected-text-color);
+    }
+
+    // Per-option intents - keyed off the className applied to each button. Renders the selected
+    // option as a solid fill in the intent color, and tints unselected options' text so an intent
+    // (e.g. danger) reads as such even before it is chosen.
+    @each $intent in (primary, success, warning, danger) {
+      .xh-button.xh-segmented-control-option--#{$intent} {
+        color: var(--xh-intent-#{$intent}-text-color);
+      }
+
+      .xh-button.xh-segmented-control-option--#{$intent}.xh-segmented-control-option--selected {
+        background-color: var(--xh-intent-#{$intent});
+        color: var(--xh-white);
+      }
+    }
+
+    // Fill mode (default) - distribute options equally across the available width.
+    &.xh-segmented-control--fill .xh-button.xh-segmented-control-option {
+      flex: 1 1 0;
+    }
+
+    // Outlined mode - border around the tray with no inner background fill.
+    &.xh-segmented-control--outlined {
+      background-color: transparent;
+      border: 1px solid var(--xh-border-color);
+    }
+
+    @each $intent in (primary, success, warning, danger) {
+      &.xh-segmented-control--outlined.xh-segmented-control--#{$intent} {
+        border-color: var(--xh-intent-#{$intent});
+      }
+    }
+
+    // Validation borders
+    &.xh-input--invalid {
+      border: var(--xh-form-field-invalid-border);
+    }
+
+    &.xh-input--warning {
+      border: var(--xh-form-field-warning-border);
+    }
+
+    &.xh-input--info {
+      border: var(--xh-form-field-info-border);
+    }
+  }
+}

--- a/mobile/cmp/input/SegmentedControl.ts
+++ b/mobile/cmp/input/SegmentedControl.ts
@@ -47,6 +47,13 @@ export interface SegmentedControlProps extends HoistProps, HoistInputProps {
     options: Array<SegmentedControlOption | SegmentedControlNullOption | OptionPrimitive>;
 
     /**
+     * True to let the options scroll horizontally when they cannot all fit at once, preserving
+     * full labels (swipe the tray to reach off-screen options). When false (default), options
+     * stay on a single row and labels truncate with an ellipsis if space is tight.
+     */
+    scrollable?: boolean;
+
+    /**
      * True to render with an outlined style - a border around the control tray
      * with no inner background fill. Border color follows the current intent.
      */
@@ -151,6 +158,7 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
         fill = true,
         intent,
         outlined,
+        scrollable,
         testId,
         ...rest
     } = getNonLayoutProps(props);
@@ -188,7 +196,8 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
             className,
             defaultIntent && `xh-segmented-control--${defaultIntent}`,
             outlined && 'xh-segmented-control--outlined',
-            fill && 'xh-segmented-control--fill'
+            fill && 'xh-segmented-control--fill',
+            scrollable && 'xh-segmented-control--scrollable'
         ),
         ref,
         onFocus: model.onFocus,

--- a/mobile/cmp/input/SegmentedControl.ts
+++ b/mobile/cmp/input/SegmentedControl.ts
@@ -12,13 +12,13 @@ import {
     SegmentedControlOption,
     useHoistInputModel
 } from '@xh/hoist/cmp/input';
-import {div} from '@xh/hoist/cmp/layout';
+import {hbox} from '@xh/hoist/cmp/layout';
 import {hoistCmp, HoistProps, Intent} from '@xh/hoist/core';
-import '@xh/hoist/desktop/register';
-import {bpSegmentedControl} from '@xh/hoist/kit/blueprint';
+import {button} from '@xh/hoist/mobile/cmp/button';
+import '@xh/hoist/mobile/register';
 import {computed, makeObservable} from '@xh/hoist/mobx';
-import {getLayoutProps, getNonLayoutProps} from '@xh/hoist/utils/react';
 import {TEST_ID} from '@xh/hoist/utils/js';
+import {getLayoutProps, getNonLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {filter, isObject} from 'lodash';
 import './SegmentedControl.scss';
@@ -26,9 +26,6 @@ import './SegmentedControl.scss';
 export type {OptionPrimitive, SegmentedControlOption, SegmentedControlNullOption};
 
 export interface SegmentedControlProps extends HoistProps, HoistInputProps {
-    /** True to render in a compact mode with reduced sizing for space-constrained contexts. */
-    compact?: boolean;
-
     /**
      * True (default) to stretch the control to fill available width,
      * distributing space equally among options.
@@ -61,11 +58,10 @@ export interface SegmentedControlProps extends HoistProps, HoistInputProps {
  * rendered as a group of toggle buttons with clear visual indication of the active
  * selection.
  *
- * Similar to ButtonGroupInput but driven by an `options` prop (like Select/RadioInput)
- * rather than Button children, and with stronger visual differentiation between selected
- * and unselected states.
- *
- * Built on Blueprint's SegmentedControl component.
+ * Similar to ButtonGroupInput but driven by an `options` prop (like Select) rather than Button
+ * children, and with stronger visual differentiation between selected and unselected states.
+ * The mobile counterpart to the desktop SegmentedControl, built on Hoist's mobile Button
+ * (no Blueprint dependency).
  */
 export const [SegmentedControl, segmentedControl] = hoistCmp.withFactory<SegmentedControlProps>({
     displayName: 'SegmentedControl',
@@ -109,7 +105,7 @@ class SegmentedControlModel extends HoistInputModel {
         });
     }
 
-    /** Map the current render value to the string key used by the Blueprint control. */
+    /** Map the current render value to the string key used to identify the selected option. */
     @computed
     get selectedKey(): string {
         const {renderValue, normalizedOptions} = this;
@@ -142,7 +138,7 @@ class SegmentedControlModel extends HoistInputModel {
 
 const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props}, ref) => {
     const {
-        // HoistInput props - exclude from passthrough to BP
+        // HoistInput props - consumed here or by the model, not passed to the tray
         bind,
         disabled,
         onChange,
@@ -150,51 +146,49 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
         tabIndex,
         value,
         commitOnChange,
-        // Consumed by model
         options,
         // Consumed by this component
-        compact,
+        fill = true,
         intent,
         outlined,
         testId,
-        // Remainder passed to BP SegmentedControl
-        ...bpProps
+        ...rest
     } = getNonLayoutProps(props);
 
-    // Resolve the effective intent per option (own intent wins over control-level default),
-    // applied via a per-button className that our SCSS keys its solid/hint coloring off of.
-    const defaultIntent = intent && intent !== 'none' ? intent : null,
-        bpOptions = model.normalizedOptions.map(opt => {
-            const optIntent = opt.intent ?? defaultIntent;
-            return {
-                value: opt._key,
-                label: opt.label,
-                icon: opt.icon,
-                disabled: opt.disabled,
-                className: optIntent ? `xh-segmented-control-option--${optIntent}` : null
-            };
-        });
+    const {selectedKey} = model,
+        defaultIntent = intent && intent !== 'none' ? intent : null;
 
-    return div({
+    const buttons = model.normalizedOptions.map(opt => {
+        const optIntent = opt.intent ?? defaultIntent,
+            selected = opt._key === selectedKey;
+        return button({
+            key: opt._key,
+            text: opt.label,
+            icon: opt.icon,
+            disabled: disabled || opt.disabled,
+            minimal: true,
+            className: classNames(
+                'xh-segmented-control-option',
+                selected && 'xh-segmented-control-option--selected',
+                optIntent && `xh-segmented-control-option--${optIntent}`
+            ),
+            onClick: () => model.onValueChange(opt._key)
+        });
+    });
+
+    return hbox({
         className: classNames(
             className,
-            compact && 'xh-segmented-control--compact',
             defaultIntent && `xh-segmented-control--${defaultIntent}`,
-            outlined && 'xh-segmented-control--outlined'
+            outlined && 'xh-segmented-control--outlined',
+            fill && 'xh-segmented-control--fill'
         ),
         ref,
         onFocus: model.onFocus,
         onBlur: model.onBlur,
         ...getLayoutProps(props),
-        [TEST_ID]: props.testId,
-        item: bpSegmentedControl({
-            ...bpProps,
-            fill: bpProps.fill ?? true,
-            size: compact ? 'small' : undefined,
-            options: bpOptions,
-            value: model.selectedKey,
-            onValueChange: model.onValueChange,
-            disabled
-        })
+        [TEST_ID]: testId,
+        items: buttons,
+        ...rest
     });
 });

--- a/mobile/cmp/input/SegmentedControl.ts
+++ b/mobile/cmp/input/SegmentedControl.ts
@@ -12,7 +12,7 @@ import {
     SegmentedControlOption,
     useHoistInputModel
 } from '@xh/hoist/cmp/input';
-import {hbox} from '@xh/hoist/cmp/layout';
+import {hbox, span} from '@xh/hoist/cmp/layout';
 import {hoistCmp, HoistProps, Intent} from '@xh/hoist/core';
 import {button} from '@xh/hoist/mobile/cmp/button';
 import '@xh/hoist/mobile/register';
@@ -161,9 +161,16 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
     const buttons = model.normalizedOptions.map(opt => {
         const optIntent = opt.intent ?? defaultIntent,
             selected = opt._key === selectedKey;
+        // Wrap the label so it can truncate with an ellipsis when the segment is too narrow,
+        // rather than hard-clipping mid-character. Pass null for icon-only options so the Button
+        // renders the icon alone (an empty span would suppress that).
+        const label = opt.label
+            ? span({className: 'xh-segmented-control-option__label', item: opt.label})
+            : null;
+
         return button({
             key: opt._key,
-            text: opt.label,
+            text: label,
             icon: opt.icon,
             disabled: disabled || opt.disabled,
             minimal: true,

--- a/mobile/cmp/input/SegmentedControl.ts
+++ b/mobile/cmp/input/SegmentedControl.ts
@@ -23,8 +23,6 @@ import classNames from 'classnames';
 import {filter, isObject} from 'lodash';
 import './SegmentedControl.scss';
 
-export type {OptionPrimitive, SegmentedControlOption, SegmentedControlNullOption};
-
 export interface SegmentedControlProps extends HoistProps, HoistInputProps {
     /**
      * True (default) to stretch the control to fill available width,

--- a/mobile/cmp/input/SegmentedControl.ts
+++ b/mobile/cmp/input/SegmentedControl.ts
@@ -47,13 +47,6 @@ export interface SegmentedControlProps extends HoistProps, HoistInputProps {
     options: Array<SegmentedControlOption | SegmentedControlNullOption | OptionPrimitive>;
 
     /**
-     * True to let the options scroll horizontally when they cannot all fit at once, preserving
-     * full labels (swipe the tray to reach off-screen options). When false (default), options
-     * stay on a single row and labels truncate with an ellipsis if space is tight.
-     */
-    scrollable?: boolean;
-
-    /**
      * True to render with an outlined style - a border around the control tray
      * with no inner background fill. Border color follows the current intent.
      */
@@ -158,7 +151,6 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
         fill = true,
         intent,
         outlined,
-        scrollable,
         testId,
         ...rest
     } = getNonLayoutProps(props);
@@ -196,8 +188,7 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
             className,
             defaultIntent && `xh-segmented-control--${defaultIntent}`,
             outlined && 'xh-segmented-control--outlined',
-            fill && 'xh-segmented-control--fill',
-            scrollable && 'xh-segmented-control--scrollable'
+            fill && 'xh-segmented-control--fill'
         ),
         ref,
         onFocus: model.onFocus,

--- a/mobile/cmp/input/index.ts
+++ b/mobile/cmp/input/index.ts
@@ -11,6 +11,7 @@ export * from './CheckboxButton';
 export * from './DateInput';
 export * from './NumberInput';
 export * from './SearchInput';
+export * from './SegmentedControl';
 export * from './Select';
 export * from './SwitchInput';
 export * from './TextInput';


### PR DESCRIPTION
## Summary

Adds a mobile `SegmentedControl` input - the mobile counterpart to the desktop component (new in v86), with a matching `options`-driven API for selecting a single value from a small set of mutually exclusive choices. Built on Hoist's mobile `Button`, with no Blueprint dependency (Blueprint is desktop-only).

## Key changes

- New `mobile/cmp/input/SegmentedControl` (`.ts` + `.scss`): single-select, options-driven API (primitives or `{value, label, icon, disabled, intent}`), with `fill` (default), `intent`, and `outlined` modes. Reproduces the desktop recessed-tray / raised-tile look against the mobile `xh-button` classes, reusing the shared `--xh-segmented-control-*` theme vars.
- Graceful overflow: options size to their content and share the leftover space; a too-narrow option ellipsis-truncates rather than hard-clipping. Outlined mode rings the selected option, since the transparent tray offers no backdrop for a filled tile.
- Lifted the shared option types (`SegmentedControlOption`, `SegmentedControlNullOption`, `OptionPrimitive`) into `@xh/hoist/cmp/input` so both platforms share one definition; the desktop component now imports them from there. Mild, compiler-caught import-location change (see changelog).
- `CHANGELOG` updated.

## Notes

- Single-select only, matching desktop; multi-select / clearable remains the role of `buttonGroupInput`.
- A pre-existing layout interaction surfaced during testing - `Card` (an HTML `<fieldset>`) not shrinking in constrained flex columns - filed separately as #4436; not addressed here.
- A matching Toolbox mobile demo will follow in the toolbox repo.
