### PR TITLE
Store: add `retainRaw` config - opt-in to drop raw data references and reduce memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
     * The `popperOptions` escape-hatch prop has been removed from the mobile `Popover`.
 
 ### 🎁 New Features
-* Added `Store.retainRaw` config (default `true`). Set to `false` to drop each record's reference
-  to its raw source data object after parsing, reducing memory usage on large stores where
+
+* Added `Store.retainRaw` config (default `true`). Set to `false` to drop each record's reference to
+  its raw source data object after parsing, reducing memory usage on large stores where
   `StoreRecord.raw` is not needed. Not compatible with `reuseRecords`.
 
 ### ⚙️ Technical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
       any custom styling that targeted  Blueprint or Popper css classes (e.g. `bp6-minimal`).
     * The `popperOptions` `popper.js` escape-hatch prop has been removed from the mobile `Popover`.
 
+### 🎁 New Features
+* Added `Store.retainRaw` config (default `true`). Set to `false` to drop each record's reference
+  to its raw source data object after parsing, reducing memory usage on large stores where
+  `StoreRecord.raw` is not needed. Not compatible with `reuseRecords`.
+
 ### ⚙️ Technical
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped Popper.js
   onto Floating UI for React 19 compatibility. The hoist `Popover` components (mobile and desktop)

--- a/data/README.md
+++ b/data/README.md
@@ -101,6 +101,7 @@ const store = new Store({
 | `loadRootAsSummary` | `boolean` | `false` | Treat root node as summary record                                                      |
 | `freezeData` | `boolean` | `true` | Freeze record data objects for immutability (set to false as performance optimization) |
 | `reuseRecords` | `boolean` | `false` | Cache records by ID and raw reference (performance)                                    |
+| `retainRaw` | `boolean` | `true` | Retain raw data reference on each record (set false to reduce memory)                  |
 | `idEncodesTreePath` | `boolean` | `false` | IDs imply fixed tree position (performance)                                            |
 | `validationIsComplex` | `boolean` | `false` | Validate all uncommitted records on every change                                       |
 

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -147,6 +147,17 @@ export interface StoreConfig {
     reuseRecords?: boolean;
 
     /**
+     * True (default) to have each StoreRecord retain a reference to the raw data object from
+     * which it was created, exposed as `StoreRecord.raw`. May be set to false to reduce memory
+     * usage on large stores - raw data objects are then eligible for garbage collection after
+     * parsing, and `StoreRecord.raw` will be null.
+     *
+     * Not compatible with `reuseRecords`, which requires retained raw data for its
+     * reference-identity checks.
+     */
+    retainRaw?: boolean;
+
+    /**
      * Set to true to always validate all uncommitted records on every change to
      * uncommitted records (add, modify, or remove). Default false.
      */
@@ -269,6 +280,7 @@ export class Store
     idEncodesTreePath: boolean;
     freezeData: boolean;
     reuseRecords: boolean;
+    retainRaw: boolean;
     validationIsComplex: boolean;
 
     @observable.ref
@@ -325,12 +337,17 @@ export class Store
         freezeData = Store.defaults.freezeData,
         idEncodesTreePath = false,
         reuseRecords = false,
+        retainRaw = true,
         validationIsComplex = false,
         experimental,
         data
     }: StoreConfig) {
         super();
         makeObservable(this);
+        throwIf(
+            reuseRecords && !retainRaw,
+            'Store cannot be configured with both `reuseRecords` and `retainRaw: false` - record reuse requires retained raw data references.'
+        );
         this.experimental = this.parseExperimental(experimental);
         this.fields = this.parseFields(fields, fieldDefaults);
         this.idSpec = this.parseIdSpec(idSpec);
@@ -343,6 +360,7 @@ export class Store
         this.freezeData = freezeData;
         this.idEncodesTreePath = idEncodesTreePath;
         this.reuseRecords = reuseRecords;
+        this.retainRaw = retainRaw;
         this.validationIsComplex = validationIsComplex;
         this.lastUpdated = Date.now();
 
@@ -1144,7 +1162,7 @@ export class Store
             }
         }
 
-        const {processRawData} = this;
+        const {processRawData, retainRaw} = this;
         let data = raw;
         if (processRawData) {
             data = processRawData(raw);
@@ -1158,7 +1176,7 @@ export class Store
         const ret = new StoreRecord({
             id,
             store: this,
-            raw,
+            raw: retainRaw ? raw : null,
             data,
             committedData: data,
             parent,

--- a/data/StoreRecord.ts
+++ b/data/StoreRecord.ts
@@ -36,7 +36,10 @@ export class StoreRecord {
     readonly isSummary: boolean;
     readonly treePath: StoreRecordId[];
 
-    /** Raw data loaded into via Store.loadData() or Store.updateData(). */
+    /**
+     * Raw data loaded via Store.loadData() or Store.updateData(). Null for locally-added records,
+     * or for all records if the parent Store was configured with `retainRaw: false`.
+     */
     readonly raw: PlainObject;
 
     /**

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -45,6 +45,9 @@ export interface CubeConfig {
     /** See {@link StoreConfig.processRawData} */
     processRawData?: (data: PlainObject) => PlainObject;
 
+    /** See {@link StoreConfig.retainRaw} */
+    retainRaw?: boolean;
+
     /** Convenience bucket for app-specific metadata associated with the loaded dataset. */
     info?: PlainObject;
 
@@ -136,6 +139,7 @@ export class Cube extends HoistBase {
         data = [],
         idSpec = 'id',
         processRawData,
+        retainRaw,
         info = {},
         lockFn,
         bucketSpecFn,
@@ -147,6 +151,7 @@ export class Cube extends HoistBase {
             fields: this.parseFields(fields, fieldDefaults),
             idSpec,
             processRawData: processRawData,
+            retainRaw: retainRaw,
             freezeData: false,
             idEncodesTreePath: true
         });


### PR DESCRIPTION
**TLDR:** New `Store` config `retainRaw` (default `true`, no behavior change). Set `false` to release each record's raw source data object for GC once parsed - `StoreRecord.raw` will be null.

### Why

Store retains every parsed raw row for the life of its record, but the framework never reads raw *content* after parse - only `reuseRecords` uses it (reference-identity checks), plus the public `StoreRecord.raw` escape hatch. For large stores this is significant heap held for nothing: ~580 B/row for a uniform 57-field payload (~58MB per 100k records), rising to ~3,400 B/row when the server omits null fields (per-row hidden classes) and ~6,240 B/row for rows with 128+ keys (V8 dictionary mode). Complements the record-data optimization in #4501, which this measurement work grew out of.

### Notes

- Opt-in only: `retainRaw: false` throws if combined with `reuseRecords`, and is unsuitable for stores where app code reads `record.raw` (as some hoist admin code does).
- `idSpec`, `processRawData`, and tree-children extraction all run during parse and are unaffected.

---

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. (None - additive, default preserves current behavior.)
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required. (Platform-agnostic data layer.)
- [x] Created Toolbox branch / PR, or determined not required. (Not required - additive config, no component changes.)