### PR TITLE
Fix "Is blank"/"Is not blank" grid column filters for tags fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 
 
 ### 🐞 Bug Fixes
+* Fixed the "Is blank" / "Is not blank" grid column filters for `tags`-typed fields - empty tag
+  arrays now correctly match "Is blank", and such filters are edited on the Custom tab rather than
+  producing a phantom blank entry in the Values list.
 * Fixed an issue where `Grid` column headers could fall out of sync with body content during
   horizontal scrolling when both `enableFullWidthScroll` and `useVirtualColumns` were enabled.
 * Ensure publication of `router5-plugin-browser` TS module augmentation.

--- a/cmp/grid/filter/GridFilterFieldSpec.ts
+++ b/cmp/grid/filter/GridFilterFieldSpec.ts
@@ -87,12 +87,11 @@ export class GridFilterFieldSpec extends BaseFilterFieldSpec {
         // Values from current column filter. `flatMap` here unwraps the array `parseVal` returns
         // for `tags`-typed fields, lining those values up with the scalar values produced by
         // `Store.getValuesForFieldFilter` above. Without this, a filter value like `'foo'` would
-        // survive as `['foo']` and dedupe incorrectly.
+        // survive as `['foo']` and dedupe incorrectly. The `filter` drops the non-selectable null
+        // value carried by a blank `tags` filter.
         const colFilterVals = flatMap(columnFilters, filter => {
             return castArray(filter.value).flatMap(val => sourceField.parseVal(val));
         })
-            // A blank ('is blank'/'is not blank') `tags` filter carries a null value that is not a
-            // real tag and should not appear as a selectable value in the list.
             .filter(it => sourceField.type !== 'tags' || it != null)
             .map(it => this.toDisplayValue(it));
 

--- a/cmp/grid/filter/GridFilterFieldSpec.ts
+++ b/cmp/grid/filter/GridFilterFieldSpec.ts
@@ -90,7 +90,11 @@ export class GridFilterFieldSpec extends BaseFilterFieldSpec {
         // survive as `['foo']` and dedupe incorrectly.
         const colFilterVals = flatMap(columnFilters, filter => {
             return castArray(filter.value).flatMap(val => sourceField.parseVal(val));
-        }).map(it => this.toDisplayValue(it));
+        })
+            // A blank ('is blank'/'is not blank') `tags` filter carries a null value that is not a
+            // real tag and should not appear as a selectable value in the list.
+            .filter(it => sourceField.type !== 'tags' || it != null)
+            .map(it => this.toDisplayValue(it));
 
         // Combine + unique - these are all values that *could* be shown in the filter UI.
         const allValues = uniqBy([...allSrcVals, ...colFilterVals], this.getUniqueValue);

