### PR TITLE
Fix CodeInput leaking a new CodeMirror editor on every re-render

### DIFF
--- a/desktop/cmp/input/CodeInput.ts
+++ b/desktop/cmp/input/CodeInput.ts
@@ -178,6 +178,7 @@ class CodeInputModel extends HoistInputModel {
 
     private themeCompartment = new Compartment();
     private editableCompartment = new Compartment();
+    private editorContainer: HTMLElement = null;
 
     get fullScreen(): boolean {
         return this.modalSupportModel.isModal;
@@ -321,9 +322,33 @@ class CodeInputModel extends HoistInputModel {
         );
     }
 
-    createCodeEditor = async (container: HTMLElement) => {
+    /**
+     * Stable ref callback for the editor container - installs a fresh EditorView when attached and
+     * disposes of it when detached.
+     *
+     * Note this must remain a stable function instance: React re-invokes callback refs whose
+     * identity changes across renders, so an inline arrow here would tear down and rebuild the
+     * editor on every render. Wrapped to return void - React 19 treats a ref callback's return
+     * value as a cleanup fn.
+     */
+    editorContainerRef = (container: HTMLElement) => {
+        this.createCodeEditor(container);
+    };
+
+    private createCodeEditor = async (container: HTMLElement) => {
+        // Always dispose of any prior editor first - CodeMirror appends its own DOM to the
+        // container, so a retained EditorView would remain visible (and stale) under its
+        // replacement, in addition to leaking.
+        XH.safeDestroy(this.editor);
+        this.editor = null;
+
+        this.editorContainer = container;
         if (!container) return;
+
         const extensions = await this.getExtensionsAsync();
+
+        // Bail if the container was detached or replaced while awaiting async extension loading.
+        if (this.editorContainer !== container) return;
 
         const state = EditorState.create({doc: this.renderValue || '', extensions});
         this.editor = new EditorView({state, parent: container});
@@ -605,11 +630,8 @@ const inputCmp = hoistCmp.factory<CodeInputModel>(({model, ...props}, ref) =>
         items: [
             div({
                 className: 'xh-code-input__inner-wrapper',
-                // We pass the container via ref to createCodeEditor, which initializes the editor inside it.
-                // Wrapped to return void — React 19 treats a ref callback's return value as a cleanup fn.
-                ref: el => {
-                    model.createCodeEditor(el);
-                }
+                // Editor is created within this container - see model.editorContainerRef.
+                ref: model.editorContainerRef
             }),
             model.showToolbar ? toolbarCmp() : actionButtonsCmp()
         ],

--- a/desktop/cmp/input/CodeInput.ts
+++ b/desktop/cmp/input/CodeInput.ts
@@ -323,35 +323,23 @@ class CodeInputModel extends HoistInputModel {
     }
 
     /**
-     * Stable ref callback for the editor container - installs a fresh EditorView when attached and
-     * disposes of it when detached.
-     *
-     * Note this must remain a stable function instance: React re-invokes callback refs whose
-     * identity changes across renders, so an inline arrow here would tear down and rebuild the
-     * editor on every render. Wrapped to return void - React 19 treats a ref callback's return
-     * value as a cleanup fn.
+     * Ref callback for the editor container - disposes of any existing editor, then installs a
+     * fresh EditorView when attached. Must be a stable instance and return void, not a promise.
      */
-    editorContainerRef = (container: HTMLElement) => {
-        this.createCodeEditor(container);
-    };
-
-    private createCodeEditor = async (container: HTMLElement) => {
-        // Always dispose of any prior editor first - CodeMirror appends its own DOM to the
-        // container, so a retained EditorView would remain visible (and stale) under its
-        // replacement, in addition to leaking.
+    createCodeEditor = (container: HTMLElement) => {
         XH.safeDestroy(this.editor);
         this.editor = null;
 
         this.editorContainer = container;
         if (!container) return;
 
-        const extensions = await this.getExtensionsAsync();
+        this.getExtensionsAsync().then(extensions => {
+            // Bail if the container was detached or replaced while loading extensions.
+            if (this.editorContainer !== container) return;
 
-        // Bail if the container was detached or replaced while awaiting async extension loading.
-        if (this.editorContainer !== container) return;
-
-        const state = EditorState.create({doc: this.renderValue || '', extensions});
-        this.editor = new EditorView({state, parent: container});
+            const state = EditorState.create({doc: this.renderValue || '', extensions});
+            this.editor = new EditorView({state, parent: container});
+        });
     };
 
     get autoFormat(): boolean {
@@ -630,8 +618,7 @@ const inputCmp = hoistCmp.factory<CodeInputModel>(({model, ...props}, ref) =>
         items: [
             div({
                 className: 'xh-code-input__inner-wrapper',
-                // Editor is created within this container - see model.editorContainerRef.
-                ref: model.editorContainerRef
+                ref: model.createCodeEditor
             }),
             model.showToolbar ? toolbarCmp() : actionButtonsCmp()
         ],


### PR DESCRIPTION
Fixes #4525

`CodeInput` was accumulating CodeMirror editors in the DOM — one per re-render. Since `.xh-code-input__inner-wrapper > .cm-editor` is absolutely positioned at `inset: 0`, the orphans stacked exactly on top of each other, each retaining the content it was created with. On `/admin/activity` the editor count grew by one per record selection (measured 5 → 6 → 7).

### Root cause

The React 19 upgrade (2c0a91b31) changed the container ref from a stable function reference to an inline arrow, to avoid returning a Promise (React 19 treats a ref callback's return value as a cleanup fn):

```ts
ref: el => { model.createCodeEditor(el); }   // new identity every render
```

React re-invokes callback refs whose identity changes, so every re-render detached (a no-op on `null`) and re-attached, appending a new `EditorView` without disposing the previous one.

### Why it looked like a dark-mode-only bug

The defect is theme-independent; only its visibility isn't. Verified by measuring both themes on the unfixed code:

| Theme | Editors stacked | Distinct stale docs | `.cm-editor` background |
|---|---|---|---|
| Light | 5 | 5 | `rgb(255, 255, 255)` — opaque |
| Dark | 5 | 5 | `rgba(0, 0, 0, 0.3)` — 30% opaque |

In light theme the top editor's opaque background completely paints over the stale layers, so the panel looks clean despite five editors behind it.

### Changes

* Restored a stable ref (`editorContainerRef`) that returns void.
* `createCodeEditor` now disposes any prior editor before creating a new one — matching `Chart`, which always destroys before re-creating.
* Added a guard for the container being swapped while awaiting async extension loading.

### Verification

`tsc --noEmit`, `eslint`, and `prettier --check` clean. Live in Toolbox, editor count stays at 1 across record switches, light/dark toggles, fullscreen enter/exit (content preserved), and typing in an editable JSON config.

### No changelog entry

The regression is limited to unreleased `87.0.0-SNAPSHOT` — released v86.x used a stable ref and is unaffected, consistent with the issue reproducing on toolbox-dev but not production.
