### PR TITLE
Store: add `loadDataAsync()` - streaming load without buffering the full raw dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@
   async iterable yielding raw records or chunks. Creates records incrementally without buffering
   the complete raw dataset in memory, then installs them in a single transaction once the source
   completes.
-* Added `ndjsonChunks()` util (`@xh/hoist/utils/async`) to read an NDJSON `Response` body
-  incrementally - the natural streaming source for `Store.loadDataAsync()`.
+* Added `XH.fetchNdjson()` to consume an NDJSON (newline-delimited JSON) response incrementally
+  as an async iterable - the natural streaming source for `Store.loadDataAsync()`, and usable
+  directly via `for await` for any streamed endpoint. Backed by a new lower-level
+  `ndjsonChunks()` util in `@xh/hoist/utils/async` for use with an existing `Response`.
 
 ### ⚙️ Technical
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped Popper.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,14 @@
     * The `popperOptions` escape-hatch prop has been removed from the mobile `Popover`.
 
 ### 🎁 New Features
-* Added `Store.loadDataAsync()` to load a complete dataset from a streaming source - a sync or
-  async iterable yielding raw records or chunks. Creates records incrementally without buffering
-  the complete raw dataset in memory, then installs them in a single transaction once the source
+
+* Added `Store.loadDataAsync()` to load a complete dataset from a streaming source - a sync or async
+  iterable yielding raw records or chunks. Creates records incrementally without buffering the
+  complete raw dataset in memory, then installs them in a single transaction once the source
   completes. `Cube.loadDataAsync()` likewise accepts a streaming source.
-* Added `XH.fetchNdjson()` to consume an NDJSON (newline-delimited JSON) response incrementally
-  as an async iterable - the natural streaming source for `Store.loadDataAsync()`, and usable
-  directly via `for await` for any streamed endpoint.
+* Added `XH.fetchNdjson()` to consume an NDJSON (newline-delimited JSON) response incrementally as
+  an async iterable - the natural streaming source for `Store.loadDataAsync()`, and usable directly
+  via `for await` for any streamed endpoint.
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
       any custom styling that targeted  Blueprint or Popper css classes (e.g. `bp6-minimal`).
     * The `popperOptions` `popper.js` escape-hatch prop has been removed from the mobile `Popover`.
 
+### 🎁 New Features
+* Added `Store.loadDataAsync()` to load a complete dataset from a streaming source - a sync or
+  async iterable yielding raw records or chunks. Creates records incrementally without buffering
+  the complete raw dataset in memory, then installs them in a single transaction once the source
+  completes.
+
 ### ⚙️ Technical
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped Popper.js
   onto Floating UI for React 19 compatibility. The hoist `Popover` components (mobile and desktop)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
   async iterable yielding raw records or chunks. Creates records incrementally without buffering
   the complete raw dataset in memory, then installs them in a single transaction once the source
   completes.
+* Added `ndjsonChunks()` util (`@xh/hoist/utils/async`) to read an NDJSON `Response` body
+  incrementally - the natural streaming source for `Store.loadDataAsync()`.
 
 ### ⚙️ Technical
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped Popper.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,7 @@
   completes.
 * Added `XH.fetchNdjson()` to consume an NDJSON (newline-delimited JSON) response incrementally
   as an async iterable - the natural streaming source for `Store.loadDataAsync()`, and usable
-  directly via `for await` for any streamed endpoint. Backed by a new lower-level
-  `ndjsonChunks()` util in `@xh/hoist/utils/async` for use with an existing `Response`.
+  directly via `for await` for any streamed endpoint.
 
 ### ⚙️ Technical
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped Popper.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Added `Store.loadDataAsync()` to load a complete dataset from a streaming source - a sync or
   async iterable yielding raw records or chunks. Creates records incrementally without buffering
   the complete raw dataset in memory, then installs them in a single transaction once the source
-  completes.
+  completes. `Cube.loadDataAsync()` likewise accepts a streaming source.
 * Added `XH.fetchNdjson()` to consume an NDJSON (newline-delimited JSON) response incrementally
   as an async iterable - the natural streaming source for `Store.loadDataAsync()`, and usable
   directly via `for await` for any streamed endpoint.

--- a/core/XH.ts
+++ b/core/XH.ts
@@ -306,6 +306,14 @@ export class XHApi {
     }
 
     /**
+     * Send an HTTP request and decode the response incrementally as NDJSON.
+     * @see FetchService.fetchNdjson
+     */
+    fetchNdjson(opts: FetchOptions, ctx?: CallContextLike): AsyncGenerator<PlainObject[]> {
+        return this.fetchService.fetchNdjson(opts, ctx);
+    }
+
+    /**
      * Send a POST request with a JSON body and decode the response as JSON.
      * @see FetchService.postJson
      */

