### PR TITLE
Store: opt-in adoptRawData zero-copy mode for connected Cube Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
   aggregate rows) are now populated via a per-View compiled assigner, measured ~5-6x smaller at
   typical view widths (more than ~20 fields), with faster row generation and aggregation reads.
   Views with very many fields and strict-CSP environments continue to use the prior route.
+* Added an opt-in `Store.adoptRawData` mode for read-only projections of already-parsed data - most
+  notably a connected Cube `View` feeding a (tree) grid. Records adopt the provider's row object as
+  their `data` by reference rather than re-parsing and copying it, collapsing the usual two per-row
+  objects to one and skipping the per-row parse on every load and update - a memory-focused
+  optimization for large, high-frequency Cube-backed grids. This is a read-only mode - the local
+  edit/commit/revert APIs throw, `freezeData` is forced off, and the data provider must supply
+  pre-parsed values. See the `adoptRawData` config docs for the full contract. Default off,
+  non-breaking.
 
 ### ⚙️ Technical
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped Popper.js

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -148,6 +148,44 @@ export interface StoreConfig {
     reuseRecords?: boolean;
 
     /**
+     * Zero-copy "turbo" mode for read-only projections of already-parsed data - most notably a
+     * connected Cube {@link View} feeding a (tree) grid.
+     *
+     * When true, the Store adopts each incoming raw object **as** its record's `data`, by reference,
+     * rather than re-parsing and copying it into a dedicated object. This collapses the usual two
+     * per-row objects (the provider's row object + the Store's parsed copy) down to one, skipping
+     * the per-row `parseRaw` field loop on every load and update. The headline win is memory; a
+     * modest reduction in allocation/GC churn on high-frequency updates is a secondary benefit.
+     *
+     * This mode puts substantial trust in the data provider and comes with a strict contract:
+     *
+     * 1. **Raw data MUST already be parsed.** `parseRaw` is skipped, so Field `type`/`parseVal` are
+     *    NOT applied - Fields become pure metadata (sort/filter/columns/export) and `data` holds
+     *    exactly what the provider supplied. Always true for Cube/View data, which the Cube has
+     *    already parsed (typically via the same field instances).
+     * 2. **The Store does not own `data`.** It never reads or writes `data` internals (including
+     *    `data.id`) and never freezes it. The provider is authoritative and may mutate rows in place.
+     * 3. **Rows may be shared across connected stores.** A View feeds the same row objects to every
+     *    connected store; with by-reference adoption their records point at one object set. Do not
+     *    mutate these objects from app code.
+     *
+     * Consequences:
+     * - **Read-only.** The local edit/commit/revert APIs (`addRecords`, `removeRecords`,
+     *   `modifyRecords`, `revertRecords`, `revert`) throw - committed always equals current.
+     *   Data still flows in via `loadData`/`updateData` (the provider path).
+     * - **Summary records are adopted too.** The dedicated summary record(s) - whether supplied via
+     *   `rawSummaryData` or extracted from the root row under `loadRootAsSummary` (e.g. a Cube
+     *   View's `includeRoot` "Total" row) - adopt their raw object as `data` by the same rules:
+     *   shared by reference, not owned, not frozen, recreated on update.
+     * - `freezeData` is forced to `false` (a frozen shared object would throw on the provider's
+     *   next in-place mutation). Explicitly passing `freezeData: true` is rejected.
+     * - `processRawData` and `reuseRecords` are incompatible and rejected at construction.
+     *
+     * Default false.
+     */
+    adoptRawData?: boolean;
+
+    /**
      * Set to true to always validate all uncommitted records on every change to
      * uncommitted records (add, modify, or remove). Default false.
      */
@@ -270,6 +308,7 @@ export class Store
     idEncodesTreePath: boolean;
     freezeData: boolean;
     reuseRecords: boolean;
+    adoptRawData: boolean;
     validationIsComplex: boolean;
 
     @observable.ref
@@ -314,25 +353,46 @@ export class Store
     private _fieldMap: Map<string, Field>;
     experimental: any;
 
-    constructor({
-        fields,
-        fieldDefaults = {},
-        idSpec = 'id',
-        processRawData = null,
-        filter = null,
-        filterIncludesChildren = false,
-        loadTreeData = true,
-        loadTreeDataFrom = 'children',
-        loadRootAsSummary = false,
-        freezeData = Store.defaults.freezeData,
-        idEncodesTreePath = false,
-        reuseRecords = false,
-        validationIsComplex = false,
-        experimental,
-        data
-    }: StoreConfig) {
+    constructor(config: StoreConfig) {
         super();
         makeObservable(this);
+
+        const {
+            fields,
+            fieldDefaults = {},
+            idSpec = 'id',
+            processRawData = null,
+            filter = null,
+            filterIncludesChildren = false,
+            loadTreeData = true,
+            loadTreeDataFrom = 'children',
+            loadRootAsSummary = false,
+            idEncodesTreePath = false,
+            reuseRecords = false,
+            adoptRawData = false,
+            validationIsComplex = false,
+            experimental,
+            data
+        } = config;
+        let freezeData = config.freezeData ?? Store.defaults.freezeData;
+
+        if (adoptRawData) {
+            // Fail fast on any config that expresses behavior this read-only, zero-copy mode cannot
+            // honor - surface the conflict rather than silently ignoring it and leaving the
+            // developer with a mistaken model of how the Store will behave. freezeData is only
+            // rejected when the developer explicitly opted in to it; the default is normalized off.
+            throwIf(
+                processRawData,
+                'Store.adoptRawData cannot be used with processRawData - the skipped parse would make it a silent no-op.'
+            );
+            throwIf(reuseRecords, 'Store.adoptRawData cannot be used with reuseRecords.');
+            throwIf(
+                config.freezeData === true,
+                'Store.adoptRawData cannot be used with freezeData: true - the provider mutates shared rows in place, so record data cannot be frozen.'
+            );
+            freezeData = false;
+        }
+
         this.experimental = this.parseExperimental(experimental);
         this.fields = this.parseFields(fields, fieldDefaults);
         this.idSpec = this.parseIdSpec(idSpec);
@@ -345,6 +405,7 @@ export class Store
         this.freezeData = freezeData;
         this.idEncodesTreePath = idEncodesTreePath;
         this.reuseRecords = reuseRecords;
+        this.adoptRawData = adoptRawData;
         this.validationIsComplex = validationIsComplex;
         this.lastUpdated = Date.now();
 
@@ -576,6 +637,7 @@ export class Store
      */
     @action
     addRecords(data: Some<PlainObject>, parentId?: StoreRecordId) {
+        this.throwIfReadOnly('addRecords');
         data = castArray(data);
         if (isEmpty(data)) return;
 
@@ -612,6 +674,7 @@ export class Store
      */
     @action
     removeRecords(records: StoreRecordOrId | StoreRecordOrId[]) {
+        this.throwIfReadOnly('removeRecords');
         records = castArray(records);
         if (isEmpty(records)) return;
 
@@ -641,6 +704,7 @@ export class Store
      */
     @action
     modifyRecords(modifications: Some<PlainObject>): StoreChangeLog {
+        this.throwIfReadOnly('modifyRecords');
         modifications = castArray(modifications);
         if (isEmpty(modifications)) return;
 
@@ -727,6 +791,7 @@ export class Store
      */
     @action
     revertRecords(records: StoreRecordOrId | StoreRecordOrId[]) {
+        this.throwIfReadOnly('revertRecords');
         records = castArray(records);
         if (isEmpty(records)) return;
 
@@ -755,9 +820,17 @@ export class Store
      */
     @action
     revert() {
+        this.throwIfReadOnly('revert');
         this._current = this._committed;
         if (this.summaryRecords) this.revertSummaryRecords(this.summaryRecords);
         this.rebuildFiltered();
+    }
+
+    private throwIfReadOnly(op: string) {
+        throwIf(
+            this.adoptRawData,
+            `Store.${op}() is unsupported when adoptRawData is enabled - this is a read-only projection (committed always equals current). Data updates flow in via loadData/updateData.`
+        );
     }
 
     /** Get a specific Field by name.*/
@@ -1138,6 +1211,23 @@ export class Store
         isSummary: boolean = false
     ): StoreRecord {
         const id = this.idSpec(raw);
+
+        // Zero-copy adoption - adopt the (already-parsed) raw object as `data` by reference, minting
+        // a fresh record identity so downstream grid transactions still fire. No processRawData,
+        // no parseRaw, no data.id write, no freeze - the Store does not own this object here.
+        // (No finalize() either - it only freezes, and freezeData is always false in this mode.)
+        // See StoreConfig.adoptRawData for the full contract.
+        if (this.adoptRawData) {
+            return new StoreRecord({
+                id,
+                store: this,
+                raw,
+                data: raw,
+                committedData: raw,
+                parent,
+                isSummary
+            });
+        }
 
         // Potentially re-use existing record if raw data is reference equal and tree path identical
         if (this.reuseRecords) {

--- a/data/StoreRecord.ts
+++ b/data/StoreRecord.ts
@@ -239,7 +239,9 @@ export class StoreRecord {
             isNil(id),
             "Record needs an ID. Use 'Store.idSpec' to specify a unique ID for each record."
         );
-        data.id = id;
+        // In adoptRawData mode the Store does not own `data` (it is the shared provider object), so
+        // we never write to it. The provider's id already matches - see StoreConfig.adoptRawData.
+        if (!store.adoptRawData) data.id = id;
 
         this.id = id;
         this.agId = 'ag_' + id.toString();


### PR DESCRIPTION
Adds an opt-in `StoreConfig.adoptRawData` mode (default `false`) for read-only projections of already-parsed data - the dominant Cube use case: a Cube feeding connected `View`(s), each driving a (tree) grid. Resolves #4506.

When enabled, each record adopts the provider's raw object **as** its `data`, by reference, instead of re-parsing and copying it. This collapses the usual two per-row objects (the `ViewRowData` plus the Store's parsed copy) down to one and skips the per-row `parseRaw` on every load and tick.

**Stacked on #4500 / #4502 - this PR targets `cube-view-row-data`, not `develop`.**

### Behavior

- Zero-copy `createRecord`: adopts raw as `data` (skips `processRawData` / `parseRaw` / `data.id` write / freeze), minting a fresh record identity each load/update so ag-Grid transactions still fire.
- Read-only: `addRecords` / `removeRecords` / `modifyRecords` / `revertRecords` / `revert` throw; data flows in via `loadData` / `updateData`. Summary records (including the `loadRootAsSummary` / `includeRoot` "Total" row) are adopted the same way.
- Construction fails fast on explicitly-incompatible config (`processRawData`, `reuseRecords`, `freezeData: true`); `freezeData` is otherwise normalized to `false`.
- Non-breaking: opt-in, default `false`, no change to existing behavior.

### Measured gains

Toolbox cube tester, 30,320 rows, real Cube -> View, Chrome with precise heap + forced GC. Isolated on standalone stores loading identical `ViewRowData`, so this measures the Store's own cost - and both modes already benefit from #4500's fast-properties factory / #4502's assigner:

| Fields | Store retained (legacy -> adopt) | Mem saved | Record build (legacy -> adopt) |
|---:|---|---:|---|
| 14 | 5.9 -> 3.3 MB | 43% | 47.9 -> 16.3 ms (2.9x) |
| 30 | 7.8 -> 3.3 MB | 57% | 83.9 -> 17.4 ms (4.8x) |
| 50 | 10.1 -> 3.4 MB | 67% | 140.6 -> 16.3 ms (8.6x) |

adoptRawData is **constant-cost** (~116 B/record, ~16 ms) regardless of field width - it adds no per-field work and no data object. Legacy scales linearly with width, so the win grows with record width. Memory is the headline; faster record build is a secondary win (end-to-end tick latency gains less, since Cube recompute + grid render dominate that path and are mode-independent).

### Verification

Cube -> View -> tree grid acceptance test (companion Toolbox PR): under a leaf tick that mutates `ViewRowData` in place, both simple- and complex-renderer cells repaint, aggregates and the `includeRoot` Total update, and unchanged rows stay stable. Edit-API and construction guards confirmed to throw at runtime. `tsc` and `eslint` clean.

Hoist P/R Checklist
-------------------

- [x] Caught up with base branch as of last change. _(Stacked on `cube-view-row-data`; caught up with that base, not `develop`.)_
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. _(Non-breaking: opt-in, default `false`.)_
- [x] Updated doc comments / prop-types, or determined not required. _(Extensive JSDoc on the `adoptRawData` config.)_
- [x] Reviewed and tested on Mobile, or determined not required. _(Data-layer change, platform-agnostic.)_
- [x] Created Toolbox branch / PR, or determined not required. _(xh/toolbox#881.)_