### PR TITLE
Use % unit on flex-basis portion of tab container flex declaration to preserve hoist-dev-utils pre v13.x behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Applied an explicit `%` unit on the `flex-basis: 0` of `TabContainer`'s flex shorthand to ensure,
   now that `postcss-flexbugs-fixes`has been removed from `hoist-dev-utils v13.x` webpack configuration,
   that the `0` is not interpreted as a `0px` basis, which can prevent the tab container from expanding.
+  * ⚠️Apps that upgrade to `hoist-dev-utils v13.x` and use `flex: 1 1 0` or `flex-basis: 0` should
+    verify that their flex layouts continue to work as expected and add an explicit unit if
+    not (e.g. `flex: 1 1 0%` or `flex-basis: 0%`).
 
 ## 86.0.1 - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 * Fixed an issue where `Grid` column headers could fall out of sync with body content during
   horizontal scrolling when both `enableFullWidthScroll` and `useVirtualColumns` were enabled.
 * Ensure publication of `router5-plugin-browser` TS module augmentation.
+* Applied an explicit `%` unit on the `flex-basis: 0` of `TabContainer`'s flex shorthand to ensure,
+  now that `postcss-flexbugs-fixes`has been removed from `hoist-dev-utils v13.x` webpack configuration,
+  that the `0` is not interpreted as a `0px` basis, which can prevent the tab container from expanding.
 
 ## 86.0.1 - 2026-06-16
 

--- a/desktop/cmp/tab/Tabs.scss
+++ b/desktop/cmp/tab/Tabs.scss
@@ -10,13 +10,15 @@
   max-width: 100%;
   max-height: 100%;
   flex-direction: column;
-  flex: 1 1 0;
+  //noinspection CssRedundantUnit
+  flex: 1 1 0%; // unit kept to avoid flexbug #4
 
   .xh-tab-wrapper {
     display: flex;
     min-width: 0;
     min-height: 0;
-    flex: 1 1 0;
+    //noinspection CssRedundantUnit
+    flex: 1 1 0%; // unit kept to avoid flexbug #4
   }
 }
 

--- a/desktop/cmp/tab/Tabs.scss
+++ b/desktop/cmp/tab/Tabs.scss
@@ -11,14 +11,14 @@
   max-height: 100%;
   flex-direction: column;
   //noinspection CssRedundantUnit
-  flex: 1 1 0%; // unit kept to avoid flexbug #4
+  flex: 1 1 0px; // unit kept to avoid flexbug #4
 
   .xh-tab-wrapper {
     display: flex;
     min-width: 0;
     min-height: 0;
     //noinspection CssRedundantUnit
-    flex: 1 1 0%; // unit kept to avoid flexbug #4
+    flex: 1 1 0px; // unit kept to avoid flexbug #4
   }
 }
 

--- a/desktop/cmp/tab/Tabs.scss
+++ b/desktop/cmp/tab/Tabs.scss
@@ -11,14 +11,14 @@
   max-height: 100%;
   flex-direction: column;
   //noinspection CssRedundantUnit
-  flex: 1 1 0px; // unit kept to avoid flexbug #4
+  flex: 1 1 0%; // unit kept to avoid flexbug #4
 
   .xh-tab-wrapper {
     display: flex;
     min-width: 0;
     min-height: 0;
     //noinspection CssRedundantUnit
-    flex: 1 1 0px; // unit kept to avoid flexbug #4
+    flex: 1 1 0%; // unit kept to avoid flexbug #4
   }
 }
 

--- a/desktop/cmp/tab/Tabs.scss
+++ b/desktop/cmp/tab/Tabs.scss
@@ -11,14 +11,16 @@
   max-height: 100%;
   flex-direction: column;
   //noinspection CssRedundantUnit
-  flex: 1 1 0%; // unit kept to avoid flexbug #4
+  flex: 1 1 0%;
+  // % unit used to avoid browser fallback to px,
+  // which prevents container expansion
 
   .xh-tab-wrapper {
     display: flex;
     min-width: 0;
     min-height: 0;
     //noinspection CssRedundantUnit
-    flex: 1 1 0%; // unit kept to avoid flexbug #4
+    flex: 1 1 0%;
   }
 }
 


### PR DESCRIPTION
### hoist-react v86, hoist-dev-utils v12.x  =  WORKING
<img width="272" height="151" alt="image" src="https://github.com/user-attachments/assets/df6ac7dc-f261-43b4-921b-abb7066ae837" />


### hoist-react v86, hoist-dev-utils v13.x  = BROKEN
<img width="271" height="149" alt="image" src="https://github.com/user-attachments/assets/7e3c0c9b-8cca-4331-a790-2e82b4c3c574" />


### hoist-react with this fix, hoist-dev-utils v13x =  WORKING
<img width="262" height="154" alt="image" src="https://github.com/user-attachments/assets/a6f89d99-e871-4ab5-826a-6d96065831de" />

This change in hoist-dev-utils:
https://github.com/xh/hoist-dev-utils/commit/eba17a6646b9713b7159ba46bab13629a64859dd
(removing line 555)
`require('postcss-flexbugs-fixes'), // Inclusion of postcss-flexbugs-fixes is from CRA.`

discontinued the stripping out of flex-basis:0 from flex: 1 1 0;
When the 0 is left in, Chrome treats is as 0px, which prevents the tab container from expanding when the flex container's height is indefinite.

To restore behavior as it was prior to hoist-dev-utils v13, we add an explicit % unit to the tab container 0 flex-basis.
desktop/cmp/tab/Tabs.scss was the only file in hoist-react to explicitly use flex: 1 1 0;



Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile: not required.
- [x] Created Toolbox branch: ot required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

