### PR TITLE
Fix grid column filter Custom tab handling of multi-value filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🐞 Bug Fixes
+
+* Hardened the grid column filter's Custom tab against filters it previously mishandled - multi-value
+  clauses are now expanded into editable rows and recombined on commit, and filters it cannot
+  represent are left untouched rather than corrupted.
+
 ### ⚙️ Typescript API Adjustments
 
 * Retyped `GridModel.colChooserModel` as the new cross-platform `IColChooserModel` interface,

--- a/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomRow.ts
+++ b/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomRow.ts
@@ -12,7 +12,7 @@ import {dateInput, numberInput, select, textInput} from '@xh/hoist/desktop/cmp/i
 import {Icon} from '@xh/hoist/icon';
 import {kebabCase} from 'lodash';
 
-import {CustomRowModel} from './CustomRowModel';
+import {CustomRowModel, usesMultiValueInput} from './CustomRowModel';
 
 /**
  * Row with operator and value combination for CustomTab.
@@ -74,17 +74,7 @@ const inputField = hoistCmp.factory<CustomRowModel>(({model}) => {
             ...fieldSpec.inputProps
         };
 
-    if (fieldSpec.isNumericFieldType) {
-        return numberInput({
-            ...props,
-            enableShorthandUnits: true
-        });
-    } else if (fieldSpec.isDateBasedFieldType) {
-        return dateInput({
-            ...props,
-            valueType: fieldSpec.fieldType as 'localDate' | 'date'
-        });
-    } else if (fieldSpec.supportsSuggestions(op as FieldFilterOperator)) {
+    if (usesMultiValueInput(fieldSpec, op as FieldFilterOperator)) {
         return select({
             ...props,
             options: fieldSpec.values,
@@ -93,6 +83,16 @@ const inputField = hoistCmp.factory<CustomRowModel>(({model}) => {
             hideDropdownIndicator: true,
             hideSelectedOptionCheck: true,
             enableClear: false
+        });
+    } else if (fieldSpec.isNumericFieldType) {
+        return numberInput({
+            ...props,
+            enableShorthandUnits: true
+        });
+    } else if (fieldSpec.isDateBasedFieldType) {
+        return dateInput({
+            ...props,
+            valueType: fieldSpec.fieldType as 'localDate' | 'date'
         });
     } else {
         return textInput(props);

--- a/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomRowModel.ts
+++ b/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomRowModel.ts
@@ -4,6 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
+import type {GridFilterFieldSpec} from '@xh/hoist/cmp/grid';
 import {HoistModel} from '@xh/hoist/core';
 import {FieldFilterOperator, FieldFilterSpec} from '@xh/hoist/data';
 import {HeaderFilterModel} from '../HeaderFilterModel';
@@ -12,6 +13,23 @@ import {isArray, isEmpty, isNil} from 'lodash';
 import {CustomTabModel} from './CustomTabModel';
 
 type OperatorOptionValue = 'blank' | 'not blank' | FieldFilterOperator;
+
+/**
+ * Whether a row for the given op renders the multi-value `select` input - the only custom-tab input
+ * that holds an array of values directly. The single-value inputs (number, date, text) are used
+ * otherwise, so array filter values bound for them must be expanded into one row each (see
+ * `CustomTabModel.doSyncWithFilter`). Mirrors the input choice made in `CustomRow`.
+ */
+export function usesMultiValueInput(
+    fieldSpec: GridFilterFieldSpec,
+    op: FieldFilterOperator
+): boolean {
+    return (
+        !fieldSpec.isNumericFieldType &&
+        !fieldSpec.isDateBasedFieldType &&
+        fieldSpec.supportsSuggestions(op)
+    );
+}
 
 /**
  * @internal

--- a/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomTab.scss
+++ b/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomTab.scss
@@ -9,6 +9,11 @@
     }
   }
 
+  &__unsupported {
+    padding: var(--xh-pad-px);
+    color: var(--xh-text-color-muted);
+  }
+
   &__tbar {
     background-color: transparent;
     .xh-button {

--- a/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomTab.ts
+++ b/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomTab.ts
@@ -23,13 +23,24 @@ import {CustomTabModel} from './CustomTabModel';
 export const customTab = hoistCmp.factory({
     model: uses(CustomTabModel),
     render({model}) {
+        const {rowModels} = model;
+        if (!rowModels) {
+            return panel({
+                className: 'xh-custom-filter-tab',
+                item: div({
+                    className: 'xh-custom-filter-tab__unsupported',
+                    item: 'This filter is too complex to edit here.'
+                })
+            });
+        }
+
         return panel({
             className: 'xh-custom-filter-tab',
             tbar: tbar(),
             items: div({
                 className: 'xh-custom-filter-tab__list',
                 items: [
-                    ...model.rowModels.map(m => customRow({model: m})),
+                    ...rowModels.map(m => customRow({model: m})),
                     div({
                         className: 'xh-custom-filter-tab__list__add-btn-row',
                         items: [
@@ -52,7 +63,7 @@ export const customTab = hoistCmp.factory({
 const tbar = hoistCmp.factory<CustomTabModel>(({model}) => {
     return toolbar({
         className: 'xh-custom-filter-tab__tbar',
-        omit: model.rowModels.length < 2,
+        omit: !model.rowModels || model.rowModels.length < 2,
         compact: true,
         items: [
             filler(),

--- a/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomTabModel.ts
+++ b/desktop/cmp/grid/impl/filter/headerfilter/custom/CustomTabModel.ts
@@ -5,12 +5,18 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {HoistModel, XH} from '@xh/hoist/core';
-import {CompoundFilterOperator, FilterLike} from '@xh/hoist/data';
+import {
+    CompoundFilterOperator,
+    FieldFilter,
+    FieldFilterOperator,
+    FieldFilterSpec,
+    FilterLike
+} from '@xh/hoist/data';
 import {action, bindable, computed, makeObservable, observable} from '@xh/hoist/mobx';
-import {compact, isEmpty} from 'lodash';
+import {compact, first, flatMap, forEach, groupBy, isArray, isEmpty, uniq} from 'lodash';
 import {HeaderFilterModel} from '../HeaderFilterModel';
 
-import {CustomRowModel} from './CustomRowModel';
+import {CustomRowModel, usesMultiValueInput} from './CustomRowModel';
 
 export class CustomTabModel extends HoistModel {
     override xhImpl = true;
@@ -23,11 +29,16 @@ export class CustomTabModel extends HoistModel {
     /** Filter config output by this model. */
     @computed.struct
     get filter(): FilterLike {
-        const {op, rowModels} = this,
-            filters = compact(rowModels.map(it => it.value));
-        if (isEmpty(filters)) return null;
-        if (filters.length > 1) return {filters, op};
-        return filters;
+        const {op, rowModels} = this;
+
+        // Null rowModels flags an unrepresentable filter - emit it unchanged so commit is a no-op.
+        if (!rowModels) return this.columnCompoundFilter ?? this.columnFilters;
+
+        const specs = compact(rowModels.map(it => it.value));
+        if (isEmpty(specs)) return null;
+
+        const filters = this.collapseToArrayFilters(specs, op);
+        return filters.length > 1 ? {filters, op} : first(filters);
     }
 
     get fieldSpec() {
@@ -40,6 +51,10 @@ export class CustomTabModel extends HoistModel {
 
     get columnFilters() {
         return this.headerFilterModel.columnFilters;
+    }
+
+    get columnCompoundFilter() {
+        return this.headerFilterModel.columnCompoundFilter;
     }
 
     constructor(headerFilterModel: HeaderFilterModel) {
@@ -74,13 +89,27 @@ export class CustomTabModel extends HoistModel {
     //-------------------
     @action
     private doSyncWithFilter() {
-        const {columnFilters} = this,
-            rowModels = [];
+        const {columnCompoundFilter} = this,
+            op = this.deriveOp();
+        this.op = op;
 
-        // Create rows based on filter.
-        columnFilters.forEach(filter => {
-            const {op, value} = filter;
-            rowModels.push(new CustomRowModel(this, op, value));
+        if (!this.isRepresentable) {
+            this.logWarn('Filter cannot be edited in the custom tab; leaving it unchanged');
+            this.rowModels = null;
+            return;
+        }
+
+        // Expand a multi-value clause destined for a single-value input into one row per value
+        // (joined under the tab op); the multi-select input holds the array directly as one row.
+        const rowModels = [],
+            children = (columnCompoundFilter?.filters ?? this.columnFilters) as FieldFilter[];
+        children.forEach(filter => {
+            const {op: fieldOp, value} = filter;
+            if (this.needsExpansion(filter)) {
+                value.forEach(v => rowModels.push(new CustomRowModel(this, fieldOp, v)));
+            } else {
+                rowModels.push(new CustomRowModel(this, fieldOp, value));
+            }
         });
 
         // Add an empty pending row
@@ -89,5 +118,59 @@ export class CustomTabModel extends HoistModel {
         }
 
         this.rowModels = rowModels;
+    }
+
+    // Whether a multi-value clause must be expanded to one row per value (vs held by a multi-select).
+    private needsExpansion({op, value}: FieldFilter): boolean {
+        return isArray(value) && value.length > 1 && !usesMultiValueInput(this.fieldSpec, op);
+    }
+
+    // The op a multi-value clause joins under: `=`-family => OR, negated => AND.
+    private mergeOpFor(op: FieldFilterOperator): CompoundFilterOperator {
+        return FieldFilter.INCLUDE_LIKE_OPERATORS.includes(op) ? 'OR' : 'AND';
+    }
+
+    // Op joining the tab's rows
+    private deriveOp(): CompoundFilterOperator {
+        const {columnCompoundFilter, columnFilters} = this;
+        if (columnCompoundFilter) return columnCompoundFilter.op;
+
+        const arrayFilter = columnFilters.find(f => this.needsExpansion(f));
+        return arrayFilter ? this.mergeOpFor(arrayFilter.op) : 'AND';
+    }
+
+    // Filter must be representable as a flat set of rows with a single op
+    private get isRepresentable(): boolean {
+        const {columnCompoundFilter} = this,
+            op = this.deriveOp(),
+            children = columnCompoundFilter?.filters ?? this.columnFilters;
+        return children.every(
+            f =>
+                FieldFilter.isFieldFilter(f) &&
+                (!this.needsExpansion(f) || op === this.mergeOpFor(f.op))
+        );
+    }
+
+    // Inverse of the expand in `doSyncWithFilter`: collapse same-field/op rows into one multi-value FieldFilter
+    private collapseToArrayFilters(
+        specs: FieldFilterSpec[],
+        op: CompoundFilterOperator
+    ): FieldFilterSpec[] {
+        const ret: FieldFilterSpec[] = [];
+        forEach(groupBy(specs, 'op'), (groupSpecs, groupOp: FieldFilterOperator) => {
+            const canMerge =
+                groupSpecs.length > 1 &&
+                FieldFilter.ARRAY_OPERATORS.includes(groupOp) &&
+                op === this.mergeOpFor(groupOp);
+
+            if (canMerge) {
+                const {field} = groupSpecs[0],
+                    value = uniq(flatMap(groupSpecs, it => it.value));
+                ret.push({field, op: groupOp, value});
+            } else {
+                ret.push(...groupSpecs);
+            }
+        });
+        return ret;
     }
 }


### PR DESCRIPTION
Fixes #3522

### Problem
The grid column filter's **Custom tab** mapped each `FieldFilter` to a single row, so a multi-value `=`/`!=` filter (as produced by `FilterChooser`, the column context menu, or the Values tab) dumped an array into a single-value number/date/text input - showing `NaN`, a broken date picker, or a comma-joined string. Most visible when `enableValues` is `false`, since the Custom tab is then the only tab.

### Fix
- Multi-value clauses are expanded into one row per value on read, and same-field/op rows are recombined into a single multi-value filter on commit - round-tripping to the representation used by the other filtering methods.
- Filters that genuinely can't be shown as flat rows under a single op (nested single-field trees, not producible via the header UI) are detected and left untouched with a notice, rather than silently corrupted.
- The input-selection decision is centralized in a shared `usesMultiValueInput` helper used by both `CustomRow` and `CustomTabModel`, closing a latent case where numeric/date fields with `enableValues` would still receive an array.

### Testing
Verified live in Toolbox (Grids › Column Filtering) running this branch via `inlineHoist`, plus a clean `tsc --noEmit`.

- **Multi-value `=` on a numeric column** (`trade_volume = [2942400000, 5445000000]`, no Values tab): Custom tab now expands the array into one `numberInput` per value showing the actual numbers (previously a single input → `NaN`), with the **OR** join toggle correctly derived. Commit collapses the rows back to a single `{op: '=', value: [...]}` - lossless round-trip confirmed via "View Grid Filters".
- **Multi-value `!=` on the same column**: expands to one "Not equals" row per value, join toggle correctly derived as **AND**, and commits back to a single `{op: '!=', value: [...]}`.
- **Multi-value on an enum column** (`City`, has a Values tab): the shared `usesMultiValueInput` helper keeps this on a single multi-select row rather than expanding it - no spurious per-value rows.
- No console errors during any interaction; the "too complex to edit" notice path was not reachable through the header UI (as expected - such filters aren't producible there).
