### PR TITLE
Fix inconsistent null precision handling between NumberInput and fmtNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* `fmtNumber` now treats a `precision` of `null` as full, unrestricted precision rather than
+  `'auto'`, aligning a `NumberInput` with `precision: null` so its blurred display matches its
+  focused and committed (full-precision) value.
+
 ## 86.1.0 - 2026-06-22
 
 ### 🎁 New Features

--- a/desktop/cmp/input/NumberInput.ts
+++ b/desktop/cmp/input/NumberInput.ts
@@ -61,7 +61,7 @@ export interface NumberInputProps extends HoistProps, LayoutProps, StyleProps, H
     /** Text to display when control is empty. */
     placeholder?: string;
 
-    /** Max decimal precision of the value, defaults to 4. */
+    /** Max decimal precision of the value, defaults to 4. Set to null for full, unrestricted precision. */
     precision?: NumericPrecision;
 
     /** Element to display inline on the right side of the input. */

--- a/format/FormatNumber.ts
+++ b/format/FormatNumber.ts
@@ -78,8 +78,9 @@ export interface NumberFormatOptions extends Omit<FormatOptions<number>, 'toolti
     omitFourDigitComma?: boolean;
 
     /**
-     * Desired number of decimal places, or 'auto' (default) to adjust the displayed precision
-     * automatically based on the scale of the value.
+     * Desired number of decimal places, 'auto' (default) to adjust the displayed precision
+     * automatically based on the scale of the value, or null for full, unrestricted precision
+     * (capped at the max supported precision, with trailing zeros trimmed).
      */
     precision?: Precision;
 
@@ -118,7 +119,7 @@ export interface NumberFormatOptions extends Omit<FormatOptions<number>, 'toolti
      *
      * e.g. `{precision:4, zeroPad:2}` will format `1.2` → "1.20" and `1.234` → "1.234"
      *
-     * Default is true if a fixed precision is set, false if precision is 'auto'.
+     * Default is true if a fixed precision is set, false if precision is 'auto' or null (full).
      */
     zeroPad?: ZeroPad;
 }
@@ -175,9 +176,16 @@ export function fmtNumber(v: number, opts?: NumberFormatOptions): ReactNode {
     } = opts ?? ({} as NumberFormatOptions);
     if (isInvalidInput(v)) return nullDisplay;
 
-    // Ensure any non-int precision is treated as 'auto', use to default zeroPad.
-    if (!isInteger(precision)) precision = 'auto';
-    if (isNil(zeroPad)) zeroPad = precision != 'auto';
+    // Resolve precision: null means full precision, other non-integers (e.g. undefined) mean 'auto'.
+    const fullPrecision = precision === null;
+    if (fullPrecision) {
+        precision = MAX_NUMERIC_PRECISION;
+    } else if (!isInteger(precision)) {
+        precision = 'auto';
+    }
+
+    // Default zeroPad to pad only for a fixed precision - 'auto' and full precision trim zeros.
+    if (isNil(zeroPad)) zeroPad = precision != 'auto' && !fullPrecision;
 
     formatConfig =
         formatConfig || buildFormatConfig(v, precision, zeroPad, withCommas, omitFourDigitComma);

--- a/mobile/cmp/input/NumberInput.ts
+++ b/mobile/cmp/input/NumberInput.ts
@@ -46,7 +46,7 @@ export interface NumberInputProps extends HoistProps, HoistInputProps, StyleProp
     /** Text to display when control is empty. */
     placeholder?: string;
 
-    /** Max decimal precision of the value, defaults to 4. */
+    /** Max decimal precision of the value, defaults to 4. Set to null for full, unrestricted precision. */
     precision?: NumericPrecision;
 
     /**


### PR DESCRIPTION
Resolves the inconsistency described in #4396.

`fmtNumber` previously collapsed `null`, `undefined`, and `'auto'` precision all to `'auto'`, while `NumberInput` treats a `null` precision as "full, unrestricted precision". The result: a `NumberInput` with `precision: null` kept full precision in its value and while focused, but auto-rounded its blurred display.

### Changes
- `fmtNumber` now treats `precision: null` as full precision (capped at the max supported precision, trailing zeros trimmed), distinct from `'auto'`. `undefined` still defaults to `'auto'`.
- `zeroPad` default updated so full precision trims trailing zeros (matching `'auto'`).
- Documented `precision: null` on `NumberFormatOptions` and both desktop/mobile `NumberInput`.

No code change needed in `NumberInput` itself - `null` already flows through, and its blurred display now matches its focused/committed value.

Closes #4396