### PR TITLE
Title admin User Data tab as "User Data & Roles" when roles are enabled

### DIFF
--- a/admin/AppModel.ts
+++ b/admin/AppModel.ts
@@ -7,9 +7,8 @@
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {TabConfig, TabContainerModel} from '@xh/hoist/cmp/tab';
 import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
-import {CallContextLike, HoistAppModel, HoistRoute, InitContext, XH} from '@xh/hoist/core';
+import {HoistAppModel, HoistRoute, InitContext, XH} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
-import {makeObservable, observable, runInAction} from '@xh/hoist/mobx';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {without} from 'lodash';
 import {RoleModuleConfig} from './tabs/userData/roles/Types';
@@ -30,12 +29,8 @@ export class AppModel extends HoistAppModel {
 
     viewManagerModels: Record<string, ViewManagerModel> = {};
 
-    /**
-     * Role-module config, loaded once at init (see {@link loadRoleModuleConfigAsync}) and shared
-     * with the Roles tab so it need not re-query. Null if not yet loaded or the query failed - the
-     * app not running the Hoist role module is reflected by a loaded config with `enabled: false`.
-     */
-    @observable.ref roleModuleConfig: RoleModuleConfig = null;
+    /** Role-module config, loaded once at init and shared with the Roles tab. */
+    roleModuleConfig: RoleModuleConfig = null;
 
     static get readonly() {
         return !XH.getUser().isHoistAdmin;
@@ -43,20 +38,18 @@ export class AppModel extends HoistAppModel {
 
     constructor() {
         super();
-        makeObservable(this);
 
         // Enable managed autosize mode across Hoist Admin console grids.
         GridModel.defaults.autosizeMode = 'managed';
     }
 
     override async initAsync(ctx: InitContext) {
-        // Determine role-module availability up-front so we can title the User Data tab and show
-        // its Roles sub-tab only when the Hoist-provided DefaultRoleService is actually in use.
-        // Swallow errors here so a transient failure doesn't block admin startup.
+        // Load role config up-front to title/show the Roles tab (see createTabs).
+        // But never block, in the unexpected case that config can't load.
         try {
             await this.loadRoleModuleConfigAsync(ctx);
         } catch (e) {
-            XH.handleException(e, {showAlert: false, logOnServer: false});
+            XH.handleException(e, {alertType: 'toast'});
         }
 
         this.tabModel = new TabContainerModel({
@@ -143,7 +136,7 @@ export class AppModel extends HoistAppModel {
 
     createTabs(): TabConfig[] {
         const conf = XH.getConf('xhAdminAppConfig', {}),
-            rolesEnabled = this.roleModuleConfig?.enabled ?? true;
+            rolesEnabled = this.roleModuleConfig?.enabled ?? false;
 
         return [
             {
@@ -232,23 +225,6 @@ export class AppModel extends HoistAppModel {
         return appCodes.find(it => it === 'app') ?? appCodes[0];
     }
 
-    /**
-     * Load the role-module config from the server, caching it on this model as the single source
-     * of truth (the Roles tab reads it from here). The config reports whether role management is
-     * enabled - i.e. the app runs the Hoist-provided `DefaultRoleService` - which drives both the
-     * Roles sub-tab's presence and its mention in the enclosing tab's title.
-     *
-     * Called once at init; the Roles tab invokes it again only if that init load did not complete.
-     * Kept on a tight timeout - this should return near-instantly. Throws on failure; callers
-     * decide whether to surface or swallow (init swallows, the Roles tab lets its loader report).
-     */
-    async loadRoleModuleConfigAsync(ctx?: CallContextLike) {
-        const config = await this.runner(ctx)
-            .span('loadRoleModuleConfig')
-            .fetchJson({url: 'roleAdmin/config', timeout: 10 * SECONDS});
-        runInAction(() => (this.roleModuleConfig = config));
-    }
-
     async initViewManagerModelsAsync(ctx: InitContext) {
         this.viewManagerModels.activityTracking = await ViewManagerModel.createAsync(
             {
@@ -258,5 +234,14 @@ export class AppModel extends HoistAppModel {
             },
             ctx
         );
+    }
+
+    //----------------
+    // Implementation
+    //----------------
+    private async loadRoleModuleConfigAsync(ctx: InitContext) {
+        this.roleModuleConfig = await this.runner(ctx)
+            .span('loadRoleModuleConfig')
+            .fetchJson({url: 'roleAdmin/config', timeout: 10 * SECONDS});
     }
 }

--- a/admin/AppModel.ts
+++ b/admin/AppModel.ts
@@ -7,9 +7,12 @@
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {TabConfig, TabContainerModel} from '@xh/hoist/cmp/tab';
 import {ViewManagerModel} from '@xh/hoist/cmp/viewmanager';
-import {HoistAppModel, HoistRoute, InitContext, XH} from '@xh/hoist/core';
+import {CallContextLike, HoistAppModel, HoistRoute, InitContext, XH} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
+import {makeObservable, observable, runInAction} from '@xh/hoist/mobx';
+import {SECONDS} from '@xh/hoist/utils/datetime';
 import {without} from 'lodash';
+import {RoleModuleConfig} from './tabs/userData/roles/Types';
 import {activityTrackingPanel} from './tabs/activity/tracking/ActivityTrackingPanel';
 import {clientsPanel} from './tabs/clients/ClientsPanel';
 import {monitorTab} from './tabs/monitor/MonitorTab';
@@ -27,23 +30,40 @@ export class AppModel extends HoistAppModel {
 
     viewManagerModels: Record<string, ViewManagerModel> = {};
 
+    /**
+     * Role-module config, loaded once at init (see {@link loadRoleModuleConfigAsync}) and shared
+     * with the Roles tab so it need not re-query. Null if not yet loaded or the query failed - the
+     * app not running the Hoist role module is reflected by a loaded config with `enabled: false`.
+     */
+    @observable.ref roleModuleConfig: RoleModuleConfig = null;
+
     static get readonly() {
         return !XH.getUser().isHoistAdmin;
     }
 
     constructor() {
         super();
-
-        this.tabModel = new TabContainerModel({
-            route: 'default',
-            tabs: this.createTabs()
-        });
+        makeObservable(this);
 
         // Enable managed autosize mode across Hoist Admin console grids.
         GridModel.defaults.autosizeMode = 'managed';
     }
 
     override async initAsync(ctx: InitContext) {
+        // Determine role-module availability up-front so we can title the User Data tab and show
+        // its Roles sub-tab only when the Hoist-provided DefaultRoleService is actually in use.
+        // Swallow errors here so a transient failure doesn't block admin startup.
+        try {
+            await this.loadRoleModuleConfigAsync(ctx);
+        } catch (e) {
+            XH.handleException(e, {showAlert: false, logOnServer: false});
+        }
+
+        this.tabModel = new TabContainerModel({
+            route: 'default',
+            tabs: this.createTabs()
+        });
+
         await this.initViewManagerModelsAsync(ctx);
         await super.initAsync(ctx);
     }
@@ -122,7 +142,8 @@ export class AppModel extends HoistAppModel {
     }
 
     createTabs(): TabConfig[] {
-        const conf = XH.getConf('xhAdminAppConfig', {});
+        const conf = XH.getConf('xhAdminAppConfig', {}),
+            rolesEnabled = this.roleModuleConfig?.enabled ?? true;
 
         return [
             {
@@ -159,6 +180,7 @@ export class AppModel extends HoistAppModel {
             },
             {
                 id: 'userData',
+                title: rolesEnabled ? 'User Data & Roles' : 'User Data',
                 icon: Icon.users(),
                 content: {
                     refreshMode: 'onShowAlways',
@@ -172,7 +194,8 @@ export class AppModel extends HoistAppModel {
                         {
                             id: 'roles',
                             icon: Icon.idBadge(),
-                            content: rolePanel
+                            content: rolePanel,
+                            omit: !rolesEnabled
                         },
                         {
                             id: 'prefs',
@@ -207,6 +230,23 @@ export class AppModel extends HoistAppModel {
     getPrimaryAppCode() {
         const appCodes = without(XH.clientApps, XH.clientAppCode, 'mobile');
         return appCodes.find(it => it === 'app') ?? appCodes[0];
+    }
+
+    /**
+     * Load the role-module config from the server, caching it on this model as the single source
+     * of truth (the Roles tab reads it from here). The config reports whether role management is
+     * enabled - i.e. the app runs the Hoist-provided `DefaultRoleService` - which drives both the
+     * Roles sub-tab's presence and its mention in the enclosing tab's title.
+     *
+     * Called once at init; the Roles tab invokes it again only if that init load did not complete.
+     * Kept on a tight timeout - this should return near-instantly. Throws on failure; callers
+     * decide whether to surface or swallow (init swallows, the Roles tab lets its loader report).
+     */
+    async loadRoleModuleConfigAsync(ctx?: CallContextLike) {
+        const config = await this.runner(ctx)
+            .span('loadRoleModuleConfig')
+            .fetchJson({url: 'roleAdmin/config', timeout: 10 * SECONDS});
+        runInAction(() => (this.roleModuleConfig = config));
     }
 
     async initViewManagerModelsAsync(ctx: InitContext) {

--- a/admin/AppModel.ts
+++ b/admin/AppModel.ts
@@ -44,13 +44,7 @@ export class AppModel extends HoistAppModel {
     }
 
     override async initAsync(ctx: InitContext) {
-        // Load role config up-front to title/show the Roles tab (see createTabs).
-        // But never block, in the unexpected case that config can't load.
-        try {
-            await this.loadRoleModuleConfigAsync(ctx);
-        } catch (e) {
-            XH.handleException(e, {alertType: 'toast'});
-        }
+        await this.loadRoleModuleConfigAsync(ctx);
 
         this.tabModel = new TabContainerModel({
             route: 'default',
@@ -240,8 +234,17 @@ export class AppModel extends HoistAppModel {
     // Implementation
     //----------------
     private async loadRoleModuleConfigAsync(ctx: InitContext) {
-        this.roleModuleConfig = await this.runner(ctx)
-            .span('loadRoleModuleConfig')
-            .fetchJson({url: 'roleAdmin/config', timeout: 10 * SECONDS});
+        // Load role config up-front to title/show the Roles tab (see createTabs).
+        // Never block startup if it can't load - the tab defaults to hidden.
+        try {
+            this.roleModuleConfig = await this.runner(ctx)
+                .span('loadRoleModuleConfig')
+                .fetchJson({url: 'roleAdmin/config', timeout: 10 * SECONDS});
+        } catch (e) {
+            XH.handleException(e, {
+                message: 'Unable to load roles configuration',
+                alertType: 'toast'
+            });
+        }
     }
 }

--- a/admin/tabs/userData/roles/RoleModel.ts
+++ b/admin/tabs/userData/roles/RoleModel.ts
@@ -4,6 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
+import {getAppModel} from '@xh/hoist/admin/AdminUtils';
 import {RecategorizeDialogModel} from '@xh/hoist/admin/tabs/userData/roles/recategorize/RecategorizeDialogModel';
 import {FilterChooserModel} from '@xh/hoist/cmp/filter';
 import {GridModel, tagsRenderer, TreeStyle} from '@xh/hoist/cmp/grid';
@@ -33,15 +34,21 @@ export class RoleModel extends HoistModel {
 
     override persistWith = RoleModel.PERSIST_WITH;
 
-    @managed gridModel: GridModel;
+    // Observable as it is created lazily post-load (once the module config is known) and gates
+    // panel rendering - see RolePanel and ensureInitializedAsync.
+    @managed @observable.ref gridModel: GridModel;
     @managed filterChooserModel: FilterChooserModel;
     @managed readonly roleEditorModel = new RoleEditorModel(this);
     @managed recategorizeDialogModel = new RecategorizeDialogModel(this);
 
     @observable.ref allRoles: HoistRole[] = [];
-    @observable.ref moduleConfig: RoleModuleConfig;
 
     @bindable showInGroups = true;
+
+    /** Role-module config - sourced from AppModel, our single load point (see RoleModel docs). */
+    get moduleConfig(): RoleModuleConfig {
+        return getAppModel().roleModuleConfig;
+    }
 
     get readonly() {
         return !XH.getUser().isHoistRoleManager;
@@ -234,16 +241,22 @@ export class RoleModel extends HoistModel {
     }
 
     private async ensureInitializedAsync(ctx: CallContext) {
-        if (this.moduleConfig) return;
+        if (this.gridModel) return;
 
-        const config = await this.runner(ctx).fetchJson({url: 'roleAdmin/config'});
-        runInAction(() => {
-            this.moduleConfig = config;
-            if (config.enabled) {
+        // Config is normally loaded by AppModel at init; ask it to (re)load only if that did not
+        // complete, keeping AppModel the single load point. Lets any failure surface via our
+        // doLoadAsync catch below, as before.
+        const appModel = getAppModel();
+        if (!appModel.roleModuleConfig) {
+            await appModel.loadRoleModuleConfigAsync(ctx);
+        }
+
+        if (this.moduleConfig.enabled) {
+            runInAction(() => {
                 this.gridModel = this.createGridModel();
                 this.filterChooserModel = this.createFilterChooserModel();
-            }
-        });
+            });
+        }
     }
 
     private processRolesFromServer(roles: Partial<HoistRole>[]): HoistRole[] {

--- a/admin/tabs/userData/roles/RoleModel.ts
+++ b/admin/tabs/userData/roles/RoleModel.ts
@@ -10,7 +10,7 @@ import {FilterChooserModel} from '@xh/hoist/cmp/filter';
 import {GridModel, tagsRenderer, TreeStyle} from '@xh/hoist/cmp/grid';
 import * as Col from '@xh/hoist/cmp/grid/columns';
 import {fragment, p} from '@xh/hoist/cmp/layout';
-import {CallContext, HoistModel, LoadSpec, managed, XH} from '@xh/hoist/core';
+import {HoistModel, LoadSpec, managed, XH} from '@xh/hoist/core';
 import {RecordActionSpec} from '@xh/hoist/data';
 import {actionCol, calcActionColWidth} from '@xh/hoist/desktop/cmp/grid';
 import {Icon} from '@xh/hoist/icon';
@@ -34,9 +34,7 @@ export class RoleModel extends HoistModel {
 
     override persistWith = RoleModel.PERSIST_WITH;
 
-    // Observable as it is created lazily post-load (once the module config is known) and gates
-    // panel rendering - see RolePanel and ensureInitializedAsync.
-    @managed @observable.ref gridModel: GridModel;
+    @managed gridModel: GridModel;
     @managed filterChooserModel: FilterChooserModel;
     @managed readonly roleEditorModel = new RoleEditorModel(this);
     @managed recategorizeDialogModel = new RecategorizeDialogModel(this);
@@ -45,7 +43,7 @@ export class RoleModel extends HoistModel {
 
     @bindable showInGroups = true;
 
-    /** Role-module config - sourced from AppModel, our single load point (see ensureInitializedAsync). */
+    /** Role-module config - loaded at init. */
     get moduleConfig(): RoleModuleConfig {
         return getAppModel().roleModuleConfig;
     }
@@ -63,6 +61,10 @@ export class RoleModel extends HoistModel {
     constructor() {
         super();
         makeObservable(this);
+
+        this.gridModel = this.createGridModel();
+        this.filterChooserModel = this.createFilterChooserModel();
+
         this.addReaction({
             track: () => this.showInGroups,
             run: showInGroups => {
@@ -81,9 +83,6 @@ export class RoleModel extends HoistModel {
         return this.runner({loadSpec})
             .span('list')
             .run(async ctx => {
-                await this.ensureInitializedAsync(ctx);
-                if (!this.moduleConfig.enabled) return;
-
                 const {data} = await XH.fetchJson({url: 'roleAdmin/list'}, ctx);
                 if (loadSpec.isStale) return;
 
@@ -238,25 +237,6 @@ export class RoleModel extends HoistModel {
         gridModel.loadData(gridData);
         if (!isRefresh) gridModel.expandAll();
         gridModel.autosizeAsync({includeCollapsedChildren: true});
-    }
-
-    private async ensureInitializedAsync(ctx: CallContext) {
-        if (this.gridModel) return;
-
-        // Config is normally loaded by AppModel at init; ask it to (re)load only if that did not
-        // complete, keeping AppModel the single load point. Lets any failure surface via our
-        // doLoadAsync catch below, as before.
-        const appModel = getAppModel();
-        if (!appModel.roleModuleConfig) {
-            await appModel.loadRoleModuleConfigAsync(ctx);
-        }
-
-        if (this.moduleConfig.enabled) {
-            runInAction(() => {
-                this.gridModel = this.createGridModel();
-                this.filterChooserModel = this.createFilterChooserModel();
-            });
-        }
     }
 
     private processRolesFromServer(roles: Partial<HoistRole>[]): HoistRole[] {

--- a/admin/tabs/userData/roles/RoleModel.ts
+++ b/admin/tabs/userData/roles/RoleModel.ts
@@ -45,7 +45,7 @@ export class RoleModel extends HoistModel {
 
     @bindable showInGroups = true;
 
-    /** Role-module config - sourced from AppModel, our single load point (see RoleModel docs). */
+    /** Role-module config - sourced from AppModel, our single load point (see ensureInitializedAsync). */
     get moduleConfig(): RoleModuleConfig {
         return getAppModel().roleModuleConfig;
     }

--- a/admin/tabs/userData/roles/RolePanel.ts
+++ b/admin/tabs/userData/roles/RolePanel.ts
@@ -9,7 +9,6 @@ import {grid} from '@xh/hoist/cmp/grid';
 import {fragment, hframe, vframe} from '@xh/hoist/cmp/layout';
 import {creates, hoistCmp} from '@xh/hoist/core';
 import {button, colChooserButton} from '@xh/hoist/desktop/cmp/button';
-import {errorMessage} from '@xh/hoist/cmp/error';
 import {filterChooser} from '@xh/hoist/desktop/cmp/filter';
 import {switchInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
@@ -25,13 +24,7 @@ export const rolePanel = hoistCmp.factory({
     model: creates(RoleModel),
 
     render({className, model}) {
-        const {moduleConfig, gridModel, readonly} = model;
-        if (!moduleConfig) return null;
-        if (!moduleConfig.enabled) {
-            return errorMessage({error: 'Default Role Module not enabled.'});
-        }
-        // Config is known and enabled, but the grid is built lazily just after - wait for it.
-        if (!gridModel) return null;
+        const {gridModel, readonly} = model;
         return fragment(
             panel({
                 className,

--- a/admin/tabs/userData/roles/RolePanel.ts
+++ b/admin/tabs/userData/roles/RolePanel.ts
@@ -25,13 +25,13 @@ export const rolePanel = hoistCmp.factory({
     model: creates(RoleModel),
 
     render({className, model}) {
-        const {moduleConfig} = model;
+        const {moduleConfig, gridModel, readonly} = model;
         if (!moduleConfig) return null;
         if (!moduleConfig.enabled) {
             return errorMessage({error: 'Default Role Module not enabled.'});
         }
-
-        const {gridModel, readonly} = model;
+        // Config is known and enabled, but the grid is built lazily just after - wait for it.
+        if (!gridModel) return null;
         return fragment(
             panel({
                 className,


### PR DESCRIPTION
The admin console's **User Data** tab hosts the Roles editor, but its title gave no hint of that — creating recurring friction around where roles are managed.

### Changes

- Title the tab **"User Data & Roles"** and show its **Roles** sub-tab only when the app runs the Hoist-provided `DefaultRoleService` (i.e. role management is enabled). When disabled, the title stays **"User Data"** and the previously-dead Roles sub-tab — which only rendered a *"Default Role Module not enabled"* message — is omitted entirely.
- Determine this via a single `roleAdmin/config` query, loaded once at admin init by `AppModel` and cached on a new `AppModel.roleModuleConfig` property (10s timeout, swallowed on failure so a transient error defaults the tab to showing Roles rather than hiding it).
- `RoleModel` now reads the config from `AppModel` (single load point) instead of fetching its own copy, asking `AppModel` to reload only if the init load didn't complete. `RolePanel` gates on `gridModel` for the brief post-load window where the config is known but the grid is still being built.

Route and in-code ids are unchanged.