### PR TITLE
Fix hidden grid columns reappearing after group then ungroup (#4473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### 🐞 Bug Fixes
 
+* Fixed grid columns configured as `hidden` becoming visible after being grouped and then
+  ungrouped. `GridModel` now re-asserts each column's configured visibility whenever `groupBy`
+  changes, keeping AG Grid's column state in sync with `columnState`.
 * Fixed `Select` to correctly handle non-primitive (object) values: selected-option matching and
   async query de-duplication now use deep equality, so object values no longer render as
   `[object Object]` or collide with one another.

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -395,11 +395,7 @@ export class GridLocalModel extends HoistModel {
                 if (!agApi) return;
                 agApi.setRowGroupColumns(groupBy);
 
-                // AG Grid re-shows any column removed from grouping, ignoring its configured
-                // visibility. Re-assert Hoist's column state for non-grouped columns so a `hidden`
-                // column does not reappear after being grouped then ungrouped. Grouped columns are
-                // left to AG Grid, which hides them as data columns while their values show in the
-                // group rows. See #4473.
+                // Re-assert configured visibility - AG Grid re-shows a column when ungrouped (#4473).
                 const state = model.columnState
                     .filter(({colId}) => !groupBy.includes(colId))
                     .map(({colId, hidden}) => ({colId, hide: hidden}));

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -392,7 +392,18 @@ export class GridLocalModel extends HoistModel {
         return {
             track: () => [model.agApi, model.groupBy],
             run: ([agApi, groupBy]) => {
-                if (agApi) agApi.setRowGroupColumns(groupBy);
+                if (!agApi) return;
+                agApi.setRowGroupColumns(groupBy);
+
+                // AG Grid re-shows any column removed from grouping, ignoring its configured
+                // visibility. Re-assert Hoist's column state for non-grouped columns so a `hidden`
+                // column does not reappear after being grouped then ungrouped. Grouped columns are
+                // left to AG Grid, which hides them as data columns while their values show in the
+                // group rows. See #4473.
+                const state = model.columnState
+                    .filter(({colId}) => !groupBy.includes(colId))
+                    .map(({colId, hidden}) => ({colId, hide: hidden}));
+                agApi.applyColumnState({state});
             }
         };
     }


### PR DESCRIPTION
Fixes #4473

### Problem
AG Grid re-shows a column when it is removed from row grouping, ignoring the column's configured visibility. Hoist drives grouping via `setRowGroupColumns` (source `api`) and ignores the resulting `columnVisible` events, so `GridModel.columnState` was never reconciled. Result: a column declared `hidden: true` (e.g. Toolbox's Win/Lose) becomes visible on the grid after being grouped and then ungrouped, and `getVisibleLeafColumns()` disagrees with what's actually displayed.

Reproduced on toolbox-dev (`winLose` is `hidden: true`):

| State | `GridModel.isColumnVisible('winLose')` | ag `column.isVisible()` |
|---|---|---|
| ungrouped | hidden | hidden |
| grouped by Win/Lose | hidden | hidden |
| **after ungroup** | hidden | **visible** ← bug |

### Fix
`groupReaction` now re-asserts each **non-grouped** column's configured visibility from `columnState` after `setRowGroupColumns`. Grouped columns are left to AG Grid, which hides them as data columns while their values show in the group rows.

### Verification (live, against real AG Grid)
- After ungroup, `winLose` is re-hidden — back in sync.
- No regression: a normally-visible column (`city`) grouped then ungrouped stays visible; grouped columns remain hidden as data columns while grouped.

Discovered while investigating #4070 (separate PR #4472).