### PR TITLE
Add per-option testId support to SegmentedControl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * `Select` now accepts a `generateOptionFn` prop to resolve an option for a selected value that is
   not present in the current options list (e.g. with `queryFn`-based selects or readonly forms),
   ensuring such values render with their proper label rather than falling back to the raw value.
+* `SegmentedControl` options (desktop and mobile) now accept a `testId`, emitted on the option's
+  rendered button as `data-testid` for E2E targeting. If an option omits its own `testId` but the
+  control has one, an id is auto-derived as `${controlTestId}-${value}` - restoring parity with
+  the legacy `ButtonGroupInput` test-hook pattern for apps migrating between the two.
 
 ### 🐞 Bug Fixes
 

--- a/cmp/input/SegmentedControlOption.ts
+++ b/cmp/input/SegmentedControlOption.ts
@@ -33,6 +33,13 @@ export interface SegmentedControlOption {
      * `intent` default. Defaults to the control's `intent`.
      */
     intent?: Intent;
+
+    /**
+     * Optional stable identifier emitted on this option's rendered button as `data-testid`, for
+     * use by E2E tests. If omitted and the control itself has a `testId`, one is auto-derived as
+     * `${controlTestId}-${value}`. If neither is set, no attribute is emitted.
+     */
+    testId?: string;
 }
 
 /**
@@ -58,4 +65,11 @@ export interface SegmentedControlNullOption {
      * `intent` default. Defaults to the control's `intent`.
      */
     intent?: Intent;
+
+    /**
+     * Optional stable identifier emitted on this option's rendered button as `data-testid`, for
+     * use by E2E tests. If omitted and the control itself has a `testId`, one is auto-derived as
+     * `${controlTestId}-null`. If neither is set, no attribute is emitted.
+     */
+    testId?: string;
 }

--- a/desktop/cmp/input/SegmentedControl.ts
+++ b/desktop/cmp/input/SegmentedControl.ts
@@ -80,6 +80,7 @@ export const [SegmentedControl, segmentedControl] = hoistCmp.withFactory<Segment
 interface NormalizedOption extends SegmentedControlOption {
     label: string;
     intent?: Intent;
+    testId?: string;
     _key: string;
 }
 
