### PR TITLE
Stop inline grid editing when clicking empty grid space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Fixed inline grid editing not ending when clicking empty grid space to the right of the last
+  column or below the last row - such clicks now commit the active edit.
+
 ## 86.1.0 - 2026-06-22
 
 ### 🎁 New Features

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -48,6 +48,7 @@ import {consumeEvent, isDisplayed, logWithDebug} from '@xh/hoist/utils/js';
 import {composeRefs, createObservableRef, getLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {compact, debounce, isBoolean, isEmpty, isEqual, isNil, max, maxBy, merge} from 'lodash';
+import {type MouseEvent} from 'react';
 import './Grid.scss';
 import {GridModel} from './GridModel';
 import {columnGroupHeader} from './impl/ColumnGroupHeader';
@@ -135,6 +136,7 @@ export const [Grid, grid] = hoistCmp.withFactory<GridProps>({
                 ],
                 testId,
                 onKeyDown: impl.onKeyDown,
+                onMouseDown: impl.onViewMouseDown,
                 ref: composeRefs(impl.viewRef, model.viewRef, ref)
             }),
             colChooserModel ? platformColChooser({model: colChooserModel}) : null,
@@ -151,12 +153,8 @@ export const [Grid, grid] = hoistCmp.withFactory<GridProps>({
 export class GridLocalModel extends HoistModel {
     override xhImpl = true;
 
-    // Structural ag-Grid elements that constitute clickable "empty" grid space - i.e. the
-    // scrollable viewports, their (column/row-sized) containers, and the rows themselves (a row
-    // spans the full viewport width, so its area to the right of the last cell is the row element).
-    // A mousedown landing directly on one of these (not a descendant) is treated as a click outside
-    // any active cell editor - cells and portaled editor popovers are always descendants, never a
-    // direct match.
+    // Structural "empty" grid space. A direct hit (not a descendant) is an outside-of-cell click;
+    // cells and portaled editor popovers are always descendants, so never match.
     private static EMPTY_SPACE_SELECTOR =
         '.ag-body-viewport, .ag-center-cols-viewport, .ag-center-cols-container, .ag-row';
 
@@ -199,8 +197,7 @@ export class GridLocalModel extends HoistModel {
             this.sizingModeReaction(),
             this.validationDisplayReaction(),
             this.modalReaction(),
-            this.dashContainerReaction(),
-            this.stopEditingOnEmptyClickReaction()
+            this.dashContainerReaction()
         );
 
         this.agOptions = merge(this.createDefaultAgOptions(), this.componentProps.agOptions || {});
@@ -854,29 +851,13 @@ export class GridLocalModel extends HoistModel {
         return this.rowKeyNavSupport?.navigateToNextCell(agParams);
     };
 
-    // ag-Grid's `stopEditingWhenCellsLoseFocus` only fires when focus moves to another focusable
-    // element. Clicking empty grid space (e.g. to the right of the last column or below the last
-    // row) does not move focus out of the grid, leaving the editor open. Catch those clicks here
-    // and commit the active edit.
-    stopEditingOnEmptyClickReaction() {
-        return {
-            track: () => this.viewRef.current,
-            run: (view: HTMLElement, prevView: HTMLElement) => {
-                prevView?.removeEventListener('mousedown', this.onViewMouseDown, true);
-                view?.addEventListener('mousedown', this.onViewMouseDown, true);
-            }
-        };
-    }
-
+    // `stopEditingWhenCellsLoseFocus` doesn't fire on clicks in empty grid space (focus stays in
+    // the grid), so commit the active edit on those clicks ourselves. Require exact match on empty
+    // space to avoid interfering with any cell portals etc.
     onViewMouseDown = (evt: MouseEvent) => {
         const {model} = this,
             target = evt.target as HTMLElement;
         if (!model.isEditing) return;
-
-        // Only react to clicks landing *directly* on a structural viewport/container background -
-        // i.e. genuine empty space. We deliberately do not match descendants: some inline editors
-        // (e.g. DateEditor's calendar) portal their popovers into the grid viewport, and their
-        // content must not be treated as an outside click. See `desktop/cmp/grid/editors`.
         if (target.matches(GridLocalModel.EMPTY_SPACE_SELECTOR)) {
             model.agApi?.stopEditing();
         }

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -153,8 +153,7 @@ export const [Grid, grid] = hoistCmp.withFactory<GridProps>({
 export class GridLocalModel extends HoistModel {
     override xhImpl = true;
 
-    // Structural "empty" grid space. A direct hit (not a descendant) is an outside-of-cell click;
-    // cells and portaled editor popovers are always descendants, so never match.
+    // Structural "empty" grid space.
     private static EMPTY_SPACE_SELECTOR =
         '.ag-body-viewport, .ag-center-cols-viewport, .ag-center-cols-container, .ag-row';
 
@@ -853,12 +852,11 @@ export class GridLocalModel extends HoistModel {
 
     // `stopEditingWhenCellsLoseFocus` doesn't fire on clicks in empty grid space (focus stays in
     // the grid), so commit the active edit on those clicks ourselves. Require exact match on empty
-    // space to avoid interfering with any cell portals etc.
+    // space to avoid interfering with cell editors.
     onViewMouseDown = (evt: MouseEvent) => {
         const {model} = this,
             target = evt.target as HTMLElement;
-        if (!model.isEditing) return;
-        if (target.matches(GridLocalModel.EMPTY_SPACE_SELECTOR)) {
+        if (model.isEditing && target.matches(GridLocalModel.EMPTY_SPACE_SELECTOR)) {
             model.agApi?.stopEditing();
         }
     };

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -151,6 +151,12 @@ export const [Grid, grid] = hoistCmp.withFactory<GridProps>({
 export class GridLocalModel extends HoistModel {
     override xhImpl = true;
 
+    // Structural ag-Grid elements that constitute clickable "empty" grid space - i.e. the
+    // scrollable viewports and their (column/row-sized) containers. A mousedown landing directly
+    // on one of these (not a descendant) is treated as a click outside any active cell editor.
+    private static EMPTY_SPACE_SELECTOR =
+        '.ag-body-viewport, .ag-center-cols-viewport, .ag-center-cols-container';
+
     @lookup(GridModel)
     private model: GridModel;
     agOptions: GridOptions;
@@ -190,7 +196,8 @@ export class GridLocalModel extends HoistModel {
             this.sizingModeReaction(),
             this.validationDisplayReaction(),
             this.modalReaction(),
-            this.dashContainerReaction()
+            this.dashContainerReaction(),
+            this.stopEditingOnEmptyClickReaction()
         );
 
         this.agOptions = merge(this.createDefaultAgOptions(), this.componentProps.agOptions || {});
@@ -842,6 +849,34 @@ export class GridLocalModel extends HoistModel {
 
     navigateToNextCell = agParams => {
         return this.rowKeyNavSupport?.navigateToNextCell(agParams);
+    };
+
+    // ag-Grid's `stopEditingWhenCellsLoseFocus` only fires when focus moves to another focusable
+    // element. Clicking empty grid space (e.g. to the right of the last column or below the last
+    // row) does not move focus out of the grid, leaving the editor open. Catch those clicks here
+    // and commit the active edit.
+    stopEditingOnEmptyClickReaction() {
+        return {
+            track: () => this.viewRef.current,
+            run: (view: HTMLElement, prevView: HTMLElement) => {
+                prevView?.removeEventListener('mousedown', this.onViewMouseDown, true);
+                view?.addEventListener('mousedown', this.onViewMouseDown, true);
+            }
+        };
+    }
+
+    onViewMouseDown = (evt: MouseEvent) => {
+        const {model} = this,
+            target = evt.target as HTMLElement;
+        if (!model.isEditing) return;
+
+        // Only react to clicks landing *directly* on a structural viewport/container background -
+        // i.e. genuine empty space. We deliberately do not match descendants: some inline editors
+        // (e.g. DateEditor's calendar) portal their popovers into the grid viewport, and their
+        // content must not be treated as an outside click. See `desktop/cmp/grid/editors`.
+        if (target.matches(GridLocalModel.EMPTY_SPACE_SELECTOR)) {
+            model.agApi?.stopEditing();
+        }
     };
 
     onCellMouseDown = evt => {

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -152,10 +152,13 @@ export class GridLocalModel extends HoistModel {
     override xhImpl = true;
 
     // Structural ag-Grid elements that constitute clickable "empty" grid space - i.e. the
-    // scrollable viewports and their (column/row-sized) containers. A mousedown landing directly
-    // on one of these (not a descendant) is treated as a click outside any active cell editor.
+    // scrollable viewports, their (column/row-sized) containers, and the rows themselves (a row
+    // spans the full viewport width, so its area to the right of the last cell is the row element).
+    // A mousedown landing directly on one of these (not a descendant) is treated as a click outside
+    // any active cell editor - cells and portaled editor popovers are always descendants, never a
+    // direct match.
     private static EMPTY_SPACE_SELECTOR =
-        '.ag-body-viewport, .ag-center-cols-viewport, .ag-center-cols-container';
+        '.ag-body-viewport, .ag-center-cols-viewport, .ag-center-cols-container, .ag-row';
 
     @lookup(GridModel)
     private model: GridModel;


### PR DESCRIPTION
Fixes #4215.

Clicking empty grid space - to the right of the last column or below the last row - did not end an active inline edit. ag-Grid's `stopEditingWhenCellsLoseFocus` only fires when focus moves to another focusable element, and these clicks keep focus within the grid.

The grid container now handles `onMouseDown` and commits the active edit when the click lands directly on a structural "empty" element (`.ag-body-viewport`, `.ag-center-cols-viewport`, `.ag-center-cols-container`, `.ag-row`). Matching the target element itself - not its ancestors - ensures cells and editor popovers portaled into the grid viewport (e.g. the `DateEditor` calendar) are never treated as outside clicks.

Verified in Toolbox's inline-editing grid:
- Clicking right of the last column commits the edit.
- Clicking below the last row commits the edit.
- The `DateEditor` calendar and `SelectEditor` dropdown continue to work normally.