### PR TITLE
Store.skipDataCopy + skipDataParsing configs (replace useRawAsData)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,15 +36,16 @@
   `includeLeaves` nor `provideLeaves` set) - leaf rows read directly from cube records, eliminating
   per-View leaf data objects and speeding up view builds for aggregate-only views over large
   datasets. Such views no longer publish a `View.result.leafMap` - see Breaking Changes.
-* Added opt-in `Store.skipDataCopy` and `Store.skipDataParsing` configs - orthogonal store
-  optimizations for large datasets. `skipDataCopy` uses each raw object *as* its record's `data`
-  by reference, parsed in place. This is most notably useful for a store loading data freshly created
-  from a FetchService.  `skipDataParsing` skips Field-level value parsing for data already in its
-  final client-side  form. See the config docs for the full contracts.  In the case of a
-  view-connected Store, both flags should typically be set to true. for optimum performance.
-* Improved `Store.processRawData` semantics implementations are now passed the Store-owned copy of the data
-  the each raw object, and are encouraged to mutate it directly, assuming they have
-  either left `skipDataCopy` set to false, or singularly own the raw data they are passed.
+* Added opt-in `Store.skipDataCopy` and `Store.skipDataParsing` configs - orthogonal performance
+  optimizations for large datasets. `skipDataCopy` uses each raw object *as* its record's `data`,
+  by reference and parsed in place - most useful for data freshly fetched via `FetchService`, with
+  no other owner. `skipDataParsing` skips Field-level value parsing for data already in its final
+  client-side form. See the config docs for the full contracts. Stores connected to a Cube `View`
+  should typically set both flags for optimal performance.
+* Improved `Store.processRawData` semantics - implementations are now passed a Store-owned shallow
+  clone of each raw object and may mutate and return it directly, with no defensive cloning needed.
+  (With `skipDataCopy` the raw object itself is passed - see that config for the ownership
+  contract.)
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,12 +36,15 @@
   `includeLeaves` nor `provideLeaves` set) - leaf rows read directly from cube records, eliminating
   per-View leaf data objects and speeding up view builds for aggregate-only views over large
   datasets. Such views no longer publish a `View.result.leafMap` - see Breaking Changes.
-* Added an opt-in `Store.useRawAsData` config for projections of already-parsed data - most notably
-  a connected Cube `View` feeding a (tree) grid, or an endpoint returning data in its final
-  client-side form. Records use the provider's row object as their `data` by reference rather than
-  re-parsing and copying it, collapsing the usual two per-row objects to one and skipping the
-  per-row parse on every load and update. Requires that raw data already match the Store's Field
-  definitions - see the `useRawAsData` config docs for the full contract.
+* Added opt-in `Store.skipDataCopy` and `Store.skipDataParsing` configs - orthogonal store
+  optimizations for large datasets. `skipDataCopy` uses each raw object *as* its record's `data`
+  by reference, parsed in place. This is most notably useful for a store loading data freshly created
+  from a FetchService.  `skipDataParsing` skips Field-level value parsing for data already in its
+  final client-side  form. See the config docs for the full contracts.  In the case of a
+  view-connected Store, both flags should typically be set to true. for optimum performance.
+* Improved `Store.processRawData` semantics implementations are now passed the Store-owned copy of the data
+  the each raw object, and are encouraged to mutate it directly, assuming they have
+  either left `skipDataCopy` set to false, or singularly own the raw data they are passed.
 
 ### 🐞 Bug Fixes
 

