### PR TITLE
Fix quick-filter/Find returning different results when grouping changes (#4070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐞 Bug Fixes
 
+* Fixed `StoreFilterField` and grid Find so an active quick-filter or find query no longer returns
+  different results when the grid's `groupBy` changes.
 * Fixed `Select` to correctly handle non-primitive (object) values: selected-option matching and
   async query de-duplication now use deep equality, so object values no longer render as
   `[object Object]` or collide with one another.

--- a/cmp/store/impl/StoreFilterFieldImplModel.ts
+++ b/cmp/store/impl/StoreFilterFieldImplModel.ts
@@ -66,7 +66,7 @@ export class StoreFilterFieldImplModel extends HoistModel {
 
         this.addReaction(
             {
-                track: () => [this.filterText, gridModel?.columns, gridModel?.groupBy],
+                track: () => [this.filterText, gridModel?.columns],
                 run: () => this.regenerateFilter(),
                 fireImmediately: true
             },
@@ -161,8 +161,7 @@ export class StoreFilterFieldImplModel extends HoistModel {
         if (excludeFields) ret = without(ret, ...excludeFields);
 
         if (gridModel) {
-            const groupBy = gridModel.groupBy,
-                visibleCols = gridModel.getVisibleLeafColumns();
+            const visibleCols = gridModel.getVisibleLeafColumns();
 
             // Push on dot-delimited grid column fields. These are supported by Grid and traverse
             // sub-objects in StoreRecord.data to display nested properties. Given that Grid treats these
@@ -182,12 +181,12 @@ export class StoreFilterFieldImplModel extends HoistModel {
             // Run exclude once more to support explicitly excluding a dot-sep field added above.
             if (excludeFields) ret = without(ret, ...excludeFields);
 
-            // Final filter for column visibility, or explicit request for inclusion.
+            // Final filter for column visibility, or explicit request for inclusion. Deliberately
+            // not keyed to groupBy, so filter results stay stable across regrouping (see #4070).
             ret = ret.filter(f => {
                 return (
                     (includeFields && includeFields.includes(f)) ||
-                    visibleCols.find(c => c.field === f) ||
-                    groupBy.includes(f)
+                    visibleCols.find(c => c.field === f)
                 );
             });
         }

--- a/desktop/cmp/grid/find/impl/GridFindFieldImplModel.ts
+++ b/desktop/cmp/grid/find/impl/GridFindFieldImplModel.ts
@@ -268,7 +268,6 @@ export class GridFindFieldImplModel extends HoistModel {
 
     private getActiveFields(): string[] {
         const {gridModel, includeFields, excludeFields} = this,
-            groupBy = gridModel.groupBy,
             visibleCols = gridModel.getVisibleLeafColumns();
 
         let ret = ['id', ...gridModel.store.fieldNames];
@@ -293,12 +292,11 @@ export class GridFindFieldImplModel extends HoistModel {
         // Run exclude once more to support explicitly excluding a dot-sep field added above.
         if (excludeFields) ret = without(ret, ...excludeFields);
 
-        // Final filter for column visibility, or explicit request for inclusion.
+        // Final filter for column visibility, or explicit request for inclusion. Deliberately not
+        // keyed to groupBy, so query results stay stable across regrouping (see #4070).
         ret = ret.filter(f => {
             return (
-                (includeFields && includeFields.includes(f)) ||
-                visibleCols.find(c => c.field === f) ||
-                groupBy.includes(f)
+                (includeFields && includeFields.includes(f)) || visibleCols.find(c => c.field === f)
             );
         });
 


### PR DESCRIPTION
Fixes #4070

### Problem
`StoreFilterField` and grid Find derived their searched-field set partly from `GridModel.groupBy`, so grouping by a **hidden** column silently added that field to the search. An active filter/query then returned different records across regroupings.

Reproduced on `develop` (Toolbox Standard grid, `winLose` hidden by default) — filtering `loser`:
- Ungrouped → **0** rows (`winLose` hidden, not searched)
- Group by Win/Lose → **438** rows (`winLose` now grouped, so it's searched)
- Ungrouped again → **0** rows

### Fix
Removed the `groupBy`-based inclusion from `getActiveFields()` in both `StoreFilterFieldImplModel` and `GridFindFieldImplModel`. The searched field set now derives from visible columns (plus explicit include/exclude) only, so it stays stable regardless of grouping. `GridFindField` still tracks `groupBy` in its reaction to keep result ordering aligned with the grid's visual row order.

### Note
Trade-off: quick-filter/Find no longer matches on a *hidden* dimension's values while grouped by it (its values are visible as group headers). This is the intended, stable behavior per discussion.

Separately noticed (not addressed here, likely warrants its own issue): ag-Grid's default un-group behavior re-shows a column that was configured `hidden`, and Hoist's `columnState` isn't reconciled — so e.g. `winLose` becomes visible on the grid after a group→ungroup cycle while `GridModel.isColumnVisible()` still reports it hidden.