--- a/data/filter/FieldFilter.ts
+++ b/data/filter/FieldFilter.ts
@@ -14,6 +14,7 @@ import {
     escapeRegExp,
     first,
     isArray,
+    isEmpty,
     isEqual,
     isNil,
     isString,
@@ -181,14 +182,16 @@ export class FieldFilter extends Filter {
         switch (op) {
             case '=':
                 opFn = v => {
-                    if (isNil(v) || v === '') v = null;
-                    return value.some(it => isEqual(v, it));
+                    // Treat null, empty string, and empty array (blank `tags`) alike as "blank".
+                    if (isNil(v) || v === '' || (isArray(v) && isEmpty(v))) v = null;
+                    // A blank filter (empty `value`) matches only blank record values.
+                    return (v == null && isEmpty(value)) || value.some(it => isEqual(v, it));
                 };
                 break;
             case '!=':
                 opFn = v => {
-                    if (isNil(v) || v === '') v = null;
-                    return !value.some(it => isEqual(v, it));
+                    if (isNil(v) || v === '' || (isArray(v) && isEmpty(v))) v = null;
+                    return (v != null || !isEmpty(value)) && !value.some(it => isEqual(v, it));
                 };
                 break;
             case '>':

--- a/data/filter/FieldFilter.ts
+++ b/data/filter/FieldFilter.ts
@@ -178,19 +178,21 @@ export class FieldFilter extends Filter {
             value = castArray(value);
         }
 
+        // Treat null, empty string, and empty array (blank `tags`) alike as "blank".
+        const isBlank = (v: any) => isNil(v) || v === '' || (isArray(v) && isEmpty(v));
+
         let regExps, opFn: (v: any) => boolean;
         switch (op) {
             case '=':
                 opFn = v => {
-                    // Treat null, empty string, and empty array (blank `tags`) alike as "blank".
-                    if (isNil(v) || v === '' || (isArray(v) && isEmpty(v))) v = null;
+                    if (isBlank(v)) v = null;
                     // A blank filter (empty `value`) matches only blank record values.
                     return (v == null && isEmpty(value)) || value.some(it => isEqual(v, it));
                 };
                 break;
             case '!=':
                 opFn = v => {
-                    if (isNil(v) || v === '' || (isArray(v) && isEmpty(v))) v = null;
+                    if (isBlank(v)) v = null;
                     return (v != null || !isEmpty(value)) && !value.some(it => isEqual(v, it));
                 };
                 break;

--- a/desktop/cmp/grid/impl/filter/headerfilter/HeaderFilterModel.ts
+++ b/desktop/cmp/grid/impl/filter/headerfilter/HeaderFilterModel.ts
@@ -101,13 +101,12 @@ export class HeaderFilterModel extends HoistModel {
         const {columnCompoundFilter, columnFilters, fieldType} = this;
         if (columnCompoundFilter) return true;
         if (isEmpty(columnFilters)) return false;
-        return columnFilters.some(
-            it =>
-                !['=', '!=', 'includes'].includes(it.op) ||
-                // 'Is blank'/'Is not blank' on a `tags` field is only representable on the custom
-                // tab - the values tab uses 'includes' and has no way to express a null tag value.
-                (fieldType === 'tags' && ['=', '!='].includes(it.op) && it.value == null)
-        );
+        return columnFilters.some(it => {
+            const isValuesTabOp = ['=', '!=', 'includes'].includes(it.op),
+                isTagsBlank =
+                    fieldType === 'tags' && ['=', '!='].includes(it.op) && it.value == null;
+            return !isValuesTabOp || isTagsBlank;
+        });
     }
 
     get commitOnChange() {

--- a/desktop/cmp/grid/impl/filter/headerfilter/HeaderFilterModel.ts
+++ b/desktop/cmp/grid/impl/filter/headerfilter/HeaderFilterModel.ts
@@ -175,8 +175,8 @@ export class HeaderFilterModel extends HoistModel {
         if (close) {
             this.parent.close();
         } else {
-            // We must wait before resetting as GridFilterModel.setFilter() is async
-            wait().then(() => this.resetTabModels());
+            // Wait as setFilter is async.
+            wait().then(() => this.syncWithFilter());
         }
     }
 

--- a/desktop/cmp/grid/impl/filter/headerfilter/HeaderFilterModel.ts
+++ b/desktop/cmp/grid/impl/filter/headerfilter/HeaderFilterModel.ts
@@ -98,10 +98,16 @@ export class HeaderFilterModel extends HoistModel {
 
     @computed
     get isCustomFilter() {
-        const {columnCompoundFilter, columnFilters} = this;
+        const {columnCompoundFilter, columnFilters, fieldType} = this;
         if (columnCompoundFilter) return true;
         if (isEmpty(columnFilters)) return false;
-        return columnFilters.some(it => !['=', '!=', 'includes'].includes(it.op));
+        return columnFilters.some(
+            it =>
+                !['=', '!=', 'includes'].includes(it.op) ||
+                // 'Is blank'/'Is not blank' on a `tags` field is only representable on the custom
+                // tab - the values tab uses 'includes' and has no way to express a null tag value.
+                (fieldType === 'tags' && ['=', '!='].includes(it.op) && it.value == null)
+        );
     }
 
     get commitOnChange() {

--- a/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomRowModel.ts
+++ b/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomRowModel.ts
@@ -8,7 +8,7 @@ import {HoistModel} from '@xh/hoist/core';
 import {FieldFilterOperator, FieldFilterSpec} from '@xh/hoist/data';
 import {HeaderFilterModel} from '../HeaderFilterModel';
 import {bindable, computed, makeObservable} from '@xh/hoist/mobx';
-import {isArray, isNil} from 'lodash';
+import {isArray, isEmpty, isNil} from 'lodash';
 import {CustomTabModel} from './CustomTabModel';
 
 type OperatorOptionValue = 'blank' | 'not blank' | FieldFilterOperator;
@@ -39,7 +39,7 @@ export class CustomRowModel extends HoistModel {
         } else if (op === 'not blank') {
             op = '!=';
             value = null;
-        } else if (isNil(value)) {
+        } else if (isNil(value) || (isArray(value) && isEmpty(value))) {
             return null;
         }
 


### PR DESCRIPTION
Re-derives the fix from #3637 against current `develop` (that branch targeted since-refactored code). The underlying bug still reproduces: a `tags` field with an empty array fails to match "Is blank" and wrongly matches "Is not blank".

### Changes
- **`FieldFilter`** — treat empty arrays (blank tags) as `null` in the `=`/`!=` op-functions, and match a blank filter against blank record values.
- **`HeaderFilterModel`** — route a tags `=`/`!=`-with-null filter to the Custom tab, since the Values tab uses `includes` and cannot express a null tag.
- **`GridFilterFieldSpec`** — strip the null tag value from the Values list (the corrected form of the inverted predicate in #3637, guarded to `tags` so genuine blank values on other field types still show).
- **`CustomRowModel`** — treat an empty-array value as blank.

### Notes
- `tsc --noEmit` and lint pass clean.
- Omits the `activateTab` tab-switch-sync tweak from #3637 - an independent UX change against now-restructured code; can be added separately if wanted.