### PR TITLE
Day-aware calendar filtering of timestamp fields (#3338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@
   comparing against midnight only. Filter field specs now default a `date` source field to
   `fieldType: 'localDate'`; set `fieldType: 'date'` explicitly to filter by exact timestamp. Applies
   to in-browser `FieldFilter` evaluation; server-side filtering is unaffected.
-* `parseFieldValue` now coerces `Date`/number inputs to `localDate` (via `LocalDate.from`) instead
-  of throwing, so enumerated timestamp values render correctly for `localDate`-typed filter specs.
+* `parseFieldValue` coerces `Date`/number to `localDate` via `LocalDate.from` instead of throwing.
 * Fixed an issue where `Grid` column headers could fall out of sync with body content during
   horizontal scrolling when both `enableFullWidthScroll` and `useVirtualColumns` were enabled.
 * Ensure publication of `router5-plugin-browser` TS module augmentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
       than the desktop `SegmentedControl` module; update any direct type imports.
 
 ### 🐞 Bug Fixes
+* Client-side filtering of a timestamp (`date`) field by calendar day now behaves intuitively. Set
+  `fieldType: 'localDate'` on a `FilterChooser` or grid column filter spec to compare against
+  full-day bounds for both range and equality operators - e.g. `> 2023-05-31` excludes all of the
+  31st, and `= 2023-05-31` matches any time that day, rather than comparing against midnight only.
+  Applies to in-browser `FieldFilter` evaluation; server-side filtering is unaffected.
 * Fixed an issue where `Grid` column headers could fall out of sync with body content during
   horizontal scrolling when both `enableFullWidthScroll` and `useVirtualColumns` were enabled.
 * Ensure publication of `router5-plugin-browser` TS module augmentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   comparing against midnight only. Filter field specs now default a `date` source field to
   `fieldType: 'localDate'`; set `fieldType: 'date'` explicitly to filter by exact timestamp. Applies
   to in-browser `FieldFilter` evaluation; server-side filtering is unaffected.
+* `parseFieldValue` now coerces `Date`/number inputs to `localDate` (via `LocalDate.from`) instead
+  of throwing, so enumerated timestamp values render correctly for `localDate`-typed filter specs.
 * Fixed an issue where `Grid` column headers could fall out of sync with body content during
   horizontal scrolling when both `enableFullWidthScroll` and `useVirtualColumns` were enabled.
 * Ensure publication of `router5-plugin-browser` TS module augmentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@
       than the desktop `SegmentedControl` module; update any direct type imports.
 
 ### 🐞 Bug Fixes
-* Client-side filtering of a timestamp (`date`) field by calendar day now behaves intuitively. Set
-  `fieldType: 'localDate'` on a `FilterChooser` or grid column filter spec to compare against
-  full-day bounds for both range and equality operators - e.g. `> 2023-05-31` excludes all of the
-  31st, and `= 2023-05-31` matches any time that day, rather than comparing against midnight only.
-  Applies to in-browser `FieldFilter` evaluation; server-side filtering is unaffected.
+* `FilterChooser` and grid column filters on a timestamp (`date`) field now filter by calendar day
+  by default, comparing against full-day bounds for both range and equality operators - e.g.
+  `> 2023-05-31` excludes all of the 31st, and `= 2023-05-31` matches any time that day, rather than
+  comparing against midnight only. Filter field specs now default a `date` source field to
+  `fieldType: 'localDate'`; set `fieldType: 'date'` explicitly to filter by exact timestamp. Applies
+  to in-browser `FieldFilter` evaluation; server-side filtering is unaffected.
 * Fixed an issue where `Grid` column headers could fall out of sync with body content during
   horizontal scrolling when both `enableFullWidthScroll` and `useVirtualColumns` were enabled.
 * Ensure publication of `router5-plugin-browser` TS module augmentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
   comparing against full-day bounds for range and equality operators rather than midnight - e.g.
   `> 2023-05-31` excludes the 31st and `= 2023-05-31` matches any time that day. Filter specs now
   default a `date` source field to `fieldType: 'localDate'`; set `fieldType: 'date'` for exact
-  timestamps.
+  timestamps. Applications using workarounds to provide similar behavior may be able to unwind that
+  behavior and rely on Hoist default behavior.
 
 
 ### 🐞 Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,14 @@
   choices. Built on Hoist's mobile `Button` (no Blueprint dependency).
     * The shared `SegmentedControlOption` option types now export from `@xh/hoist/cmp/input` rather
       than the desktop `SegmentedControl` module; update any direct type imports.
+* `FilterChooser` and grid column filters on a timestamp (`date`) field now filter by calendar day,
+  comparing against full-day bounds for range and equality operators rather than midnight - e.g.
+  `> 2023-05-31` excludes the 31st and `= 2023-05-31` matches any time that day. Filter specs now
+  default a `date` source field to `fieldType: 'localDate'`; set `fieldType: 'date'` for exact
+  timestamps. Applies to in-browser `FieldFilter` evaluation only.
+
 
 ### 🐞 Bug Fixes
-* `FilterChooser` and grid column filters on a timestamp (`date`) field now filter by calendar day
-  by default, comparing against full-day bounds for both range and equality operators - e.g.
-  `> 2023-05-31` excludes all of the 31st, and `= 2023-05-31` matches any time that day, rather than
-  comparing against midnight only. Filter field specs now default a `date` source field to
-  `fieldType: 'localDate'`; set `fieldType: 'date'` explicitly to filter by exact timestamp. Applies
-  to in-browser `FieldFilter` evaluation; server-side filtering is unaffected.
-* `parseFieldValue` coerces `Date`/number to `localDate` via `LocalDate.from` instead of throwing.
 * Fixed an issue where `Grid` column headers could fall out of sync with body content during
   horizontal scrolling when both `enableFullWidthScroll` and `useVirtualColumns` were enabled.
 * Ensure publication of `router5-plugin-browser` TS module augmentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   comparing against full-day bounds for range and equality operators rather than midnight - e.g.
   `> 2023-05-31` excludes the 31st and `= 2023-05-31` matches any time that day. Filter specs now
   default a `date` source field to `fieldType: 'localDate'`; set `fieldType: 'date'` for exact
-  timestamps. Applies to in-browser `FieldFilter` evaluation only.
+  timestamps.
 
 
 ### 🐞 Bug Fixes

--- a/admin/tabs/userData/roles/RoleModel.ts
+++ b/admin/tabs/userData/roles/RoleModel.ts
@@ -12,12 +12,10 @@ import {fragment, p} from '@xh/hoist/cmp/layout';
 import {CallContext, HoistModel, LoadSpec, managed, XH} from '@xh/hoist/core';
 import {RecordActionSpec} from '@xh/hoist/data';
 import {actionCol, calcActionColWidth} from '@xh/hoist/desktop/cmp/grid';
-import {fmtDate} from '@xh/hoist/format';
 import {Icon} from '@xh/hoist/icon';
 import {action, bindable, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 import {compact, groupBy, mapValues} from 'lodash';
-import moment from 'moment/moment';
 import {RoleEditorModel} from './editor/RoleEditorModel';
 import {HoistRole, RoleModuleConfig} from './Types';
 
@@ -397,23 +395,7 @@ export class RoleModel extends HoistModel {
                 config.directoryGroupsSupported && 'effectiveDirectoryGroupNames',
                 'effectiveRoleNames',
                 'lastUpdatedBy',
-                {
-                    field: 'lastUpdated',
-                    example: 'YYYY-MM-DD',
-                    valueParser: (v, op) => {
-                        let ret = moment(v, ['YYYY-MM-DD', 'YYYYMMDD'], true);
-                        if (!ret.isValid()) return null;
-
-                        // Note special handling for '>' & '<=' queries.
-                        if (['>', '<='].includes(op)) {
-                            ret = moment(ret).endOf('day');
-                        }
-
-                        return ret.toDate();
-                    },
-                    valueRenderer: v => fmtDate(v),
-                    ops: ['>', '>=', '<', '<=']
-                }
+                {field: 'lastUpdated', fieldType: 'localDate'} //for usable day-aware filtering.
             ]),
             persistWith: {...RoleModel.PERSIST_WITH, path: 'mainFilterChooser'}
         });