--- a/data/README.md
+++ b/data/README.md
@@ -149,12 +149,10 @@ store.updateData({
 **`loadDataAsync(rawData, rawSummaryData?)`** - Streaming counterpart to `loadData()`. Accepts a
 sync or async iterable yielding raw records (or arrays/chunks of records), creating records
 incrementally without buffering the complete raw dataset in memory - useful for very large
-datasets read incrementally from a fetch `Response` body stream. For NDJSON responses, pair with
-the `ndjsonChunks()` util from `@xh/hoist/utils/async`:
+datasets streamed from the server. Pair with `XH.fetchNdjson()` for NDJSON responses:
 
 ```typescript
-const response = await XH.fetch({url: 'myRows'});
-await store.loadDataAsync(ndjsonChunks(response));
+await store.loadDataAsync(XH.fetchNdjson({url: 'myRows'}));
 ```
 
 The Store updates in a single transaction once the source completes, and remains unchanged if

--- a/data/README.md
+++ b/data/README.md
@@ -146,6 +146,12 @@ store.updateData({
 });
 ```
 
+**`loadDataAsync(rawData, rawSummaryData?)`** - Streaming counterpart to `loadData()`. Accepts a
+sync or async iterable yielding raw records (or arrays/chunks of records), creating records
+incrementally without buffering the complete raw dataset in memory - useful for very large
+datasets read incrementally from a fetch `Response` body stream (e.g. NDJSON). The Store updates
+in a single transaction once the source completes, and remains unchanged if the source throws.
+
 ### Local Modifications
 
 Stores track uncommitted changes separately from server-sourced data:

--- a/data/README.md
+++ b/data/README.md
@@ -149,8 +149,16 @@ store.updateData({
 **`loadDataAsync(rawData, rawSummaryData?)`** - Streaming counterpart to `loadData()`. Accepts a
 sync or async iterable yielding raw records (or arrays/chunks of records), creating records
 incrementally without buffering the complete raw dataset in memory - useful for very large
-datasets read incrementally from a fetch `Response` body stream (e.g. NDJSON). The Store updates
-in a single transaction once the source completes, and remains unchanged if the source throws.
+datasets read incrementally from a fetch `Response` body stream. For NDJSON responses, pair with
+the `ndjsonChunks()` util from `@xh/hoist/utils/async`:
+
+```typescript
+const response = await XH.fetch({url: 'myRows'});
+await store.loadDataAsync(ndjsonChunks(response));
+```
+
+The Store updates in a single transaction once the source completes, and remains unchanged if
+the source throws.
 
 ### Local Modifications
 

--- a/data/README.md
+++ b/data/README.md
@@ -146,10 +146,11 @@ store.updateData({
 });
 ```
 
-**`loadDataAsync(rawData, rawSummaryData?)`** - Streaming counterpart to `loadData()`. Accepts a
-sync or async iterable yielding raw records (or arrays/chunks of records), creating records
-incrementally without buffering the complete raw dataset in memory - useful for very large
-datasets streamed from the server. Pair with `XH.fetchNdjson()` for NDJSON responses:
+**`loadDataAsync(rawData)`** - Streaming counterpart to `loadData()`. Accepts a sync or async
+iterable yielding raw records (or arrays/chunks of records), creating records incrementally
+without buffering the complete raw dataset in memory - useful for very large datasets streamed
+from the server. Does not accept summary data (an aggregate cannot precede its stream) - install
+via `updateData({rawSummaryData})` after loading. Pair with `XH.fetchNdjson()` for NDJSON:
 
 ```typescript
 await store.loadDataAsync(XH.fetchNdjson({url: 'myRows'}));

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -420,48 +420,33 @@ export class Store
      * installed in a single observable transaction, exactly as with `loadData()`. If the source
      * throws, the Store remains unchanged.
      *
+     * Note this method does not accept summary data - a summary is an aggregate, unavailable
+     * until a stream completes. Any pre-existing summary records are cleared. Install summary
+     * data via `updateData({rawSummaryData})` after loading, if desired. Not supported for
+     * stores with `loadRootAsSummary` - such payloads nest all row data within a single root
+     * node and cannot be streamed.
+     *
      * @param rawData - iterable yielding raw records, or chunks (arrays) of raw records.
-     * @param rawSummaryData - source data for optional summary record(s), representing
-     *      custom aggregations for the dataset, if desired.
      */
     async loadDataAsync(
-        rawData: AsyncIterable<Some<PlainObject>> | Iterable<Some<PlainObject>>,
-        rawSummaryData?: Some<PlainObject>
+        rawData: AsyncIterable<Some<PlainObject>> | Iterable<Some<PlainObject>>
     ): Promise<void> {
-        const {loadRootAsSummary} = this;
+        throwIf(
+            this.loadRootAsSummary,
+            'loadDataAsync does not support loadRootAsSummary - load via loadData(), or install summary records separately via updateData().'
+        );
 
-        // Create any provided summary records up-front, so streamed records are checked for ID
-        // collisions against them (as with loadData).
-        let summaryRecords: StoreRecord[] = rawSummaryData
-            ? castArray(rawSummaryData).map(it => this.createRecord(it, null, true))
-            : null;
-
-        let summaryIds = new Set<StoreRecordId>(summaryRecords?.map(it => it.id) ?? []),
-            rootSummary: PlainObject = null;
-        const recordMap = new Map<StoreRecordId, StoreRecord>();
+        const recordMap = new Map<StoreRecordId, StoreRecord>(),
+            summaryIds = new Set<StoreRecordId>();
 
         for await (const chunk of rawData) {
             for (const raw of castArray(chunk)) {
-                if (loadRootAsSummary) {
-                    throwIf(
-                        rootSummary || rawSummaryData,
-                        'Incorrect call to loadDataAsync with loadRootAsSummary=true. Summary data should be in a single root node with top-level row data as its children.'
-                    );
-                    rootSummary = raw;
-                } else {
-                    this.createRecords([raw], null, recordMap, summaryIds);
-                }
+                this.createRecords([raw], null, recordMap, summaryIds);
             }
         }
 
-        if (rootSummary) {
-            summaryRecords = [this.createRecord(rootSummary, null, true)];
-            summaryIds = new Set(summaryRecords.map(it => it.id));
-            this.createRecords(rootSummary.children ?? [], null, recordMap, summaryIds);
-        }
-
         runInAction(() => {
-            this.summaryRecords = summaryRecords;
+            this.summaryRecords = null;
             this._committed = this._current = this._committed.withNewRecords(recordMap);
             this.rebuildFiltered();
             this.lastLoaded = this.lastUpdated = Date.now();

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -411,9 +411,10 @@ export class Store
      * Records as needed - the streaming counterpart to {@link loadData}.
      *
      * Use to load very large datasets without buffering the complete raw dataset in a single
-     * array - e.g. rows read incrementally from a fetch `Response` body stream (NDJSON or
-     * similar). The source may be a sync or async iterable, yielding individual raw records or
-     * arrays (chunks) of records.
+     * array - e.g. rows streamed incrementally from the server. The source may be a sync or
+     * async iterable, yielding individual raw records or arrays (chunks) of records - see
+     * {@link FetchService.fetchNdjson} for the natural source when streaming NDJSON, e.g.
+     * `store.loadDataAsync(XH.fetchNdjson({url}))`.
      *
      * The Store is not modified until the source has been fully consumed - all records are then
      * installed in a single observable transaction, exactly as with `loadData()`. If the source

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -23,7 +23,7 @@ import {
     ValidationResult
 } from '@xh/hoist/data';
 import {StoreValidator} from '@xh/hoist/data/impl/StoreValidator';
-import {action, computed, makeObservable, observable} from '@xh/hoist/mobx';
+import {action, computed, makeObservable, observable, runInAction} from '@xh/hoist/mobx';
 import {logWithDebug, throwIf, warnIf} from '@xh/hoist/utils/js';
 import equal from 'fast-deep-equal';
 import {
@@ -460,18 +460,12 @@ export class Store
             this.createRecords(rootSummary.children ?? [], null, recordMap, summaryIds);
         }
 
-        this.installLoadedRecords(recordMap, summaryRecords);
-    }
-
-    @action
-    private installLoadedRecords(
-        records: Map<StoreRecordId, StoreRecord>,
-        summaryRecords: StoreRecord[]
-    ) {
-        this.summaryRecords = summaryRecords;
-        this._committed = this._current = this._committed.withNewRecords(records);
-        this.rebuildFiltered();
-        this.lastLoaded = this.lastUpdated = Date.now();
+        runInAction(() => {
+            this.summaryRecords = summaryRecords;
+            this._committed = this._current = this._committed.withNewRecords(recordMap);
+            this.rebuildFiltered();
+            this.lastLoaded = this.lastUpdated = Date.now();
+        });
     }
 
     /**

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -407,6 +407,73 @@ export class Store
     }
 
     /**
+     * Load a new and complete dataset from a streaming source, replacing any/all pre-existing
+     * Records as needed - the streaming counterpart to {@link loadData}.
+     *
+     * Use to load very large datasets without buffering the complete raw dataset in a single
+     * array - e.g. rows read incrementally from a fetch `Response` body stream (NDJSON or
+     * similar). The source may be a sync or async iterable, yielding individual raw records or
+     * arrays (chunks) of records.
+     *
+     * The Store is not modified until the source has been fully consumed - all records are then
+     * installed in a single observable transaction, exactly as with `loadData()`. If the source
+     * throws, the Store remains unchanged.
+     *
+     * @param rawData - iterable yielding raw records, or chunks (arrays) of raw records.
+     * @param rawSummaryData - source data for optional summary record(s), representing
+     *      custom aggregations for the dataset, if desired.
+     */
+    async loadDataAsync(
+        rawData: AsyncIterable<Some<PlainObject>> | Iterable<Some<PlainObject>>,
+        rawSummaryData?: Some<PlainObject>
+    ): Promise<void> {
+        const {loadRootAsSummary} = this;
+
+        // Create any provided summary records up-front, so streamed records are checked for ID
+        // collisions against them (as with loadData).
+        let summaryRecords: StoreRecord[] = rawSummaryData
+            ? castArray(rawSummaryData).map(it => this.createRecord(it, null, true))
+            : null;
+
+        let summaryIds = new Set<StoreRecordId>(summaryRecords?.map(it => it.id) ?? []),
+            rootSummary: PlainObject = null;
+        const recordMap = new Map<StoreRecordId, StoreRecord>();
+
+        for await (const chunk of rawData) {
+            for (const raw of castArray(chunk)) {
+                if (loadRootAsSummary) {
+                    throwIf(
+                        rootSummary || rawSummaryData,
+                        'Incorrect call to loadDataAsync with loadRootAsSummary=true. Summary data should be in a single root node with top-level row data as its children.'
+                    );
+                    rootSummary = raw;
+                } else {
+                    this.createRecords([raw], null, recordMap, summaryIds);
+                }
+            }
+        }
+
+        if (rootSummary) {
+            summaryRecords = [this.createRecord(rootSummary, null, true)];
+            summaryIds = new Set(summaryRecords.map(it => it.id));
+            this.createRecords(rootSummary.children ?? [], null, recordMap, summaryIds);
+        }
+
+        this.installLoadedRecords(recordMap, summaryRecords);
+    }
+
+    @action
+    private installLoadedRecords(
+        records: Map<StoreRecordId, StoreRecord>,
+        summaryRecords: StoreRecord[]
+    ) {
+        this.summaryRecords = summaryRecords;
+        this._committed = this._current = this._committed.withNewRecords(records);
+        this.rebuildFiltered();
+        this.lastLoaded = this.lastUpdated = Date.now();
+    }
+
+    /**
      * Add, update, or delete Records in this Store. Note that objects passed to this method
      * for adds and updates should have all the raw source data required to create those Records -
      * i.e. they should be in the same form as when passed to `loadData()`. The added/updated

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -8,7 +8,7 @@
 import {HoistBase, managed, PlainObject, Some} from '@xh/hoist/core';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {forEachAsync} from '@xh/hoist/utils/async';
-import {defaultsDeep, isEmpty} from 'lodash';
+import {defaultsDeep, isArray, isEmpty} from 'lodash';
 import {Store, StoreRecordIdSpec, StoreTransaction} from '../Store';
 import {StoreRecord} from '../StoreRecord';
 import {BucketSpec} from './BucketSpec';
@@ -273,14 +273,25 @@ export class Cube extends HoistBase {
      * Populate this cube with a new dataset.
      * This method largely delegates to {@link Store.loadData} - see that method for more info.
      *
+     * May also be passed a streaming source - a sync or async iterable yielding raw records or
+     * chunks of records - loaded via {@link Store.loadDataAsync}, e.g.
+     * `cube.loadDataAsync(XH.fetchNdjson({url}))`.
+     *
      * Note that this method will update its views asynchronously in order to avoid locking up the
      * browser when attached to multiple expensive views.
      *
-     * @param rawData - flat array of lowest/leaf level data rows.
+     * @param rawData - flat array of lowest/leaf level data rows, or a streaming source of same.
      * @param info - optional metadata to associate with this cube/dataset.
      */
-    async loadDataAsync(rawData: PlainObject[], info: PlainObject = {}): Promise<void> {
-        this.store.loadData(rawData);
+    async loadDataAsync(
+        rawData: PlainObject[] | AsyncIterable<Some<PlainObject>> | Iterable<Some<PlainObject>>,
+        info: PlainObject = {}
+    ): Promise<void> {
+        if (isArray(rawData)) {
+            this.store.loadData(rawData);
+        } else {
+            await this.store.loadDataAsync(rawData);
+        }
         this.setInfo(info);
         await forEachAsync(this._connectedViews, v => v.noteCubeLoaded());
     }

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -184,7 +184,8 @@ export class FetchService extends HoistService {
         }
 
         // The runner will manage the lifecycle, but we won't await it here -- return
-        // the generator straight away.
+        // the generator straight away. Don't produce unhandled exceptions from telemetry
+        // only. Generator will already produce them.
         let ret: AsyncGenerator<PlainObject[]>;
         runner
             .run(async innerCtx => {
@@ -199,8 +200,7 @@ export class FetchService extends HoistService {
                 await fetchPromise;
                 await streamPromise;
             })
-            .catch(noop); // Telemetry-scoping promise only - failures reach the consumer via the generator.
-
+            .catch(noop);
         return ret;
     }
 

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -164,7 +164,7 @@ export class FetchService extends HoistService {
      * non-Store streaming.
      */
     async *fetchNdjson(opts: FetchOptions, ctx?: CallContextLike): AsyncGenerator<PlainObject[]> {
-        yield* ndjsonChunks(await this.fetchInternalAsync(opts, ctx));
+        yield* this.ndjsonChunks(await this.fetchInternalAsync(opts, ctx));
     }
 
     /**
@@ -566,6 +566,31 @@ export class FetchService extends HoistService {
     }
 
     /**
+     * Read an NDJSON Response body incrementally, yielding chunks (arrays) of parsed records as
+     * they arrive off the network. Each line is parsed with native JSON.parse, partial trailing
+     * lines are carried across chunk boundaries, and no more than one network chunk of raw text
+     * is buffered.
+     */
+    private async *ndjsonChunks(response: Response): AsyncGenerator<PlainObject[]> {
+        const reader = response.body.getReader(),
+            decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+            const {done, value} = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, {stream: true});
+            const lines = buffer.split('\n');
+            buffer = lines.pop(); // retain any partial trailing line for the next chunk
+            if (lines.length) yield lines.filter(Boolean).map(it => JSON.parse(it));
+        }
+
+        buffer += decoder.decode();
+        if (buffer.trim()) yield [JSON.parse(buffer)];
+    }
+
+    /**
      * Create an Error to throw when a fetchJson call encounters a SyntaxError.
      * @param fetchOptions - original options passed to FetchService.
      * @param cause - object thrown by native {@link response.json}.
@@ -839,32 +864,4 @@ export interface FetchException extends HoistException {
      * @see FetchOptions.autoAbortKey
      */
     isFetchAborted: boolean;
-}
-
-//------------------------
-// Implementation
-//------------------------
-/**
- * Read an NDJSON Response body incrementally, yielding chunks (arrays) of parsed records as
- * they arrive off the network. Each line is parsed with native JSON.parse, partial trailing
- * lines are carried across chunk boundaries, and no more than one network chunk of raw text
- * is buffered.
- */
-async function* ndjsonChunks(response: Response): AsyncGenerator<PlainObject[]> {
-    const reader = response.body.getReader(),
-        decoder = new TextDecoder();
-    let buffer = '';
-
-    while (true) {
-        const {done, value} = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, {stream: true});
-        const lines = buffer.split('\n');
-        buffer = lines.pop(); // retain any partial trailing line for the next chunk
-        if (lines.length) yield lines.filter(Boolean).map(it => JSON.parse(it));
-    }
-
-    buffer += decoder.decode();
-    if (buffer.trim()) yield [JSON.parse(buffer)];
 }

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -20,7 +20,6 @@ import {
 } from '@xh/hoist/core';
 import {Exception, HoistException, TimeoutException} from '@xh/hoist/exception';
 import {PromiseTimeoutSpec} from '@xh/hoist/promise';
-import {ndjsonChunks} from '@xh/hoist/utils/async';
 import {isLocalDate, SECONDS} from '@xh/hoist/utils/datetime';
 import {apiDeprecated, warnIf} from '@xh/hoist/utils/js';
 import {StatusCodes} from 'http-status-codes';
@@ -840,4 +839,32 @@ export interface FetchException extends HoistException {
      * @see FetchOptions.autoAbortKey
      */
     isFetchAborted: boolean;
+}
+
+//------------------------
+// Implementation
+//------------------------
+/**
+ * Read an NDJSON Response body incrementally, yielding chunks (arrays) of parsed records as
+ * they arrive off the network. Each line is parsed with native JSON.parse, partial trailing
+ * lines are carried across chunk boundaries, and no more than one network chunk of raw text
+ * is buffered.
+ */
+async function* ndjsonChunks(response: Response): AsyncGenerator<PlainObject[]> {
+    const reader = response.body.getReader(),
+        decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+        const {done, value} = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, {stream: true});
+        const lines = buffer.split('\n');
+        buffer = lines.pop(); // retain any partial trailing line for the next chunk
+        if (lines.length) yield lines.filter(Boolean).map(it => JSON.parse(it));
+    }
+
+    buffer += decoder.decode();
+    if (buffer.trim()) yield [JSON.parse(buffer)];
 }

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -20,6 +20,7 @@ import {
 } from '@xh/hoist/core';
 import {Exception, HoistException, TimeoutException} from '@xh/hoist/exception';
 import {PromiseTimeoutSpec} from '@xh/hoist/promise';
+import {ndjsonChunks} from '@xh/hoist/utils/async';
 import {isLocalDate, SECONDS} from '@xh/hoist/utils/datetime';
 import {apiDeprecated, warnIf} from '@xh/hoist/utils/js';
 import {StatusCodes} from 'http-status-codes';
@@ -43,7 +44,8 @@ export interface FetchServiceDefaults {
  *
  * Wraps the standard Fetch API with CORS enabled, credentials included, and redirects followed.
  * Provides JSON convenience methods (`fetchJson`, `postJson`, `putJson`, `patchJson`,
- * `deleteJson`, `getJson`) that handle serialization and content-type headers automatically.
+ * `deleteJson`, `getJson`) that handle serialization and content-type headers automatically,
+ * plus `fetchNdjson` for consuming streamed NDJSON responses incrementally.
  *
  * Key features:
  * - Configurable timeouts (default 30s) via {@link FetchOptions.timeout}
@@ -150,6 +152,20 @@ export class FetchService extends HoistService {
      */
     async getJson(opts: FetchOptions, ctx?: CallContextLike): Promise<any> {
         return this.fetchInternalAsync({asJson: true, method: 'GET', ...opts}, ctx);
+    }
+
+    /**
+     * Send an HTTP request and decode the response body incrementally as NDJSON - newline
+     * delimited JSON, aka JSON Lines / JSONL - yielding chunks (arrays) of parsed records as
+     * they arrive off the network. No more than one network chunk of raw text is buffered,
+     * making this suitable for consuming very large or long-running streamed responses.
+     *
+     * The natural source for {@link Store.loadDataAsync} - e.g.
+     * `store.loadDataAsync(XH.fetchNdjson({url}))` - or iterate directly via `for await` for
+     * non-Store streaming.
+     */
+    async *fetchNdjson(opts: FetchOptions, ctx?: CallContextLike): AsyncGenerator<PlainObject[]> {
+        yield* ndjsonChunks(await this.fetchInternalAsync(opts, ctx));
     }
 
     /**

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -23,7 +23,7 @@ import {PromiseTimeoutSpec} from '@xh/hoist/promise';
 import {isLocalDate, SECONDS} from '@xh/hoist/utils/datetime';
 import {apiDeprecated, warnIf} from '@xh/hoist/utils/js';
 import {StatusCodes} from 'http-status-codes';
-import {isDate, isFunction, isNil, isObject, isString, omit, omitBy, truncate} from 'lodash';
+import {isDate, isFunction, isNil, isObject, isString, noop, omit, omitBy, truncate} from 'lodash';
 import {IStringifyOptions, stringify} from 'qs';
 import ShortUniqueId from 'short-unique-id';
 
@@ -162,9 +162,46 @@ export class FetchService extends HoistService {
      * The natural source for {@link Store.loadDataAsync} - e.g.
      * `store.loadDataAsync(XH.fetchNdjson({url}))` - or iterate directly via `for await` for
      * non-Store streaming.
+     *
+     * Tracing spans and `track` cover the full lifetime of the stream, through complete
+     * consumption. Note that `timeout` covers the request phase only - no timeout applies while
+     * the stream is being read.
      */
-    async *fetchNdjson(opts: FetchOptions, ctx?: CallContextLike): AsyncGenerator<PlainObject[]> {
-        yield* this.ndjsonChunks(await this.fetchInternalAsync(opts, ctx));
+    fetchNdjson(opts: FetchOptions, ctx?: CallContextLike): AsyncGenerator<PlainObject[]> {
+        opts = this.withCorrelationId(opts);
+
+        let runner = this.runner(ctx);
+
+        // Configure special track and spanning across the async consumption.
+        const spanConfig = this.createSpanConfig(opts),
+            {track} = opts;
+        if (spanConfig) {
+            runner = runner.span(spanConfig);
+        }
+        if (track) {
+            const trackOptions: TrackOptions = isString(track) ? {message: track} : track;
+            runner = runner.track({...trackOptions, correlationId: opts.correlationId as string});
+        }
+
+        // The runner will manage the lifecycle, but we won't await it here -- return
+        // the generator straight away.
+        let ret: AsyncGenerator<PlainObject[]>;
+        runner
+            .run(async innerCtx => {
+                const fetchPromise = this.fetchInternalAsync(opts, innerCtx, true);
+
+                let onComplete: (err?: unknown) => void;
+                const streamPromise = new Promise<void>(
+                    (res, rej) => (onComplete = err => (err ? rej(err) : res()))
+                );
+                ret = this.streamNdjson(opts, innerCtx, fetchPromise, onComplete);
+
+                await fetchPromise;
+                await streamPromise;
+            })
+            .catch(noop); // Telemetry-scoping promise only - failures reach the consumer via the generator.
+
+        return ret;
     }
 
     /**
@@ -217,7 +254,15 @@ export class FetchService extends HoistService {
     //-----------------------
     // Implementation
     //-----------------------
-    private async fetchInternalAsync(opts: FetchOptions, ctx?: CallContextLike): Promise<any> {
+    /**
+     * @param forStreaming - true when called by fetchNdjson, which applies its own span and
+     *      track across the full stream lifetime - suppresses both here.
+     */
+    private async fetchInternalAsync(
+        opts: FetchOptions,
+        ctx?: CallContextLike,
+        forStreaming: boolean = false
+    ): Promise<any> {
         // Default to deprecated context
         ctx ??= {span: opts.span, loadSpec: opts.loadSpec as LoadSpec};
         apiDeprecated('FetchOptions.span', {
@@ -234,7 +279,7 @@ export class FetchService extends HoistService {
         });
         opts = omit(opts, 'span', 'loadSpec');
 
-        let spanConfig = this.createSpanConfig(opts),
+        let spanConfig = forStreaming ? null : this.createSpanConfig(opts),
             runner = spanConfig ? this.runner(ctx).span(spanConfig) : this.runner(ctx),
             ret = runner.run(ctx => {
                 opts = this.withCorrelationId(opts);
@@ -245,7 +290,7 @@ export class FetchService extends HoistService {
             });
 
         // 2) Apply tracking
-        if (opts.track) {
+        if (opts.track && !forStreaming) {
             const {correlationId, track} = opts;
             const trackOptions: TrackOptions = isString(track) ? {message: track} : track;
             warnIf(
@@ -566,6 +611,38 @@ export class FetchService extends HoistService {
     }
 
     /**
+     * Await the pending request, then stream its body - wrapping any failure raised while
+     * reading or parsing the stream in an enriched FetchException.
+     *
+     * Reports the streaming phase's outcome via the `onComplete` callback - with any error on
+     * failure, and unconditionally on exit to cover early termination by the consumer.
+     * Request-phase failures propagate already-enriched and without an `onComplete` error - the
+     * caller observes them on the fetch promise directly.
+     */
+    private async *streamNdjson(
+        opts: FetchOptions,
+        ctx: CallContextLike,
+        fetchPromise: Promise<Response>,
+        onComplete: (err?: unknown) => void
+    ): AsyncGenerator<PlainObject[]> {
+        try {
+            const response = await fetchPromise;
+            try {
+                yield* this.ndjsonChunks(response);
+            } catch (e) {
+                const ex =
+                    e?.name === 'AbortError'
+                        ? this.abortedException(opts, ctx, e)
+                        : this.streamFailedException(opts, ctx, response, e);
+                onComplete(ex);
+                throw ex;
+            }
+        } finally {
+            onComplete(); // only finally blocks run if the consumer exits its loop early
+        }
+    }
+
+    /**
      * Read an NDJSON Response body incrementally, yielding chunks (arrays) of parsed records as
      * they arrive off the network. Each line is parsed with native JSON.parse, partial trailing
      * lines are carried across chunk boundaries, and no more than one network chunk of raw text
@@ -618,7 +695,7 @@ export class FetchService extends HoistService {
      */
     private abortedException(
         fetchOptions: FetchOptions,
-        callContext: CallContext,
+        callContext: CallContextLike,
         cause: any
     ): FetchException {
         return this.createException({
@@ -660,6 +737,29 @@ export class FetchService extends HoistService {
     }
 
     /**
+     * Create an Error to throw when a fetch call fails while reading or parsing its streamed
+     * response body.
+     * @param fetchOptions - original options passed to FetchService.
+     * @param response - response whose body was being streamed.
+     * @param cause - underlying error raised while reading or parsing the stream.
+     */
+    private streamFailedException(
+        fetchOptions: FetchOptions,
+        callContext: CallContextLike,
+        response: Response,
+        cause: any
+    ): FetchException {
+        return this.createException({
+            name: 'Fetch Stream Failed',
+            message: `Failure while reading streamed response, url: "${fetchOptions.url}" - ${cause.message}`,
+            httpStatus: response.status,
+            fetchOptions,
+            callContext,
+            cause
+        });
+    }
+
+    /**
      * Create an Error for when the server called by fetch does not respond
      * @param fetchOptions - original options the app passed to FetchService.fetch
      * @param cause - object thrown by native fetch
@@ -690,8 +790,11 @@ export class FetchService extends HoistService {
 
     private createException(attributes: PlainObject) {
         const {fetchOptions} = attributes;
+        // Prefer the header actually sent - fall back to the resolved option for exceptions
+        // created against pre-resolution options (e.g. streaming failures).
         const correlationId: string =
-            fetchOptions?.headers?.[FetchService.defaults.correlationIdHeaderKey] ?? null;
+            fetchOptions?.headers?.[FetchService.defaults.correlationIdHeaderKey] ??
+            (isString(fetchOptions?.correlationId) ? fetchOptions.correlationId : null);
         const traceId: string = fetchOptions?.traceId ?? null;
 
         return Exception.create({

--- a/utils/async/AsyncUtils.ts
+++ b/utils/async/AsyncUtils.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {XH} from '@xh/hoist/core';
+import {PlainObject, XH} from '@xh/hoist/core';
 import {wait} from '@xh/hoist/promise';
 
 /**
@@ -70,6 +70,39 @@ export async function whileAsync(
         }
         fn();
     }
+}
+
+/**
+ * Read an NDJSON (newline-delimited JSON) `Response` body incrementally, yielding chunks
+ * (arrays) of parsed records as they arrive off the network. Each line is parsed with native
+ * `JSON.parse`, and no more than one network chunk of raw text is buffered - partial trailing
+ * lines are carried across chunk boundaries.
+ *
+ * The natural source for {@link Store.loadDataAsync} when streaming large datasets from the
+ * server - pass a `Response` from `XH.fetch()`:
+ *
+ * ```typescript
+ * const response = await XH.fetch({url: 'myRows'});
+ * await store.loadDataAsync(ndjsonChunks(response));
+ * ```
+ */
+export async function* ndjsonChunks<T = PlainObject>(response: Response): AsyncGenerator<T[]> {
+    const reader = response.body.getReader(),
+        decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+        const {done, value} = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, {stream: true});
+        const lines = buffer.split('\n');
+        buffer = lines.pop(); // retain any partial trailing line for the next chunk
+        if (lines.length) yield lines.filter(Boolean).map(it => JSON.parse(it));
+    }
+
+    buffer += decoder.decode();
+    if (buffer.trim()) yield [JSON.parse(buffer)];
 }
 
 export interface AsyncLoopOptions {

--- a/utils/async/AsyncUtils.ts
+++ b/utils/async/AsyncUtils.ts
@@ -78,13 +78,9 @@ export async function whileAsync(
  * `JSON.parse`, and no more than one network chunk of raw text is buffered - partial trailing
  * lines are carried across chunk boundaries.
  *
- * The natural source for {@link Store.loadDataAsync} when streaming large datasets from the
- * server - pass a `Response` from `XH.fetch()`:
- *
- * ```typescript
- * const response = await XH.fetch({url: 'myRows'});
- * await store.loadDataAsync(ndjsonChunks(response));
- * ```
+ * Lower-level primitive behind {@link FetchService.fetchNdjson}, which is the preferred entry
+ * point for Hoist-issued requests. Use this util directly when you already hold a `Response`
+ * from another source.
  */
 export async function* ndjsonChunks<T = PlainObject>(response: Response): AsyncGenerator<T[]> {
     const reader = response.body.getReader(),

--- a/utils/async/AsyncUtils.ts
+++ b/utils/async/AsyncUtils.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {PlainObject, XH} from '@xh/hoist/core';
+import {XH} from '@xh/hoist/core';
 import {wait} from '@xh/hoist/promise';
 
 /**
@@ -70,35 +70,6 @@ export async function whileAsync(
         }
         fn();
     }
-}
-
-/**
- * Read an NDJSON (newline-delimited JSON) `Response` body incrementally, yielding chunks
- * (arrays) of parsed records as they arrive off the network. Each line is parsed with native
- * `JSON.parse`, and no more than one network chunk of raw text is buffered - partial trailing
- * lines are carried across chunk boundaries.
- *
- * Lower-level primitive behind {@link FetchService.fetchNdjson}, which is the preferred entry
- * point for Hoist-issued requests. Use this util directly when you already hold a `Response`
- * from another source.
- */
-export async function* ndjsonChunks<T = PlainObject>(response: Response): AsyncGenerator<T[]> {
-    const reader = response.body.getReader(),
-        decoder = new TextDecoder();
-    let buffer = '';
-
-    while (true) {
-        const {done, value} = await reader.read();
-        if (done) break;
-
-        buffer += decoder.decode(value, {stream: true});
-        const lines = buffer.split('\n');
-        buffer = lines.pop(); // retain any partial trailing line for the next chunk
-        if (lines.length) yield lines.filter(Boolean).map(it => JSON.parse(it));
-    }
-
-    buffer += decoder.decode();
-    if (buffer.trim()) yield [JSON.parse(buffer)];
 }
 
 export interface AsyncLoopOptions {


### PR DESCRIPTION
**TLDR:** New `Store.loadDataAsync(rawData)` - the streaming counterpart to `loadData()` - plus `XH.fetchNdjson()` - a FetchService convenience that fetches and decodes an NDJSON response incrementally, the natural source for the new load method (`store.loadDataAsync(XH.fetchNdjson({url}))`) and directly iterable via `for await` for non-Store streaming.

### Why

Today `loadData()` requires the complete raw dataset as one array, so a large load's peak heap includes every parsed raw row at once - and chunked `updateData({add})` calls are not a substitute (per-transaction RecordSet rebuilds and observable churn). With a streaming source, rows can instead be consumed as they arrive: parsing overlaps download, and each raw row becomes garbage as soon as its record is built.

Measured motivation: NDJSON parsed line-at-a-time via native `JSON.parse` costs only ~12% over one monolithic parse (179ms vs 159ms, 100k rows x 57 fields) while never holding more than one row of raw input. Pairs with #4504 (`retainRaw: false`) to eliminate raw-row retention entirely - together, peak heap during load approaches the steady-state record set. Also complements #4501.

### `Store.loadDataAsync(rawData)`

- Accepts a sync or async iterable yielding raw records (or arrays/chunks of records), creating records incrementally as the source yields. The Store is untouched until the source completes, then all records install in a single observable transaction - identical downstream behavior to `loadData()`. If the source throws, the Store remains unchanged.
- Mirrors `loadData()` semantics for row data: duplicate-ID checks (including cross-chunk) and tree data via nested `children`. Deliberately does NOT accept summary data - a summary is an aggregate, unavailable until a stream completes; install via `updateData({rawSummaryData})` after loading. `loadRootAsSummary` stores throw (such payloads nest all rows in a single root node and cannot be streamed).
- `Cube.loadDataAsync()` likewise accepts a streaming source for its rawData, delegating to the new Store method - `cube.loadDataAsync(XH.fetchNdjson({url}))`. Array inputs take the existing synchronous path unchanged.
- Purely additive - `loadData()` is untouched.

### `XH.fetchNdjson(opts)`

- Issues the request eagerly through the standard managed fetch pipeline (correlation IDs, traceparent, interceptors, default headers) and returns an `AsyncGenerator` yielding arrays of parsed records as chunks arrive - no more than one network chunk of raw text is ever buffered.
- **Telemetry scopes to the full stream lifetime**: a single client-kind span (per OTel semconv, ending when the response is fully read) and a `track` entry that fires on stream completion/failure with true elapsed time. The server-side span nests under it via the propagated traceparent, so traces decompose generation vs. download/consumption. A failed request closes the span even if the returned generator is never consumed.
- **Enriched exceptions across both phases**: request-phase failures throw the usual FetchExceptions; failures while reading/parsing the stream throw a new `Fetch Stream Failed` FetchException carrying the response status, URL, correlation ID, and cause - and mid-stream aborts map to the routine `abortedException`, keeping `catchDefault()` quiet.
- Known limitation, documented in-method: `timeout` covers the request phase only - no timeout applies while the stream is being read. In-flight stream abort via `autoAbortKey` is a noted follow-up.

### Notes

- Compiles and lints clean; not yet exercised at runtime - planning to validate against a live Toolbox app (streaming NDJSON + equivalence vs `loadData` on the same dataset) before merge.

---

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. (None - additive API.)
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required. (Platform-agnostic data layer.)
- [x] Created Toolbox branch / PR, or determined not required. (xh/toolbox#880 - draft pending the runtime validation note above.)


