### PR TITLE
Add exported `HoistRoute` type so route `omit` key type-checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
 
 * Retyped `GridModel.colChooserModel` as the new cross-platform `IColChooserModel` interface,
   replacing the bare `HoistModel` type and exposing `isOpen`, `open()`, and `close()` directly.
+* Added the exported `HoistRoute` type - Router5's `Route` extended with Hoist's `omit` key - and
+  retyped `HoistAppModel.getRoutes()` to return it, so declarative route exclusion (e.g.
+  `omit: !XH.getUser().isHoistAdmin`) now type-checks without a cast.
 
 ### 🤖 AI Docs + Tooling
 

--- a/admin/AppModel.ts
+++ b/admin/AppModel.ts
@@ -7,10 +7,9 @@
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {TabConfig, TabContainerModel} from '@xh/hoist/cmp/tab';
 import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
-import {HoistAppModel, InitContext, XH} from '@xh/hoist/core';
+import {HoistAppModel, HoistRoute, InitContext, XH} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {without} from 'lodash';
-import {Route} from 'router5';
 import {activityTrackingPanel} from './tabs/activity/tracking/ActivityTrackingPanel';
 import {clientsPanel} from './tabs/clients/ClientsPanel';
 import {monitorTab} from './tabs/monitor/MonitorTab';
@@ -49,7 +48,7 @@ export class AppModel extends HoistAppModel {
         await super.initAsync(ctx);
     }
 
-    override getRoutes(): Route[] {
+    override getRoutes(): HoistRoute[] {
         return [
             {
                 name: 'default',
@@ -66,7 +65,7 @@ export class AppModel extends HoistAppModel {
         return [];
     }
 
-    getTabRoutes(): Route[] {
+    getTabRoutes(): HoistRoute[] {
         return [
             {
                 name: 'general',

--- a/appcontainer/RouterModel.ts
+++ b/appcontainer/RouterModel.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistModel} from '../core';
+import {HoistModel, HoistRoute} from '../core';
 import {action, observable, makeObservable} from '@xh/hoist/mobx';
 import {mergeDeep} from '@xh/hoist/utils/js';
 import {isOmitted} from '@xh/hoist/utils/impl';
@@ -38,11 +38,11 @@ export class RouterModel extends HoistModel {
     /**
      * Add routes to the router.
      *
-     * @param routes - collection of router5 route spec.
-     *      This method supports an additional keyword 'omit' on each spec, in order to allow declarative
-     *      exclusion.  Otherwise these are Router5 configs to be passed directly to the Router5 API.
+     * @param routes - collection of {@link HoistRoute} specs. In addition to the standard Router5
+     *      route config, each spec supports an `omit` keyword to allow declarative exclusion.
+     *      Otherwise these are Router5 configs to be passed directly to the Router5 API.
      */
-    addRoutes(routes: object[]) {
+    addRoutes(routes: HoistRoute[]) {
         this.router.add(this.preprocessRoutes(routes));
     }
 
@@ -100,7 +100,7 @@ export class RouterModel extends HoistModel {
         return ret;
     }
 
-    private preprocessRoutes(routes) {
+    private preprocessRoutes(routes: HoistRoute[]): HoistRoute[] {
         const ret = routes.filter(r => !isOmitted(r));
         ret.forEach(r => {
             if (r.children) r.children = this.preprocessRoutes(r.children);

--- a/core/HoistAppModel.ts
+++ b/core/HoistAppModel.ts
@@ -5,8 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {webSocketIndicator} from '@xh/hoist/cmp/websocket';
-import {AppOptionSpec, HoistModel, InitContext, Thunkable} from './';
-import {Route} from 'router5';
+import {AppOptionSpec, HoistModel, HoistRoute, InitContext, Thunkable} from './';
 import {ReactNode} from 'react';
 /**
  * Specialized base class for defining the central model for a Hoist app as specified by its
@@ -52,7 +51,7 @@ export class HoistAppModel extends HoistModel {
     /**
      * Provide the initial set of Router5 Routes to be used by this application.
      */
-    getRoutes(): Route[] {
+    getRoutes(): HoistRoute[] {
         return [];
     }
 

--- a/core/types/Types.ts
+++ b/core/types/Types.ts
@@ -9,6 +9,7 @@ import {LocalDate} from '@xh/hoist/utils/datetime';
 import {MomentInput} from 'moment';
 import {Component, FunctionComponent, ReactElement} from 'react';
 import {DebounceSettings} from 'lodash';
+import {Route} from 'router5';
 
 /** Values available for intents. */
 export type Intent = 'primary' | 'success' | 'warning' | 'danger';
@@ -55,13 +56,21 @@ export type DebounceSpec = number | (DebounceSettings & {interval: number});
  * function that returns a ReactElement. In either case, the function will be called with no arguments.
  */
 export type Content =
-    | ReactElement
-    | FunctionComponent
-    | Component
-    | ElementFactory
-    | (() => ReactElement);
+    ReactElement | FunctionComponent | Component | ElementFactory | (() => ReactElement);
 
 export type DateLike = Date | LocalDate | MomentInput;
+
+/**
+ * A Router5 {@link Route} spec, extended with Hoist's `omit` support for declarative exclusion of
+ * routes at registration time (e.g. role-gated sections). Note `omit` is evaluated once when routes
+ * are added to the router during app startup - it is not reactive.
+ *
+ * @see HoistAppModel.getRoutes
+ */
+export interface HoistRoute extends Omit<Route, 'children'> {
+    omit?: Thunkable<boolean>;
+    children?: HoistRoute[];
+}
 
 /** Valid units for the {@link LocalDate} adjustment methods. */
 export type LocalDateUnit =

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -150,10 +150,12 @@ numeric-only parameters). See the
 ### Conditional Route Exclusion
 
 Routes support an `omit` property (a Hoist extension, not part of Router5) that allows
-declarative exclusion of routes at registration time. This is useful for role-gated sections:
+declarative exclusion of routes at registration time. This is useful for role-gated sections.
+`getRoutes()` returns `HoistRoute[]` - Hoist's `Route` type extended with the optional `omit` key -
+so the property type-checks without any cast:
 
 ```typescript
-override getRoutes() {
+override getRoutes(): HoistRoute[] {
     return [{
         name: 'default',
         path: '/app',


### PR DESCRIPTION
## Summary

`HoistAppModel.getRoutes()` returned router5's `Route[]`, which does not declare the `omit` key that `RouterModel.preprocessRoutes` actually honors at registration time. The documented role-gating pattern (`omit: !XH.getUser().isHoistAdmin`) therefore failed to type-check with `TS2353`.

## Changes

- Added an exported `HoistRoute` type (`core/types/Types.ts`) — router5's `Route` extended with an optional `omit` key. Uses recursive `children` so `omit` type-checks on nested child routes too, not just the top level.
- Retyped `HoistAppModel.getRoutes()`, the admin `AppModel` `getRoutes()`/`getTabRoutes()`, and `RouterModel.addRoutes()`/`preprocessRoutes()` to use `HoistRoute`.
- Updated the routing docs example and added a changelog entry.

`tsc --noEmit` and `lint:code` pass clean.