### PR TITLE
Distinguish explicitly-set preferences from defaults; real unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
 
 * `PrefService.unset()` now performs a true server-side unset, clearing the user's stored value so
   the preference reverts to its (possibly changing) default and `isSet()` reports `false`.
-  Previously it persisted the current default as an explicit user value. Requires a hoist-core
-  version providing the `xh/unsetPrefs` endpoint.
+  Previously it persisted the current default as an explicit user value. Falls back to the legacy
+  behavior against hoist-core versions that predate the `xh/unsetPrefs` endpoint.
 
 ## 86.3.0 - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## 87.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* Added `PrefService.isSet()` to report whether the current user has an explicit value on file for a
+  preference vs. receiving its server-side default - a distinction that cannot be reliably inferred
+  by comparing the value to the default. Requires a hoist-core version that emits the backing
+  `isSet` flag; against older servers all prefs report as unset.
+
+### 🐞 Bug Fixes
+
+* `PrefService.unset()` now performs a true server-side unset, clearing the user's stored value so
+  the preference reverts to its (possibly changing) default and `isSet()` reports `false`.
+  Previously it persisted the current default as an explicit user value. Requires a hoist-core
+  version providing the `xh/unsetPrefs` endpoint.
+
 ## 86.3.0 - 2026-07-10
 
 ### 🎁 New Features

