### PR TITLE
NdjsonResult API for fetchNdjson + StringInternSpec.retainMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   its raw source data object after parsing, reducing memory usage on large stores where
   `StoreRecord.raw` is not needed. Not compatible with `reuseRecords`.
 * Added `Store.loadDataAsync()` to load a complete dataset from a streaming source - a sync or
-  async iterable yielding raw records or chunks. Creates records incrementally without buffering
+  async iterable yielding raw records. Creates records incrementally without buffering
   the complete raw dataset in memory, then installs them in a single transaction once the source
   completes. `Cube.loadDataAsync()` likewise accepts a streaming source.
 * Added `XH.fetchNdjson()` to consume an NDJSON (newline-delimited JSON) response incrementally.
@@ -64,6 +64,8 @@
 * Retyped `BaseRow.data` from `ViewRowData` to `PlainObject`, reflecting that custom `Aggregator`
   implementations may only rely on queried field values - not `ViewRowData` metadata - when reading
   row data. Use row-level getters such as `BaseRow.isLeaf` in place of `data.cubeRowType`.
+* Corrected `ChildRawData.rawData` type from `PlainObject[]` to `PlainObject` - the runtime has
+  always expected a single raw record per object, and an array would throw on load.
 
 ### 📚 Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,14 @@
   async iterable yielding raw records or chunks. Creates records incrementally without buffering
   the complete raw dataset in memory, then installs them in a single transaction once the source
   completes. `Cube.loadDataAsync()` likewise accepts a streaming source.
-* Added `XH.fetchNdjson()` to consume an NDJSON (newline-delimited JSON) response incrementally
-  as an async iterable - the natural streaming source for `Store.loadDataAsync()`, and usable
-  directly via `for await` for any streamed endpoint. Optionally pairs with hoist-core v41's
-  `BaseController.renderNdjson()`.
+* Added `XH.fetchNdjson()` to consume an NDJSON (newline-delimited JSON) response incrementally.
+  Returns a `lines` async iterable of parsed records - the natural streaming source for
+  `Store.loadDataAsync()` - plus a `meta` promise for an optional leading metadata record.
+  Optionally pairs with hoist-core v41's `BaseController.renderNdjson()`.
 * Added `FetchOptions.internStrings` to intern (deduplicate) repeated string values within large
   JSON and NDJSON responses, reducing retained memory for high-volume tabular datasets. Interned
-  values are also shared across successive fetches of the same logical dataset, as identified by
-  a required app-provided key.
+  values may also be shared across successive fetches of the same logical dataset, as identified
+  by a required app-provided key, per a configurable `retainMode`.
 * Cube `View`s no longer copy leaf row data when leaves are not exposed on their results (neither
   `includeLeaves` nor `provideLeaves` set) - leaf rows read directly from cube records, eliminating
   per-View leaf data objects and speeding up view builds for aggregate-only views over large

