### PR TITLE
Fix NumberEditor to allow leading -, +, . and guard reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Fixed grid `NumberEditor` to allow starting an edit by typing `-`, `+`, or `.` (e.g. to enter a
+  negative or decimal value), while reliably rejecting other non-numeric keypresses.
+
 ## 86.1.0 - 2026-06-22
 
 ### 🎁 New Features

--- a/desktop/cmp/grid/editors/NumberEditor.ts
+++ b/desktop/cmp/grid/editors/NumberEditor.ts
@@ -6,8 +6,8 @@
  */
 import {withDefault} from '@xh/hoist/utils/js';
 import {isNil} from 'lodash';
-import {useCallback, useEffect} from 'react';
-import {CustomCellEditorProps, useGridCellEditor} from '@xh/hoist/kit/ag-grid';
+import {useEffect} from 'react';
+import {CustomCellEditorProps} from '@xh/hoist/kit/ag-grid';
 import {hoistCmp} from '@xh/hoist/core';
 import {numberInput, NumberInputProps} from '@xh/hoist/desktop/cmp/input';
 import '@xh/hoist/desktop/register';
@@ -39,20 +39,19 @@ export const [NumberEditor, numberEditor] = hoistCmp.withFactory<NumberEditorPro
     }
 });
 
-const useNumberGuard = ({onValueChange, eventKey}: CustomCellEditorProps) => {
-    // Needed (strangely) by agGrid to trigger call of isCancelBeforeStart
+// Characters that can validly begin a numeric entry - digits, sign, and decimal point.
+const NUMBER_START_RE = /[0-9.+-]/;
+
+const useNumberGuard = ({onValueChange, eventKey, stopEditing}: CustomCellEditorProps) => {
+    // When editing is started by typing a printable character, seed the editor with it if it can
+    // legally begin a number (digit, `-`, `+`, or `.`), otherwise stop editing to reject the
+    // keystroke - reverting to the original value, as the editor was never seeded.
     useEffect(() => {
-        if (eventKey?.length === 1) onValueChange(eventKey);
-    }, [eventKey, onValueChange]);
-
-    // Gets called before editor component is rendered, to give agGrid a chance to
-    // cancel the editing before it even starts if char is not a number.
-    const isCancelBeforeStart = useCallback(
-        () => eventKey?.length === 1 && '1234567890'.indexOf(eventKey) < 0,
-        [eventKey]
-    );
-
-    useGridCellEditor({
-        isCancelBeforeStart
-    });
+        if (eventKey?.length !== 1) return;
+        if (NUMBER_START_RE.test(eventKey)) {
+            onValueChange(eventKey);
+        } else {
+            stopEditing(true);
+        }
+    }, [eventKey, onValueChange, stopEditing]);
 };


### PR DESCRIPTION
Fixes #4299

### Problem
- `NumberEditor` rejected any non-digit first character, so you couldn't begin an edit by typing `-`, `+`, or `.` (e.g. to enter a negative or decimal value).
- The non-numeric keypress guard also silently stopped rejecting invalid characters after the first cell edit in a grid.

### Root cause
Cancellation relied on agGrid calling `isCancelBeforeStart`, a callback our component only registers as it renders. agGrid reads it during the parent editor's render (before our child sets it); the existing `onValueChange`-in-effect trick papered over this only on the first edit, then agGrid's async update path broke the timing on subsequent edits.

### Fix
Reworked the guard to run deterministically in the editor's own effect: valid number-start characters (digit, `-`, `+`, `.`) seed the input, anything else stops editing and reverts.

### Testing
Verified in Toolbox (Grids → Inline Editing, `Amount` column):
- Typing `-` / `.` starts a numeric edit.
- Typing a letter is rejected — including after a prior cell commit (the regression).