--- a/admin/tabs/userData/roles/RoleModel.ts
+++ b/admin/tabs/userData/roles/RoleModel.ts
@@ -395,7 +395,7 @@ export class RoleModel extends HoistModel {
                 config.directoryGroupsSupported && 'effectiveDirectoryGroupNames',
                 'effectiveRoleNames',
                 'lastUpdatedBy',
-                {field: 'lastUpdated', fieldType: 'localDate'} //for usable day-aware filtering.
+                'lastUpdated'
             ]),
             persistWith: {...RoleModel.PERSIST_WITH, path: 'mainFilterChooser'}
         });

--- a/data/Field.ts
+++ b/data/Field.ts
@@ -166,7 +166,9 @@ export function parseFieldValue(
         case 'date':
             return isLocalDate(val) ? val.date : isDate(val) ? val : new Date(val);
         case 'localDate':
-            return isLocalDate(val) ? val : LocalDate.get(val);
+            if (isLocalDate(val)) return val;
+            // `get` parses strict 'YYYYMMDD'/'YYYY-MM-DD' strings; `from` coerces Date/number/moment.
+            return isString(val) ? LocalDate.get(val) : LocalDate.from(val);
     }
 
     throw XH.exception(`Unknown field type '${type}'`);

--- a/data/filter/BaseFilterFieldSpec.ts
+++ b/data/filter/BaseFilterFieldSpec.ts
@@ -22,9 +22,10 @@ export interface BaseFilterFieldSpecConfig {
     /** Identifying field name to filter on. */
     field: string;
     /**
-     * Type of field, will default from related field on source if provided, or 'auto'.
-     * Set to 'localDate' on a field backed by a `date` (timestamp) to filter by calendar day -
-     * range and equality operators then compare against full-day bounds rather than midnight.
+     * Type of field, will default from related field on source if provided, or 'auto'. A `date`
+     * (timestamp) source defaults to 'localDate' so filtering compares by calendar day (range and
+     * equality operators use full-day bounds). Set explicitly to 'date' to filter by exact
+     * timestamp instead.
      */
     fieldType?: FieldType;
     /** DisplayName, will default from related field on source if provided */
@@ -81,7 +82,11 @@ export abstract class BaseFilterFieldSpec extends HoistBase {
         this.source = source;
 
         const sourceField = this.sourceField;
-        this.fieldType = fieldType ?? sourceField?.type ?? 'auto';
+        // Default a `date` (timestamp) source to `localDate` so filtering compares by calendar day
+        // rather than against midnight (#3338). Apps wanting exact-timestamp filtering can set
+        // `fieldType: 'date'` explicitly.
+        this.fieldType =
+            fieldType ?? (sourceField?.type === 'date' ? 'localDate' : sourceField?.type) ?? 'auto';
         this.displayName = displayName ?? sourceField?.displayName ?? genDisplayName(field);
         this.ops = this.parseOperators(ops);
         this.forceSelection = forceSelection ?? false;

--- a/data/filter/BaseFilterFieldSpec.ts
+++ b/data/filter/BaseFilterFieldSpec.ts
@@ -183,7 +183,12 @@ export abstract class BaseFilterFieldSpec extends HoistBase {
             : ['>', '>=', '<', '<=', '=', '!='];
     }
 
+    private get isLocalDateFilteringTimestamp(): boolean {
+        return this.fieldType === 'localDate' && this.sourceField?.type === 'date';
+    }
+
     private get isEnumerableByDefault(): boolean {
+        if (this.isLocalDateFilteringTimestamp) return false;
         switch (this.fieldType) {
             case 'int':
             case 'number':

--- a/data/filter/BaseFilterFieldSpec.ts
+++ b/data/filter/BaseFilterFieldSpec.ts
@@ -21,7 +21,11 @@ import {FieldFilterOperator} from './Types';
 export interface BaseFilterFieldSpecConfig {
     /** Identifying field name to filter on. */
     field: string;
-    /** Type of field, will default from related field on source if provided, or 'auto'. */
+    /**
+     * Type of field, will default from related field on source if provided, or 'auto'.
+     * Set to 'localDate' on a field backed by a `date` (timestamp) to filter by calendar day -
+     * range and equality operators then compare against full-day bounds rather than midnight.
+     */
     fieldType?: FieldType;
     /** DisplayName, will default from related field on source if provided */
     displayName?: string;

--- a/data/filter/FieldFilter.ts
+++ b/data/filter/FieldFilter.ts
@@ -112,9 +112,9 @@ export class FieldFilter extends Filter {
     // Overrides
     //-----------------
     override getTestFn(store?: Store): FilterTestFn {
-        let {field, op, value} = this,
-            regExps;
+        const {field, op, value} = this;
 
+        let storeFieldType: FieldType;
         if (store) {
             const storeField = store.getField(field);
             if (!storeField) {
@@ -127,18 +127,57 @@ export class FieldFilter extends Filter {
                 }
                 return () => true;
             }
+            storeFieldType = storeField.type;
+        }
 
-            const fieldType = storeField.type === 'tags' ? 'string' : storeField.type;
+        const opFn = this.getOpFn(op, value, storeFieldType);
+
+        if (!store) return r => opFn(r[field]);
+
+        return (r: StoreRecord) => {
+            const val = r.get(field);
+            if (opFn(val)) return true;
+
+            // Maximize chances of matching. Always pass adds ...
+            if (r.isAdd) return true;
+
+            // ... and check any differing original value as well
+            const committedVal = r.committedData[field];
+            return committedVal !== val && opFn(committedVal);
+        };
+    }
+
+    private getOpFn(
+        op: FieldFilterOperator,
+        value: any,
+        storeFieldType?: FieldType
+    ): (v: any) => boolean {
+        const RANGE_OPS = FieldFilter.RANGE_LIKE_OPERATORS,
+            ARR_OPS = FieldFilter.ARRAY_OPERATORS;
+
+        // Day-aware filtering for LocalDate value(s) over a timestamp field - compares against
+        // full calendar-day bounds for range and equality operators (#3338).
+        const firstVal = isArray(value) ? value[0] : value;
+        if (
+            storeFieldType === 'date' &&
+            LocalDate.isLocalDate(firstVal) &&
+            (RANGE_OPS.includes(op) || op === '=' || op === '!=')
+        ) {
+            return this.getDayBoundedOpFn(op, value);
+        }
+
+        // Coerce candidate value(s) to the store field's type when filtering against a store.
+        if (storeFieldType) {
+            const fieldType = storeFieldType === 'tags' ? 'string' : storeFieldType;
             value = isArray(value)
                 ? value.map(v => parseFieldValue(v, fieldType))
                 : parseFieldValue(value, fieldType);
         }
-
-        if (FieldFilter.ARRAY_OPERATORS.includes(op)) {
+        if (ARR_OPS.includes(op)) {
             value = castArray(value);
         }
 
-        let opFn: (v: any) => boolean;
+        let regExps, opFn: (v: any) => boolean;
         switch (op) {
             case '=':
                 opFn = v => {
@@ -197,20 +236,45 @@ export class FieldFilter extends Filter {
             default:
                 throw XH.exception(`Unknown operator: ${op}`);
         }
+        return opFn;
+    }
 
-        if (!store) return r => opFn(r[field]);
+    // Compare a timestamp against full calendar-day bounds `[dayStart, nextDayStart)` so a
+    // LocalDate value filters by date part. Supports range and equality operators (#3338).
+    private getDayBoundedOpFn(
+        op: FieldFilterOperator,
+        value: LocalDate | LocalDate[]
+    ): (v: any) => boolean {
+        const toMillis = (v: any) => (v instanceof Date ? v.getTime() : v);
 
-        return (r: StoreRecord) => {
-            const val = r.get(field);
-            if (opFn(val)) return true;
+        // Equality ops test the date part against any of the candidate day(s).
+        if (op === '=' || op === '!=') {
+            const ranges = castArray(value).map(d => [
+                    d.date.getTime(),
+                    d.nextDay().date.getTime()
+                ]),
+                inAnyDay = (t: number) => ranges.some(([start, next]) => t >= start && t < next);
+            return op === '='
+                ? v => !isNil(v) && inAnyDay(toMillis(v))
+                : v => isNil(v) || !inAnyDay(toMillis(v));
+        }
 
-            // Maximize chances of matching. Always pass adds ...
-            if (r.isAdd) return true;
-
-            // ... and check any differing original value as well
-            const committedVal = r.committedData[field];
-            return committedVal !== val && opFn(committedVal);
-        };
+        // Range ops compare against the bounds of a single day.
+        const day = value as LocalDate,
+            dayStart = day.date.getTime(),
+            nextDayStart = day.nextDay().date.getTime();
+        switch (op) {
+            case '>':
+                return v => !isNil(v) && toMillis(v) >= nextDayStart;
+            case '>=':
+                return v => !isNil(v) && toMillis(v) >= dayStart;
+            case '<':
+                return v => !isNil(v) && toMillis(v) < dayStart;
+            case '<=':
+                return v => !isNil(v) && toMillis(v) < nextDayStart;
+            default:
+                throw XH.exception(`Unsupported calendar-day operator: ${op}`);
+        }
     }
 
     override equals(other: Filter): boolean {


### PR DESCRIPTION
Resolves #3338. A fresh, smaller take on the long-stale #3362 (closed).

Filtering a timestamp (`date`) field by calendar day now works correctly **by default**, comparing against full-day bounds instead of midnight - e.g. `> 2023-05-31` excludes all of the 31st, and `= 2023-05-31` matches any time that day.

### Key changes
- **Day-aware comparison in `FieldFilter`:** when a `LocalDate` value is applied to a `date` (timestamp) field, range (`>`/`>=`/`<`/`<=`) and equality (`=`/`!=`) operators compare against `[dayStart, nextDayStart)`. Bounds are computed once from the filter value, keeping the per-record predicate to integer comparisons. `getTestFn` was refactored so the main path stays unobstructed - field resolution + record wrapping live there, and all value coercion / operator dispatch (including the calendar-day case) moved into `getOpFn`.
- **New default:** filter field specs now default a `date` source field to `fieldType: 'localDate'`, so both `FilterChooser` and grid column filters get day-aware behavior without per-spec opt-in. Apps wanting exact-timestamp filtering can set `fieldType: 'date'` explicitly (with a `valueParser` for `FilterChooser`).
- **Admin Roles cleanup:** the `lastUpdated` FilterChooser entry drops its hand-rolled `moment` valueParser (and now the explicit type), relying on the new default.

### Scope / notes
- Applies to **client-side** `FieldFilter` evaluation. Programmatic filtering is unaffected unless a `LocalDate` value is passed (the default change only touches the FilterChooser / grid-filter spec layer, not directly-constructed `FieldFilter`s). Server-side filtering (e.g. Activity Tracking, which posts filters to `trackLogAdmin`) is unaffected and would need separate server support.
- Not a breaking change: the prior midnight behavior was buggy/unusable for date filtering; this corrects it. The `date` fieldType remains available for explicit exact-timestamp use.
- Value enumeration stays off for timestamp-by-day filtering (per #3389, which concerned the Values tab, not the comparison semantics).