### PR TITLE
StringInternSpec.excludeFields - skip interning of known high-cardinality fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@
 * Added `FetchOptions.internStrings` to intern (deduplicate) repeated string values within large
   JSON and NDJSON responses, reducing retained memory for high-volume tabular datasets. Interned
   values may also be shared across successive fetches of the same logical dataset, as identified
-  by a required app-provided key, per a configurable `retainMode`.
+  by a required app-provided key, per a configurable `retainMode`. Skip known high-cardinality
+  fields (e.g. UUID columns) via `excludeFields`.
 * Cube `View`s no longer copy leaf row data when leaves are not exposed on their results (neither
   `includeLeaves` nor `provideLeaves` set) - leaf rows read directly from cube records, eliminating
   per-View leaf data objects and speeding up view builds for aggregate-only views over large

--- a/svc/FetchService.ts
+++ b/svc/FetchService.ts
@@ -1005,6 +1005,14 @@ export interface StringInternSpec {
     childrenKey?: string;
 
     /**
+     * Record properties to skip when interning. Use for fields whose values are known to be
+     * unique or nearly so - e.g. UUIDs, formatted timestamps, or free-text notes - where
+     * interning adds per-value lookup time and per-distinct-value cache entries with little or
+     * no deduplication benefit. Default null - all string-valued properties are interned.
+     */
+    excludeFields?: string[];
+
+    /**
      * How long interned values are held for reuse by later responses with the same key.
      * Default 'nextCall'.
      *

--- a/svc/impl/StringInterner.ts
+++ b/svc/impl/StringInterner.ts
@@ -28,8 +28,17 @@ import type {StringInternSpec} from '../FetchService';
  */
 export class StringInterner {
     /** Latest spec provided for this key - adopted on each call, so settings may vary. */
-    spec: StringInternSpec;
+    get spec(): StringInternSpec {
+        return this._spec;
+    }
 
+    set spec(spec: StringInternSpec) {
+        this._spec = spec;
+        this.excludeFields = spec.excludeFields?.length ? new Set(spec.excludeFields) : null;
+    }
+
+    private _spec: StringInternSpec;
+    private excludeFields: Set<string> = null;
     private committed: Map<string, string> = new Map();
     private pending: Map<string, string> = null;
 
@@ -116,11 +125,12 @@ export class StringInterner {
     private internRow(row: PlainObject) {
         if (!isPlainObject(row)) return;
 
-        const {pending, committed} = this,
+        const {pending, committed, excludeFields} = this,
             {childrenKey} = this.spec;
         for (const k in row) {
             const v = row[k];
             if (isString(v)) {
+                if (excludeFields?.has(k)) continue;
                 this.processed++;
                 let c = pending.get(v);
                 if (c === undefined) {

--- a/svc/impl/StringInterner.ts
+++ b/svc/impl/StringInterner.ts
@@ -129,8 +129,7 @@ export class StringInterner {
             {childrenKey} = this.spec;
         for (const k in row) {
             const v = row[k];
-            if (isString(v)) {
-                if (excludeFields?.has(k)) continue;
+            if (isString(v) && !excludeFields?.has(k)) {
                 this.processed++;
                 let c = pending.get(v);
                 if (c === undefined) {


### PR DESCRIPTION
Adds `excludeFields` to `StringInternSpec` - named record properties to skip when interning fetch responses.

- For fields known to be unique or nearly so (e.g. UUIDs, high-precision string timestamp representations), interning pays per-value lookups and per-generation cache entries with no deduplication benefit - exclusion avoids both.
- Applies at any depth the interner visits, including `childrenKey` recursion.
- Excluded fields are omitted from intern stats, which continue to reflect only what interning actually touched.