### PR TITLE
Add "View Surrounding Lines" action to Admin Console log viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@
       any custom styling that targeted  Blueprint or Popper css classes (e.g. `bp6-minimal`).
     * The `popperOptions` `popper.js` escape-hatch prop has been removed from the mobile `Popover`.
 
+### 🎁 New Features
+* Added a `View Surrounding Lines` right-click action to the Admin Console log viewer. Clears any
+  active filter and reloads the log around the selected line, then re-selects it and centers it in
+  the viewport - useful for examining the context around a hit found via filtering.
+* Added a `position` option to `GridModel.ensureRecordsVisibleAsync()` and
+  `ensureSelectionVisibleAsync()`, along with a matching `ensureVisiblePosition` option on
+  `selectAsync()`. Allows callers to request that a row be scrolled to the `top`, `middle`, or
+  `bottom` of the viewport, rather than the default of scrolling the minimum amount required.
+
 ### ⚙️ Technical
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped Popper.js
   onto Floating UI for React 19 compatibility. The hoist `Popover` components (mobile and desktop)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,13 +49,6 @@
   definitions - see the `useRawAsData` config docs for the full contract.
 * Added an `icon` prop to `Badge`, rendered before the badge's content. Spacing between the icon and
   content is controlled by the new `--xh-badge-gap` CSS variable.
-
-### 🐞 Bug Fixes
-
-* Fixed `View.getDimensionValues()` returning sets of `undefined` rather than the actual unique
-  values for each dimension.
-
-### 🎁 New Features
 * Added a `View Surrounding Lines` right-click action to the Admin Console log viewer. Clears any
   active filter and reloads the log around the selected line, then re-selects it and centers it in
   the viewport - useful for examining the context around a hit found via filtering.
@@ -63,6 +56,11 @@
   `ensureSelectionVisibleAsync()`, along with a matching `ensureVisiblePosition` option on
   `selectAsync()`. Allows callers to request that a row be scrolled to the `top`, `middle`, or
   `bottom` of the viewport, rather than the default of scrolling the minimum amount required.
+
+### 🐞 Bug Fixes
+
+* Fixed `View.getDimensionValues()` returning sets of `undefined` rather than the actual unique
+  values for each dimension.
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,10 @@
 * Added a `View Surrounding Lines` right-click action to the Admin Console log viewer. Clears any
   active filter and reloads the log around the selected line, then re-selects it and centers it in
   the viewport - useful for examining the context around a hit found via filtering.
-* Added a `position` option to `GridModel.ensureRecordsVisibleAsync()` and
-  `ensureSelectionVisibleAsync()`, along with a matching `ensureVisiblePosition` option on
-  `selectAsync()`. Allows callers to request that a row be scrolled to the `top`, `middle`, or
-  `bottom` of the viewport, rather than the default of scrolling the minimum amount required.
+* Added a `position` option to `GridModel.ensureRecordsVisibleAsync()`,
+  `ensureSelectionVisibleAsync()`, and `selectAsync()`. Allows callers to request that a row be
+  scrolled to the `top`, `middle`, or `bottom` of the viewport, rather than just scrolling the
+  minimum amount required.
 
 ### 🐞 Bug Fixes
 

--- a/admin/tabs/cluster/instances/logs/LogDisplayModel.ts
+++ b/admin/tabs/cluster/instances/logs/LogDisplayModel.ts
@@ -15,6 +15,9 @@ import {debounced} from '@xh/hoist/utils/js';
 import {escapeRegExp, maxBy} from 'lodash';
 import {LogViewerModel} from './LogViewerModel';
 
+/** Lines of context to show above the target line when viewing surrounding logs. */
+const SURROUNDING_LEAD_IN_LINES = 100;
+
 /**
  * @internal
  */
@@ -135,9 +138,29 @@ export class LogDisplayModel extends HoistModel {
         gridModel.agApi?.ensureNodeVisible(lastRecord);
     }
 
