### PR TITLE
Add `lossless` option to `fmtQuantity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* Added a `lossless` option to `fmtQuantity` to compact values to millions / billions units only
+  when doing so loses no precision, rendering the full value otherwise (e.g. `7,100,100` stays
+  `7,100,100` rather than collapsing to `7.10m`).
+
 ## 86.1.0 - 2026-06-22
 
 ### 🎁 New Features

--- a/format/FormatNumber.ts
+++ b/format/FormatNumber.ts
@@ -14,6 +14,7 @@ import {
     isNil,
     isNumber,
     isString,
+    isUndefined,
     round
 } from 'lodash';
 import Numbro from 'numbro';
@@ -124,9 +125,17 @@ export interface NumberFormatOptions extends Omit<FormatOptions<number>, 'toolti
 }
 
 export interface QuantityFormatOptions extends NumberFormatOptions {
+    /** True to compact values >= 1 million into units of millions (m). Default true. */
     useMillions?: boolean;
 
+    /** True to compact values >= 1 billion into units of billions (b). Default true. */
     useBillions?: boolean;
+
+    /**
+     * True to compact to m/b units only when no precision is lost, else render the full value.
+     * Default false.
+     */
+    lossless?: boolean;
 }
 
 /** Config for pos/neg/neutral color classes. */
@@ -271,20 +280,46 @@ export function fmtQuantity(v: number, opts?: QuantityFormatOptions) {
     saveOriginal(v, opts);
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
-    const lessThanM = Math.abs(v) < MILLION,
-        lessThanB = Math.abs(v) < BILLION;
-
     defaults(opts, {
         ledger: true,
         label: true,
-        precision: lessThanM ? 0 : 2,
         useMillions: true,
-        useBillions: true
+        useBillions: true,
+        lossless: false
     });
 
-    if (lessThanM || !opts.useMillions) return fmtNumber(v, opts);
-    if (lessThanB || !opts.useBillions) return fmtMillions(v, opts);
-    return fmtBillions(v, opts);
+    const absV = Math.abs(v),
+        lessM = absV < MILLION,
+        lessB = absV < BILLION,
+        targetPrecision = opts.precision ?? (lessM ? 0 : 2);
+
+    // Compute scaling if any. Lossless flag may preclude.
+    let scale = !lessB && opts.useBillions ? BILLION : !lessM && opts.useMillions ? MILLION : null;
+    if (scale && opts.lossless) {
+        const precision = parsePrecision(absV / scale, targetPrecision),
+            lossy = v % (scale / 10 ** precision) !== 0;
+        if (lossy) scale = null;
+    }
+
+    // Resolve render precision (unless the caller set one).
+    if (isUndefined(opts.precision)) {
+        if (opts.lossless) {
+            // Full precision - replace with `precision: null` once that PR lands.
+            opts.precision = MAX_NUMERIC_PRECISION;
+            opts.zeroPad = false;
+        } else {
+            opts.precision = targetPrecision;
+        }
+    }
+
+    switch (scale) {
+        case BILLION:
+            return fmtBillions(v, opts);
+        case MILLION:
+            return fmtMillions(v, opts);
+        default:
+            return fmtNumber(v, opts);
+    }
 }
 
 /**
@@ -462,6 +497,23 @@ function calcStyleFromColorSpec(v: number, colorSpec: ColorSpec | boolean): CSSP
     return !isString(possibleStyles) ? possibleStyles : {};
 }
 
+/**
+ * Resolve a precisionSpec to a concrete number of decimal places. A fixed precision is used as-is
+ * (capped at max), while 'auto' is derived from the scale of the value.
+ */
+function parsePrecision(v: number, precisionSpec: Precision): number {
+    // Fixed precision - use requested, capped at max.
+    if (precisionSpec !== 'auto') return Math.min(precisionSpec, MAX_NUMERIC_PRECISION);
+
+    // 'auto' - derive from the scale of the value.
+    const absVal = Math.abs(v);
+    if (absVal === 0) return 2;
+    if (absVal < 0.01) return 6;
+    if (absVal < 100) return 4;
+    if (absVal < 10000) return 2;
+    return 0;
+}
+
 function buildFormatConfig(
     v: number,
     precisionSpec: Precision,
@@ -472,24 +524,7 @@ function buildFormatConfig(
     const absVal = Math.abs(v),
         config: Numbro.Format = {};
 
-    let precision: number;
-    if (precisionSpec === 'auto') {
-        // Auto-precision - base on scale of number
-        if (absVal === 0) {
-            precision = 2;
-        } else if (absVal < 0.01) {
-            precision = 6;
-        } else if (absVal < 100) {
-            precision = 4;
-        } else if (absVal < 10000) {
-            precision = 2;
-        } else {
-            precision = 0;
-        }
-    } else {
-        // Fixed precision - use requested, capped at max.
-        precision = precisionSpec < MAX_NUMERIC_PRECISION ? precisionSpec : MAX_NUMERIC_PRECISION;
-    }
+    const precision = parsePrecision(v, precisionSpec);
 
     // If zeroPad gte precision, treat as `true` to pad out to (but not beyond) full precision.
     // We don't support applying some precision (rounding) then padding out zeroes after that.

--- a/format/FormatNumber.ts
+++ b/format/FormatNumber.ts
@@ -301,7 +301,7 @@ export function fmtQuantity(v: number, opts?: QuantityFormatOptions) {
         lessB = absV < BILLION,
         targetPrecision = opts.precision ?? (lessM ? 0 : 2);
 
-    // Compute scaling if any. Lossless flag may preclude.
+    // Compute scaling, if any (Lossless flag may preclude).
     let scale = !lessB && opts.useBillions ? BILLION : !lessM && opts.useMillions ? MILLION : null;
     if (scale && opts.lossless) {
         const precision = parsePrecision(absV / scale, targetPrecision),
@@ -311,13 +311,7 @@ export function fmtQuantity(v: number, opts?: QuantityFormatOptions) {
 
     // Resolve render precision (unless the caller set one).
     if (isUndefined(opts.precision)) {
-        if (opts.lossless) {
-            // Full precision - replace with `precision: null` once that PR lands.
-            opts.precision = MAX_NUMERIC_PRECISION;
-            opts.zeroPad = false;
-        } else {
-            opts.precision = targetPrecision;
-        }
+        opts.precision = opts.lossless ? null : targetPrecision;
     }
 
     switch (scale) {

--- a/format/FormatNumber.ts
+++ b/format/FormatNumber.ts
@@ -126,10 +126,10 @@ export interface NumberFormatOptions extends Omit<FormatOptions<number>, 'toolti
 }
 
 export interface QuantityFormatOptions extends NumberFormatOptions {
-    /** True to compact values >= 1 million into units of millions (m). Default true. */
+    /** True to compact values \>= 1 million into units of millions (m). Default true. */
     useMillions?: boolean;
 
-    /** True to compact values >= 1 billion into units of billions (b). Default true. */
+    /** True to compact values \>= 1 billion into units of billions (b). Default true. */
     useBillions?: boolean;
 
     /**

--- a/mcp/data/ts-registry.ts
+++ b/mcp/data/ts-registry.ts
@@ -1432,7 +1432,7 @@ function extractSymbolDetail(entry: SymbolEntry): SymbolDetail | null {
  *
  * `JSDoc.getDescription()` returns the text before the first JSDoc block tag,
  * but the TS parser treats ANY line whose first non-whitespace char is `@` as a
- * tag boundary - even inside a fenced ``` code block. So a canonical-usage
+ * tag boundary - even inside a fenced code block. So a canonical-usage
  * example containing e.g. `@observable.ref` silently truncates the description
  * mid-example, dropping everything after it (further examples, "SEE ALSO"
  * lists, trailing prose). See #4352.


### PR DESCRIPTION
Adds a `lossless` option to `fmtQuantity` (issue #4219). When set, the formatter compacts to millions / billions units **only** when doing so loses no precision; otherwise it renders the full value at its natural precision.

- `7,100,000` → `7.10m` (exact, compacts)
- `7,100,100` → `7,100,100` (would lose the trailing `100`, so renders full)
- `123.456` with `lossless` → `123.456` (no longer rounded to `123`)

### Changes
- New `lossless` opt on `QuantityFormatOptions` (default false).
- Extracted the auto/fixed precision resolution out of `buildFormatConfig` into a shared `parsePrecision` helper, reused by the compaction-exactness check.
- Compaction decision uses the standard display precision as its threshold; `lossless` independently drives full-precision rendering when not compacting.

Closes #4219

### Not changing the default tooltip
The issue also floated defaulting `tooltip: true` for non-`lossless` lossy renders. Skipped: that would silently add hover tooltips to every existing `fmtQuantity` call site - a broad, app-wide behavior change disproportionate to an opt-in feature. `lossless` already surfaces the lost precision inline, and `tooltip: true` remains available per-call.
