### PR TITLE
Store: opt-in useRawAsData zero-copy mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,7 @@
   their `data` by reference rather than re-parsing and copying it, collapsing the usual two per-row
   objects to one and skipping the per-row parse on every load and update - a memory-focused
   optimization for large, high-frequency Cube-backed grids. This is a read-only mode - the local
-  edit/commit/revert APIs throw, `freezeData` is forced off, and the data provider must supply
-  pre-parsed values. See the `adoptRawData` config docs for the full contract. Default off,
-  non-breaking.
+  edit/commit/revert APIs throw. See the `adoptRawData` config docs for the full contract.
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,12 +30,12 @@
   JSON and NDJSON responses, reducing retained memory for high-volume tabular datasets. Interned
   values are also shared across successive fetches of the same logical dataset, as identified by
   a required app-provided key.
-* Added an opt-in `Store.adoptRawData` mode for read-only projections of already-parsed data - most
-  notably a connected Cube `View` feeding a (tree) grid. Records adopt the provider's row object as
-  their `data` by reference rather than re-parsing and copying it, collapsing the usual two per-row
-  objects to one and skipping the per-row parse on every load and update - a memory-focused
-  optimization for large, high-frequency Cube-backed grids. This is a read-only mode - the local
-  edit/commit/revert APIs throw. See the `adoptRawData` config docs for the full contract.
+* Added an opt-in `Store.useRawAsData` config for projections of already-parsed data - most notably
+  a connected Cube `View` feeding a (tree) grid, or an endpoint returning data in its final
+  client-side form. Records use the provider's row object as their `data` by reference rather than
+  re-parsing and copying it, collapsing the usual two per-row objects to one and skipping the
+  per-row parse on every load and update. Requires that raw data already match the Store's Field
+  definitions - see the `useRawAsData` config docs for the full contract.
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@
   JSON and NDJSON responses, reducing retained memory for high-volume tabular datasets. Interned
   values are also shared across successive fetches of the same logical dataset, as identified by
   a required app-provided key.
+* Added an opt-in `Store.adoptRawData` mode for read-only projections of already-parsed data - most
+  notably a connected Cube `View` feeding a (tree) grid. Records adopt the provider's row object as
+  their `data` by reference rather than re-parsing and copying it, collapsing the usual two per-row
+  objects to one and skipping the per-row parse on every load and update - a memory-focused
+  optimization for large, high-frequency Cube-backed grids. This is a read-only mode - the local
+  edit/commit/revert APIs throw, `freezeData` is forced off, and the data provider must supply
+  pre-parsed values. See the `adoptRawData` config docs for the full contract. Default off,
+  non-breaking.
 
 ### ⚙️ Technical
 