--- a/data/README.md
+++ b/data/README.md
@@ -102,7 +102,8 @@ const store = new Store({
 | `freezeData` | `boolean` | `true` | Freeze record data objects for immutability (set to false as performance optimization) |
 | `reuseRecords` | `boolean` | `false` | Cache records by ID and raw reference (performance)                                    |
 | `retainRaw` | `boolean` | `true` | Retain raw data reference on each record (set false to reduce memory)                  |
-| `useRawAsData` | `boolean` | `false` | Use each raw object *as* its record's `data`, skipping the parse/copy (memory)        |
+| `skipDataCopy` | `boolean` | `false` | Use each raw object *as* its record's `data`, by reference - zero-copy (memory)       |
+| `skipDataParsing` | `boolean` | `false` | Skip Field-level value parsing - data already in final client-side form (performance) |
 | `idEncodesTreePath` | `boolean` | `false` | IDs imply fixed tree position (performance)                                            |
 | `validationIsComplex` | `boolean` | `false` | Validate all uncommitted records on every change                                       |
 
@@ -792,16 +793,18 @@ const store = new Store({
 
 ### Processing Raw Data with `processRawData`
 
-Transform data before it enters the Store:
+Transform data before it enters the Store. The function is handed a Store-owned shallow clone of
+each raw object - mutate it in place and return it (no defensive cloning needed), or return a
+replacement object:
 
 ```typescript
 const store = new Store({
     fields: ['fullName', 'salary'],
-    processRawData: raw => ({
-        ...raw,
-        fullName: `${raw.firstName} ${raw.lastName}`,
-        salary: raw.salary / 100  // Convert cents to dollars
-    })
+    processRawData: raw => {
+        raw.fullName = `${raw.firstName} ${raw.lastName}`;
+        raw.salary = raw.salary / 100; // Convert cents to dollars
+        return raw;
+    }
 });
 ```
 

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -88,8 +88,14 @@ export interface StoreConfig {
 
     /**
      * Function to run on each individual data object presented to `loadData()` prior to creating
-     * a `StoreRecord` from that object. This function must return an object, cloning the original
-     * object if edits are necessary.
+     * a `StoreRecord` from that object. Must return an object - either the object it was passed,
+     * edited in place, or a replacement.
+     *
+     * The Store passes this function its own shallow clone of each raw object, so top-level edits
+     * are safe and efficient - mutate and return it, no defensive cloning needed. (Nested values
+     * are still shared with the source object and should be replaced rather than mutated.) With
+     * `skipDataCopy` the raw object itself is passed and adopted - see that config for the
+     * ownership contract.
      */
     processRawData?: (data: PlainObject) => PlainObject;
 
@@ -159,18 +165,30 @@ export interface StoreConfig {
 
     /**
      * True to use each incoming raw object *as* its record's `data`, by reference, rather than
-     * parsing and copying it. A zero-copy mode for already-parsed data - e.g. a connected Cube
-     * {@link View}, or a server endpoint returning data in its final client-side form.
+     * copying it into a Store-owned object. A zero-copy mode for large datasets - e.g. a
+     * connected Cube {@link View}, or a server endpoint returning data in its final client-side
+     * form.
      *
-     * Raw data must already match what the Store's Fields would parse - `type`, `parseVal`, and
-     * `defaultValue` are not applied. The Store never modifies or freezes raw objects (regardless
-     * of `freezeData`); the provider may mutate rows in place but must then publish via
-     * `updateData()`, as `loadData()` would skip reference-equal objects as unchanged.
+     * Setting this flag hands ownership of raw objects to the Store: it installs its shared
+     * Field-defaults prototype on each adopted plain object (so missing Fields resolve to their
+     * `defaultValue` - objects with a custom prototype, e.g. class instances, are adopted with
+     * their prototype intact) and, unless `skipDataParsing` is also set, parses Field values in
+     * place, directly on the raw object. The Store never freezes adopted objects (regardless of
+     * `freezeData`) or writes `data.id`; the provider may mutate rows in place but must then
+     * publish via `updateData()`, as `loadData()` would skip reference-equal objects as unchanged.
      *
      * `data` will carry every key on the raw object, not just declared Fields. Not compatible
-     * with `processRawData` or `reuseRecords`. Default false.
+     * with `reuseRecords`. Default false.
      */
-    useRawAsData?: boolean;
+    skipDataCopy?: boolean;
+
+    /**
+     * True to skip Field-level parsing when creating or updating record data - values are taken
+     * as-is, with no {@link FieldType} coercion and no XSS sanitization. For data already in its
+     * final client-side form, where the per-value parse is unwanted overhead. Missing Fields
+     * still resolve to their `defaultValue`. Default false.
+     */
+    skipDataParsing?: boolean;
 
     /**
      * Set to true to always validate all uncommitted records on every change to
@@ -296,7 +314,8 @@ export class Store
     freezeData: boolean;
     reuseRecords: boolean;
     retainRaw: boolean;
-    useRawAsData: boolean;
+    skipDataCopy: boolean;
+    skipDataParsing: boolean;
     validationIsComplex: boolean;
 
     @observable.ref
@@ -354,7 +373,8 @@ export class Store
         idEncodesTreePath = false,
         reuseRecords = false,
         retainRaw = true,
-        useRawAsData = false,
+        skipDataCopy = false,
+        skipDataParsing = false,
         validationIsComplex = false,
         experimental,
         data
@@ -366,12 +386,8 @@ export class Store
             'Store cannot be configured with both `reuseRecords` and `retainRaw: false` - record reuse requires retained raw data references.'
         );
         throwIf(
-            useRawAsData && processRawData,
-            'Store.useRawAsData cannot be used with processRawData.'
-        );
-        throwIf(
-            useRawAsData && reuseRecords,
-            'Store.useRawAsData cannot be used with reuseRecords.'
+            skipDataCopy && reuseRecords,
+            'Store.skipDataCopy cannot be used with reuseRecords.'
         );
 
         this.experimental = this.parseExperimental(experimental);
@@ -387,7 +403,8 @@ export class Store
         this.idEncodesTreePath = idEncodesTreePath;
         this.reuseRecords = reuseRecords;
         this.retainRaw = retainRaw;
-        this.useRawAsData = useRawAsData;
+        this.skipDataCopy = skipDataCopy;
+        this.skipDataParsing = skipDataParsing;
         this.validationIsComplex = validationIsComplex;
         this.lastUpdated = Date.now();
 
@@ -673,7 +690,7 @@ export class Store
             throwIf(isNil(id), `Must provide 'id' property for new records.`);
             throwIf(this.getById(id), `Duplicate id '${id}' provided for new record.`);
 
-            const parsedData = this.parseRaw(it),
+            const parsedData = this.parseData(it),
                 parent = this.getById(parentId);
 
             return new StoreRecord({
@@ -1228,20 +1245,6 @@ export class Store
     ): StoreRecord {
         const id = this.idSpec(raw);
 
-        // Zero-copy - use the raw object as `data` by reference, with no parsing, no data.id
-        // write, and no freeze. The Store does not own this object - see StoreConfig.useRawAsData.
-        if (this.useRawAsData) {
-            return new StoreRecord({
-                id,
-                store: this,
-                raw,
-                data: raw,
-                committedData: raw,
-                parent,
-                isSummary
-            });
-        }
-
         // Potentially re-use existing record if raw data is reference equal and tree path identical
         if (this.reuseRecords) {
             const cached = this._committed?.recordMap.get(id);
@@ -1250,17 +1253,15 @@ export class Store
             }
         }
 
-        const {processRawData, retainRaw} = this;
+        const {skipDataCopy, processRawData, retainRaw} = this;
         let data = raw;
         if (processRawData) {
-            data = processRawData(raw);
-            throwIf(
-                !data,
-                'Store.processRawData should return an object. If writing/editing, be sure to return a clone!'
-            );
+            // For efficiency hand processRawData the object it can typically mutate
+            data = processRawData(skipDataCopy ? raw : {...raw});
+            throwIf(!data, 'Store.processRawData should return an object.');
         }
 
-        data = this.parseRaw(data);
+        data = this.parseData(data);
         const ret = new StoreRecord({
             id,
             store: this,
@@ -1307,16 +1308,33 @@ export class Store
         return new Set(this.summaryRecords?.map(it => it.id) ?? []);
     }
 
+    /** Produce a StoreRecord's data object from source data, per this Store's copy/parse configs. */
+    private parseData(data: PlainObject): PlainObject {
+        const {skipDataCopy, skipDataParsing, _dataDefaults} = this;
+        if (skipDataCopy) {
+            // Install the shared defaults prototype on plain objects so missing Fields resolve
+            // to their defaultValue, as in copy mode. A single shared prototype keeps this cheap
+            // (V8 caches the transition per shape) and a no-op for re-adopted objects. Objects
+            // with a custom prototype (e.g. ViewRowData) are adopted with their prototype intact.
+            if (Object.getPrototypeOf(data) === Object.prototype) {
+                Object.setPrototypeOf(data, _dataDefaults);
+            }
+            if (!skipDataParsing) this.parseInPlace(data);
+            return data;
+        }
+        return this.parseRaw(data);
+    }
+
     private parseRaw(data: PlainObject): PlainObject {
         // a) create/prepare the data object
         const ret = Object.create(this._dataDefaults);
 
-        // b) apply parsed data as needed.
-        const {_fieldMap} = this;
+        // b) apply parsed (or with skipDataParsing, verbatim) data as needed.
+        const {_fieldMap, skipDataParsing} = this;
         forIn(data, (raw, name) => {
             const field = _fieldMap.get(name);
             if (field) {
-                const val = field.parseVal(raw);
+                const val = skipDataParsing ? (raw ?? field.defaultValue) : field.parseVal(raw);
                 if (val !== field.defaultValue) {
                     ret[name] = val;
                 }
@@ -1326,18 +1344,29 @@ export class Store
         return ret;
     }
 
+    // Parse Field values in place, directly onto the given object (see skipDataCopy). Iterates
+    // declared Fields rather than object keys - undeclared keys are left untouched. Writes only
+    // values changed by parsing - a no-op on already-parsed data, with missing Fields reading
+    // their defaultValue through the prototype installed by parseData.
+    private parseInPlace(data: PlainObject) {
+        this._fieldMap.forEach((field, name) => {
+            const cur = data[name],
+                val = field.parseVal(cur);
+            if (val !== cur) data[name] = val;
+        });
+    }
+
     private parseUpdate(data: PlainObject, update: PlainObject): PlainObject {
-        const {_fieldMap} = this;
+        const {_fieldMap, skipDataParsing} = this;
 
         // a) clone the existing object
-        const ret = Object.create(this._dataDefaults);
-        Object.assign(ret, data);
+        const ret = Object.assign(Object.create(this._dataDefaults), data);
 
-        // b) apply changes
+        // b) apply changes - null/undefined always reverts a Field to its defaultValue
         forIn(update, (raw, name) => {
             const field = _fieldMap.get(name);
             if (field) {
-                const val = field.parseVal(raw);
+                const val = skipDataParsing ? (raw ?? field.defaultValue) : field.parseVal(raw);
                 if (val !== field.defaultValue) {
                     ret[name] = val;
                 } else {

--- a/data/StoreRecord.ts
+++ b/data/StoreRecord.ts
@@ -295,11 +295,11 @@ export class StoreRecord {
     // --------------------------
     /**
      * True if this record's `data` object belongs to it alone and may be written to and frozen.
-     * False only for records holding a provider-owned raw object under `useRawAsData`.
+     * False for all records of a Store with `skipDataCopy`, which adopts provider-owned objects.
      * @internal
      */
     get ownsData(): boolean {
-        return this.data !== this.raw;
+        return !this.store.skipDataCopy;
     }
 
     /**
@@ -334,14 +334,15 @@ export interface StoreRecordConfig {
 
     /**
      * Data for this StoreRecord, pre-processed if applicable by `Store.processRawData()` and
-     * `Field.parseVal()`. Note this must be a new object dedicated to this StoreRecord.
-     * This object will be enhanced with an id and frozen.
+     * `Field.parseVal()`. Unless the Store is configured with `skipDataCopy`, this must be a new
+     * object dedicated to this StoreRecord, and will be enhanced with an id and frozen.
      */
     data: PlainObject;
 
     /**
-     * The original data for the StoreRecord, prior to any Store pre-processing.
-     * This data is for reference only and will not be altered by this object.
+     * The original data for the StoreRecord, prior to any Store pre-processing. For reference
+     * only and never altered by this object. Note that a Store with `skipDataCopy` adopts and
+     * parses raw objects in place - see that config for the ownership contract.
      */
     raw?: PlainObject;
 

--- a/data/cube/README.md
+++ b/data/cube/README.md
@@ -195,10 +195,12 @@ There are two ways to consume View results:
 **Option 1: Connected stores (recommended for grids)**
 
 Provide one or more stores via `ViewConfig.stores`. The View auto-loads hierarchical data
-into them whenever the query results change:
+into them whenever the query results change. View rows are already parsed and owned by the View,
+so connected stores should set `skipDataCopy` and `skipDataParsing` to use them as record data
+directly, skipping a per-row copy and re-parse:
 
 ```typescript
-const store = new Store({fields: [...]});
+const store = new Store({fields: [...], skipDataCopy: true, skipDataParsing: true});
 
 const view = cube.createView({
     query: {dimensions: ['region', 'product']},

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -583,11 +583,30 @@ export class View
             'Store.reuseRecords cannot be used on a Store that is connected to a Cube View'
         );
 
+        // Views own and cache those same rows, sharing them across all connected stores --
+        // configs that would write to them are unsafe.
+        throwIf(
+            ret.some(s => s.skipDataCopy && !s.skipDataParsing),
+            'Store.skipDataCopy requires skipDataParsing on a Store that is connected to a Cube View - parsing in place would modify View-owned row data.'
+        );
+        if (ret.some(s => s.skipDataCopy && s.processRawData)) {
+            this.logWarn(
+                'Store.processRawData on a `skipDataCopy` Store connected to a Cube View is passed View-owned row data - it must return a replacement object rather than mutate the row it is given.'
+            );
+        }
+
         throwIf(
             ret.some(s => s.idEncodesTreePath) &&
                 (!isNil(this.cube.bucketSpecFn) || !isNil(this.cube.omitFn)),
             'Store.idEncodesTreePath cannot be used on a Store that is connected to a Cube with a `bucketSpecFn` or `omitFn`'
         );
+
+        // View row data is already parsed and owned by this View - recommend zero-copy configs
+        if (ret.some(s => !s.skipDataCopy || !s.skipDataParsing)) {
+            this.logWarn(
+                'Store(s) connected to a Cube View should set `skipDataCopy` and `skipDataParsing` for optimal performance - View rows are already parsed and can be used as record data directly.'
+            );
+        }
 
         return ret;
     }


### PR DESCRIPTION
Replaces the not-yet-released `Store.useRawAsData` config with two orthogonal, opt-in performance configs for large datasets:

- `skipDataCopy` - use each raw object *as* its record's `data`, by reference and parsed in place. The Store takes ownership of adopted objects, installing its shared Field-defaults prototype on plain objects so missing Fields still resolve to their `defaultValue`.
- `skipDataParsing` - skip Field-level value parsing (type coercion + XSS sanitization) for data already in its final client-side form. Honored on load and update paths.

Also included:

- Improved `Store.processRawData` semantics - implementations are now handed a Store-owned shallow clone of each raw object and can mutate and return it directly, no defensive cloning needed. Now compatible with `skipDataCopy` (the raw object itself is passed).
- Cube `View` guards the unsafe combination (`skipDataCopy` without `skipDataParsing` would parse in place on View-owned rows) and logs a recommendation to set both flags on connected stores, which use View rows as record data directly.
- Changelog + data/cube README updates, including the recommended zero-copy flags in the connected-store example.