+    /**
+     * Clear any active filter and reload the log positioned around the given line, to show it in
+     * the context of its surrounding entries. The target line is re-selected once loaded.
+     */
+    viewSurroundingLines(rowNum: number) {
+        // Keep the target line within the loaded window, even if maxLines is small.
+        const leadIn = Math.min(SURROUNDING_LEAD_IN_LINES, Math.floor((this.maxLines - 1) / 2));
+
+        this.pendingSelectRowNum = rowNum;
+
+        // Order matters: the `tail` reaction below resets startLine, so flip tail off *first* and
+        // do not wrap these writes in an action - they must interleave with that reaction.
+        this.tail = false;
+        this.pattern = '';
+        this.startLine = Math.max(1, rowNum - leadIn);
+    }
+
     //---------------------------------
     // Implementation
     //---------------------------------
+    /** Line number to select on the next load, set by {@link viewSurroundingLines}. */
+    private pendingSelectRowNum: number = null;
+
     private createGridModel() {
         return new GridModel({
             selModel: 'multiple',
@@ -169,6 +192,13 @@ export class LogDisplayModel extends HoistModel {
             ],
             rowClassFn: () => 'xh-log-display__row',
             contextMenu: [
+                {
+                    text: 'View Surrounding Lines',
+                    icon: Icon.search(),
+                    recordsRequired: 1,
+                    actionFn: ({record}) => this.viewSurroundingLines(record.data.rowNum)
+                },
+                '-',
                 'copy',
                 '-',
                 {
@@ -200,7 +230,12 @@ export class LogDisplayModel extends HoistModel {
 
         gridModel.loadData(gridData);
 
-        if (tailActive) {
+        const {pendingSelectRowNum} = this;
+        if (pendingSelectRowNum != null) {
+            // Records are keyed by line number, so we can select the target line by its rowNum.
+            this.pendingSelectRowNum = null;
+            gridModel.selectAsync(pendingSelectRowNum, {ensureVisiblePosition: 'middle'});
+        } else if (tailActive) {
             this.scrollToTail();
         }
     }

--- a/admin/tabs/cluster/instances/logs/LogDisplayModel.ts
+++ b/admin/tabs/cluster/instances/logs/LogDisplayModel.ts
@@ -62,6 +62,9 @@ export class LogDisplayModel extends HoistModel {
     @bindable
     logRootPath: string;
 
+    // Line number to select on the next load
+    private pendingSelectRowNum: number = null;
+
     get tailActive(): boolean {
         return this.tail && !this.gridModel.hasSelection;
     }
@@ -135,39 +138,26 @@ export class LogDisplayModel extends HoistModel {
         gridModel.agApi?.ensureNodeVisible(lastRecord);
     }
 
-    /**
-     * Clear any active filter and reload the log positioned around the given line, to show it in
-     * the context of its surrounding entries. The target line is re-selected once loaded.
-     */
-    viewSurroundingLines(rowNum: number) {
-        // Keep the target line within the loaded window when maxLines is small. A cleared maxLines
-        // input defers to the server's (much larger) default window, so a full lead-in is safe.
+    //---------------------------------
+    // Implementation
+    //---------------------------------
+    /** Clear any active filter and reload the log around the given line, re-selecting it. */
+    private viewSurroundingLines(rowNum: number) {
+        // Keep the target in the loaded window - a cleared maxLines defers to the server default.
         const {maxLines} = this,
-            /** Lines of context to show above the target line when viewing surrounding logs. */
-            SURROUNDING_LEAD_IN_LINES = 100,
-            leadIn = maxLines
-                ? Math.min(SURROUNDING_LEAD_IN_LINES, Math.floor((maxLines - 1) / 2))
-                : SURROUNDING_LEAD_IN_LINES;
+            WIN = 100,
+            leadIn = maxLines ? Math.min(WIN, Math.floor((maxLines - 1) / 2)) : WIN;
 
         this.pendingSelectRowNum = rowNum;
 
-        // Order matters: the `tail` reaction in the constructor resets startLine, so flip tail off
-        // *first* and do not wrap writes in an action - they must interleave with that
-        // reaction.
+        // The tail reaction resets startLine - flip tail off first, and not within an action.
         this.tail = false;
         this.pattern = '';
         this.startLine = Math.max(1, rowNum - leadIn);
 
-        // Load directly, as the writes above can all be no-ops - e.g. when re-running this on a
-        // line we have already centered. Debounced, so collapses with any reaction-driven load.
+        // Load directly, as the writes above can all be no-ops - debounce collapses any dupes.
         this.loadLog();
     }
-
-    //---------------------------------
-    // Implementation
-    //---------------------------------
-    /** Line number to select on the next load, set by {@link viewSurroundingLines}. */
-    private pendingSelectRowNum: number = null;
 
     private createGridModel() {
         return new GridModel({
@@ -240,7 +230,6 @@ export class LogDisplayModel extends HoistModel {
 
         const {pendingSelectRowNum} = this;
         if (pendingSelectRowNum != null) {
-            // Records are keyed by line number, so we can select the target line by its rowNum.
             this.pendingSelectRowNum = null;
             gridModel.selectAsync(pendingSelectRowNum, {ensureVisiblePosition: 'middle'});
         } else if (tailActive) {

--- a/admin/tabs/cluster/instances/logs/LogDisplayModel.ts
+++ b/admin/tabs/cluster/instances/logs/LogDisplayModel.ts
@@ -143,16 +143,25 @@ export class LogDisplayModel extends HoistModel {
      * the context of its surrounding entries. The target line is re-selected once loaded.
      */
     viewSurroundingLines(rowNum: number) {
-        // Keep the target line within the loaded window, even if maxLines is small.
-        const leadIn = Math.min(SURROUNDING_LEAD_IN_LINES, Math.floor((this.maxLines - 1) / 2));
+        // Keep the target line within the loaded window when maxLines is small. A cleared maxLines
+        // input defers to the server's (much larger) default window, so a full lead-in is safe.
+        const {maxLines} = this,
+            leadIn = maxLines
+                ? Math.min(SURROUNDING_LEAD_IN_LINES, Math.floor((maxLines - 1) / 2))
+                : SURROUNDING_LEAD_IN_LINES;
 
         this.pendingSelectRowNum = rowNum;
 
-        // Order matters: the `tail` reaction below resets startLine, so flip tail off *first* and
-        // do not wrap these writes in an action - they must interleave with that reaction.
+        // Order matters: the `tail` reaction in the constructor resets startLine, so flip tail off
+        // *first* and do not wrap these writes in an action - they must interleave with that
+        // reaction.
         this.tail = false;
         this.pattern = '';
         this.startLine = Math.max(1, rowNum - leadIn);
+
+        // Load directly, as the writes above can all be no-ops - e.g. when re-running this on a
+        // line we have already centered. Debounced, so collapses with any reaction-driven load.
+        this.loadLog();
     }
 
     //---------------------------------

--- a/admin/tabs/cluster/instances/logs/LogDisplayModel.ts
+++ b/admin/tabs/cluster/instances/logs/LogDisplayModel.ts
@@ -15,9 +15,6 @@ import {debounced} from '@xh/hoist/utils/js';
 import {escapeRegExp, maxBy} from 'lodash';
 import {LogViewerModel} from './LogViewerModel';
 
-/** Lines of context to show above the target line when viewing surrounding logs. */
-const SURROUNDING_LEAD_IN_LINES = 100;
-
 /**
  * @internal
  */
@@ -146,6 +143,8 @@ export class LogDisplayModel extends HoistModel {
         // Keep the target line within the loaded window when maxLines is small. A cleared maxLines
         // input defers to the server's (much larger) default window, so a full lead-in is safe.
         const {maxLines} = this,
+            /** Lines of context to show above the target line when viewing surrounding logs. */
+            SURROUNDING_LEAD_IN_LINES = 100,
             leadIn = maxLines
                 ? Math.min(SURROUNDING_LEAD_IN_LINES, Math.floor((maxLines - 1) / 2))
                 : SURROUNDING_LEAD_IN_LINES;
@@ -153,7 +152,7 @@ export class LogDisplayModel extends HoistModel {
         this.pendingSelectRowNum = rowNum;
 
         // Order matters: the `tail` reaction in the constructor resets startLine, so flip tail off
-        // *first* and do not wrap these writes in an action - they must interleave with that
+        // *first* and do not wrap writes in an action - they must interleave with that
         // reaction.
         this.tail = false;
         this.pattern = '';

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -853,8 +853,8 @@ export class GridModel extends HoistModel {
             ensureVisible?: boolean;
             /**
              * Where to position the selection within the viewport when scrolling it into view.
-             * Default of null scrolls the minimum amount required. Ignored if `ensureVisible`
-             * is false.
+             * Default of null scrolls the minimum amount required. If multiple records are
+             * selected, applies to the first of them. Ignored if `ensureVisible` is false.
              */
             ensureVisiblePosition?: GridScrollPosition;
             /** True (default) to clear previous selection (rather than add to it). */
@@ -936,7 +936,8 @@ export class GridModel extends HoistModel {
         opts: {
             /**
              * Where to position the selection within the viewport. Default of null scrolls the
-             * minimum amount required to bring it into view.
+             * minimum amount required to bring it into view. If multiple records are selected,
+             * applies to the first of them.
              */
             position?: GridScrollPosition;
         } = {}
@@ -964,8 +965,9 @@ export class GridModel extends HoistModel {
         records: Some<StoreRecord>,
         opts: {
             /**
-             * Where to position the record(s) within the viewport. Default of null scrolls the
-             * minimum amount required to bring them into view.
+             * Where to position the record within the viewport. Default of null scrolls the
+             * minimum amount required to bring it into view. If multiple records are provided,
+             * applies to the first of them.
              */
             position?: GridScrollPosition;
         } = {}
@@ -1011,7 +1013,10 @@ export class GridModel extends HoistModel {
         if (indexCount === 1) {
             agApi.ensureIndexVisible(indices[0], position);
         } else if (indexCount > 1) {
-            agApi.ensureIndexVisible(max(indices), position);
+            // Scroll to the last record, then the first - showing the start of the range and as
+            // much of the rest as will fit. Any requested position applies to the first record,
+            // as that call lands last and wins.
+            agApi.ensureIndexVisible(max(indices));
             agApi.ensureIndexVisible(min(indices), position);
         }
     }

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -115,6 +115,7 @@ import {
     ColChooserConfig,
     ColumnState,
     GridModelPersistOptions,
+    GridScrollPosition,
     GroupRowRenderer,
     RowClassFn,
     RowClassRuleFn
@@ -850,13 +851,21 @@ export class GridModel extends HoistModel {
              * visible if it is within a collapsed node or outside of the visible scroll window.
              */
             ensureVisible?: boolean;
+            /**
+             * Where to position the selection within the viewport when scrolling it into view.
+             * Default of null scrolls the minimum amount required. Ignored if `ensureVisible`
+             * is false.
+             */
+            ensureVisiblePosition?: GridScrollPosition;
             /** True (default) to clear previous selection (rather than add to it). */
             clearSelection?: boolean;
         } = {}
     ) {
-        const {ensureVisible = true, clearSelection = true} = opts;
+        const {ensureVisible = true, ensureVisiblePosition = null, clearSelection = true} = opts;
         this.selModel.select(records, clearSelection);
-        if (ensureVisible) await this.ensureSelectionVisibleAsync();
+        if (ensureVisible) {
+            await this.ensureSelectionVisibleAsync({position: ensureVisiblePosition});
+        }
     }
 
     /**
@@ -920,12 +929,22 @@ export class GridModel extends HoistModel {
      *
      * Any selected records that are hidden because their parent rows are collapsed will first
      * be revealed by expanding their parent rows.
+     *
+     * @param opts - additional scrolling options
      */
-    async ensureSelectionVisibleAsync() {
+    async ensureSelectionVisibleAsync(
+        opts: {
+            /**
+             * Where to position the selection within the viewport. Default of null scrolls the
+             * minimum amount required to bring it into view.
+             */
+            position?: GridScrollPosition;
+        } = {}
+    ) {
         await this.whenReadyAsync();
         if (!this.isReady) return;
 
-        return this.ensureRecordsVisibleAsync(this.selectedRecords);
+        return this.ensureRecordsVisibleAsync(this.selectedRecords, opts);
     }
 
     /**
@@ -939,8 +958,20 @@ export class GridModel extends HoistModel {
      * be revealed by expanding their parent rows.
      *
      * @param records - one or more record(s) for which to ensure visibility.
+     * @param opts - additional scrolling options
      */
-    async ensureRecordsVisibleAsync(records: Some<StoreRecord>) {
+    async ensureRecordsVisibleAsync(
+        records: Some<StoreRecord>,
+        opts: {
+            /**
+             * Where to position the record(s) within the viewport. Default of null scrolls the
+             * minimum amount required to bring them into view.
+             */
+            position?: GridScrollPosition;
+        } = {}
+    ) {
+        const {position = null} = opts;
+
         await this.whenReadyAsync();
         if (!this.isReady) return;
 
@@ -978,10 +1009,10 @@ export class GridModel extends HoistModel {
         }
 
         if (indexCount === 1) {
-            agApi.ensureIndexVisible(indices[0]);
+            agApi.ensureIndexVisible(indices[0], position);
         } else if (indexCount > 1) {
-            agApi.ensureIndexVisible(max(indices));
-            agApi.ensureIndexVisible(min(indices));
+            agApi.ensureIndexVisible(max(indices), position);
+            agApi.ensureIndexVisible(min(indices), position);
         }
     }
 

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -852,11 +852,7 @@ export class GridModel extends HoistModel {
              * visible if it is within a collapsed node or outside of the visible scroll window.
              */
             ensureVisible?: boolean;
-            /**
-             * Where to position the selection within the viewport when scrolling it into view.
-             * Default of null scrolls the minimum amount required. If multiple records are
-             * selected, applies to the first of them. Ignored if `ensureVisible` is false.
-             */
+            /** Position of the selection in the viewport - default null scrolls minimally. */
             ensureVisiblePosition?: GridScrollPosition;
             /** True (default) to clear previous selection (rather than add to it). */
             clearSelection?: boolean;
@@ -935,11 +931,7 @@ export class GridModel extends HoistModel {
      */
     async ensureSelectionVisibleAsync(
         opts: {
-            /**
-             * Where to position the selection within the viewport. Default of null scrolls the
-             * minimum amount required to bring it into view. If multiple records are selected,
-             * applies to the first of them.
-             */
+            /** Position of the selection in the viewport - default null scrolls minimally. */
             position?: GridScrollPosition;
         } = {}
     ) {
@@ -965,11 +957,7 @@ export class GridModel extends HoistModel {
     async ensureRecordsVisibleAsync(
         records: Some<StoreRecord>,
         opts: {
-            /**
-             * Where to position the record within the viewport. Default of null scrolls the
-             * minimum amount required to bring it into view. If multiple records are provided,
-             * applies to the first of them.
-             */
+            /** Position of the record in the viewport - default null scrolls minimally. */
             position?: GridScrollPosition;
         } = {}
     ) {
@@ -1014,9 +1002,7 @@ export class GridModel extends HoistModel {
         if (indexCount === 1) {
             agApi.ensureIndexVisible(indices[0], position);
         } else if (indexCount > 1) {
-            // Scroll to the last record, then the first - showing the start of the range and as
-            // much of the rest as will fit. Any requested position applies to the first record,
-            // as that call lands last and wins.
+            // Scroll to last then first to show the range start - position applies to the first.
             agApi.ensureIndexVisible(max(indices));
             agApi.ensureIndexVisible(min(indices), position);
         }

--- a/cmp/grid/Types.ts
+++ b/cmp/grid/Types.ts
@@ -62,6 +62,12 @@ export type GridGroupSortFn = (
 ) => number;
 
 /**
+ * Where to position a row within the viewport when scrolling to make it visible.
+ * Null (default) will scroll the minimum amount required to bring the row into view.
+ */
+export type GridScrollPosition = 'top' | 'middle' | 'bottom';
+
+/**
  * Closure to generate CSS class names for a row.
  * @param record - the StoreRecord associated with the rendered row.
  * @returns CSS class(es) to apply to the row level.

--- a/cmp/grid/Types.ts
+++ b/cmp/grid/Types.ts
@@ -74,10 +74,7 @@ export type GridGroupSortFn = (
     }
 ) => number;
 
-/**
- * Where to position a row within the viewport when scrolling to make it visible.
- * Null (default) will scroll the minimum amount required to bring the row into view.
- */
+/** Position of a row in the viewport when scrolled into view - default null scrolls minimally. */
 export type GridScrollPosition = 'top' | 'middle' | 'bottom';
 
 /**


### PR DESCRIPTION
Adds a "View Surrounding Lines" right-click action to the Admin Console log viewer. After filtering for a term, right-clicking a matching line clears the filter and reloads the log positioned around that line, then re-selects it and centers it in the viewport - letting you read a hit in the context of the entries around it without manually clearing the filter and hunting for the line number.