--- a/data/README.md
+++ b/data/README.md
@@ -102,6 +102,7 @@ const store = new Store({
 | `freezeData` | `boolean` | `true` | Freeze record data objects for immutability (set to false as performance optimization) |
 | `reuseRecords` | `boolean` | `false` | Cache records by ID and raw reference (performance)                                    |
 | `retainRaw` | `boolean` | `true` | Retain raw data reference on each record (set false to reduce memory)                  |
+| `useRawAsData` | `boolean` | `false` | Use each raw object *as* its record's `data`, skipping the parse/copy (memory)        |
 | `idEncodesTreePath` | `boolean` | `false` | IDs imply fixed tree position (performance)                                            |
 | `validationIsComplex` | `boolean` | `false` | Validate all uncommitted records on every change                                       |
 

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -158,38 +158,23 @@ export interface StoreConfig {
     retainRaw?: boolean;
 
     /**
-     * Zero-copy "turbo" mode for read-only projections of already-parsed data - most notably a
-     * connected Cube {@link View} feeding a (tree) grid.
+     * True to adopt each incoming raw object *as* its record's `data`, by reference, rather than
+     * re-parsing and copying it into a dedicated object. A zero-copy mode for read-only
+     * projections of already-parsed data - most notably a connected Cube {@link View} feeding a
+     * (tree) grid. Halves per-row object count, with memory the headline win.
      *
-     * When true, the Store adopts each incoming raw object **as** its record's `data`, by reference,
-     * rather than re-parsing and copying it into a dedicated object. This collapses the usual two
-     * per-row objects (the provider's row object + the Store's parsed copy) down to one, skipping
-     * the per-row `parseRaw` field loop on every load and update. The headline win is memory; a
-     * modest reduction in allocation/GC churn on high-frequency updates is a secondary benefit.
-     *
-     * This mode puts substantial trust in the data provider and comes with a strict contract:
-     *
-     * 1. **Raw data MUST already be parsed.** `parseRaw` is skipped, so Field `type`/`parseVal` are
-     *    NOT applied - Fields become pure metadata (sort/filter/columns/export) and `data` holds
-     *    exactly what the provider supplied. Always true for Cube/View data, which the Cube has
-     *    already parsed (typically via the same field instances).
-     * 2. **The Store does not own `data`.** It never reads or writes `data` internals (including
-     *    `data.id`) and never freezes it. The provider is authoritative and may mutate rows in place.
-     * 3. **Rows may be shared across connected stores.** A View feeds the same row objects to every
-     *    connected store; with by-reference adoption their records point at one object set. Do not
-     *    mutate these objects from app code.
+     * Strict contract with the data provider:
+     * 1. Raw data must already be parsed - `parseRaw` is skipped and Field `type`/`parseVal` are
+     *    NOT applied. (Always true for Cube/View data.)
+     * 2. The Store does not own, modify, or freeze `data` - the provider is authoritative and may
+     *    mutate rows in place.
+     * 3. Rows may be shared by reference across connected stores (as a View does) - do not mutate
+     *    them from app code.
      *
      * Consequences:
-     * - **Read-only.** The local edit/commit/revert APIs (`addRecords`, `removeRecords`,
-     *   `modifyRecords`, `revertRecords`, `revert`) throw - committed always equals current.
-     *   Data still flows in via `loadData`/`updateData` (the provider path).
-     * - **Summary records are adopted too.** The dedicated summary record(s) - whether supplied via
-     *   `rawSummaryData` or extracted from the root row under `loadRootAsSummary` (e.g. a Cube
-     *   View's `includeRoot` "Total" row) - adopt their raw object as `data` by the same rules:
-     *   shared by reference, not owned, not frozen, recreated on update.
-     * - `freezeData` is forced to `false` (a frozen shared object would throw on the provider's
-     *   next in-place mutation). Explicitly passing `freezeData: true` is rejected.
-     * - `processRawData` and `reuseRecords` are incompatible and rejected at construction.
+     * - Read-only: the local edit/commit/revert APIs throw. Data still flows in via
+     *   `loadData`/`updateData`. Summary records are adopted by the same rules.
+     * - `freezeData` is ignored (never frozen); `processRawData` and `reuseRecords` are rejected.
      *
      * Default false.
      */
@@ -363,51 +348,39 @@ export class Store
     private _fieldMap: Map<string, Field>;
     experimental: any;
 
-    constructor(config: StoreConfig) {
+    constructor({
+        fields,
+        fieldDefaults = {},
+        idSpec = 'id',
+        processRawData = null,
+        filter = null,
+        filterIncludesChildren = false,
+        loadTreeData = true,
+        loadTreeDataFrom = 'children',
+        loadRootAsSummary = false,
+        freezeData = Store.defaults.freezeData,
+        idEncodesTreePath = false,
+        reuseRecords = false,
+        retainRaw = true,
+        adoptRawData = false,
+        validationIsComplex = false,
+        experimental,
+        data
+    }: StoreConfig) {
         super();
         makeObservable(this);
-
-        const {
-            fields,
-            fieldDefaults = {},
-            idSpec = 'id',
-            processRawData = null,
-            filter = null,
-            filterIncludesChildren = false,
-            loadTreeData = true,
-            loadTreeDataFrom = 'children',
-            loadRootAsSummary = false,
-            idEncodesTreePath = false,
-            reuseRecords = false,
-            retainRaw = true,
-            adoptRawData = false,
-            validationIsComplex = false,
-            experimental,
-            data
-        } = config;
-        let freezeData = config.freezeData ?? Store.defaults.freezeData;
-
         throwIf(
             reuseRecords && !retainRaw,
             'Store cannot be configured with both `reuseRecords` and `retainRaw: false` - record reuse requires retained raw data references.'
         );
-
-        if (adoptRawData) {
-            // Fail fast on any config that expresses behavior this read-only, zero-copy mode cannot
-            // honor - surface the conflict rather than silently ignoring it and leaving the
-            // developer with a mistaken model of how the Store will behave. freezeData is only
-            // rejected when the developer explicitly opted in to it; the default is normalized off.
-            throwIf(
-                processRawData,
-                'Store.adoptRawData cannot be used with processRawData - the skipped parse would make it a silent no-op.'
-            );
-            throwIf(reuseRecords, 'Store.adoptRawData cannot be used with reuseRecords.');
-            throwIf(
-                config.freezeData === true,
-                'Store.adoptRawData cannot be used with freezeData: true - the provider mutates shared rows in place, so record data cannot be frozen.'
-            );
-            freezeData = false;
-        }
+        throwIf(
+            adoptRawData && processRawData,
+            'Store.adoptRawData cannot be used with processRawData.'
+        );
+        throwIf(
+            adoptRawData && reuseRecords,
+            'Store.adoptRawData cannot be used with reuseRecords.'
+        );
 
         this.experimental = this.parseExperimental(experimental);
         this.fields = this.parseFields(fields, fieldDefaults);
@@ -1277,9 +1250,8 @@ export class Store
 
         // Zero-copy adoption - adopt the (already-parsed) raw object as `data` by reference, minting
         // a fresh record identity so downstream grid transactions still fire. No processRawData,
-        // no parseRaw, no data.id write, no freeze - the Store does not own this object here.
-        // (No finalize() either - it only freezes, and freezeData is always false in this mode.)
-        // See StoreConfig.adoptRawData for the full contract.
+        // no parseRaw, no data.id write, no freeze (finalize skips it in this mode) - the Store
+        // does not own this object here. See StoreConfig.adoptRawData for the full contract.
         if (this.adoptRawData) {
             return new StoreRecord({
                 id,

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -161,29 +161,18 @@ export interface StoreConfig {
      * True to use each incoming raw object *as* its record's `data`, by reference, rather than
      * re-parsing and copying it into a dedicated object. A zero-copy mode for projections of
      * already-parsed data - most notably a connected Cube {@link View} feeding a (tree) grid, or a
-     * server endpoint returning data already in its final client-side form. Halves per-row object
-     * count, with memory the headline win.
+     * server endpoint returning data already in its final client-side form.
      *
-     * Strict contract with the data provider:
-     * 1. Raw data must already be parsed, and parsed *identically* to what the Store's Field
-     *    definitions would produce - `parseRaw` is skipped, so Field `type` and `parseVal` are not
-     *    applied and Field `defaultValue` is not supplied for missing keys (a missing key reads as
-     *    `undefined`, not its default). Note that local edits via `modifyRecords()` *do* run
-     *    `Field.parseVal`, so raw data that does not already match its Field types will yield a
-     *    Store where edited and untouched records disagree on value type.
-     * 2. The Store never modifies or freezes a raw object - the provider stays authoritative and
-     *    retains the right to mutate its own rows in place. Note that `freezeData` therefore offers
-     *    app code no protection against writing to record data. Data objects the Store creates
-     *    itself, for local adds and edits, *are* owned and frozen per `freezeData` as usual.
-     * 3. When the provider does mutate a row in place, it must publish via `updateData()`, never
-     *    `loadData()`. `loadData()` reuses an existing record whenever its data is unchanged, and a
-     *    row mutated in place is reference-equal to what its record already holds - so the update
-     *    would be dropped and the grid would render stale values. `updateData()` always installs
-     *    the new record identity.
+     * Contract with the data provider:
+     * 1. Raw data must already be parsed as the Store's Field definitions would parse it - Field
+     *    `type`, `parseVal`, and `defaultValue` are not applied.
+     * 2. The Store never modifies or freezes a raw object (regardless of `freezeData`) - the
+     *    provider stays authoritative and may mutate its own rows in place.
+     * 3. A row mutated in place must be published via `updateData()`, not `loadData()`, which
+     *    would skip the reference-equal object as unchanged.
      *
-     * Note that `data` will carry every key present on the raw object, not just those declared as
-     * Fields, that rows may be shared by reference across connected stores (as a View does), and
-     * that `processRawData` and `reuseRecords` are rejected as incompatible.
+     * Note that `data` will carry every key present on the raw object, not just those declared
+     * as Fields. Not compatible with `processRawData` or `reuseRecords`.
      *
      * Default false.
      */

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -159,22 +159,16 @@ export interface StoreConfig {
 
     /**
      * True to use each incoming raw object *as* its record's `data`, by reference, rather than
-     * re-parsing and copying it into a dedicated object. A zero-copy mode for projections of
-     * already-parsed data - most notably a connected Cube {@link View} feeding a (tree) grid, or a
-     * server endpoint returning data already in its final client-side form.
+     * parsing and copying it. A zero-copy mode for already-parsed data - e.g. a connected Cube
+     * {@link View}, or a server endpoint returning data in its final client-side form.
      *
-     * Contract with the data provider:
-     * 1. Raw data must already be parsed as the Store's Field definitions would parse it - Field
-     *    `type`, `parseVal`, and `defaultValue` are not applied.
-     * 2. The Store never modifies or freezes a raw object (regardless of `freezeData`) - the
-     *    provider stays authoritative and may mutate its own rows in place.
-     * 3. A row mutated in place must be published via `updateData()`, not `loadData()`, which
-     *    would skip the reference-equal object as unchanged.
+     * Raw data must already match what the Store's Fields would parse - `type`, `parseVal`, and
+     * `defaultValue` are not applied. The Store never modifies or freezes raw objects (regardless
+     * of `freezeData`); the provider may mutate rows in place but must then publish via
+     * `updateData()`, as `loadData()` would skip reference-equal objects as unchanged.
      *
-     * Note that `data` will carry every key present on the raw object, not just those declared
-     * as Fields. Not compatible with `processRawData` or `reuseRecords`.
-     *
-     * Default false.
+     * `data` will carry every key on the raw object, not just declared Fields. Not compatible
+     * with `processRawData` or `reuseRecords`. Default false.
      */
     useRawAsData?: boolean;
 
@@ -1234,10 +1228,8 @@ export class Store
     ): StoreRecord {
         const id = this.idSpec(raw);
 
-        // Zero-copy - use the (already-parsed) raw object as `data` by reference, minting a fresh
-        // record identity so downstream grid transactions still fire. No processRawData, no
-        // parseRaw, and (as `data === raw`) no data.id write and no freeze - the Store does not own
-        // this object. See StoreConfig.useRawAsData for the full contract.
+        // Zero-copy - use the raw object as `data` by reference, with no parsing, no data.id
+        // write, and no freeze. The Store does not own this object - see StoreConfig.useRawAsData.
         if (this.useRawAsData) {
             return new StoreRecord({
                 id,

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -158,6 +158,44 @@ export interface StoreConfig {
     retainRaw?: boolean;
 
     /**
+     * Zero-copy "turbo" mode for read-only projections of already-parsed data - most notably a
+     * connected Cube {@link View} feeding a (tree) grid.
+     *
+     * When true, the Store adopts each incoming raw object **as** its record's `data`, by reference,
+     * rather than re-parsing and copying it into a dedicated object. This collapses the usual two
+     * per-row objects (the provider's row object + the Store's parsed copy) down to one, skipping
+     * the per-row `parseRaw` field loop on every load and update. The headline win is memory; a
+     * modest reduction in allocation/GC churn on high-frequency updates is a secondary benefit.
+     *
+     * This mode puts substantial trust in the data provider and comes with a strict contract:
+     *
+     * 1. **Raw data MUST already be parsed.** `parseRaw` is skipped, so Field `type`/`parseVal` are
+     *    NOT applied - Fields become pure metadata (sort/filter/columns/export) and `data` holds
+     *    exactly what the provider supplied. Always true for Cube/View data, which the Cube has
+     *    already parsed (typically via the same field instances).
+     * 2. **The Store does not own `data`.** It never reads or writes `data` internals (including
+     *    `data.id`) and never freezes it. The provider is authoritative and may mutate rows in place.
+     * 3. **Rows may be shared across connected stores.** A View feeds the same row objects to every
+     *    connected store; with by-reference adoption their records point at one object set. Do not
+     *    mutate these objects from app code.
+     *
+     * Consequences:
+     * - **Read-only.** The local edit/commit/revert APIs (`addRecords`, `removeRecords`,
+     *   `modifyRecords`, `revertRecords`, `revert`) throw - committed always equals current.
+     *   Data still flows in via `loadData`/`updateData` (the provider path).
+     * - **Summary records are adopted too.** The dedicated summary record(s) - whether supplied via
+     *   `rawSummaryData` or extracted from the root row under `loadRootAsSummary` (e.g. a Cube
+     *   View's `includeRoot` "Total" row) - adopt their raw object as `data` by the same rules:
+     *   shared by reference, not owned, not frozen, recreated on update.
+     * - `freezeData` is forced to `false` (a frozen shared object would throw on the provider's
+     *   next in-place mutation). Explicitly passing `freezeData: true` is rejected.
+     * - `processRawData` and `reuseRecords` are incompatible and rejected at construction.
+     *
+     * Default false.
+     */
+    adoptRawData?: boolean;
+
+    /**
      * Set to true to always validate all uncommitted records on every change to
      * uncommitted records (add, modify, or remove). Default false.
      */
@@ -281,6 +319,7 @@ export class Store
     freezeData: boolean;
     reuseRecords: boolean;
     retainRaw: boolean;
+    adoptRawData: boolean;
     validationIsComplex: boolean;
 
     @observable.ref
@@ -324,30 +363,52 @@ export class Store
     private _fieldMap: Map<string, Field>;
     experimental: any;
 
-    constructor({
-        fields,
-        fieldDefaults = {},
-        idSpec = 'id',
-        processRawData = null,
-        filter = null,
-        filterIncludesChildren = false,
-        loadTreeData = true,
-        loadTreeDataFrom = 'children',
-        loadRootAsSummary = false,
-        freezeData = Store.defaults.freezeData,
-        idEncodesTreePath = false,
-        reuseRecords = false,
-        retainRaw = true,
-        validationIsComplex = false,
-        experimental,
-        data
-    }: StoreConfig) {
+    constructor(config: StoreConfig) {
         super();
         makeObservable(this);
+
+        const {
+            fields,
+            fieldDefaults = {},
+            idSpec = 'id',
+            processRawData = null,
+            filter = null,
+            filterIncludesChildren = false,
+            loadTreeData = true,
+            loadTreeDataFrom = 'children',
+            loadRootAsSummary = false,
+            idEncodesTreePath = false,
+            reuseRecords = false,
+            retainRaw = true,
+            adoptRawData = false,
+            validationIsComplex = false,
+            experimental,
+            data
+        } = config;
+        let freezeData = config.freezeData ?? Store.defaults.freezeData;
+
         throwIf(
             reuseRecords && !retainRaw,
             'Store cannot be configured with both `reuseRecords` and `retainRaw: false` - record reuse requires retained raw data references.'
         );
+
+        if (adoptRawData) {
+            // Fail fast on any config that expresses behavior this read-only, zero-copy mode cannot
+            // honor - surface the conflict rather than silently ignoring it and leaving the
+            // developer with a mistaken model of how the Store will behave. freezeData is only
+            // rejected when the developer explicitly opted in to it; the default is normalized off.
+            throwIf(
+                processRawData,
+                'Store.adoptRawData cannot be used with processRawData - the skipped parse would make it a silent no-op.'
+            );
+            throwIf(reuseRecords, 'Store.adoptRawData cannot be used with reuseRecords.');
+            throwIf(
+                config.freezeData === true,
+                'Store.adoptRawData cannot be used with freezeData: true - the provider mutates shared rows in place, so record data cannot be frozen.'
+            );
+            freezeData = false;
+        }
+
         this.experimental = this.parseExperimental(experimental);
         this.fields = this.parseFields(fields, fieldDefaults);
         this.idSpec = this.parseIdSpec(idSpec);
@@ -361,6 +422,7 @@ export class Store
         this.idEncodesTreePath = idEncodesTreePath;
         this.reuseRecords = reuseRecords;
         this.retainRaw = retainRaw;
+        this.adoptRawData = adoptRawData;
         this.validationIsComplex = validationIsComplex;
         this.lastUpdated = Date.now();
 
@@ -638,6 +700,7 @@ export class Store
      */
     @action
     addRecords(data: Some<PlainObject>, parentId?: StoreRecordId) {
+        this.throwIfReadOnly('addRecords');
         data = castArray(data);
         if (isEmpty(data)) return;
 
@@ -674,6 +737,7 @@ export class Store
      */
     @action
     removeRecords(records: StoreRecordOrId | StoreRecordOrId[]) {
+        this.throwIfReadOnly('removeRecords');
         records = castArray(records);
         if (isEmpty(records)) return;
 
@@ -703,6 +767,7 @@ export class Store
      */
     @action
     modifyRecords(modifications: Some<PlainObject>): StoreChangeLog {
+        this.throwIfReadOnly('modifyRecords');
         modifications = castArray(modifications);
         if (isEmpty(modifications)) return;
 
@@ -789,6 +854,7 @@ export class Store
      */
     @action
     revertRecords(records: StoreRecordOrId | StoreRecordOrId[]) {
+        this.throwIfReadOnly('revertRecords');
         records = castArray(records);
         if (isEmpty(records)) return;
 
@@ -817,9 +883,17 @@ export class Store
      */
     @action
     revert() {
+        this.throwIfReadOnly('revert');
         this._current = this._committed;
         if (this.summaryRecords) this.revertSummaryRecords(this.summaryRecords);
         this.rebuildFiltered();
+    }
+
+    private throwIfReadOnly(op: string) {
+        throwIf(
+            this.adoptRawData,
+            `Store.${op}() is unsupported when adoptRawData is enabled - this is a read-only projection (committed always equals current). Data updates flow in via loadData/updateData.`
+        );
     }
 
     /** Get a specific Field by name.*/
@@ -1200,6 +1274,23 @@ export class Store
         isSummary: boolean = false
     ): StoreRecord {
         const id = this.idSpec(raw);
+
+        // Zero-copy adoption - adopt the (already-parsed) raw object as `data` by reference, minting
+        // a fresh record identity so downstream grid transactions still fire. No processRawData,
+        // no parseRaw, no data.id write, no freeze - the Store does not own this object here.
+        // (No finalize() either - it only freezes, and freezeData is always false in this mode.)
+        // See StoreConfig.adoptRawData for the full contract.
+        if (this.adoptRawData) {
+            return new StoreRecord({
+                id,
+                store: this,
+                raw,
+                data: raw,
+                committedData: raw,
+                parent,
+                isSummary
+            });
+        }
 
         // Potentially re-use existing record if raw data is reference equal and tree path identical
         if (this.reuseRecords) {

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -158,27 +158,36 @@ export interface StoreConfig {
     retainRaw?: boolean;
 
     /**
-     * True to adopt each incoming raw object *as* its record's `data`, by reference, rather than
-     * re-parsing and copying it into a dedicated object. A zero-copy mode for read-only
-     * projections of already-parsed data - most notably a connected Cube {@link View} feeding a
-     * (tree) grid. Halves per-row object count, with memory the headline win.
+     * True to use each incoming raw object *as* its record's `data`, by reference, rather than
+     * re-parsing and copying it into a dedicated object. A zero-copy mode for projections of
+     * already-parsed data - most notably a connected Cube {@link View} feeding a (tree) grid, or a
+     * server endpoint returning data already in its final client-side form. Halves per-row object
+     * count, with memory the headline win.
      *
      * Strict contract with the data provider:
-     * 1. Raw data must already be parsed - `parseRaw` is skipped and Field `type`/`parseVal` are
-     *    NOT applied. (Always true for Cube/View data.)
-     * 2. The Store does not own, modify, or freeze `data` - the provider is authoritative and may
-     *    mutate rows in place.
-     * 3. Rows may be shared by reference across connected stores (as a View does) - do not mutate
-     *    them from app code.
+     * 1. Raw data must already be parsed, and parsed *identically* to what the Store's Field
+     *    definitions would produce - `parseRaw` is skipped, so Field `type` and `parseVal` are not
+     *    applied and Field `defaultValue` is not supplied for missing keys (a missing key reads as
+     *    `undefined`, not its default). Note that local edits via `modifyRecords()` *do* run
+     *    `Field.parseVal`, so raw data that does not already match its Field types will yield a
+     *    Store where edited and untouched records disagree on value type.
+     * 2. The Store never modifies or freezes a raw object - the provider stays authoritative and
+     *    retains the right to mutate its own rows in place. Note that `freezeData` therefore offers
+     *    app code no protection against writing to record data. Data objects the Store creates
+     *    itself, for local adds and edits, *are* owned and frozen per `freezeData` as usual.
+     * 3. When the provider does mutate a row in place, it must publish via `updateData()`, never
+     *    `loadData()`. `loadData()` reuses an existing record whenever its data is unchanged, and a
+     *    row mutated in place is reference-equal to what its record already holds - so the update
+     *    would be dropped and the grid would render stale values. `updateData()` always installs
+     *    the new record identity.
      *
-     * Consequences:
-     * - Read-only: the local edit/commit/revert APIs throw. Data still flows in via
-     *   `loadData`/`updateData`. Summary records are adopted by the same rules.
-     * - `freezeData` is ignored (never frozen); `processRawData` and `reuseRecords` are rejected.
+     * Note that `data` will carry every key present on the raw object, not just those declared as
+     * Fields, that rows may be shared by reference across connected stores (as a View does), and
+     * that `processRawData` and `reuseRecords` are rejected as incompatible.
      *
      * Default false.
      */
-    adoptRawData?: boolean;
+    useRawAsData?: boolean;
 
     /**
      * Set to true to always validate all uncommitted records on every change to
@@ -304,7 +313,7 @@ export class Store
     freezeData: boolean;
     reuseRecords: boolean;
     retainRaw: boolean;
-    adoptRawData: boolean;
+    useRawAsData: boolean;
     validationIsComplex: boolean;
 
     @observable.ref
@@ -362,7 +371,7 @@ export class Store
         idEncodesTreePath = false,
         reuseRecords = false,
         retainRaw = true,
-        adoptRawData = false,
+        useRawAsData = false,
         validationIsComplex = false,
         experimental,
         data
@@ -374,12 +383,12 @@ export class Store
             'Store cannot be configured with both `reuseRecords` and `retainRaw: false` - record reuse requires retained raw data references.'
         );
         throwIf(
-            adoptRawData && processRawData,
-            'Store.adoptRawData cannot be used with processRawData.'
+            useRawAsData && processRawData,
+            'Store.useRawAsData cannot be used with processRawData.'
         );
         throwIf(
-            adoptRawData && reuseRecords,
-            'Store.adoptRawData cannot be used with reuseRecords.'
+            useRawAsData && reuseRecords,
+            'Store.useRawAsData cannot be used with reuseRecords.'
         );
 
         this.experimental = this.parseExperimental(experimental);
@@ -395,7 +404,7 @@ export class Store
         this.idEncodesTreePath = idEncodesTreePath;
         this.reuseRecords = reuseRecords;
         this.retainRaw = retainRaw;
-        this.adoptRawData = adoptRawData;
+        this.useRawAsData = useRawAsData;
         this.validationIsComplex = validationIsComplex;
         this.lastUpdated = Date.now();
 
@@ -673,7 +682,6 @@ export class Store
      */
     @action
     addRecords(data: Some<PlainObject>, parentId?: StoreRecordId) {
-        this.throwIfReadOnly('addRecords');
         data = castArray(data);
         if (isEmpty(data)) return;
 
@@ -710,7 +718,6 @@ export class Store
      */
     @action
     removeRecords(records: StoreRecordOrId | StoreRecordOrId[]) {
-        this.throwIfReadOnly('removeRecords');
         records = castArray(records);
         if (isEmpty(records)) return;
 
@@ -740,7 +747,6 @@ export class Store
      */
     @action
     modifyRecords(modifications: Some<PlainObject>): StoreChangeLog {
-        this.throwIfReadOnly('modifyRecords');
         modifications = castArray(modifications);
         if (isEmpty(modifications)) return;
 
@@ -827,7 +833,6 @@ export class Store
      */
     @action
     revertRecords(records: StoreRecordOrId | StoreRecordOrId[]) {
-        this.throwIfReadOnly('revertRecords');
         records = castArray(records);
         if (isEmpty(records)) return;
 
@@ -856,17 +861,9 @@ export class Store
      */
     @action
     revert() {
-        this.throwIfReadOnly('revert');
         this._current = this._committed;
         if (this.summaryRecords) this.revertSummaryRecords(this.summaryRecords);
         this.rebuildFiltered();
-    }
-
-    private throwIfReadOnly(op: string) {
-        throwIf(
-            this.adoptRawData,
-            `Store.${op}() is unsupported when adoptRawData is enabled - this is a read-only projection (committed always equals current). Data updates flow in via loadData/updateData.`
-        );
     }
 
     /** Get a specific Field by name.*/
@@ -1248,11 +1245,11 @@ export class Store
     ): StoreRecord {
         const id = this.idSpec(raw);
 
-        // Zero-copy adoption - adopt the (already-parsed) raw object as `data` by reference, minting
-        // a fresh record identity so downstream grid transactions still fire. No processRawData,
-        // no parseRaw, no data.id write, no freeze (finalize skips it in this mode) - the Store
-        // does not own this object here. See StoreConfig.adoptRawData for the full contract.
-        if (this.adoptRawData) {
+        // Zero-copy - use the (already-parsed) raw object as `data` by reference, minting a fresh
+        // record identity so downstream grid transactions still fire. No processRawData, no
+        // parseRaw, and (as `data === raw`) no data.id write and no freeze - the Store does not own
+        // this object. See StoreConfig.useRawAsData for the full contract.
+        if (this.useRawAsData) {
             return new StoreRecord({
                 id,
                 store: this,

--- a/data/StoreRecord.ts
+++ b/data/StoreRecord.ts
@@ -237,8 +237,6 @@ export class StoreRecord {
             isNil(id),
             "Record needs an ID. Use 'Store.idSpec' to specify a unique ID for each record."
         );
-        // In adoptRawData mode the Store does not own `data` (it is the shared provider object), so
-        // we never write to it. The provider's id already matches - see StoreConfig.adoptRawData.
         if (!store.adoptRawData) data.id = id;
 
         this.id = id;
@@ -304,7 +302,8 @@ export class StoreRecord {
      * @internal
      */
     finalize() {
-        if (this.store.freezeData) {
+        const {store} = this;
+        if (store.freezeData && !store.adoptRawData) {
             Object.freeze(this.data);
         }
     }

--- a/data/StoreRecord.ts
+++ b/data/StoreRecord.ts
@@ -92,18 +92,6 @@ export class StoreRecord {
         return this.committedData === this.data;
     }
 
-    /**
-     * True if this record's `data` object belongs to it alone, and can therefore be written to and
-     * frozen by the Store.
-     *
-     * False only when the Store is configured with `useRawAsData` *and* this record's data is the
-     * raw object supplied by the data provider - which the Store must leave untouched. Records
-     * added or modified locally get their own data object, and so own it even in that mode.
-     */
-    get ownsData(): boolean {
-        return this.data !== this.raw;
-    }
-
     get parent(): StoreRecord {
         return this.parentId != null ? this.store.getById(this.parentId) : null;
     }
@@ -305,6 +293,15 @@ export class StoreRecord {
     // --------------------------
     // Protected methods
     // --------------------------
+    /**
+     * True if this record's `data` object belongs to it alone and may be written to and frozen.
+     * False only for records holding a provider-owned raw object under `useRawAsData`.
+     * @internal
+     */
+    get ownsData(): boolean {
+        return this.data !== this.raw;
+    }
+
     /**
      * Finalize this record for use in Store, post acceptance by RecordSet.
      *

--- a/data/StoreRecord.ts
+++ b/data/StoreRecord.ts
@@ -237,7 +237,9 @@ export class StoreRecord {
             isNil(id),
             "Record needs an ID. Use 'Store.idSpec' to specify a unique ID for each record."
         );
-        data.id = id;
+        // In adoptRawData mode the Store does not own `data` (it is the shared provider object), so
+        // we never write to it. The provider's id already matches - see StoreConfig.adoptRawData.
+        if (!store.adoptRawData) data.id = id;
 
         this.id = id;
         this.agId = 'ag_' + id.toString();

--- a/data/StoreRecord.ts
+++ b/data/StoreRecord.ts
@@ -92,6 +92,18 @@ export class StoreRecord {
         return this.committedData === this.data;
     }
 
+    /**
+     * True if this record's `data` object belongs to it alone, and can therefore be written to and
+     * frozen by the Store.
+     *
+     * False only when the Store is configured with `useRawAsData` *and* this record's data is the
+     * raw object supplied by the data provider - which the Store must leave untouched. Records
+     * added or modified locally get their own data object, and so own it even in that mode.
+     */
+    get ownsData(): boolean {
+        return this.data !== this.raw;
+    }
+
     get parent(): StoreRecord {
         return this.parentId != null ? this.store.getById(this.parentId) : null;
     }
@@ -237,7 +249,6 @@ export class StoreRecord {
             isNil(id),
             "Record needs an ID. Use 'Store.idSpec' to specify a unique ID for each record."
         );
-        if (!store.adoptRawData) data.id = id;
 
         this.id = id;
         this.agId = 'ag_' + id.toString();
@@ -253,6 +264,8 @@ export class StoreRecord {
          */
         this.treePath = parent ? [...parent.treePath, id.toString()] : [id.toString()];
         this.isSummary = isSummary;
+
+        if (this.ownsData) data.id = id;
     }
 
     /**
@@ -302,8 +315,7 @@ export class StoreRecord {
      * @internal
      */
     finalize() {
-        const {store} = this;
-        if (store.freezeData && !store.adoptRawData) {
+        if (this.store.freezeData && this.ownsData) {
             Object.freeze(this.data);
         }
     }


### PR DESCRIPTION
Rebase of #4507 by @haynesjm42 onto `develop`, removing the stack dependency on the in-progress #4501 / #4503 branches. Supersedes #4507 (authorship preserved). Resolves #4506.

Adds an opt-in `StoreConfig.useRawAsData` mode (default `false`) for projections of already-parsed data - most notably a connected Cube `View` feeding a (tree) grid, or an endpoint returning data already in its final client-side form. When enabled, each record uses the provider's raw object **as** its `data`, by reference, instead of re-parsing and copying it - collapsing the usual two per-row objects down to one and skipping the per-row `parseRaw` on every load and tick.

### Behavior

- Zero-copy `createRecord`: uses raw as `data` (skips `processRawData` / `parseRaw` / the `data.id` write / freeze), minting a fresh record identity each load/update so ag-Grid transactions still fire. Summary records (including the `loadRootAsSummary` / `includeRoot` "Total" row) follow the same rules.
- Local edits are supported. The edit APIs are copy-on-write - `parseRaw` and `parseUpdate` always build a fresh object - so `addRecords` / `modifyRecords` / `revertRecords` / `revert` never mutate the provider's object.
- New `StoreRecord.ownsData` getter (`data !== raw`) determines whether this record owns its data object. The `data.id` write and `Object.freeze` are skipped only for the adopted raw object; data objects the Store creates itself, for local adds and edits, are owned and frozen per `freezeData` as usual.
- Construction rejects explicitly-incompatible config (`processRawData`, `reuseRecords`).
- Non-breaking: opt-in, default `false`, no change to existing behavior.

### Contract

Documented in full on the config. In short: raw data must already be parsed *identically* to what the Store's Field definitions would produce (`Field.parseVal` is not applied, and `Field.defaultValue` is not supplied for missing keys); the Store never modifies or freezes the raw object; and in-place mutations must be published via `updateData()`, never `loadData()` - which reuses records whose data is unchanged, and would therefore drop a mutation made in place.

### Measured gains

Benchmarked on `develop` (Ryzen 9 5900X, Chrome with precise heap + forced GC, dev build). Medians of repeated interleaved A/B runs.

**Store in isolation** - standalone Stores loading identical `ViewRowData`, 30,320 rows:

| Fields | Store retained | Mem saved | `loadData` |
|---:|---|---:|---|
| 14 | 6.2 -> 3.5 MB | 45% | 40 -> 16 ms (2.4x) |
| 30 | 28.1 -> 3.5 MB | 88% | 122 -> 19 ms (6.6x) |
| 50 | 50.3 -> 3.5 MB | 93% | 174 -> 18 ms (9.6x) |

`useRawAsData` is **constant-cost** - ~120 B and ~500 ns per record regardless of field width, since it adds no per-field work and no data object. Legacy scales linearly with width, so the win grows with record width. Note that ~95% of legacy's cost is `createRecords` (`parseRaw` plus the data-object allocation); `Object.freeze` is only ~5%, so `freezeData: false` is not a meaningful substitute.

**Real-world profile** - Cube of 31k records / 174 fields, connected `View` querying 35 fields, 50,156 `StoreRecords`, full-row streaming ticks:

| | legacy | `useRawAsData` |
|---|---|---|
| Store retained | 127.0 MB | 77.6 MB (**-49.4 MB**) |
| Initial load / re-query | 627 ms | 427 ms (**-32%**) |
| Tick, ~2k rows (View+Store) | 67 ms | 50 ms |
| Tick, ~5k rows (View+Store) | 159 ms | 104 ms |

Memory is the headline: ~1 kB per record, holding across every configuration measured, and multiplied across concurrent Store instances. Per-tick CPU is a real but secondary win - Cube recompute dominates that path and is mode-independent.

### Verification

`tsc` and `eslint` clean. Cube -> View -> tree grid acceptance test in the companion Toolbox PR (xh/toolbox#881, updated on `store-adopt-raw-data-develop`): under a leaf tick that mutates `ViewRowData` in place, both simple- and complex-renderer cells repaint, aggregates and the `includeRoot` Total update, and unchanged rows stay stable. Inline editing is exercised in both modes.

### Rebase notes

- Constructor merged with develop's `retainRaw` config. `retainRaw` is moot in this mode since `raw` *is* `data`.
- Develop's streaming `Store.loadDataAsync()` routes through `createRecords` -> `createRecord`, so it picks up the zero-copy path with no extra changes.
- The gains quoted on #4507 were benchmarked on the stacked base (#4501/#4503), whose fast-properties factory / assigner make the *legacy* path substantially cheaper. Against `develop` the legacy baseline is far more expensive, so the memory saving is larger here (88-93% at 30-50 fields, vs 57-67% on that stack). Expect these figures to narrow once #4501/#4503 land.

See #4507 for the original discussion and measurement methodology.

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. _(Non-breaking: opt-in, default `false`.)_
- [x] Updated doc comments / prop-types, or determined not required. _(Extensive JSDoc on the `useRawAsData` config, plus `StoreRecord.ownsData`; added to the `data/README.md` Store config table.)_
- [x] Reviewed and tested on Mobile, or determined not required. _(Data-layer change, platform-agnostic.)_
- [x] Created Toolbox branch / PR, or determined not required. _(xh/toolbox#881.)_
