### PR TITLE
Cube View: zero-copy leaf row data for aggregate-only views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
       for popovers. Test popover-based UI (menus, selects, date inputs, filter choosers) and adjust
       any custom styling that targeted Blueprint or Popper CSS classes (e.g. `bp6-minimal`).
     * The `popperOptions` escape-hatch prop has been removed from the mobile `Popover`.
+* `View.result.leafMap` is now null unless the `Query` sets `includeLeaves` or `provideLeaves`. Set
+  either flag if an aggregate-only view needs leaf access, or read source records from `Cube.store`.
 
 ### 🎁 New Features
 
@@ -33,8 +35,7 @@
 * Cube `View`s no longer copy leaf row data when leaves are not exposed on their results (neither
   `includeLeaves` nor `provideLeaves` set) - leaf rows read directly from cube records, eliminating
   per-View leaf data objects and speeding up view builds for aggregate-only views over large
-  datasets. Note leaf entries in `View.result.leafMap` now expose the cube record's own data object
-  as their `data` in this case.
+  datasets. Such views no longer publish a `View.result.leafMap` - see Breaking Changes.
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@
   JSON and NDJSON responses, reducing retained memory for high-volume tabular datasets. Interned
   values are also shared across successive fetches of the same logical dataset, as identified by
   a required app-provided key.
+* Cube `View`s no longer copy leaf row data when leaves are not exposed on their results (neither
+  `includeLeaves` nor `provideLeaves` set) - leaf rows read directly from cube records, eliminating
+  per-View leaf data objects and speeding up view builds for aggregate-only views over large
+  datasets. Note leaf entries in `View.result.leafMap` now expose the cube record's own data object
+  as their `data` in this case.
+
+### 🐞 Bug Fixes
+
+* Fixed `View.getDimensionValues()` returning sets of `undefined` rather than the actual unique
+  values for each dimension.
 
 ### ⚙️ Technical
 