--- a/svc/PrefService.ts
+++ b/svc/PrefService.ts
@@ -31,8 +31,9 @@ export class PrefService extends HoistService {
 
     static instance: PrefService;
 
-    private _data = {};
-    private _updates = {};
+    private _data: Record<string, PrefEntry> = {};
+    private _updates: Record<string, any> = {};
+    private _unsets = new Set<string>();
 
     override async initAsync(ctx: InitContext) {
         // Flush on page teardown while the page is still alive.
@@ -50,6 +51,25 @@ export class PrefService extends HoistService {
      */
     hasKey(key: string): boolean {
         return this._data.hasOwnProperty(key);
+    }
+
+    /**
+     * Check whether the current user has an explicit value on file for the given preference, vs.
+     * receiving the preference's server-side default value.
+     *
+     * Note this is distinct from comparing the current value to the default - a user can explicitly
+     * set a value that happens to equal the default (still "set"), and defaults can change over
+     * time. This flag reflects the authoritative server state: whether a `UserPreference` record
+     * exists for this user + key.
+     *
+     * @param key - unique key used to identify the pref.
+     */
+    isSet(key: string): boolean {
+        const pref = this._data[key];
+        throwIf(!pref, `Preference key not found: '${key}'`);
+        // Coerce to boolean - `isSet` is absent when running against a hoist-core version that
+        // predates server support for this flag, in which case treat prefs as unset.
+        return !!pref.isSet;
     }
 
     /**
@@ -91,19 +111,35 @@ export class PrefService extends HoistService {
 
         // Change local value to sanitized copy and fire.
         value = deepFreeze(cloneDeep(value));
-        this._data[key].value = value;
+        const pref = this._data[key];
+        pref.value = value;
+        pref.isSet = true;
 
-        // Schedule serialization to storage
+        // Schedule serialization to storage, superseding any pending unset for this key.
         this._updates[key] = value;
+        this._unsets.delete(key);
         this.pushPendingBuffered();
     }
 
     /**
-     * Restore a preference to its default value.
+     * Restore a preference to its default value, clearing the user's explicit value on the server.
+     *
+     * Unlike `set()`, this fully removes the user's value (deleting the backing `UserPreference`
+     * record) rather than persisting the default as an explicit value - so {@link isSet} will
+     * report `false` afterwards. Change is saved to the server asynchronously (see `set()`).
      */
     unset(key: string) {
-        // TODO: round-trip this to the server as a proper unset?
-        this.set(key, this._data[key]?.defaultValue);
+        const pref = this._data[key];
+        throwIf(!pref, `Cannot unset preference ${key}: not found`);
+        if (!pref.isSet) return;
+
+        pref.value = pref.defaultValue;
+        pref.isSet = false;
+
+        // Schedule a real server-side unset, superseding any pending update for this key.
+        this._unsets.add(key);
+        delete this._updates[key];
+        this.pushPendingBuffered();
     }
 
     /**
@@ -125,24 +161,37 @@ export class PrefService extends HoistService {
      * and when page is hidden/terminated.
      */
     async pushPendingAsync() {
-        const updates = this._updates;
-        if (isEmpty(updates)) return;
+        const updates = this._updates,
+            unsets = Array.from(this._unsets);
+        if (isEmpty(updates) && isEmpty(unsets)) return;
 
         // Clear synchronously with the capture, so overlapping flushes cannot post twice.
         this._updates = {};
+        this._unsets = new Set();
 
         await this.runner()
             .span('set')
-            .run(ctx =>
-                terminationSafePostJson(
-                    {
-                        url: 'xh/setPrefs',
-                        body: updates,
-                        params: {clientUsername: XH.getUsername()}
-                    },
-                    ctx
-                )
-            );
+            .run(async ctx => {
+                const clientUsername = XH.getUsername(),
+                    tasks = [];
+                if (!isEmpty(updates)) {
+                    tasks.push(
+                        terminationSafePostJson(
+                            {url: 'xh/setPrefs', body: updates, params: {clientUsername}},
+                            ctx
+                        )
+                    );
+                }
+                if (!isEmpty(unsets)) {
+                    tasks.push(
+                        terminationSafePostJson(
+                            {url: 'xh/unsetPrefs', body: unsets, params: {clientUsername}},
+                            ctx
+                        )
+                    );
+                }
+                await Promise.all(tasks);
+            });
     }
 
     //-------------------
@@ -200,4 +249,12 @@ export class PrefService extends HoistService {
                 return false;
         }
     }
+}
+
+interface PrefEntry {
+    type: string;
+    value: any;
+    defaultValue: any;
+    /** True if the user has an explicit value on file, vs. the server-side default. */
+    isSet: boolean;
 }

--- a/svc/PrefService.ts
+++ b/svc/PrefService.ts
@@ -30,10 +30,8 @@ export class PrefService extends HoistService {
     override telemetryPrefix = 'xh.client.prefs';
 
     static instance: PrefService;
-
     private _data: Record<string, PrefEntry> = {};
-    private _updates: Record<string, any> = {};
-    private _unsets = new Set<string>();
+    private _updates: Record<string, any> = {}; // undefined indicates unset
 
     override async initAsync(ctx: InitContext) {
         // Flush on page teardown while the page is still alive.
@@ -57,19 +55,11 @@ export class PrefService extends HoistService {
      * Check whether the current user has an explicit value on file for the given preference, vs.
      * receiving the preference's server-side default value.
      *
-     * Note this is distinct from comparing the current value to the default - a user can explicitly
-     * set a value that happens to equal the default (still "set"), and defaults can change over
-     * time. This flag reflects the authoritative server state: whether a `UserPreference` record
-     * exists for this user + key.
-     *
      * @param key - unique key used to identify the pref.
      */
     isSet(key: string): boolean {
-        const pref = this._data[key];
-        throwIf(!pref, `Preference key not found: '${key}'`);
-        // Coerce to boolean - `isSet` is absent when running against a hoist-core version that
-        // predates server support for this flag, in which case treat prefs as unset.
-        return !!pref.isSet;
+        this.ensureKeyExists(key);
+        return !!this._data[key].isSet;
     }
 
     /**
@@ -115,30 +105,27 @@ export class PrefService extends HoistService {
         pref.value = value;
         pref.isSet = true;
 
-        // Schedule serialization to storage, superseding any pending unset for this key.
+        // Schedule serialization to storage
         this._updates[key] = value;
-        this._unsets.delete(key);
         this.pushPendingBuffered();
     }
 
     /**
      * Restore a preference to its default value, clearing the user's explicit value on the server.
      *
-     * Unlike `set()`, this fully removes the user's value (deleting the backing `UserPreference`
-     * record) rather than persisting the default as an explicit value - so {@link isSet} will
-     * report `false` afterwards. Change is saved to the server asynchronously (see `set()`).
+     * Unlike `set()`, this clears the user's explicit value rather than persisting the default as
+     * one - so {@link isSet} will report `false` afterwards. Saved asynchronously (see `set()`).
      */
     unset(key: string) {
+        this.ensureKeyExists(key);
         const pref = this._data[key];
-        throwIf(!pref, `Cannot unset preference ${key}: not found`);
-        if (!pref.isSet) return;
+        if (!pref.isSet && isEqual(pref.value, pref.defaultValue)) return;
 
         pref.value = pref.defaultValue;
         pref.isSet = false;
 
-        // Schedule a real server-side unset, superseding any pending update for this key.
-        this._unsets.add(key);
-        delete this._updates[key];
+        // Schedule serialization to storage
+        this._updates[key] = undefined;
         this.pushPendingBuffered();
     }
 
@@ -161,31 +148,44 @@ export class PrefService extends HoistService {
      * and when page is hidden/terminated.
      */
     async pushPendingAsync() {
-        const updates = this._updates,
-            unsets = Array.from(this._unsets);
-        if (isEmpty(updates) && isEmpty(unsets)) return;
+        const updates = this._updates;
+        if (isEmpty(updates)) return;
 
         // Clear synchronously with the capture, so overlapping flushes cannot post twice.
         this._updates = {};
-        this._unsets = new Set();
+
+        // Partition into value updates and unsets.
+        // On a core that predates unset support, fall back to persisting default
+        const setPrefs = {},
+            unsetKeys = [];
+        forEach(updates, (value, key) => {
+            const pref = this._data[key];
+            if (value !== undefined) {
+                setPrefs[key] = value;
+            } else if (pref.hasOwnProperty('isSet')) {
+                unsetKeys.push(key);
+            } else {
+                setPrefs[key] = pref.defaultValue;
+            }
+        });
 
         await this.runner()
-            .span('set')
+            .span('update')
             .run(async ctx => {
                 const clientUsername = XH.getUsername(),
                     tasks = [];
-                if (!isEmpty(updates)) {
+                if (!isEmpty(setPrefs)) {
                     tasks.push(
                         terminationSafePostJson(
-                            {url: 'xh/setPrefs', body: updates, params: {clientUsername}},
+                            {url: 'xh/setPrefs', body: setPrefs, params: {clientUsername}},
                             ctx
                         )
                     );
                 }
-                if (!isEmpty(unsets)) {
+                if (!isEmpty(unsetKeys)) {
                     tasks.push(
                         terminationSafePostJson(
-                            {url: 'xh/unsetPrefs', body: unsets, params: {clientUsername}},
+                            {url: 'xh/unsetPrefs', body: unsetKeys, params: {clientUsername}},
                             ctx
                         )
                     );
@@ -221,9 +221,13 @@ export class PrefService extends HoistService {
             });
     }
 
-    private validateBeforeSet(key, value) {
+    private ensureKeyExists(key: string) {
+        throwIf(!this.hasKey(key), `Preference key not found: '${key}'`);
+    }
+
+    private validateBeforeSet(key: string, value: any) {
+        this.ensureKeyExists(key);
         const pref = this._data[key];
-        throwIf(!pref, `Cannot set preference ${key}: not found`);
         throwIf(value === undefined, `Cannot set preference ${key}: value not defined`);
         throwIf(
             !this.valueIsOfType(value, pref.type),
@@ -255,6 +259,5 @@ interface PrefEntry {
     type: string;
     value: any;
     defaultValue: any;
-    /** True if the user has an explicit value on file, vs. the server-side default. */
     isSet: boolean;
 }

--- a/svc/README.md
+++ b/svc/README.md
@@ -186,6 +186,12 @@ XH.setPref('gridPageSize', 100);
 
 // Immediate save - no alias, access service directly
 await XH.prefService.pushAsync('criticalPref', value);
+
+// Distinguish an explicit user value from the server-side default
+if (XH.prefService.isSet('gridPageSize')) { /* user has customized this */ }
+
+// Clear the user's value, reverting to the default (real server-side unset)
+XH.prefService.unset('gridPageSize');
 ```
 
 Preferences are type-validated against server-defined types: `string`, `int`, `long`, `double`,


### PR DESCRIPTION
Lets client code reliably determine whether the current user has **explicitly set** a preference vs. receiving its **server-side default** - a distinction that cannot be inferred by comparing the value to the default (a user can explicitly set a value equal to the default, and defaults can change over time).

### Changes
- Added `PrefService.isSet(key)`, reading a new `isSet` flag from the pref payload. Returns a guaranteed boolean (reports `false` against a server that predates the flag).
- Fixed `PrefService.unset()` to perform a true server-side unset via the new `xh/unsetPrefs` endpoint - clearing the user's stored value so the pref reverts to its (possibly changing) default and `isSet()` reports `false`. Previously it persisted the current default *as* an explicit user value (with a standing TODO to fix). Local state updates synchronously; the server round-trip is buffered/debounced like `set()`.

### Compatibility
Both new APIs degrade gracefully via feature-detection (presence of the `isSet` flag in the pref payload), so no `MIN_HOIST_CORE_VERSION` bump is required:
- `isSet()` reports `false` against a core that predates the flag.
- `unset()` falls back to the legacy behavior (persisting the default as an explicit value) against a core that lacks the `xh/unsetPrefs` endpoint.

Paired server PR: xh/hoist-core#573