### PR TITLE
Cube: build ViewRowData row objects via per-View codegen'd assigner - ~5-6x smaller rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   (defaults included) on the optimized path - apps relying on `Object.keys(record.data)` or
   spread/`JSON.stringify` of `data` returning only non-default fields should use
   `record.getModifiedValues()` or `record.getValues()` as appropriate instead.
+* Applied the same optimization to Cube `View` row data - `ViewRowData` objects (leaf and
+  aggregate rows) are now populated via a per-View compiled assigner, measured ~5-6x smaller at
+  typical view widths (more than ~20 fields), with faster row generation and aggregation reads.
+  Views with very many fields and strict-CSP environments continue to use the prior route.
 
 ### ⚙️ Technical
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped Popper.js

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -21,6 +21,7 @@ import {
     StoreRecord,
     StoreRecordId
 } from '@xh/hoist/data';
+import {RecordDataAssigner, RecordDataFactory} from '@xh/hoist/data/impl/RecordDataFactory';
 import {ViewRowData} from '@xh/hoist/data/cube/ViewRowData';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {shallowEqualArrays} from '@xh/hoist/utils/impl';
@@ -131,6 +132,9 @@ export class View
     private _bucketDependentFields = new Set<string>();
     _aggContext: AggregationContext = null;
     _rowCache: Map<string, BaseRow> = null;
+    // Compiled per-query assigner keeping ViewRowData objects in V8 fast-properties mode, or
+    // null to use legacy keyed-assignment loops - see RecordDataFactory.createAssigner.
+    _rowDataAssigner: RecordDataAssigner = null;
 
     /** @internal - applications should use {@link Cube.createView} */
     constructor(config: ViewConfig) {
@@ -140,6 +144,7 @@ export class View
         const {query, stores = [], connect = false} = config;
 
         this.query = query;
+        this._rowDataAssigner = this.createRowDataAssigner();
         this.stores = this.parseStores(stores);
         this._rowCache = new Map();
         this.fullUpdate();
@@ -201,6 +206,7 @@ export class View
         if (oldQuery.equals(newQuery)) return;
 
         this.query = newQuery;
+        this._rowDataAssigner = this.createRowDataAssigner();
 
         // If the cube is changing then we need to clear the row cache, and potentially disconnect
         // from the old cube and connect to the new one
@@ -516,6 +522,10 @@ export class View
         }
 
         return false;
+    }
+
+    private createRowDataAssigner(): RecordDataAssigner {
+        return RecordDataFactory.createAssigner(this.query.fields.map(it => it.name));
     }
 
     private cachedRow<T extends BaseRow>(id: string, children: BaseRow[], fn: () => T): T {

--- a/data/cube/row/BaseRow.ts
+++ b/data/cube/row/BaseRow.ts
@@ -142,28 +142,60 @@ export abstract class BaseRow {
         this.children = children;
         children.forEach(it => (it.parent = this));
 
-        view.fields.forEach(({name}) => (data[name] = null));
-        Object.assign(data, appliedDimensions);
-
-        this.canAggregate = reduce(
-            view.fields,
-            (ret, field) => {
-                const {name} = field;
+        // Install field values (and the parallel canAggregate flags) via compiled assigner when
+        // available, keeping these objects in V8 fast-properties mode - see
+        // RecordDataFactory.createAssigner.
+        const {_rowDataAssigner} = view;
+        if (_rowDataAssigner) {
+            const {fields} = view,
+                ctx = view._aggContext,
+                len = fields.length,
+                dataVals = new Array(len),
+                canAggVals = new Array(len);
+            for (let i = 0; i < len; i++) {
+                const field = fields[i],
+                    {name} = field;
                 if (appliedDimensions.hasOwnProperty(name)) {
-                    ret[name] = false;
+                    dataVals[i] = appliedDimensions[name];
+                    canAggVals[i] = false;
                 } else {
-                    const {aggregator, canAggregateFn} = field,
-                        ctx = view._aggContext;
-
-                    ret[name] =
+                    const {aggregator, canAggregateFn} = field;
+                    dataVals[i] = null;
+                    canAggVals[i] = !!(
                         aggregator &&
                         (!canAggregateFn ||
-                            canAggregateFn(dimOrBucketName, val, appliedDimensions, ctx));
+                            canAggregateFn(dimOrBucketName, val, appliedDimensions, ctx))
+                    );
                 }
-                return ret;
-            },
-            {}
-        );
+            }
+            _rowDataAssigner(data, dataVals);
+            const canAggregate = {};
+            _rowDataAssigner(canAggregate, canAggVals);
+            this.canAggregate = canAggregate;
+        } else {
+            view.fields.forEach(({name}) => (data[name] = null));
+            Object.assign(data, appliedDimensions);
+
+            this.canAggregate = reduce(
+                view.fields,
+                (ret, field) => {
+                    const {name} = field;
+                    if (appliedDimensions.hasOwnProperty(name)) {
+                        ret[name] = false;
+                    } else {
+                        const {aggregator, canAggregateFn} = field,
+                            ctx = view._aggContext;
+
+                        ret[name] =
+                            aggregator &&
+                            (!canAggregateFn ||
+                                canAggregateFn(dimOrBucketName, val, appliedDimensions, ctx));
+                    }
+                    return ret;
+                },
+                {}
+            );
+        }
 
         this.computeAggregates();
     }