--- a/data/cube/README.md
+++ b/data/cube/README.md
@@ -225,6 +225,11 @@ addReaction({
 });
 ```
 
+Note that `leafMap` is populated only when the query sets `includeLeaves` or `provideLeaves`. Views
+that expose no leaves hold them as zero-copy references to the source `Cube` record data - a
+significant memory and build-time win on large datasets, but not safe to publish. Read source
+records from `cube.store` directly if you need them.
+
 **Update triggers:** View data updates when either:
 - The underlying Cube data changes (requires `connect: true`)
 - The `view.query` is modified via `view.updateQuery()`

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -236,7 +236,7 @@ export class View
 
         return fields.map(field => {
             const values = new Set();
-            _leafMap.forEach(leaf => values.add(leaf[field.name]));
+            _leafMap.forEach(leaf => values.add(leaf.data[field.name]));
             return {field, values};
         });
     }
@@ -291,6 +291,12 @@ export class View
     //------------------------
     // Implementation
     //------------------------
+    /** True if leaf rows can use cube record data directly - i.e. leaves not exposed on results. */
+    get useReferenceLeaves(): boolean {
+        const {includeLeaves, provideLeaves} = this.query;
+        return !includeLeaves && !provideLeaves;
+    }
+
     @logWithDebug
     private fullUpdate() {
         this.filterRecords();

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -61,6 +61,14 @@ export interface ViewConfig {
 
 export interface ViewResult {
     rows: ViewRowData[];
+
+    /**
+     * Leaf-level rows, keyed by the id of their source Cube record.
+     *
+     * Null unless the Query sets {@link Query.includeLeaves} or {@link Query.provideLeaves} - views
+     * that expose no leaves keep them as zero-copy references to Cube record data, which is not
+     * safe to publish. Use {@link Cube.store} to read source records directly in that case.
+     */
     leafMap: Map<StoreRecordId, LeafRow>;
 }
 
@@ -340,7 +348,11 @@ export class View
 
     private updateResults() {
         const {_leafMap, _rowDatas} = this;
-        this.result = {rows: _rowDatas, leafMap: _leafMap};
+        this.result = {
+            rows: _rowDatas,
+            // Reference-mode leaves adopt Cube record data outright - never publish them.
+            leafMap: this.useReferenceLeaves ? null : _leafMap
+        };
         this.info = this.cube.info;
         this.cubeUpdated = this.cube.lastUpdated;
         this.lastUpdated = Date.now();

--- a/data/cube/row/AggregateRow.ts
+++ b/data/cube/row/AggregateRow.ts
@@ -8,6 +8,7 @@
 import {PlainObject} from '@xh/hoist/core';
 import {CubeField} from '../CubeField';
 import {View} from '../View';
+import {ViewRowData} from '../ViewRowData';
 import {BaseRow} from './BaseRow';
 
 /**
@@ -38,6 +39,7 @@ export class AggregateRow extends BaseRow {
 
         this.dim = dim;
         this.dimName = dimName;
+        this.data = new ViewRowData(id);
         this.data.cubeRowType = 'aggregate';
         this.data.cubeLabel = strVal;
         this.data.cubeDimension = dimName;

--- a/data/cube/row/BaseRow.ts
+++ b/data/cube/row/BaseRow.ts
@@ -20,9 +20,9 @@ import {RowUpdate} from './RowUpdate';
 export abstract class BaseRow {
     readonly view: View = null;
     readonly id: string = null;
-    readonly data: ViewRowData;
 
     // readonly, but set by subclasses
+    data: ViewRowData;
     parent: BaseRow = null;
     children: BaseRow[] = null;
     locked: boolean = false;
@@ -41,7 +41,6 @@ export abstract class BaseRow {
     constructor(view: View, id: string) {
         this.view = view;
         this.id = id;
-        this.data = new ViewRowData(id);
     }
 
     //-----------------------

--- a/data/cube/row/BaseRow.ts
+++ b/data/cube/row/BaseRow.ts
@@ -47,6 +47,10 @@ export abstract class BaseRow {
     // For all rows types
     //------------------------
     noteBucketed(bucketSpec: BucketSpec, bucketVal: any) {
+        // Reference-mode leaves share their cube record's data object - never mutate it. Such
+        // leaves are not exposed on results, so their bucket metadata has no consumer anyway.
+        if (this.isLeaf && this.view.useReferenceLeaves) return;
+
         this.data.cubeBuckets ??= {};
         this.data.cubeBuckets[bucketSpec.name] = bucketVal;
         this.children?.forEach(it => it.noteBucketed(bucketSpec, bucketVal));

--- a/data/cube/row/BucketRow.ts
+++ b/data/cube/row/BucketRow.ts
@@ -9,6 +9,7 @@ import {PlainObject} from '@xh/hoist/core';
 import {BaseRow} from './BaseRow';
 import {BucketSpec} from '../BucketSpec';
 import {View} from '../View';
+import {ViewRowData} from '../ViewRowData';
 
 /**
  *  Row within a dataset produced by a Cube / View representing aggregated data on a dimension that
@@ -35,6 +36,7 @@ export class BucketRow extends BaseRow {
         super(view, id);
 
         this.bucketSpec = bucketSpec;
+        this.data = new ViewRowData(id);
         this.data.cubeRowType = 'bucket';
         this.data.cubeLabel = bucketSpec.labelFn(bucketVal);
         this.data.cubeDimension = bucketSpec.name;

--- a/data/cube/row/LeafRow.ts
+++ b/data/cube/row/LeafRow.ts
@@ -9,14 +9,16 @@ import {PlainObject} from '@xh/hoist/core';
 import {StoreRecord, StoreRecordId} from '@xh/hoist/data';
 import {isEmpty} from 'lodash';
 import {View} from '../View';
+import {ViewRowData} from '../ViewRowData';
 import {BaseRow} from './BaseRow';
 import {RowUpdate} from './RowUpdate';
 
 /**
  * Row within a dataset produced by a Cube or View representing leaf-level data. These rows have a
  * 1-1 relationship with the source records loaded into the Cube's internal store - i.e. they are
- * not computed aggregates, although the data they contain is a shallow copy of the original and
- * limited to the fields requested by the View / Query that produced them.
+ * not computed aggregates. How their data relates to the source record depends on
+ * {@link View.useReferenceLeaves} - a zero-copy reference to the record's own data when leaves are
+ * not exposed on results, or a per-View shallow copy limited to the queried fields when they are.
  *
  * This is an internal data structure - {@link ViewRowData} is the public row-level data API.
  */
@@ -34,33 +36,49 @@ export class LeafRow extends BaseRow {
     constructor(view: View, id: string, rawRecord: StoreRecord) {
         super(view, id);
         this.cubeRecordId = rawRecord.id;
-        this.data.cubeRowType = 'leaf';
-        this.data.cubeLabel = rawRecord.id.toString();
-        this.data.cubeDimension = null;
 
-        view.fields.forEach(({name}) => {
-            this.data[name] = rawRecord.data[name];
-        });
+        if (view.useReferenceLeaves) {
+            // Never exposed on results or stores - adopt the record's data outright
+            this.data = rawRecord.data as ViewRowData;
+        } else {
+            const data = (this.data = new ViewRowData(id));
+            data.cubeRowType = 'leaf';
+            data.cubeLabel = rawRecord.id.toString();
+            data.cubeDimension = null;
+
+            view.fields.forEach(({name}) => {
+                data[name] = rawRecord.data[name];
+            });
+        }
     }
 
     applyLeafDataUpdate(newRec: StoreRecord, updatedRowDatas: Set<PlainObject>) {
-        const {view, parent, data} = this,
+        const {view, data} = this,
             newData = newRec.data,
-            updates = [];
+            updates = [],
+            {useReferenceLeaves} = view;
 
+        // 1) Calculate diff.
         view.fields.forEach(field => {
             const name = field.name,
                 oldValue = data[name],
                 newValue = newData[name];
             if (oldValue !== newValue) {
-                data[name] = newValue;
                 updates.push(new RowUpdate(field, oldValue, newValue));
             }
         });
 
+        // 2) Apply new values to our data. Always swap reference to avoid retaining old record.
+        if (useReferenceLeaves) {
+            this.data = newData as ViewRowData;
+        } else {
+            updates.forEach(({field, newValue}) => (data[field.name] = newValue));
+        }
+
+        // 3) Propagate any updates to ancestors and consumers
         if (!isEmpty(updates)) {
-            updatedRowDatas.add(this.data);
-            if (parent) parent.applyDataUpdate(updates, updatedRowDatas);
+            if (!useReferenceLeaves) updatedRowDatas.add(data);
+            this.parent?.applyDataUpdate(updates, updatedRowDatas);
         }
     }
 }

--- a/data/cube/row/LeafRow.ts
+++ b/data/cube/row/LeafRow.ts
@@ -38,8 +38,7 @@ export class LeafRow extends BaseRow {
         this.cubeRecordId = rawRecord.id;
 
         if (view.useReferenceLeaves) {
-            // Never exposed on results or stores - adopt the record's data outright
-            this.data = rawRecord.data as ViewRowData;
+            this.data = rawRecord.data as ViewRowData; // adopt the record's data outright!
         } else {
             const data = (this.data = new ViewRowData(id));
             data.cubeRowType = 'leaf';


### PR DESCRIPTION
Cube `View`s create one `ViewRowData` per leaf per view, copying every queried field from the source record - even when the query exposes no leaves at all (neither `includeLeaves` nor `provideLeaves`). For that aggregate-only case - the common pivot/summary configuration - the copies are pure overhead: leaf data is only ever read as aggregation input and never surfaces on results or in connected stores.

Leaf rows in such views now use the cube record's `data` object directly, by reference. On update, the reference is swapped after diffing for `RowUpdate`s - the aggregation update path is otherwise unchanged, as is copy behavior for views that do expose leaves. No API changes.

### Measured

Toolbox cube tester, 100,000 records / 14 fields, Chrome with `--js-flags=--expose-gc --enable-precise-memory-info`, retained heap delta over empty-cube baseline in a fresh tab per run (repeatability ±0.1MB):

| | Before | After |
|---|---:|---:|
| Retained memory | 66.9 MB | 54.7 MB (**-18%**) |
| View recompute | 185 ms | 122 ms (**-34%**) |
| Cube load | 405 ms | 332 ms (**-18%**) |

### Notes

- Leaf entries in `View.result.leafMap` now expose the record's own data object as their `data` in this mode (so `data.id` is the cube record id, and all cube fields are readable). `LeafRow.cubeRecordId` and field reads are unaffected.
- Also fixes `View.getDimensionValues()`, which read field values off `LeafRow` instances rather than their `data` and has returned Sets of `undefined` since the v41 View refactor (#2258).
- An extension of this approach to leaf-exposing views via per-record prototype delegation was prototyped and benchmarked at a **+14% memory regression** - V8 gives each object used as a prototype its own dedicated map, and each delegated child a hidden-class lineage rooted at it, outweighing the saved field slots. Happy to share methodology/numbers if useful.

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. _(Non-breaking: internal-only change; `leafMap` data shape note in CHANGELOG.)_
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required. _(Data-layer change, platform-agnostic.)_
- [x] Created Toolbox branch / PR, or determined not required. _(No API change - verified against Toolbox cube tester as-is.)_
