### PR TITLE
Fix inline grid cell editors to commit value when editing ends (#4134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### 🐞 Bug Fixes
 
+* Fixed inline grid cell editors to reliably commit their value when editing ends, including popup
+  editors (e.g. `textAreaEditor`) within a dialog, which previously dropped edits on Enter or
+  click-away.
 * Fixed `Select` to correctly handle non-primitive (object) values: selected-option matching and
   async query de-duplication now use deep equality, so object values no longer render as
   `[object Object]` or collide with one another.

--- a/desktop/cmp/grid/editors/impl/InlineEditorModel.ts
+++ b/desktop/cmp/grid/editors/impl/InlineEditorModel.ts
@@ -35,7 +35,12 @@ export function useInlineEditorModel(
 
     useGridCellEditor({
         // This is called in full-row editing when the user tabs into the cell
-        focusIn: useCallback(() => impl.focus(), [impl])
+        focusIn: useCallback(() => impl.focus(), [impl]),
+        // Backstop to flush any pending edit when editing ends, in case no blur fired (#4134).
+        isCancelAfterEnd: useCallback(() => {
+            impl.ref.current?.doCommit();
+            return false;
+        }, [impl])
     });
 
     return component({


### PR DESCRIPTION
### Problem
Popup cell editors (e.g. `textAreaEditor` with `editorIsPopup: true`) opened from a grid **within a dialog** dropped their edit when the user pressed Enter or clicked elsewhere in the grid — the app's `onCommit` never fired and the value was not committed. Clicking fully outside the grid worked (a real blur fired first). Regressed vs. the older class-based ag-Grid editor.

### Cause
The ag-Grid React hooks editor API has no `getValue` pull path — the value is only *pushed* to ag-Grid via `onValueChange`, which the Hoist input calls from its commit lifecycle (blur / Enter). When ag-Grid tears down a popup editor on `stopEditing`, no native blur fires, so the input never commits.

### Fix
Add an `isCancelAfterEnd` callback in `useInlineEditorModel`. ag-Grid calls it synchronously on every normal stop-editing path (before reading the value) and **not** on cancel (Escape). It flushes any pending commit via the input's `doCommit()`, which is idempotent — a no-op when the input isn't dirty (already-committed / untouched cells). This restores the commit-on-stop semantics for all inline editors as a general, safe backstop.

### Verification (Toolbox → Grids → Inline Editing)
- ✅ Reproduced: popup edit in modal dialog dropped the value + `onCommit` (store stayed Clean); fixed after change (value committed, `onCommit` fired).
- ✅ Single-cell: Enter / click-away commit; Escape cancels.
- ✅ Full-row editing: multi-cell edits commit (including the active cell via the backstop); Escape reverts the whole row with no commit.

Fixes #4134

🤖 Generated with [Claude Code](https://claude.com/claude-code)