--- a/data/cube/row/LeafRow.ts
+++ b/data/cube/row/LeafRow.ts
@@ -38,9 +38,23 @@ export class LeafRow extends BaseRow {
         this.data.cubeLabel = rawRecord.id.toString();
         this.data.cubeDimension = null;
 
-        view.fields.forEach(({name}) => {
-            this.data[name] = rawRecord.data[name];
-        });
+        // Install field values via compiled assigner when available, keeping this data object in
+        // V8 fast-properties mode - see RecordDataFactory.createAssigner.
+        const {_rowDataAssigner} = view;
+        if (_rowDataAssigner) {
+            const {fields} = view,
+                len = fields.length,
+                vals = new Array(len),
+                recData = rawRecord.data;
+            for (let i = 0; i < len; i++) {
+                vals[i] = recData[fields[i].name];
+            }
+            _rowDataAssigner(this.data, vals);
+        } else {
+            view.fields.forEach(({name}) => {
+                this.data[name] = rawRecord.data[name];
+            });
+        }
     }
 
     applyLeafDataUpdate(newRec: StoreRecord, updatedRowDatas: Set<PlainObject>) {

--- a/data/impl/RecordDataFactory.ts
+++ b/data/impl/RecordDataFactory.ts
@@ -86,6 +86,35 @@ export class RecordDataFactory {
         return new RecordDataFactory(fields);
     }
 
+    /**
+     * Compile an assigner that installs the given field names onto a target object via
+     * constant-key (named) property stores - `(target, values) => void`, with `values` in
+     * `fieldNames` order.
+     *
+     * Unlike dynamic keyed-store loops (`obj[name] = val`), named stores are exempt from V8's
+     * fast-properties limit on dynamically-added properties, so objects populated this way remain
+     * in fast mode with a hidden class shared across all identically-shaped instances. Used by
+     * Cube `View` to build `ViewRowData` row objects, which take their field properties
+     * post-construction and cannot use the literal-factory route above.
+     *
+     * Returns null under the same conditions as {@link create} - caller should fall back to its
+     * legacy assignment loop.
+     */
+    static createAssigner(fieldNames: string[]): RecordDataAssigner {
+        if (
+            !RecordDataFactory.enabled ||
+            fieldNames.length > RecordDataFactory.MAX_FACTORY_FIELDS ||
+            fieldNames.includes('__proto__') ||
+            !isCodegenSupported()
+        ) {
+            return null;
+        }
+        const body = fieldNames
+            .map((name, idx) => `t[${JSON.stringify(name)}]=v[${idx}];`)
+            .join('');
+        return new Function('t', 'v', body) as RecordDataAssigner;
+    }
+
     /** Array of per-field default values, in slot order - clone to seed a values array. */
     cloneDefaults(): any[] {
         return this.defaults.slice();
@@ -113,6 +142,9 @@ export class RecordDataFactory {
         this.createFn = new Function('v', body) as (values: any[]) => PlainObject;
     }
 }
+
+/** Assigner function compiled by {@link RecordDataFactory.createAssigner}. @internal */
+export type RecordDataAssigner = (target: PlainObject, values: any[]) => void;
 
 //------------------------
 // Implementation


### PR DESCRIPTION
Fixes #4502. **Stacked on #4501** (`record-data-factory`) - review just this PR's single commit; merge after #4501 lands (GitHub will retarget to `develop` when its branch is deleted).

**TLDR:** Cube `View`s build one `ViewRowData` per leaf and aggregate row via dynamic keyed-store loops - the same V8 dictionary-mode trap #4501 fixed for `Store` records, with the cliff at ~20-30 view fields. These rows are heavily retained (`_rowCache`, `_leafMap`, `result.rows`, and as `StoreRecord.raw` in every bound store). Populating them through a per-View compiled **named-property assigner** keeps them fast: **~5-6x smaller rows** (1,658 → 337 B/row at 30 fields; 3,192 → 553 at 57), ~10x faster row construction, ~1.55x faster aggregation-style reads. For a 50k-leaf, 30-field view: ~83MB → ~17MB, per view. No API changes; wide-field and strict-CSP environments transparently keep the current route.

### Why a different mechanism than #4501

`ViewRowData` is a real class (getters like `isCubeLeaf`, `instanceof` identity) that takes its field properties post-construction - it can't use the literal-object factory. The assigner exploits a narrower V8 rule, verified by probe: the fast-properties limit applies only to keyed stores that *create new map transitions*; constant-key (named) stores are exempt. A compiled `t["fieldA"]=v[0];...` keeps instances fast with a shared hidden class through ~120 properties, and the late `children`/`cubeBuckets` adds and all value-rewrite paths (`computeAggregates`, `applyLeafDataUpdate`/`applyDataUpdate`) are shape-safe - the updates machinery needed no changes.

### What changed

- **`RecordDataFactory.createAssigner(fieldNames)`** - sibling to `create()`, sharing all its guards (≤100 fields, `__proto__` name, CSP feature-detection, internal kill switch).
- **`View`** - compiles one assigner per query, recompiles on `updateQuery`.
- **`LeafRow` ctor / `BaseRow.initAggregate`** - use the assigner when available; each keeps its original loop as the fallback. The per-aggregate-row `canAggregate` map is built via the same assigner, fixing its parallel dictionary-mode fate in passing.

Measurement detail, probe methodology, and the transition-following artifact that initially masked the problem are written up in #4502.

<details>
<summary>Validation</summary>

- 20-assertion headless suite: fast mode + shared maps at scale (50k rows, first/last instance), post-`children`/`cubeBuckets`/`_cubeLeafChildren` adds, keyed value rewrites never demote, plain-object `canAggregate` targets, guards (threshold/CSP/`__proto__`/kill switch), exotic field names, exact leaf and aggregate value parity vs the legacy loops.
- In-app against the live Toolbox Cube tester (20k facts): aggregate sum parity before/after streaming updates, `canAggregateFn` semantics preserved (`quantity` null at fund level, aggregated at symbol level), dimension switching with assigner recompile, leaves mode with exact leaf-vs-cube-record parity, legacy-path A/B in the same session (identical behavior incl. row-identity on updates), clean console.
- Note: in real (Babel) builds, `ViewRowData`'s bare class-field declarations emit as `undefined` own props, so row shapes carry 7 base props rather than the 5 in TS-stripped simulations - confirmed compatible; doesn't change the cliff or the fix.

</details>

---

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change. (Stacked on #4501, which is.)
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. (None - `ViewRowData` shape/API unchanged; row field props simply present for all view fields, as before.)
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required. (Platform-agnostic data layer.)
- [x] Created Toolbox branch / PR, or determined not required. (Validated against existing Cube tester - no toolbox changes needed; xh/toolbox#879 covers the grid-side testbed.)