@@ -92,13 +93,14 @@ class SegmentedControlModel extends HoistInputModel {
         return options.map((o: any, idx: number) => {
             const key = String(idx);
             if (isObject(o)) {
-                const {label, value, icon, disabled, intent} = o as SegmentedControlOption;
+                const {label, value, icon, disabled, intent, testId} = o as SegmentedControlOption;
                 return {
                     value: this.toInternal(value),
                     label: label ?? (icon ? '' : String(value)),
                     icon,
                     disabled,
                     intent,
+                    testId,
                     _key: key
                 };
             } else {
@@ -163,13 +165,15 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
     // applied via a per-button className that our SCSS keys its solid/hint coloring off of.
     const defaultIntent = intent && intent !== 'none' ? intent : null,
         bpOptions = model.normalizedOptions.map(opt => {
-            const optIntent = opt.intent ?? defaultIntent;
+            const optIntent = opt.intent ?? defaultIntent,
+                optTestId = opt.testId ?? (testId ? `${testId}-${String(opt.value)}` : null);
             return {
                 value: opt._key,
                 label: opt.label,
                 icon: opt.icon,
                 disabled: opt.disabled,
-                className: optIntent ? `xh-segmented-control-option--${optIntent}` : null
+                className: optIntent ? `xh-segmented-control-option--${optIntent}` : null,
+                ...(optTestId ? {[TEST_ID]: optTestId} : null)
             };
         });
 

--- a/mobile/cmp/input/SegmentedControl.ts
+++ b/mobile/cmp/input/SegmentedControl.ts
@@ -85,6 +85,7 @@ export const [SegmentedControl, segmentedControl] = hoistCmp.withFactory<Segment
 interface NormalizedOption extends SegmentedControlOption {
     label: string;
     intent?: Intent;
+    testId?: string;
     _key: string;
 }
 
@@ -97,13 +98,14 @@ class SegmentedControlModel extends HoistInputModel {
         return options.map((o: any, idx: number) => {
             const key = String(idx);
             if (isObject(o)) {
-                const {label, value, icon, disabled, intent} = o as SegmentedControlOption;
+                const {label, value, icon, disabled, intent, testId} = o as SegmentedControlOption;
                 return {
                     value: this.toInternal(value),
                     label: label ?? (icon ? '' : String(value)),
                     icon,
                     disabled,
                     intent,
+                    testId,
                     _key: key
                 };
             } else {
@@ -168,7 +170,8 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
 
     const buttons = model.normalizedOptions.map(opt => {
         const optIntent = opt.intent ?? defaultIntent,
-            selected = opt._key === selectedKey;
+            selected = opt._key === selectedKey,
+            optTestId = opt.testId ?? (testId ? `${testId}-${String(opt.value)}` : null);
         // Wrap the label so it can truncate with an ellipsis when the segment is too narrow,
         // rather than hard-clipping mid-character. Pass null for icon-only options so the Button
         // renders the icon alone (an empty span would suppress that).
@@ -187,7 +190,8 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
                 selected && 'xh-segmented-control-option--selected',
                 optIntent && `xh-segmented-control-option--${optIntent}`
             ),
-            onClick: () => model.onValueChange(opt._key)
+            onClick: () => model.onValueChange(opt._key),
+            testId: optTestId
         });
     });
 


### PR DESCRIPTION
## Summary

Adds an optional per-option `testId` to `SegmentedControl` (desktop and mobile), emitted on each option's rendered button as `data-testid`. When an option omits its own `testId` but the control has one, an id is auto-derived as `${controlTestId}-${value}`.

Restores parity with `ButtonGroupInput`'s per-option test-hook pattern for apps migrating between the two, so E2E suites don't have to fall back to matching options by label.

## Changes

- `cmp/input/SegmentedControlOption.ts` - adds optional `testId?: string` to both `SegmentedControlOption` and `SegmentedControlNullOption`.
- `desktop/cmp/input/SegmentedControl.ts` - threads `testId` through `normalizedOptions` and emits it on each `bpOption` entry via `[TEST_ID]`. Blueprint's internal `SegmentedControlOption` spreads unknown props onto the underlying `Button`, and `data-*` attrs bypass Blueprint's `removeNonHTMLProps` filter, so the attribute reaches the DOM `<button>`.
- `mobile/cmp/input/SegmentedControl.ts` - same threading, passed to the mobile `button`'s existing `testId` prop.
- `CHANGELOG.md` - single bullet under 87.0.0-SNAPSHOT → New Features.

## Precedence per option

1. Explicit `option.testId` wins.
2. Else, if the control has a `testId`, derive `${controlTestId}-${String(opt.value)}` (matches `ButtonGroupInput`'s legacy `<control>-<value>` shape - value, not label).
3. Else, omit the attribute (preserves current behavior).

`String(opt.value)` is applied to the value after the model's `toInternal` normalization, so it matches the identity path the component already uses. `null` values produce `${controlTestId}-null`; boolean values produce e.g. `${controlTestId}-false`.

## Test plan

- [ ] In toolbox `InputsPanel.ts` (desktop) and `InputsPage.ts` (mobile) `SegmentedControl` demos, add `testId: 'sc-demo'` to a `segmentedControl({...})` call and confirm each rendered button carries `data-testid="sc-demo-<value>"` via DevTools.
- [ ] Add an explicit `testId` on one entry in `scOptions` and confirm it wins over the derived form on that specific button.
- [ ] Remove all `testId` props and confirm no `data-testid` attribute is emitted on the option buttons.
- [ ] Verify desktop container `data-testid` (on the wrapper div) still coexists with per-option ids on the inne