--- a/core/XH.ts
+++ b/core/XH.ts
@@ -27,6 +27,8 @@ import {
     JsonBlobService,
     LocalStorageService,
     MetricsService,
+    NdjsonFetchOptions,
+    NdjsonResult,
     PrefService,
     SessionStorageService,
     TrackService,
@@ -309,7 +311,7 @@ export class XHApi {
      * Send an HTTP request and decode the response incrementally as NDJSON.
      * @see FetchService.fetchNdjson
      */
-    fetchNdjson(opts: FetchOptions, ctx?: CallContextLike): AsyncGenerator<PlainObject[]> {
+    fetchNdjson(opts: NdjsonFetchOptions, ctx?: CallContextLike): NdjsonResult {
         return this.fetchService.fetchNdjson(opts, ctx);
     }
 

--- a/core/types/Types.ts
+++ b/core/types/Types.ts
@@ -32,6 +32,9 @@ export type NonEmptyArray<T> = [T, ...T[]];
 export type Thunkable<T> = T | (() => T);
 export type Awaitable<T> = Promise<T> | T;
 
+/** Convenience type for accepting a sync or async iterable of Ts - e.g. a streaming source. */
+export type AnyIterable<T> = Iterable<T> | AsyncIterable<T>;
+
 /** Convenience type for a "plain", string-keyed object holding any kind of values. */
 export type PlainObject = Record<string, any>;
 

--- a/data/README.md
+++ b/data/README.md
@@ -155,7 +155,7 @@ from the server. Does not accept summary data (an aggregate cannot precede its s
 via `updateData({rawSummaryData})` after loading. Pair with `XH.fetchNdjson()` for NDJSON:
 
 ```typescript
-await store.loadDataAsync(XH.fetchNdjson({url: 'myRows'}));
+await store.loadDataAsync(XH.fetchNdjson({url: 'myRows'}).lines);
 ```
 
 The Store updates in a single transaction once the source completes, and remains unchanged if

--- a/data/README.md
+++ b/data/README.md
@@ -149,7 +149,7 @@ store.updateData({
 ```
 
 **`loadDataAsync(rawData)`** - Streaming counterpart to `loadData()`. Accepts a sync or async
-iterable yielding raw records (or arrays/chunks of records), creating records incrementally
+iterable yielding raw records, creating records incrementally
 without buffering the complete raw dataset in memory - useful for very large datasets streamed
 from the server. Does not accept summary data (an aggregate cannot precede its stream) - install
 via `updateData({rawSummaryData})` after loading. Pair with `XH.fetchNdjson()` for NDJSON:

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -459,7 +459,7 @@ export class Store
      * array - e.g. rows streamed incrementally from the server. The source may be a sync or
      * async iterable, yielding individual raw records or arrays (chunks) of records - see
      * {@link FetchService.fetchNdjson} for the natural source when streaming NDJSON, e.g.
-     * `store.loadDataAsync(XH.fetchNdjson({url}))`.
+     * `store.loadDataAsync(XH.fetchNdjson({url}).lines)`.
      *
      * The Store is not modified until the source has been fully consumed - all records are then
      * installed in a single observable transaction, exactly as with `loadData()`. If the source

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -6,7 +6,7 @@
  */
 
 import type {GridFilterBindTarget} from '@xh/hoist/cmp/grid';
-import {HoistBase, managed, PlainObject, Some, XH} from '@xh/hoist/core';
+import {AnyIterable, HoistBase, managed, PlainObject, Some, XH} from '@xh/hoist/core';
 import {
     Field,
     FieldSpec,
@@ -234,10 +234,10 @@ export interface ChildRawData {
     parentId: string;
 
     /**
-     * Data for the child records to be added. Can include a `children` property to be processed
+     * Data for the child record to be added. Can include a `children` property to be processed
      * into new (grand)child records.
      */
-    rawData: PlainObject[];
+    rawData: PlainObject;
 }
 
 export type StoreRecordIdSpec = string | ((data: PlainObject) => StoreRecordId);
@@ -457,8 +457,8 @@ export class Store
      *
      * Use to load very large datasets without buffering the complete raw dataset in a single
      * array - e.g. rows streamed incrementally from the server. The source may be a sync or
-     * async iterable, yielding individual raw records or arrays (chunks) of records - see
-     * {@link FetchService.fetchNdjson} for the natural source when streaming NDJSON, e.g.
+     * async iterable yielding individual raw records - see {@link FetchService.fetchNdjson}
+     * for the natural source when streaming NDJSON, e.g.
      * `store.loadDataAsync(XH.fetchNdjson({url}).lines)`.
      *
      * The Store is not modified until the source has been fully consumed - all records are then
@@ -471,11 +471,9 @@ export class Store
      * stores with `loadRootAsSummary` - such payloads nest all row data within a single root
      * node and cannot be streamed.
      *
-     * @param rawData - iterable yielding raw records, or chunks (arrays) of raw records.
+     * @param rawData - iterable yielding raw records.
      */
-    async loadDataAsync(
-        rawData: AsyncIterable<Some<PlainObject>> | Iterable<Some<PlainObject>>
-    ): Promise<void> {
+    async loadDataAsync(rawData: AnyIterable<PlainObject>): Promise<void> {
         throwIf(
             this.loadRootAsSummary,
             'loadDataAsync does not support loadRootAsSummary - load via loadData(), or install summary records separately via updateData().'
@@ -484,10 +482,8 @@ export class Store
         const recordMap = new Map<StoreRecordId, StoreRecord>(),
             summaryIds = new Set<StoreRecordId>();
 
-        for await (const chunk of rawData) {
-            for (const raw of castArray(chunk)) {
-                this.createRecords([raw], null, recordMap, summaryIds);
-            }
+        for await (const raw of rawData) {
+            this.createRecordDeep(raw, null, recordMap, summaryIds);
         }
 
         runInAction(() => {
@@ -574,9 +570,9 @@ export class Store
                 if (isChildRawDataObject(it)) {
                     const {rawData, parentId} = it,
                         parent = !isNil(parentId) ? this.getOrThrow(parentId) : null;
-                    this.createRecords([rawData], parent, addRecs);
+                    this.createRecordDeep(rawData, parent, addRecs);
                 } else {
-                    this.createRecords([it], null, addRecs);
+                    this.createRecordDeep(it, null, addRecs);
                 }
             });
         }
@@ -1283,24 +1279,30 @@ export class Store
         recordMap: Map<StoreRecordId, StoreRecord> = new Map(),
         summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
     ) {
-        const {loadTreeData, loadTreeDataFrom} = this;
-
-        rawData.forEach(raw => {
-            const rec = this.createRecord(raw, parent),
-                {id} = rec;
-
-            throwIf(
-                recordMap.has(id) || summaryRecordIds.has(id),
-                `ID ${id} is not unique. Use the 'Store.idSpec' config to resolve a unique ID for each record.`
-            );
-
-            recordMap.set(id, rec);
-
-            if (loadTreeData && raw[loadTreeDataFrom]) {
-                this.createRecords(raw[loadTreeDataFrom], rec, recordMap, summaryRecordIds);
-            }
-        });
+        rawData.forEach(raw => this.createRecordDeep(raw, parent, recordMap, summaryRecordIds));
         return recordMap;
+    }
+
+    // Create a record - and recursively records for its tree children - installing all in recordMap.
+    private createRecordDeep(
+        raw: PlainObject,
+        parent: StoreRecord,
+        recordMap: Map<StoreRecordId, StoreRecord>,
+        summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
+    ) {
+        const rec = this.createRecord(raw, parent),
+            {id} = rec;
+
+        throwIf(
+            recordMap.has(id) || summaryRecordIds.has(id),
+            `ID ${id} is not unique. Use the 'Store.idSpec' config to resolve a unique ID for each record.`
+        );
+
+        recordMap.set(id, rec);
+
+        if (this.loadTreeData && raw[this.loadTreeDataFrom]) {
+            this.createRecords(raw[this.loadTreeDataFrom], rec, recordMap, summaryRecordIds);
+        }
     }
 
     private get summaryRecordIds(): Set<StoreRecordId> {

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -280,7 +280,7 @@ export class Cube extends HoistBase {
      *
      * May also be passed a streaming source - a sync or async iterable yielding raw records or
      * chunks of records - loaded via {@link Store.loadDataAsync}, e.g.
-     * `cube.loadDataAsync(XH.fetchNdjson({url}))`.
+     * `cube.loadDataAsync(XH.fetchNdjson({url}).lines)`.
      *
      * Note that this method will update its views asynchronously in order to avoid locking up the
      * browser when attached to multiple expensive views.

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 
-import {HoistBase, managed, PlainObject, Some} from '@xh/hoist/core';
+import {AnyIterable, HoistBase, managed, PlainObject, Some} from '@xh/hoist/core';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {forEachAsync} from '@xh/hoist/utils/async';
 import {defaultsDeep, isArray, isEmpty} from 'lodash';
@@ -278,8 +278,8 @@ export class Cube extends HoistBase {
      * Populate this cube with a new dataset.
      * This method largely delegates to {@link Store.loadData} - see that method for more info.
      *
-     * May also be passed a streaming source - a sync or async iterable yielding raw records or
-     * chunks of records - loaded via {@link Store.loadDataAsync}, e.g.
+     * May also be passed a streaming source - a sync or async iterable yielding raw records -
+     * loaded via {@link Store.loadDataAsync}, e.g.
      * `cube.loadDataAsync(XH.fetchNdjson({url}).lines)`.
      *
      * Note that this method will update its views asynchronously in order to avoid locking up the
@@ -289,7 +289,7 @@ export class Cube extends HoistBase {
      * @param info - optional metadata to associate with this cube/dataset.
      */
     async loadDataAsync(
-        rawData: PlainObject[] | AsyncIterable<Some<PlainObject>> | Iterable<Some<PlainObject>>,
+        rawData: PlainObject[] | AnyIterable<PlainObject>,
         info: PlainObject = {}
     ): Promise<void> {
         if (isArray(rawData)) {

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -23,20 +23,10 @@ import {PromiseTimeoutSpec} from '@xh/hoist/promise';
 import {isLocalDate, SECONDS} from '@xh/hoist/utils/datetime';
 import {apiDeprecated, warnIf} from '@xh/hoist/utils/js';
 import {StatusCodes} from 'http-status-codes';
-import {
-    isDate,
-    isEqual,
-    isFunction,
-    isNil,
-    isObject,
-    isString,
-    noop,
-    omit,
-    omitBy,
-    truncate
-} from 'lodash';
+import {isDate, isFunction, isNil, isObject, isString, noop, omit, omitBy, truncate} from 'lodash';
 import {IStringifyOptions, stringify} from 'qs';
 import ShortUniqueId from 'short-unique-id';
+import {NdjsonResultImpl} from './impl/NdjsonResultImpl';
 import {StringInterner} from './impl/StringInterner';
 
 export interface FetchServiceDefaults {
@@ -166,13 +156,19 @@ export class FetchService extends HoistService {
 
     /**
      * Send an HTTP request and decode the response body incrementally as NDJSON - newline
-     * delimited JSON, aka JSON Lines / JSONL - yielding chunks (arrays) of parsed records as
-     * they arrive off the network. No more than one network chunk of raw text is buffered,
-     * making this suitable for consuming very large or long-running streamed responses.
+     * delimited JSON, aka JSON Lines / JSONL. Returns an {@link NdjsonResult} whose `lines`
+     * generator yields chunks (arrays) of parsed records as they arrive off the network. No
+     * more than one network chunk of raw text is buffered, making this suitable for consuming
+     * very large or long-running streamed responses.
      *
      * The natural source for {@link Store.loadDataAsync} - e.g.
-     * `store.loadDataAsync(XH.fetchNdjson({url}))` - or iterate directly via `for await` for
-     * non-Store streaming.
+     * `store.loadDataAsync(XH.fetchNdjson({url}).lines)` - or iterate `lines` directly via
+     * `for await` for non-Store streaming.
+     *
+     * Set {@link NdjsonFetchOptions.firstLineIsMeta} to treat the first record in the stream as
+     * out-of-band metadata, delivered via the result's `meta` promise rather than `lines`. The
+     * promise resolves as soon as the record arrives - before `lines` is consumed - so callers
+     * can use it to decide how to process the balance of the stream.
      *
      * Tracing spans and `track` cover the full lifetime of the stream, through complete
      * consumption. Note that `timeout` covers the request phase only - no timeout applies while
@@ -181,7 +177,7 @@ export class FetchService extends HoistService {
      * A stream truncated by a server-side failure surfaces as a 'Fetch Stream Failed' exception -
      * hoist-core's `renderNdjson` guarantees such a stream ends with an unparseable line.
      */
-    fetchNdjson(opts: FetchOptions, ctx?: CallContextLike): AsyncGenerator<PlainObject[]> {
+    fetchNdjson(opts: NdjsonFetchOptions, ctx?: CallContextLike): NdjsonResult {
         opts = this.withCorrelationId(opts);
 
         let runner = this.runner(ctx);
@@ -198,21 +194,20 @@ export class FetchService extends HoistService {
         }
 
         // The runner will manage the lifecycle, but we won't await it here -- return
-        // the generator straight away. Don't produce unhandled exceptions from telemetry
-        // only. Generator will already produce them.
-        let ret: AsyncGenerator<PlainObject[]>;
+        // the result straight away. Also stifle telemetry exception. Stream already produces them.
+        let ret: NdjsonResultImpl;
         runner
             .run(async innerCtx => {
-                const fetchPromise = this.fetchInternalAsync(opts, innerCtx, true);
-
-                let onComplete: (err?: unknown) => void;
-                const streamPromise = new Promise<void>(
-                    (res, rej) => (onComplete = err => (err ? rej(err) : res()))
+                ret = new NdjsonResultImpl(
+                    this.fetchInternalAsync(opts, innerCtx, true),
+                    opts,
+                    this.getInterner(opts.internStrings),
+                    (cause, response) =>
+                        cause?.name === 'AbortError'
+                            ? this.abortedException(opts, innerCtx, cause)
+                            : this.streamFailedException(opts, innerCtx, response, cause)
                 );
-                ret = this.streamNdjson(opts, innerCtx, fetchPromise, onComplete);
-
-                await fetchPromise;
-                await streamPromise;
+                await ret.whenCompleteAsync();
             })
             .catch(noop);
         return ret;
@@ -297,9 +292,6 @@ export class FetchService extends HoistService {
     // Implementation
     //-----------------------
     private static readonly defaultIdGenerator = new ShortUniqueId({length: 16});
-
-    /** Marker written by hoist-core's `renderNdjson` when a stream fails after committing. */
-    private static readonly NDJSON_POISON = '//xh-ndjson-stream-error';
 
     /**
      * @param forStreaming - true when called by fetchNdjson, which applies its own span and
@@ -663,99 +655,19 @@ export class FetchService extends HoistService {
     }
 
     /**
-     * Await the pending request, then stream its body - wrapping any failure raised while
-     * reading or parsing the stream in an enriched FetchException.
-     *
-     * Reports the streaming phase's outcome via the `onComplete` callback - with any error on
-     * failure, and unconditionally on exit to cover early termination by the consumer.
-     * Request-phase failures propagate already-enriched and without an `onComplete` error - the
-     * caller observes them on the fetch promise directly.
-     */
-    private async *streamNdjson(
-        opts: FetchOptions,
-        ctx: CallContextLike,
-        fetchPromise: Promise<Response>,
-        onComplete: (err?: unknown) => void
-    ): AsyncGenerator<PlainObject[]> {
-        const interner = this.getInterner(opts.internStrings);
-        try {
-            const response = await fetchPromise;
-            try {
-                yield* this.ndjsonChunks(response, interner);
-                interner?.commit();
-            } catch (e) {
-                const ex =
-                    e?.name === 'AbortError'
-                        ? this.abortedException(opts, ctx, e)
-                        : this.streamFailedException(opts, ctx, response, e);
-                onComplete(ex);
-                throw ex;
-            }
-        } finally {
-            // Only finally blocks run if the consumer exits its loop early. Discard any
-            // uncommitted interned values - no-op after a successful commit above.
-            interner?.abort();
-            onComplete();
-        }
-    }
-
-    /**
-     * Read an NDJSON Response body incrementally, yielding chunks (arrays) of parsed records as
-     * they arrive off the network. Each line is parsed with native JSON.parse, partial trailing
-     * lines are carried across chunk boundaries, and no more than one network chunk of raw text
-     * is buffered.
-     *
-     * Note the final-buffer parse below doubles as truncation detection - a stream cut short by
-     * a server-side failure ends with an unparseable line (see fetchNdjson) and throws here.
-     */
-    private async *ndjsonChunks(
-        response: Response,
-        interner: StringInterner
-    ): AsyncGenerator<PlainObject[]> {
-        const reader = response.body.getReader(),
-            decoder = new TextDecoder();
-        let buffer = '';
-
-        while (true) {
-            const {done, value} = await reader.read();
-            if (done) break;
-
-            buffer += decoder.decode(value, {stream: true});
-            const lines = buffer.split('\n');
-            buffer = lines.pop(); // retain any partial trailing line for the next chunk
-            if (lines.length) {
-                const chunk = lines.filter(Boolean).map(it => JSON.parse(it));
-                interner?.intern(chunk);
-                yield chunk;
-            }
-        }
-
-        buffer += decoder.decode();
-        if (buffer.trim()) {
-            if (buffer.trim() === FetchService.NDJSON_POISON) {
-                throw Exception.create({
-                    name: 'NDJSON Stream Error',
-                    message: 'NDJSON stream terminated by a server-side failure - see server logs.'
-                });
-            }
-            const chunk = [JSON.parse(buffer)];
-            interner?.intern(chunk);
-            yield chunk;
-        }
-    }
-
-    /**
      * Get or create the {@link StringInterner} for the given spec's key, or null if interning
-     * was not requested. An existing interner is replaced (dropping its cached generation) if
-     * the spec has changed since it was created.
+     * was not requested. Interners are retained per key with the latest spec adopted on each
+     * call - see {@link clearInternCaches} to reset.
      */
     private getInterner(spec: StringInternSpec): StringInterner {
         if (!spec) return null;
         const {interners} = this;
         let ret = interners.get(spec.key);
-        if (!ret || !isEqual(ret.spec, spec)) {
+        if (!ret) {
             ret = new StringInterner(spec);
             interners.set(spec.key, ret);
+        } else {
+            ret.spec = spec;
         }
         return ret;
     }
@@ -1020,8 +932,9 @@ export interface FetchOptions {
      * into child records via `childrenKey`. No-op for response payloads of any other shape.
      *
      * Interned values are also optionally shared across successive responses with the same `key` -
-     * e.g. a polling refresh of the same grid - with cache retention bounded to the values
-     * present in the most recent complete response for each key.
+     * e.g. a polling refresh of the same grid - with cache retention per each key's
+     * {@link StringInternSpec.retainMode}, by default bounded to the values present in the most
+     * recent complete response.
      */
     internStrings?: StringInternSpec;
 
@@ -1050,6 +963,28 @@ export interface FetchOptions {
     traceId?: string;
 }
 
+/** Options for {@link FetchService.fetchNdjson}. */
+export interface NdjsonFetchOptions extends FetchOptions {
+    /**
+     * True to treat the first record in the stream as metadata, delivered via
+     * {@link NdjsonResult.meta} rather than yielded with the data records. Default false.
+     */
+    firstLineIsMeta?: boolean;
+}
+
+/** Streamed result returned by {@link FetchService.fetchNdjson}. */
+export interface NdjsonResult {
+    /** Parsed data records, yielded in chunks (arrays) as they arrive off the network. */
+    lines: AsyncGenerator<PlainObject[]>;
+
+    /**
+     * Leading metadata record - null unless requested via
+     * {@link NdjsonFetchOptions.firstLineIsMeta}. Resolves as soon as the record arrives,
+     * without requiring `lines` to be consumed - null if the stream was empty.
+     */
+    meta: Promise<PlainObject> | null;
+}
+
 /**
  * Spec for string-value interning of a fetch response.
  * @see FetchOptions.internStrings
@@ -1070,12 +1005,23 @@ export interface StringInternSpec {
     childrenKey?: string;
 
     /**
-     * True (default) to hold each response's interned values for reuse by the next response
-     * with the same key. Set false to intern within each response only - appropriate for large
-     * one-shot datasets that will not be refetched, where a retained cache would pin the last
-     * response's distinct values for no future benefit.
+     * How long interned values are held for reuse by later responses with the same key.
+     * Default 'nextCall'.
+     *
+     * - 'nextCall' (default) - hold the values in each committed response for reuse by the next.
+     *   Values not re-seen are evicted, bounding the cache to the latest response - the right
+     *   mode for polling/refresh of a comparable dataset.
+     * - 'always' - hold every value ever committed, until {@link FetchService.clearInternCaches}.
+     *   Useful when successive responses cover different slices of a dataset (e.g. paging, or
+     *   alternating filters), where 'nextCall' would evict values about to recur.
+     * - 'never' - intern within each response only. Appropriate for large one-shot datasets that
+     *   will not be refetched, where a retained cache would pin the last response's distinct
+     *   values for no future benefit.
+     *
+     * May be varied across calls sharing a key without resetting the cache - the mode governs
+     * only how each completing response's values are installed for reuse.
      */
-    retainAcrossFetches?: boolean;
+    retainMode?: 'never' | 'nextCall' | 'always';
 }
 
 /**

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -157,8 +157,8 @@ export class FetchService extends HoistService {
     /**
      * Send an HTTP request and decode the response body incrementally as NDJSON - newline
      * delimited JSON, aka JSON Lines / JSONL. Returns an {@link NdjsonResult} whose `lines`
-     * generator yields chunks (arrays) of parsed records as they arrive off the network. No
-     * more than one network chunk of raw text is buffered, making this suitable for consuming
+     * generator yields parsed records one at a time as they arrive off the network. No more
+     * than one network chunk of raw text is buffered, making this suitable for consuming
      * very large or long-running streamed responses.
      *
      * The natural source for {@link Store.loadDataAsync} - e.g.
@@ -974,8 +974,8 @@ export interface NdjsonFetchOptions extends FetchOptions {
 
 /** Streamed result returned by {@link FetchService.fetchNdjson}. */
 export interface NdjsonResult {
-    /** Parsed data records, yielded in chunks (arrays) as they arrive off the network. */
-    lines: AsyncGenerator<PlainObject[]>;
+    /** Parsed data records, yielded individually as they arrive off the network. */
+    lines: AsyncGenerator<PlainObject>;
 
     /**
      * Leading metadata record - null unless requested via

--- a/svc/impl/NdjsonResultImpl.ts
+++ b/svc/impl/NdjsonResultImpl.ts
@@ -1,0 +1,167 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+
+import {PlainObject} from '@xh/hoist/core';
+import {Exception} from '@xh/hoist/exception';
+import {noop} from 'lodash';
+import type {FetchException, NdjsonFetchOptions, NdjsonResult} from '../FetchService';
+import {StringInterner} from './StringInterner';
+
+/**
+ * Decodes a streamed NDJSON Response body into chunks of parsed records - implementation helper
+ * for {@link FetchService.fetchNdjson}, which remains the public entry point and injects all
+ * service-level concerns via constructor arguments. Implements {@link NdjsonResult} and is
+ * returned to callers directly.
+ *
+ * @internal
+ */
+export class NdjsonResultImpl implements NdjsonResult {
+    /** Marker written by hoist-core's `renderNdjson` when a stream fails after committing. */
+    private static readonly POISON = '//xh-ndjson-stream-error';
+
+    /** Parsed data records - see {@link NdjsonResult.lines}. */
+    readonly lines: AsyncGenerator<PlainObject[]>;
+
+    /** Leading metadata record - see {@link NdjsonResult.meta}. */
+    readonly meta: Promise<PlainObject> | null = null;
+
+    /**
+     * Settles when streaming has finished - resolving after complete consumption or early
+     * termination by the consumer, rejecting on a streaming-phase failure. Request-phase
+     * failures are not reported here - see {@link whenCompleteAsync}, which covers both phases.
+     */
+    private completion: Promise<void>;
+
+    private onComplete: (err?: unknown) => void;
+
+    constructor(
+        private response: Promise<Response>,
+        opts: NdjsonFetchOptions,
+        private interner: StringInterner,
+        private enrichError: (cause: any, response: Response) => FetchException
+    ) {
+        this.completion = new Promise<void>(
+            (res, rej) => (this.onComplete = err => (err ? rej(err) : res()))
+        );
+
+        const stream = this.stream();
+        if (opts.firstLineIsMeta) {
+            // Eagerly read through the first record so `meta` resolves without requiring
+            // `lines` to be consumed - callers typically need it up-front to decide how to
+            // process the balance of the stream.
+            const first = stream.next();
+            this.meta = first.then(({done, value}) => (done ? null : value[0]));
+
+            // Mark any rejection as observed - avoids unhandled-rejection noise
+            this.meta.catch(noop);
+
+            this.lines = this.linesAfterMeta(first, stream);
+        } else {
+            this.lines = stream;
+        }
+    }
+
+    /**
+     * Resolves once the request has completed and its stream has been fully consumed (or the
+     * consumer exited early) - rejects on a failure in either phase. Use to track the full
+     * lifetime of the stream, e.g. for spanning and telemetry.
+     */
+    async whenCompleteAsync(): Promise<void> {
+        await this.response;
+        await this.completion;
+    }
+
+    //-----------------------
+    // Implementation
+    //-----------------------
+    /**
+     * Await the pending request, then stream its body - wrapping any failure raised while
+     * reading or parsing the stream via the configured `enrichError`.
+     *
+     * Settles `completion` on exit - see that property for its exact semantics.
+     */
+    private async *stream(): AsyncGenerator<PlainObject[]> {
+        const {interner, enrichError, onComplete} = this;
+        try {
+            const response = await this.response;
+            try {
+                yield* this.chunks(response);
+                interner?.commit();
+            } catch (e) {
+                const ex = enrichError(e, response);
+                onComplete(ex);
+                throw ex;
+            }
+        } finally {
+            // Only finally blocks run if the consumer exits its loop early. Discard any
+            // uncommitted interned values - no-op after a successful commit above.
+            interner?.abort();
+            onComplete();
+        }
+    }
+
+    /**
+     * Read an NDJSON Response body incrementally, yielding chunks (arrays) of parsed records as
+     * they arrive off the network. Each line is parsed with native JSON.parse, partial trailing
+     * lines are carried across chunk boundaries, and no more than one network chunk of raw text
+     * is buffered.
+     *
+     * Note the final-buffer parse below doubles as truncation detection - a stream cut short by
+     * a server-side failure ends with an unparseable line (see fetchNdjson) and throws here.
+     */
+    private async *chunks(response: Response): AsyncGenerator<PlainObject[]> {
+        const {interner} = this,
+            reader = response.body.getReader(),
+            decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+            const {done, value} = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, {stream: true});
+            const lines = buffer.split('\n');
+            buffer = lines.pop(); // retain any partial trailing line for the next chunk
+            const chunk = lines.filter(Boolean).map(it => JSON.parse(it));
+            if (chunk.length) {
+                interner?.intern(chunk);
+                yield chunk;
+            }
+        }
+
+        buffer += decoder.decode();
+        if (buffer.trim()) {
+            if (buffer.trim() === NdjsonResultImpl.POISON) {
+                throw Exception.create({
+                    name: 'NDJSON Stream Error',
+                    message: 'NDJSON stream terminated by a server-side failure - see server logs.'
+                });
+            }
+            const chunk = [JSON.parse(buffer)];
+            interner?.intern(chunk);
+            yield chunk;
+        }
+    }
+
+    /**
+     * Yield the balance of the eagerly-read first chunk, then delegate to the remaining stream.
+     */
+    private async *linesAfterMeta(
+        first: Promise<IteratorResult<PlainObject[]>>,
+        stream: AsyncGenerator<PlainObject[]>
+    ): AsyncGenerator<PlainObject[]> {
+        try {
+            const {done, value} = await first; // rethrows any failure hit reading the meta record
+            if (!done) {
+                if (value.length > 1) yield value.slice(1);
+                yield* stream;
+            }
+        } finally {
+            await stream.return(null); // ensure inner cleanup if the consumer exits early
+        }
+    }
+}

--- a/svc/impl/NdjsonResultImpl.ts
+++ b/svc/impl/NdjsonResultImpl.ts
@@ -12,7 +12,7 @@ import type {FetchException, NdjsonFetchOptions, NdjsonResult} from '../FetchSer
 import {StringInterner} from './StringInterner';
 
 /**
- * Decodes a streamed NDJSON Response body into chunks of parsed records - implementation helper
+ * Decodes a streamed NDJSON Response body into parsed records - implementation helper
  * for {@link FetchService.fetchNdjson}, which remains the public entry point and injects all
  * service-level concerns via constructor arguments. Implements {@link NdjsonResult} and is
  * returned to callers directly.
@@ -24,7 +24,7 @@ export class NdjsonResultImpl implements NdjsonResult {
     private static readonly POISON = '//xh-ndjson-stream-error';
 
     /** Parsed data records - see {@link NdjsonResult.lines}. */
-    readonly lines: AsyncGenerator<PlainObject[]>;
+    readonly lines: AsyncGenerator<PlainObject>;
 
     /** Leading metadata record - see {@link NdjsonResult.meta}. */
     readonly meta: Promise<PlainObject> | null = null;
@@ -54,7 +54,7 @@ export class NdjsonResultImpl implements NdjsonResult {
             // `lines` to be consumed - callers typically need it up-front to decide how to
             // process the balance of the stream.
             const first = stream.next();
-            this.meta = first.then(({done, value}) => (done ? null : value[0]));
+            this.meta = first.then(({done, value}) => (done ? null : value));
 
             // Mark any rejection as observed - avoids unhandled-rejection noise
             this.meta.catch(noop);
@@ -79,17 +79,17 @@ export class NdjsonResultImpl implements NdjsonResult {
     // Implementation
     //-----------------------
     /**
-     * Await the pending request, then stream its body - wrapping any failure raised while
-     * reading or parsing the stream via the configured `enrichError`.
+     * Await the pending request, then stream its body one record at a time - wrapping any
+     * failure raised while reading or parsing the stream via the configured `enrichError`.
      *
      * Settles `completion` on exit - see that property for its exact semantics.
      */
-    private async *stream(): AsyncGenerator<PlainObject[]> {
+    private async *stream(): AsyncGenerator<PlainObject> {
         const {interner, enrichError, onComplete} = this;
         try {
             const response = await this.response;
             try {
-                yield* this.chunks(response);
+                yield* this.records(response);
                 interner?.commit();
             } catch (e) {
                 const ex = enrichError(e, response);
@@ -105,15 +105,15 @@ export class NdjsonResultImpl implements NdjsonResult {
     }
 
     /**
-     * Read an NDJSON Response body incrementally, yielding chunks (arrays) of parsed records as
-     * they arrive off the network. Each line is parsed with native JSON.parse, partial trailing
-     * lines are carried across chunk boundaries, and no more than one network chunk of raw text
-     * is buffered.
+     * Read an NDJSON Response body incrementally, yielding parsed records as they arrive off
+     * the network. Each line is parsed with native JSON.parse, partial trailing lines are
+     * carried across chunk boundaries, and no more than one network chunk of raw text is
+     * buffered.
      *
      * Note the final-buffer parse below doubles as truncation detection - a stream cut short by
      * a server-side failure ends with an unparseable line (see fetchNdjson) and throws here.
      */
-    private async *chunks(response: Response): AsyncGenerator<PlainObject[]> {
+    private async *records(response: Response): AsyncGenerator<PlainObject> {
         const {interner} = this,
             reader = response.body.getReader(),
             decoder = new TextDecoder();
@@ -126,10 +126,11 @@ export class NdjsonResultImpl implements NdjsonResult {
             buffer += decoder.decode(value, {stream: true});
             const lines = buffer.split('\n');
             buffer = lines.pop(); // retain any partial trailing line for the next chunk
-            const chunk = lines.filter(Boolean).map(it => JSON.parse(it));
-            if (chunk.length) {
-                interner?.intern(chunk);
-                yield chunk;
+            for (const line of lines) {
+                if (!line) continue;
+                const record = JSON.parse(line);
+                interner?.intern(record);
+                yield record;
             }
         }
 
@@ -141,25 +142,22 @@ export class NdjsonResultImpl implements NdjsonResult {
                     message: 'NDJSON stream terminated by a server-side failure - see server logs.'
                 });
             }
-            const chunk = [JSON.parse(buffer)];
-            interner?.intern(chunk);
-            yield chunk;
+            const record = JSON.parse(buffer);
+            interner?.intern(record);
+            yield record;
         }
     }
 
     /**
-     * Yield the balance of the eagerly-read first chunk, then delegate to the remaining stream.
+     * Delegate to the remaining stream once the eagerly-read meta record has settled.
      */
     private async *linesAfterMeta(
-        first: Promise<IteratorResult<PlainObject[]>>,
-        stream: AsyncGenerator<PlainObject[]>
-    ): AsyncGenerator<PlainObject[]> {
+        first: Promise<IteratorResult<PlainObject>>,
+        stream: AsyncGenerator<PlainObject>
+    ): AsyncGenerator<PlainObject> {
         try {
-            const {done, value} = await first; // rethrows any failure hit reading the meta record
-            if (!done) {
-                if (value.length > 1) yield value.slice(1);
-                yield* stream;
-            }
+            const {done} = await first; // rethrows any failure hit reading the meta record
+            if (!done) yield* stream;
         } finally {
             await stream.return(null); // ensure inner cleanup if the consumer exits early
         }

--- a/svc/impl/StringInterner.ts
+++ b/svc/impl/StringInterner.ts
@@ -14,11 +14,11 @@ import type {StringInternSpec} from '../FetchService';
  * key and shared across fetches of that dataset - see {@link FetchOptions.internStrings}.
  *
  * Values are deduplicated into an internal pending map spanning a whole response (all chunks
- * of an NDJSON stream), with lookups falling back to the previous committed generation, so
- * values repeated across successive fetches share a single canonical string. Calling `commit()`
- * installs the pending values as the new generation, bounding cache retention to the strings
- * present in the latest completed response. This cross-fetch retention is optional - specs may
- * opt out via `retainAcrossFetches: false` to intern within each response only.
+ * of an NDJSON stream), with lookups falling back to the previously committed values, so values
+ * repeated across successive fetches share a single canonical string. Calling `commit()`
+ * installs the pending values per the spec's `retainMode` - by default replacing the committed
+ * set, bounding cache retention to the strings present in the latest completed response. See
+ * {@link StringInternSpec.retainMode} for the 'always' and 'never' variants.
  *
  * The pending map is opened lazily by `intern()`. A response that fails or is abandoned before
  * commit should be `abort()`ed to discard its pending values - the previously committed
@@ -27,9 +27,9 @@ import type {StringInternSpec} from '../FetchService';
  * @internal
  */
 export class StringInterner {
-    readonly spec: StringInternSpec;
+    /** Latest spec provided for this key - adopted on each call, so settings may vary. */
+    spec: StringInternSpec;
 
-    private readonly childrenKey: string;
     private committed: Map<string, string> = new Map();
     private pending: Map<string, string> = null;
 
@@ -40,13 +40,12 @@ export class StringInterner {
 
     constructor(spec: StringInternSpec) {
         this.spec = spec;
-        this.childrenKey = spec.childrenKey;
     }
 
     /**
      * Stats for the most recently committed cycle (i.e. response) - all zero if none committed:
      *  - `processed` - total string values encountered.
-     *  - `retained` - distinct values held in the resulting generation, with `retainedPct` of
+     *  - `retained` - distinct values in the committed response, with `retainedPct` of
      *     processed. Lower percentage = more duplication removed.
      *  - `carried` - retained values already present in the previous generation, with
      *    `carriedPct` of retained. Higher percentage = more stability across refreshes.
@@ -81,21 +80,31 @@ export class StringInterner {
     }
 
     /**
-     * Install pending values as the new committed generation, evicting values not re-seen.
-     * No-op on the committed generation if the spec opts out via `retainAcrossFetches: false` -
-     * `committed` then remains permanently empty, and interning is per-response only.
+     * Install pending values for reuse by later responses, per the spec's `retainMode`:
+     * 'nextCall' (default) replaces the committed set, evicting values not re-seen; 'always'
+     * merges into it; 'never' discards, leaving `committed` permanently empty so interning is
+     * per-response only.
      */
     commit() {
-        if (this.pending) {
-            this.lastStats = {
-                processed: this.processed,
-                retained: this.pending.size,
-                carried: this.carried
-            };
-            if (this.spec.retainAcrossFetches !== false) this.committed = this.pending;
-            this.pending = null;
-            this.processed = this.carried = 0;
+        const {pending, committed} = this;
+        if (!pending) return;
+
+        switch (this.spec.retainMode ?? 'nextCall') {
+            case 'nextCall':
+                this.committed = pending;
+                break;
+            case 'always':
+                pending.forEach(v => committed.set(v, v));
+                break;
         }
+
+        this.lastStats = {
+            processed: this.processed,
+            retained: pending.size,
+            carried: this.carried
+        };
+        this.pending = null;
+        this.processed = this.carried = 0;
     }
 
     /** Discard pending values without committing. No-op if already committed or aborted. */
@@ -108,7 +117,8 @@ export class StringInterner {
     // Implementation
     //------------------
     private internRow(row: PlainObject) {
-        const {pending, committed, childrenKey} = this;
+        const {pending, committed} = this,
+            {childrenKey} = this.spec;
         for (const k in row) {
             const v = row[k];
             if (isString(v)) {

--- a/svc/impl/StringInterner.ts
+++ b/svc/impl/StringInterner.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 
-import {PlainObject} from '@xh/hoist/core';
+import {PlainObject, Some} from '@xh/hoist/core';
 import {isArray, isPlainObject, isString, round} from 'lodash';
 import type {StringInternSpec} from '../FetchService';
 
@@ -66,12 +66,8 @@ export class StringInterner {
 
     /**
      * Intern string values within the given data, mutating it in place.
-     *
-     * Accepts an array of records, or a single plain-object record - the latter treated as a
-     * root node, with its own string values interned and `childrenKey` recursion applying as
-     * usual. Values of any other shape are ignored.
      */
-    intern(data: PlainObject | PlainObject[]) {
+    intern(data: Some<PlainObject>) {
         this.pending ??= new Map();
         if (isArray(data)) {
             data.forEach(row => this.internRow(row));

--- a/svc/impl/StringInterner.ts
+++ b/svc/impl/StringInterner.ts
@@ -73,10 +73,11 @@ export class StringInterner {
      */
     intern(data: PlainObject | PlainObject[]) {
         this.pending ??= new Map();
-        const rows = isArray(data) ? data : [data];
-        rows.forEach(row => {
-            if (isPlainObject(row)) this.internRow(row);
-        });
+        if (isArray(data)) {
+            data.forEach(row => this.internRow(row));
+        } else {
+            this.internRow(data);
+        }
     }
 
     /**
@@ -117,6 +118,8 @@ export class StringInterner {
     // Implementation
     //------------------
     private internRow(row: PlainObject) {
+        if (!isPlainObject(row)) return;
+
         const {pending, committed} = this,
             {childrenKey} = this.spec;
         for (const k in row) {


### PR DESCRIPTION
Pre-release adjustments to the v87 NDJSON streaming and string-interning APIs.

* `XH.fetchNdjson()` now returns an `NdjsonResult` - `lines` (the chunked record stream, e.g. `store.loadDataAsync(XH.fetchNdjson({url}).lines)`) plus `meta`, a promise for an optional leading metadata record requested via the new `firstLineIsMeta` option. `meta` resolves eagerly as soon as the first record arrives, so apps can use it before consuming `lines`.
* Implementation: NDJSON stream mechanics extracted from `FetchService` into `svc/impl/NdjsonResultImpl`, which implements `NdjsonResult` and is returned to callers directly. Service concerns (interning, exception enrichment) are injected via constructor args; the runner tracks the full stream lifetime via `whenCompleteAsync()`.
* Replaced `StringInternSpec.retainAcrossFetches` with `retainMode: 'never' | 'nextCall' | 'always'` - the new `'always'` mode suits successive responses covering different slices of a dataset (paging, alternating filters). Specs are adopted per call and interners persist per key until `clearInternCaches()` - never reset by spec changes.