### PR TITLE
Fixed CHANGELOG.md for generateOptionFn change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* `Select` now accepts a `generateOptionFn` prop to resolve an option for a selected value that is
+  not present in the current options list (e.g. with `queryFn`-based selects or readonly forms),
+  ensuring such values render with their proper label rather than falling back to the raw value.
+
+### 🐞 Bug Fixes
+
+* Fixed `Select` to correctly handle non-primitive (object) values: selected-option matching and
+  async query de-duplication now use deep equality, so object values no longer render as
+  `[object Object]` or collide with one another.
+
 ### ⚙️ Typescript API Adjustments
 
 * Retyped `GridModel.colChooserModel` as the new cross-platform `IColChooserModel` interface,
@@ -33,9 +45,6 @@
 * Added a `lossless` option to `fmtQuantity` to compact values to millions / billions units only
   when doing so loses no precision, rendering the full value otherwise (e.g. `7,100,100` stays
   `7,100,100` rather than collapsing to `7.10m`).
-* `Select` now accepts a `generateOptionFn` prop to resolve an option for a selected value that is
-  not present in the current options list (e.g. with `queryFn`-based selects or readonly forms),
-  ensuring such values render with their proper label rather than falling back to the raw value.
 
 ### 🐞 Bug Fixes
 
@@ -51,9 +60,6 @@
 * Fixed `Select` (and `SelectEditor`) dropdown menu sizing: windowed menus now auto-size to their
   option labels instead of the control/cell width, and an explicit `menuWidth` is respected rather
   than overridden by content auto-sizing.
-* Fixed `Select` to correctly handle non-primitive (object) values: selected-option matching and
-  async query de-duplication now use deep equality, so object values no longer render as
-  `[object Object]` or collide with one another.
 
 ### ⚙️ Typescript API Adjustments
 


### PR DESCRIPTION
Changelog for the generateOptionFn was placed in the wrong release block.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

