### PR TITLE
`CheckboxButton` no longer leaks `HoistInputProps` into underlying HTML `<button>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* `CheckboxButton` no longer leaks `HoistInputProps` into underlying HTML `<button>` element.
+
 ## 86.1.0 - 2026-06-22
 
 ### 🎁 New Features

--- a/desktop/cmp/input/CheckboxButton.ts
+++ b/desktop/cmp/input/CheckboxButton.ts
@@ -47,7 +47,27 @@ class CheckboxButtonInputModel extends HoistInputModel {
 // Implementation
 //----------------------------------
 const cmp = hoistCmp.factory<CheckboxButtonInputModel>(
-    ({model, text, icon, rightIcon, checkedIcon, uncheckedIcon, iconSide, ...props}, ref) => {
+    (
+        {
+            // HoistInput props - exclude from passthrough to BP
+            bind,
+            value,
+            commitOnChange,
+            onChange,
+            onCommit,
+            // Consumed by this component
+            model,
+            text,
+            icon,
+            rightIcon,
+            checkedIcon,
+            uncheckedIcon,
+            iconSide,
+            // Remainder passed to hoist button & BP button
+            ...props
+        },
+        ref
+    ) => {
         const checked = !!model.renderValue,
             toggleIcon = checked
                 ? withDefault(checkedIcon, Icon.checkSquare({prefix: 'fas', intent: 'primary'}))

--- a/mobile/cmp/input/CheckboxButton.ts
+++ b/mobile/cmp/input/CheckboxButton.ts
@@ -44,7 +44,24 @@ class CheckboxButtonInputModel extends HoistInputModel {
 // Implementation
 //----------------------------------
 const cmp = hoistCmp.factory<CheckboxButtonInputModel>(
-    ({model, text, checkedIcon, uncheckedIcon, ...props}, ref) => {
+    (
+        {
+            // HoistInput props - exclude from passthrough to Onsen
+            bind,
+            value,
+            commitOnChange,
+            onChange,
+            onCommit,
+            // Consumed by this component
+            model,
+            text,
+            checkedIcon,
+            uncheckedIcon,
+            // Remainder passed to hoist button & Onsen button
+            ...props
+        },
+        ref
+    ) => {
         const checked = !!model.renderValue;
         return button({
             text: withDefault(text, model.getField()?.displayName),


### PR DESCRIPTION
I came across this issue when testing an email scheduler whose `form` has
`fieldDefaults: {commitOnChange: true,...`  and a `checkboxButton` formField.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes: not a breaking change
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile: changed on mobile as well.
- [x] Created Toolbox branch: not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

