### PR TITLE
FetchService: add internStrings option - dedupe repeated string values in JSON/NDJSON responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,20 @@
 * Added `XH.fetchNdjson()` to consume an NDJSON (newline-delimited JSON) response incrementally
   as an async iterable - the natural streaming source for `Store.loadDataAsync()`, and usable
   directly via `for await` for any streamed endpoint.
+* Added `FetchOptions.internStrings` to intern (deduplicate) repeated string values within large
+  JSON and NDJSON responses, reducing retained memory for high-volume tabular datasets. Interned
+  values are also shared across successive fetches of the same logical dataset, as identified by
+  a required app-provided key.
 
 ### ⚙️ Technical
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped Popper.js
   onto Floating UI for React 19 compatibility. The hoist `Popover` components (mobile and desktop)
   have been updated so no app call-site changes are required.
 * Applied type adjustments to meet React 19's stricter `@types/react` typing.
+* Field XSS protection now preserves the reference identity of string values that sanitization
+  does not modify (the common case). Previously every parsed string value was replaced with a
+  freshly-allocated copy, doubling string memory on stores retaining raw data and defeating any
+  upstream deduplication of repeated values.
 
 ### 📚 Libraries
 * react `18.2 → 19.2`

--- a/data/Field.ts
+++ b/data/Field.ts
@@ -145,13 +145,13 @@ export function parseFieldValue(
         case 'tags':
             val = castArray(val);
             val = val.map(v => {
-                v = !enableXssProtection || !isString(v) ? v : DOMPurify.sanitize(v);
+                v = !enableXssProtection || !isString(v) ? v : sanitizeVal(v);
                 return v.toString();
             });
             return val;
         case 'auto':
         case 'json':
-            return !enableXssProtection || !isString(val) ? val : DOMPurify.sanitize(val);
+            return !enableXssProtection || !isString(val) ? val : sanitizeVal(val);
         case 'int':
             val = toNumber(val);
             return isFinite(val) ? Math.trunc(val) : null;
@@ -161,7 +161,7 @@ export function parseFieldValue(
             return !!val;
         case 'pwd':
         case 'string':
-            val = !enableXssProtection || !isString(val) ? val : DOMPurify.sanitize(val);
+            val = !enableXssProtection || !isString(val) ? val : sanitizeVal(val);
             return val.toString();
         case 'date':
             return isLocalDate(val) ? val.date : isDate(val) ? val : new Date(val);
@@ -172,6 +172,18 @@ export function parseFieldValue(
     }
 
     throw XH.exception(`Unknown field type '${type}'`);
+}
+
+/**
+ * Sanitize via DOMPurify, preserving the reference identity of values it does not modify.
+ * DOMPurify allocates a fresh string on every call, even when sanitization is a no-op -
+ * returning the original in that case keeps values deduplicated upstream (e.g. via
+ * `FetchOptions.internStrings`) shared, and avoids retaining a second copy of every parsed
+ * string value alongside `StoreRecord.raw`.
+ */
+function sanitizeVal(val: string): string {
+    const ret = DOMPurify.sanitize(val);
+    return ret === val ? val : ret;
 }
 
 /** Data types for Fields used within Hoist Store Records and Cubes. */

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -265,14 +265,18 @@ export class FetchService extends HoistService {
     }
 
     /**
-     * Clear all string-interning caches maintained for {@link FetchOptions.internStrings}.
+     * Clear string-interning caches maintained for {@link FetchOptions.internStrings} - all of
+     * them, or just the cache for a single key.
      *
      * Interned strings referenced by live records remain retained by those records - this
      * releases only the cache's own references. Useful after tearing down large views whose
-     * datasets will not be refetched.
+     * datasets will not be refetched, where the cache would otherwise continue to retain the
+     * last response's distinct values.
+     *
+     * @param key - specific {@link InternStringsSpec.key} to clear, or omit to clear all.
      */
-    clearInternCaches() {
-        this.interners.clear();
+    clearInternCaches(key?: string) {
+        key ? this.interners.delete(key) : this.interners.clear();
     }
 
     /**

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -1054,6 +1054,14 @@ export interface InternStringsSpec {
      * null - no recursion.
      */
     childrenKey?: string;
+
+    /**
+     * True (default) to hold each response's interned values for reuse by the next response
+     * with the same key. Set false to intern within each response only - appropriate for large
+     * one-shot datasets that will not be refetched, where a retained cache would pin the last
+     * response's distinct values for no future benefit.
+     */
+    retainAcrossFetches?: boolean;
 }
 
 /**

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -23,9 +23,21 @@ import {PromiseTimeoutSpec} from '@xh/hoist/promise';
 import {isLocalDate, SECONDS} from '@xh/hoist/utils/datetime';
 import {apiDeprecated, warnIf} from '@xh/hoist/utils/js';
 import {StatusCodes} from 'http-status-codes';
-import {isDate, isFunction, isNil, isObject, isString, noop, omit, omitBy, truncate} from 'lodash';
+import {
+    isDate,
+    isEqual,
+    isFunction,
+    isNil,
+    isObject,
+    isString,
+    noop,
+    omit,
+    omitBy,
+    truncate
+} from 'lodash';
 import {IStringifyOptions, stringify} from 'qs';
 import ShortUniqueId from 'short-unique-id';
+import {StringInterner} from './impl/StringInterner';
 
 const defaultIdGenerator = new ShortUniqueId({length: 16});
 
@@ -79,6 +91,7 @@ export class FetchService extends HoistService {
     private autoAborters = {};
     private _defaultHeaders: DefaultHeaders[] = [];
     private _interceptors: FetchInterceptor[] = [];
+    private interners: Map<string, StringInterner> = new Map();
 
     /** Default timeout to be used for all requests made via this service */
     defaultTimeout: PromiseTimeoutSpec = 30 * SECONDS;
@@ -249,6 +262,17 @@ export class FetchService extends HoistService {
         aborter.abort();
         delete autoAborters[autoAbortKey];
         return true;
+    }
+
+    /**
+     * Clear all string-interning caches maintained for {@link FetchOptions.internStrings}.
+     *
+     * Interned strings referenced by live records remain retained by those records - this
+     * releases only the cache's own references. Useful after tearing down large views whose
+     * datasets will not be refetched.
+     */
+    clearInternCaches() {
+        this.interners.clear();
     }
 
     //-----------------------
@@ -484,9 +508,14 @@ export class FetchService extends HoistService {
         callCtx: CallContext
     ): Promise<any> {
         if (this.NO_JSON_RESPONSES.includes(r.status)) return null;
-        return r.json().catchWhen('SyntaxError', e => {
+        const ret = await r.json().catchWhen('SyntaxError', e => {
             throw this.jsonParseException(opts, callCtx, e);
         });
+
+        const interner = this.getInterner(opts.internStrings);
+        interner?.intern(ret);
+        interner?.commit();
+        return ret;
     }
 
     private async safeResponseTextAsync(response: Response) {
@@ -625,10 +654,12 @@ export class FetchService extends HoistService {
         fetchPromise: Promise<Response>,
         onComplete: (err?: unknown) => void
     ): AsyncGenerator<PlainObject[]> {
+        const interner = this.getInterner(opts.internStrings);
         try {
             const response = await fetchPromise;
             try {
-                yield* this.ndjsonChunks(response);
+                yield* this.ndjsonChunks(response, interner);
+                interner?.commit();
             } catch (e) {
                 const ex =
                     e?.name === 'AbortError'
@@ -638,7 +669,10 @@ export class FetchService extends HoistService {
                 throw ex;
             }
         } finally {
-            onComplete(); // only finally blocks run if the consumer exits its loop early
+            // Only finally blocks run if the consumer exits its loop early. Discard any
+            // uncommitted interned values - no-op after a successful commit above.
+            interner?.abort();
+            onComplete();
         }
     }
 
@@ -648,7 +682,10 @@ export class FetchService extends HoistService {
      * lines are carried across chunk boundaries, and no more than one network chunk of raw text
      * is buffered.
      */
-    private async *ndjsonChunks(response: Response): AsyncGenerator<PlainObject[]> {
+    private async *ndjsonChunks(
+        response: Response,
+        interner: StringInterner
+    ): AsyncGenerator<PlainObject[]> {
         const reader = response.body.getReader(),
             decoder = new TextDecoder();
         let buffer = '';
@@ -660,11 +697,33 @@ export class FetchService extends HoistService {
             buffer += decoder.decode(value, {stream: true});
             const lines = buffer.split('\n');
             buffer = lines.pop(); // retain any partial trailing line for the next chunk
-            if (lines.length) yield lines.filter(Boolean).map(it => JSON.parse(it));
+            if (lines.length) {
+                const chunk = lines.filter(Boolean).map(it => JSON.parse(it));
+                yield interner ? interner.intern(chunk) : chunk;
+            }
         }
 
         buffer += decoder.decode();
-        if (buffer.trim()) yield [JSON.parse(buffer)];
+        if (buffer.trim()) {
+            const chunk = [JSON.parse(buffer)];
+            yield interner ? interner.intern(chunk) : chunk;
+        }
+    }
+
+    /**
+     * Get or create the {@link StringInterner} for the given spec's key, or null if interning
+     * was not requested. An existing interner is replaced (dropping its cached generation) if
+     * the spec has changed since it was created.
+     */
+    private getInterner(spec: InternStringsSpec): StringInterner {
+        if (!spec) return null;
+        const {interners} = this;
+        let ret = interners.get(spec.key);
+        if (!ret || !isEqual(ret.spec, spec)) {
+            ret = new StringInterner(spec);
+            interners.set(spec.key, ret);
+        }
+        return ret;
     }
 
     /**
@@ -918,6 +977,22 @@ export interface FetchOptions {
     autoAbortKey?: string;
 
     /**
+     * If set, intern string values in array-based JSON and NDJSON responses to reduce retained
+     * memory on large tabular datasets - each distinct string value is stored once and shared
+     * across all rows, rather than duplicated per row as produced by JSON parsing.
+     *
+     * Applies to string values at the root level of each object within an array response (or
+     * each NDJSON record). A single plain-object response is treated as a root record and
+     * processed likewise. Nested values are not processed, with the exception of recursion
+     * into child records via `childrenKey`. No-op for response payloads of any other shape.
+     *
+     * Interned values are additionally shared across successive responses with the same `key` -
+     * e.g. a polling refresh of the same grid - with cache retention bounded to the values
+     * present in the most recent complete response for each key.
+     */
+    internStrings?: InternStringsSpec;
+
+    /**
      * True to decode the HTTP response as JSON. Default false.
      */
     asJson?: boolean;
@@ -940,6 +1015,26 @@ export interface FetchOptions {
      * @internal
      */
     traceId?: string;
+}
+
+/**
+ * Spec for string-value interning of a fetch response.
+ * @see FetchOptions.internStrings
+ */
+export interface InternStringsSpec {
+    /**
+     * Identifies the logical dataset. Successive responses fetched with the same key share
+     * interned values across fetches, with cache retention bounded to the latest response.
+     * Cleared via {@link FetchService.clearInternCaches}.
+     */
+    key: string;
+
+    /**
+     * Property of each record containing nested child records to recurse into, for tree data -
+     * typically 'children'. Match to the consuming Store's `loadTreeDataFrom` config. Default
+     * null - no recursion.
+     */
+    childrenKey?: string;
 }
 
 /**

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -275,6 +275,19 @@ export class FetchService extends HoistService {
         this.interners.clear();
     }
 
+    /**
+     * Snapshot of string-interning stats for each active {@link FetchOptions.internStrings}
+     * key, covering the most recently completed response per key: total string values
+     * processed, distinct values retained (with % of processed - lower = more duplication
+     * removed), and values carried over from the prior generation (with % of retained -
+     * higher = more stability across refreshes).
+     *
+     * Convenient from the console via `console.table(XH.fetchService.getInternStats())`.
+     */
+    getInternStats(): PlainObject[] {
+        return Array.from(this.interners.values()).map(it => it.stats);
+    }
+
     //-----------------------
     // Implementation
     //-----------------------

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -712,14 +712,16 @@ export class FetchService extends HoistService {
             buffer = lines.pop(); // retain any partial trailing line for the next chunk
             if (lines.length) {
                 const chunk = lines.filter(Boolean).map(it => JSON.parse(it));
-                yield interner ? interner.intern(chunk) : chunk;
+                interner?.intern(chunk);
+                yield chunk;
             }
         }
 
         buffer += decoder.decode();
         if (buffer.trim()) {
             const chunk = [JSON.parse(buffer)];
-            yield interner ? interner.intern(chunk) : chunk;
+            interner?.intern(chunk);
+            yield chunk;
         }
     }
 

--- a/svc/impl/StringInterner.ts
+++ b/svc/impl/StringInterner.ts
@@ -65,19 +65,18 @@ export class StringInterner {
     }
 
     /**
-     * Intern string values within the given data, in place. Returns the same value.
+     * Intern string values within the given data, mutating it in place.
      *
      * Accepts an array of records, or a single plain-object record - the latter treated as a
      * root node, with its own string values interned and `childrenKey` recursion applying as
-     * usual. Any other value passes through untouched.
+     * usual. Values of any other shape are ignored.
      */
-    intern<T>(data: T): T {
+    intern(data: PlainObject | PlainObject[]) {
         this.pending ??= new Map();
         const rows = isArray(data) ? data : [data];
         rows.forEach(row => {
             if (isPlainObject(row)) this.internRow(row);
         });
-        return data;
     }
 
     /** Install pending values as the new committed generation, evicting values not re-seen. */

--- a/svc/impl/StringInterner.ts
+++ b/svc/impl/StringInterner.ts
@@ -79,7 +79,11 @@ export class StringInterner {
         });
     }
 
-    /** Install pending values as the new committed generation, evicting values not re-seen. */
+    /**
+     * Install pending values as the new committed generation, evicting values not re-seen.
+     * No-op on the committed generation if the spec opts out via `retainAcrossFetches: false` -
+     * `committed` then remains permanently empty, and interning is per-response only.
+     */
     commit() {
         if (this.pending) {
             this.lastStats = {
@@ -87,7 +91,7 @@ export class StringInterner {
                 retained: this.pending.size,
                 carried: this.carried
             };
-            this.committed = this.pending;
+            if (this.spec.retainAcrossFetches !== false) this.committed = this.pending;
             this.pending = null;
             this.processed = this.carried = 0;
         }

--- a/svc/impl/StringInterner.ts
+++ b/svc/impl/StringInterner.ts
@@ -6,7 +6,7 @@
  */
 
 import {PlainObject} from '@xh/hoist/core';
-import {isArray, isPlainObject, isString} from 'lodash';
+import {isArray, isPlainObject, isString, round} from 'lodash';
 import type {InternStringsSpec} from '../FetchService';
 
 /**
@@ -32,9 +32,36 @@ export class StringInterner {
     private committed: Map<string, string> = new Map();
     private pending: Map<string, string> = null;
 
+    // Live counters for the in-progress cycle, snapshotted to lastStats on commit.
+    private processed = 0;
+    private carried = 0;
+    private lastStats: PlainObject = null;
+
     constructor(spec: InternStringsSpec) {
         this.spec = spec;
         this.childrenKey = spec.childrenKey;
+    }
+
+    /**
+     * Stats for the most recently committed cycle (i.e. response) - all zero if none committed:
+     *  - `processed` - total string values encountered.
+     *  - `retained` - distinct values held in the resulting generation, with `retainedPct` of
+     *     processed. Lower percentage = more duplication removed.
+     *  - `carried` - retained values already present in the previous generation, with
+     *    `carriedPct` of retained. Higher percentage = more stability across refreshes.
+     *
+     * Introspect from the console via `XH.fetchService.getInternStats()`.
+     */
+    get stats(): PlainObject {
+        const {processed = 0, retained = 0, carried = 0} = this.lastStats ?? {};
+        return {
+            key: this.spec.key,
+            processed,
+            retained,
+            retainedPct: processed ? round((100 * retained) / processed, 1) : 0,
+            carried,
+            carriedPct: retained ? round((100 * carried) / retained, 1) : 0
+        };
     }
 
     /**
@@ -56,14 +83,21 @@ export class StringInterner {
     /** Install pending values as the new committed generation, evicting values not re-seen. */
     commit() {
         if (this.pending) {
+            this.lastStats = {
+                processed: this.processed,
+                retained: this.pending.size,
+                carried: this.carried
+            };
             this.committed = this.pending;
             this.pending = null;
+            this.processed = this.carried = 0;
         }
     }
 
     /** Discard pending values without committing. No-op if already committed or aborted. */
     abort() {
         this.pending = null;
+        this.processed = this.carried = 0;
     }
 
     //------------------
@@ -74,9 +108,15 @@ export class StringInterner {
         for (const k in row) {
             const v = row[k];
             if (isString(v)) {
+                this.processed++;
                 let c = pending.get(v);
                 if (c === undefined) {
-                    c = committed.get(v) ?? v;
+                    c = committed.get(v);
+                    if (c !== undefined) {
+                        this.carried++;
+                    } else {
+                        c = v;
+                    }
                     pending.set(c, c);
                 }
                 row[k] = c;

--- a/svc/impl/StringInterner.ts
+++ b/svc/impl/StringInterner.ts
@@ -1,0 +1,88 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+
+import {PlainObject} from '@xh/hoist/core';
+import {isArray, isPlainObject, isString} from 'lodash';
+import type {InternStringsSpec} from '../FetchService';
+
+/**
+ * Generational string-interning cache for a logical dataset, identified by an app-provided
+ * key and shared across fetches of that dataset - see {@link FetchOptions.internStrings}.
+ *
+ * Values are deduplicated into an internal pending map spanning a whole response (all chunks
+ * of an NDJSON stream), with lookups falling back to the previous committed generation, so
+ * values repeated across successive fetches share a single canonical string. Calling `commit()`
+ * installs the pending values as the new generation, bounding cache retention to the strings
+ * present in the latest completed response.
+ *
+ * The pending map is opened lazily by `intern()`. A response that fails or is abandoned before
+ * commit should be `abort()`ed to discard its pending values - the previously committed
+ * generation remains in place either way.
+ *
+ * @internal
+ */
+export class StringInterner {
+    readonly spec: InternStringsSpec;
+
+    private readonly childrenKey: string;
+    private committed: Map<string, string> = new Map();
+    private pending: Map<string, string> = null;
+
+    constructor(spec: InternStringsSpec) {
+        this.spec = spec;
+        this.childrenKey = spec.childrenKey;
+    }
+
+    /**
+     * Intern string values within the given data, in place. Returns the same value.
+     *
+     * Accepts an array of records, or a single plain-object record - the latter treated as a
+     * root node, with its own string values interned and `childrenKey` recursion applying as
+     * usual. Any other value passes through untouched.
+     */
+    intern<T>(data: T): T {
+        this.pending ??= new Map();
+        const rows = isArray(data) ? data : [data];
+        rows.forEach(row => {
+            if (isPlainObject(row)) this.internRow(row);
+        });
+        return data;
+    }
+
+    /** Install pending values as the new committed generation, evicting values not re-seen. */
+    commit() {
+        if (this.pending) {
+            this.committed = this.pending;
+            this.pending = null;
+        }
+    }
+
+    /** Discard pending values without committing. No-op if already committed or aborted. */
+    abort() {
+        this.pending = null;
+    }
+
+    //------------------
+    // Implementation
+    //------------------
+    private internRow(row: PlainObject) {
+        const {pending, committed, childrenKey} = this;
+        for (const k in row) {
+            const v = row[k];
+            if (isString(v)) {
+                let c = pending.get(v);
+                if (c === undefined) {
+                    c = committed.get(v) ?? v;
+                    pending.set(c, c);
+                }
+                row[k] = c;
+            } else if (k === childrenKey) {
+                this.intern(v);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**TLDR:** New `FetchOptions.internStrings` config interns (deduplicates) repeated string values in array-based JSON and NDJSON responses, so each distinct value is held once on the heap and shared across all rows - and across successive fetches of the same logical dataset. Companion fix: Field XSS protection now preserves the reference identity of strings that sanitization does not modify.

### Why

`JSON.parse` allocates a fresh string per occurrence - a low-cardinality column repeated across 100k rows costs ~32+ B per duplicate, and V8 performs no runtime string deduplication of parse output. For the large tabular payloads feeding Stores and Cubes this is significant retained heap for content that is overwhelmingly repetitive (sectors, regions, statuses, date strings across columns). Measured on a synthetic 500k-row payload with 8 distinct values: **15.2 MB freed** (34.3 → 19.1 MB retained).

Complements `retainRaw: false` (#4504): interning collapses duplicated string *values*, `retainRaw` discards the raw row *shells* - each addresses the half the other can't.

### How

- `internStrings: {key: 'positionsGrid', childrenKey?: 'children'}` on any JSON-decoding fetch method or `fetchNdjson`.
- New `StringInterner` (`svc/impl`) - a generational per-key cache held by `FetchService`:
  - Dedupes root-level string values across all rows of a response (including all chunks of an NDJSON stream), with `childrenKey` recursion for tree data. A single plain-object payload is treated as a root record.
  - Lookups fall back to the previous completed generation, so a polling refresh shares strings with the records it replaces (minimizing old-gen GC churn between loads).
  - `commit()` on complete consumption swaps in the new generation - retention is bounded to values present in the latest complete response per key. Failed or abandoned responses are `abort()`ed, discarding pending values.
  - Interner is recreated (dropping its cache) if the spec for a key changes. `XH.fetchService.clearInternCaches(key?)` releases a single dataset's cache (e.g. on teardown of a view that will not refetch) or all of them.
  - `retainAcrossFetches: false` opts a key out of holding values between responses - values still dedupe within each response, appropriate for large one-shot datasets that will not be refetched.
- Introspectable stats: `XH.fetchService.getInternStats()` reports, per key, the latest response's string values processed, distinct values retained (% of processed), and values carried over from the prior generation (% of retained).
- **`Field.parseFieldValue` fix:** DOMPurify allocates a fresh string on every call even when sanitization is a no-op (the common case). Values now keep their original reference when unchanged - without this, default XSS protection would silently re-duplicate every interned value on its way into `record.data` (and it independently doubles string memory on raw-retaining stores today).

### Notes

- Interning effects are invisible to `===` (content equality) - verification was done via forced-GC heap measurement, not equality assertions. Worth keeping in mind for any future changes to the write-back path.
- Root-level values only by design: the volume case is flat tabular data. Nested structures (beyond `childrenKey`) pass through untouched.
- Concurrent in-flight fetches sharing a key blur generation boundaries slightly (union generation) - interning correctness is unaffected.

---

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change. (Targets `dataPerformance`, which builds on develop.)
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. (None - additive, opt-in.)
- [x] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required. (Platform-agnostic fetch/data layer - believed not required.)
- [x] Created Toolbox branch / PR, or determined not required. (Toolbox `grid-test-ndjson` branch - the admin Grid test panel streaming path now loads with `retainRaw: false` + `internStrings`, ready for heap-snapshot verification.)

