### PR TITLE
Cube: convert ViewRowData to an interface, clone View rows from per-View templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 * Added `Store.retainRaw` config (default `true`). Set to `false` to drop each record's reference to
   its raw source data object after parsing, reducing memory usage on large stores where
-  `StoreRecord.raw` is not needed. Not compatible with `reuseRecords`.
+  `StoreRecord.raw` is not needed. Not compatible with `reuseRecords: true`.
 * Added `Store.loadDataAsync()` to load a complete dataset from a streaming source - a sync or
   async iterable yielding raw records. Creates records incrementally without buffering
   the complete raw dataset in memory, then installs them in a single transaction once the source
@@ -60,6 +60,11 @@
   objects to one and skipping the per-row parse on every load and update. Local modification APIs
   (e.g. `modifyRecords`) throw in this mode - see the `projectionOnly` config docs for the full
   contract.
+* Enhanced `Store.reuseRecords` to also accept a version specification - a raw data property name
+  or a function deriving a version value - reusing the existing record whenever an incoming raw
+  object yields an unchanged version. Applies to both `loadData()` and `updateData()`, where
+  unchanged-version updates are dropped as no-ops. Recommended for stores connected to a Cube
+  `View` as `reuseRecords: 'cubeRowVersion'`.
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@
       any custom styling that targeted Blueprint or Popper CSS classes (e.g. `bp6-minimal`).
     * The `popperOptions` escape-hatch prop has been removed from the mobile `Popover`.
 * `View.result.leafMap` is now null unless the `Query` sets `includeLeaves` or `provideLeaves`. Set
-     either flag if an aggregate-only view needs leaf access, or read source records from `Cube.store`.
-* `StoreRecord.data` should now be read by field name only.  Enumerating or spreading them
-  `JSON.stringify()` do not reliably see default field values. Review any code enumerating `data`
-   directly and use `StoreRecord.getValues()` / `getModifiedValues()` instead.  This would
-   previously have been not reliable; avoiding it becomes even more critical with new memory
-   optimization in Hoist 87.
+  either flag if an aggregate-only view needs leaf access, or read source records from `Cube.store`.
+* `ViewRowData.cubeLeaves` getter has been replaced by the exported `getCubeLeaves()` helper - update
+  any code reading `row.cubeLeaves` to call `getCubeLeaves(row)`.  This changes supports important
+  memory optimizations in this version.
+* `StoreRecord.data` should now be read by field name only as enumerating, spreading, of calling
+  `JSON.stringify()` on this object does not reliably see default field values. Review any code
+   enumerating `data` directly and use `StoreRecord.getValues()` / `getModifiedValues()` instead.
+   This would previously have been not reliable; avoiding it becomes even more critical with new
+   memory optimizations in this version.
 
 ### 🎁 New Features
 
@@ -43,6 +46,9 @@
   established sparse form for lightly-populated records, and a fixed shape cloned from a shared
   per-Store template for more wide records. Avoids dropping into V8's memory-hungry "dictionary"
   mode, substantially reducing per-record memory on stores with wide records.
+* Improved Cube `View` memory efficiency - `ViewRowData` rows are now plain objects cloned from a
+  shared per-View template, so all rows in a View share one compact, fixed shape. Substantially
+  reduces per-row memory and speeds up view builds, especially for queries with many fields.
 * Cube `View`s no longer copy leaf row data when leaves are not exposed on their results (neither
   `includeLeaves` nor `provideLeaves` set) - leaf rows read directly from cube records, eliminating
   per-View leaf data objects and speeding up view builds for aggregate-only views over large

--- a/admin/tabs/activity/tracking/ActivityTrackingModel.ts
+++ b/admin/tabs/activity/tracking/ActivityTrackingModel.ts
@@ -26,7 +26,7 @@ import {
     PlainObject,
     XH
 } from '@xh/hoist/core';
-import {Cube, CubeFieldSpec, FieldSpec, ViewRowData} from '@xh/hoist/data';
+import {Cube, CubeFieldSpec, FieldSpec, getCubeLeaves, ViewRowData} from '@xh/hoist/data';
 import {dateRenderer, dateTimeSecRenderer, numberRenderer} from '@xh/hoist/format';
 import {action, computed, makeObservable, observable} from '@xh/hoist/mobx';
 import {LocalDate} from '@xh/hoist/utils/datetime';
@@ -166,7 +166,7 @@ export class ActivityTrackingModel extends HoistModel implements ActivityDetailP
             {
                 track: () => this.gridModel.selectedRecords,
                 run: recs =>
-                    (this.trackLogs = recs.flatMap(r => (r.raw as ViewRowData).cubeLeaves)),
+                    (this.trackLogs = recs.flatMap(r => getCubeLeaves(r.raw as ViewRowData))),
                 debounce: 100
             }
         );

--- a/data/README.md
+++ b/data/README.md
@@ -100,7 +100,7 @@ const store = new Store({
 | `loadTreeDataFrom` | `string` | `'children'` | Property containing child records                                                      |
 | `loadRootAsSummary` | `boolean` | `false` | Treat root node as summary record                                                      |
 | `freezeData` | `boolean` | `true` | Freeze record data objects for immutability (set to false as performance optimization) |
-| `reuseRecords` | `boolean` | `false` | Cache records by ID and raw reference (performance)                                    |
+| `reuseRecords` | `boolean\|string\|fn` | `false` | Reuse records when raw data yields an unchanged version (performance)                  |
 | `retainRaw` | `boolean` | `true` | Retain raw data reference on each record (set false to reduce memory)                  |
 | `projectionOnly` | `boolean` | `false` | Read-only projection of data parsed elsewhere - adopts raw objects as record `data`. Recommended for View-connected stores |
 | `idEncodesTreePath` | `boolean` | `false` | IDs imply fixed tree position (performance)                                            |
@@ -780,15 +780,29 @@ record1 === record3;  // false - new instance with updated data
 
 This preserves ag-Grid row state (expansion, selection) for unchanged records across data refreshes.
 
-**Optimization with `reuseRecords`:** For large datasets with immutable raw data objects, set
-`reuseRecords: true` to skip the fieldwise comparison. Records are reused when the raw data
-object itself is reference-identical, avoiding equality checks and record creation overhead:
+**Optimization with `reuseRecords`:** For large datasets whose provider can cheaply identify
+unchanged records, set `reuseRecords` to derive a *version* from each incoming raw object,
+snapshotted on the record when built. Records are reused when a later raw object yields an equal
+version, skipping parsing, comparison, and record creation for each hit. Applies to `updateData()`
+as well, where unchanged-version updates are dropped as no-ops. `loadData()` misses still fall
+back to the standard fieldwise comparison:
 
 ```typescript
 const store = new Store({
-    reuseRecords: true  // Use raw data identity instead of fieldwise comparison
+    reuseRecords: true  // version is the raw object itself - requires stable, immutable raws
+});
+
+const store = new Store({
+    reuseRecords: 'lastUpdated' // version is a raw property, e.g. a server-provided stamp
+});
+
+const store = new Store({
+    reuseRecords: raw => [raw.type, raw.seq] // or derived - compared via deep equality
 });
 ```
+
+For stores connected to a Cube `View`, use `reuseRecords: 'cubeRowVersion'` - a stamp the View
+maintains on every row it publishes.
 
 ### Tuning Memory for Large Datasets
 
@@ -797,7 +811,7 @@ memory. They stack, and both are opt-in:
 
 | Knob | What it does | When to use |
 |------|--------------|-------------|
-| `retainRaw: false` | Drops each record's reference to its raw source object once parsed | Your app never reads `StoreRecord.raw`. Incompatible with `reuseRecords` |
+| `retainRaw: false` | Drops each record's reference to its raw source object once parsed | Your app never reads `StoreRecord.raw`. Incompatible with `reuseRecords: true` |
 | `internStrings` (a `FetchOptions` config) | Deduplicates repeated string values across a response | Your data has many repeated string values (categories, statuses, names) |
 
 Record `data` objects themselves are built for memory efficiency out of the box, with a
@@ -822,13 +836,18 @@ Transform data before it enters the Store:
 ```typescript
 const store = new Store({
     fields: ['fullName', 'salary'],
-    processRawData: raw => ({
-        ...raw,
-        fullName: `${raw.firstName} ${raw.lastName}`,
-        salary: raw.salary / 100  // Convert cents to dollars
-    })
+    processRawData: raw => {
+        raw.fullName = `${raw.firstName} ${raw.lastName}`;
+        raw.salary = raw.salary / 100; // Convert cents to dollars
+        return raw;
+    }
 });
 ```
+
+For efficiency, prefer modifying and returning the raw object in place (as above) - typically the
+raw data is transient and there is no need to allocate a clone. If the app does cache, share, or
+otherwise re-use the raw data, be careful to return a modified clone instead. In-place edits will
+also be visible on `StoreRecord.raw`.
 
 ### Composite or Alternate IDs with `idSpec`
 

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -102,9 +102,11 @@ export interface StoreConfig {
     data?: PlainObject[];
 
     /**
-     * Function to run on each individual data object presented to `loadData()` prior to creating
-     * a `StoreRecord` from that object. This function must return an object, cloning the original
-     * object if edits are necessary.
+     * Function to pre-process individual data objects presented to `loadData()` prior to creating
+     * a `StoreRecord` from that object. For efficiency, apps may mutate and return the passed
+     * object in place - typically the raw data is transient (e.g. freshly fetched) and there is
+     * no need to allocate a clone. If the app *does* cache, share, or otherwise
+     * re-use the raw data, be careful to return a modified clone instead.
      */
     processRawData?: (data: PlainObject) => PlainObject;
 
@@ -143,23 +145,36 @@ export interface StoreConfig {
     idEncodesTreePath?: boolean;
 
     /**
-     * Performance optimization for large datasets with immutable raw data objects.
+     * Performance optimization for large datasets whose provider can cheaply identify unchanged
+     * records across loads and updates.
      *
      * By default, Store reuses existing StoreRecord instances when new data is loaded with
-     * matching IDs and identical field values (determined via deep equality comparison). This
+     * matching IDs and identical field values (determined via equality comparison). This
      * preserves row state in grids for unchanged records.
      *
-     * When `reuseRecords` is true, the Store skips the fieldwise comparison and instead reuses
-     * records when the raw data object itself is **reference-identical** to the previously loaded
-     * object. This avoids equality checks, record creation, and raw data processing overhead.
+     * Set to instead derive a *version* from each incoming raw object, snapshotted on the record
+     * when built. A record is then reused whenever a later raw object for its id yields an equal
+     * version, skipping raw data processing, parsing, and construction entirely:
      *
-     * Only use this when your data source provides stable object references for unchanged records.
-     * Should not be used with a `processRawData` function that depends on external state, as that
-     * function will be bypassed on subsequent reloads of reference-identical data.
+     *   - `true` - the version is the raw object itself, compared by reference. Requires the
+     *     source to provide stable references for unchanged records and to never mutate them -
+     *     use a form below for sources that mutate rows in place.
+     *   - string - the version is the named raw property, e.g. a server-provided timestamp or
+     *     sequence number. Use `'cubeRowVersion'` for stores connected to a Cube {@link View} -
+     *     a stamp the View maintains on every row data object it creates or mutates.
+     *   - function - the version is the returned value, for nested or composite stamps. Compared
+     *     via deep equality, so tuples work - e.g. `raw => [raw.type, raw.seq]`. A null/undefined
+     *     version never matches.
+     *
+     * Applies to `loadData()` and `updateData()` alike - an update yielding an unchanged version
+     * is dropped from the transaction as a no-op.
+     *
+     * Should not be used with a `processRawData` function that depends on external state as that
+     * function will be bypassed for reused records.
      *
      * Default false.
      */
-    reuseRecords?: boolean;
+    reuseRecords?: boolean | string | ((raw: PlainObject) => unknown);
 
     /**
      * True (default) to have each StoreRecord retain a reference to the raw data object from
@@ -167,15 +182,17 @@ export interface StoreConfig {
      * usage on large stores - raw data objects are then eligible for garbage collection after
      * parsing, and `StoreRecord.raw` will be null.
      *
-     * Not compatible with `reuseRecords`, which requires retained raw data for its
-     * reference-identity checks.
+     * Setting to false is not compatible with `reuseRecords: true`, which requires retained raw
+     * data for its reference-identity check. The string and function `reuseRecords` forms may be
+     * used, however.
      */
     retainRaw?: boolean;
 
     /**
      * True to mark this store as a read-only projection of data owned and parsed elsewhere.
-     * Recommended for stores connected to a Cube {@link View} - for improved performance, when no
-     * additional record parsing or local data modification is required. Default false.
+     * Recommended for stores connected to a Cube {@link View} - typically paired with
+     * `reuseRecords: 'cubeRowVersion'` - for improved performance, when no additional record
+     * parsing or local data modification is required. Default false.
      *
      * Each incoming raw object is used *as* its record's `data`, by reference, skipping the
      * per-record parse and copy on every load and update. Raw data must already match what the
@@ -184,10 +201,12 @@ export interface StoreConfig {
      * may mutate rows in place but must then publish via `updateData()`, as `loadData()` would
      * skip reference-equal objects as unchanged.
      *
-     * `data` will carry every key on the raw object, not just declared Fields. As a read-only
-     * projection, local modification APIs (`addRecords`, `modifyRecords`, `removeRecords`,
-     * `revertRecords`, and `revert`) throw - data updates flow in via `loadData()`/`updateData()`.
-     * Not compatible with `processRawData` or `reuseRecords`.
+     * `data` will carry every key on the raw object, not just declared Fields - but only declared
+     * Field values participate in the equality checks `loadData()` uses to detect unchanged
+     * records for reuse. As a read-only projection, local modification APIs (`addRecords`,
+     * `modifyRecords`, `removeRecords`, `revertRecords`, and `revert`) throw - data updates flow
+     * in via `loadData()`/`updateData()`.
+     * Not compatible with `processRawData`.
      */
     projectionOnly?: boolean;
 
@@ -322,7 +341,7 @@ export class Store
     loadRootAsSummary: boolean;
     idEncodesTreePath: boolean;
     freezeData: boolean;
-    reuseRecords: boolean;
+    reuseRecords: boolean | string | ((raw: PlainObject) => unknown);
     retainRaw: boolean;
     readonly projectionOnly: boolean;
     validationIsComplex: boolean;
@@ -366,6 +385,7 @@ export class Store
     private _dataTemplate: PlainObject = null;
     private _dataDefaults: PlainObject = null;
     private _denseRecordThreshold: number;
+    private _reuseVersionFn: (raw: PlainObject) => unknown;
 
     // Scratch state shared by parseRaw/parseUpdate - the first `n` entries of the parallel
     // name/value buffers are the current record's non-default fields, filled and fully consumed
@@ -398,16 +418,12 @@ export class Store
         super();
         makeObservable(this);
         throwIf(
-            reuseRecords && !retainRaw,
-            'Store cannot be configured with both `reuseRecords` and `retainRaw: false` - record reuse requires retained raw data references.'
+            reuseRecords === true && !retainRaw,
+            'Store cannot be configured with both `reuseRecords: true` and `retainRaw: false` - the reference-identity check requires retained raw data. Provide a string or function `reuseRecords` version to combine record reuse with `retainRaw: false`.'
         );
         throwIf(
             projectionOnly && processRawData,
             'Store.projectionOnly cannot be used with processRawData - a projection adopts data already parsed by its provider.'
-        );
-        throwIf(
-            projectionOnly && reuseRecords,
-            'Store.projectionOnly cannot be used with reuseRecords.'
         );
 
         this.experimental = this.parseExperimental(experimental);
@@ -431,13 +447,9 @@ export class Store
 
         this.validator = new StoreValidator({store: this});
         this._fieldMap = this.createFieldMap();
+        this._reuseVersionFn = this.createReuseFn();
         this._dataDefaults = this.createDataDefaults();
-        // Spreading converts the defaults object (built by keyed assignment, and so itself in
-        // dictionary mode for wider stores) into V8 fast-properties mode, so per-record clones of
-        // it hit the fast clone path. Deliberately a distinct object from `_dataDefaults`, which
-        // serves as the sparse form's prototype - V8 declines the fast clone path for any object
-        // that has been used as a prototype.
-        this._dataTemplate = {...this._dataDefaults};
+        this._dataTemplate = {...this._dataDefaults}; // Clone for fast-props mode.
         this._denseRecordThreshold =
             this.experimental.denseRecordThreshold ?? DENSE_RECORD_THRESHOLD;
         if (data) this.loadData(data);
@@ -597,15 +609,19 @@ export class Store
         // 1) Pre-process updates and adds into Records
         let updateRecs: StoreRecord[], addRecs: Map<StoreRecordId, StoreRecord>;
         if (update) {
-            updateRecs = update.map(it => {
+            updateRecs = [];
+            update.forEach(it => {
                 const recId = this.idSpec(it),
                     rec = this.getOrThrow(
                         recId,
                         'In order to update grid data, records must have stable ids. Note: XH.genId() will not provide such ids.'
                     ),
                     parent = rec.parent,
-                    isSummary = some(this.summaryRecords, {id: recId});
-                return this.createRecord(it, parent, isSummary);
+                    isSummary = some(this.summaryRecords, {id: recId}),
+                    newRec = this.createRecord(it, parent, isSummary);
+
+                // Reused records signal an unchanged version - drop such updates as no-ops.
+                if (newRec !== this._committed?.getById(recId)) updateRecs.push(newRec);
             });
         }
         if (add) {
@@ -1276,10 +1292,12 @@ export class Store
         parent: StoreRecord,
         isSummary: boolean = false
     ): StoreRecord {
-        const id = this.idSpec(raw);
+        const id = this.idSpec(raw),
+            reuseVersion = this._reuseVersionFn(raw),
+            cached = this.getReusableRecord(id, reuseVersion, parent);
+        if (cached) return cached;
 
-        // Zero-copy - use the raw object as `data` by reference, with no parsing, no data.id
-        // write, and no freeze. The Store does not own this object - see StoreConfig.projectionOnly.
+        // Projections can re-use raw data with no reparsing.
         if (this.projectionOnly) {
             return new StoreRecord({
                 id,
@@ -1288,26 +1306,16 @@ export class Store
                 data: raw,
                 committedData: raw,
                 parent,
-                isSummary
+                isSummary,
+                reuseVersion
             });
-        }
-
-        // Potentially re-use existing record if raw data is reference equal and tree path identical
-        if (this.reuseRecords) {
-            const cached = this._committed?.recordMap.get(id);
-            if (cached?.raw === raw && equal(cached.parent?.treePath, parent?.treePath)) {
-                return cached;
-            }
         }
 
         const {processRawData, retainRaw} = this;
         let data = raw;
         if (processRawData) {
             data = processRawData(raw);
-            throwIf(
-                !data,
-                'Store.processRawData should return an object. If writing/editing, be sure to return a clone!'
-            );
+            throwIf(!data, 'Store.processRawData must return an object.');
         }
 
         data = this.parseRaw(data);
@@ -1318,13 +1326,31 @@ export class Store
             data,
             committedData: data,
             parent,
-            isSummary
+            isSummary,
+            reuseVersion
         });
 
         // Finalize summary only.  Non-summary finalized by RecordSet
         if (isSummary) ret.finalize();
 
         return ret;
+    }
+
+    // Committed record to re-use for an incoming raw with matching version and tree position.
+    private getReusableRecord(
+        id: StoreRecordId,
+        version: unknown,
+        parent: StoreRecord
+    ): StoreRecord {
+        if (version == null) return null;
+        const cached = this._committed?.recordMap.get(id);
+        // Derived versions compare by deep equality, `reuseRecords: true` by reference only.
+        return cached &&
+            (cached._reuseVersion === version ||
+                (this.reuseRecords !== true && equal(cached._reuseVersion, version))) &&
+            (this.idEncodesTreePath || equal(cached.parent?.treePath, parent?.treePath))
+            ? cached
+            : null;
     }
 
     private createRecords(
@@ -1457,6 +1483,14 @@ export class Store
         const ret = new Map();
         this.fields.forEach(r => ret.set(r.name, r));
         return ret;
+    }
+
+    private createReuseFn(): (raw: PlainObject) => unknown {
+        const {reuseRecords} = this;
+        if (isFunction(reuseRecords)) return reuseRecords;
+        if (isString(reuseRecords)) return raw => raw[reuseRecords];
+        if (reuseRecords === true) return raw => raw;
+        return () => null;
     }
 
     private parseExperimental(experimental) {

--- a/data/StoreRecord.ts
+++ b/data/StoreRecord.ts
@@ -64,6 +64,9 @@ export class StoreRecord {
 
     private _treePath: StoreRecordId[];
 
+    /** @internal - version snapshot for `StoreConfig.reuseRecords` comparisons. */
+    readonly _reuseVersion: unknown;
+
     /**
      * Unique ID for representing record within ag-Grid node API.
      *
@@ -250,7 +253,16 @@ export class StoreRecord {
      * @internal
      */
     constructor(config: StoreRecordConfig) {
-        const {id, store, raw, data, committedData, parent, isSummary} = config;
+        const {
+            id,
+            store,
+            raw,
+            data,
+            committedData,
+            parent,
+            isSummary,
+            reuseVersion = null
+        } = config;
         throwIf(
             isNil(id),
             "Record needs an ID. Use 'Store.idSpec' to specify a unique ID for each record."
@@ -266,6 +278,7 @@ export class StoreRecord {
         this.parentId = parent?.id;
         // Root record paths are built lazily by the getter - we may never need for flat data.
         this._treePath = parent ? [...parent.treePath, idStr] : null;
+        this._reuseVersion = reuseVersion;
         this.isSummary = isSummary;
 
         if (this.ownsData) data.id = id;
@@ -373,4 +386,7 @@ export interface StoreRecordConfig {
      * information in grids when enabled.
      */
     isSummary?: boolean;
+
+    /** @internal - version snapshot for `StoreConfig.reuseRecords` comparisons. */
+    reuseVersion?: unknown;
 }

--- a/data/cube/Query.ts
+++ b/data/cube/Query.ts
@@ -85,7 +85,7 @@ export interface QueryConfig {
     includeLeaves?: boolean;
 
     /**
-     * True to provide access to leaf nodes via the {@link ViewRowData.cubeLeaves} getter on the
+     * True to provide access to leaf nodes via the {@link getCubeLeaves} helper on the
      * lowest level of aggregated `dimensions`. This will allow programmatic access to the leaves
      * used to produce a given aggregation, without exposing them as `children` in a way that would
      * cause them to be rendered in a tree grid.

--- a/data/cube/README.md
+++ b/data/cube/README.md
@@ -126,7 +126,7 @@ const view = cube.createView({
 
 ```typescript
 // Like includeLeaves, but leaves are accessible programmatically via
-// ViewRowData.cubeLeaves rather than rendered as tree children.
+// the getCubeLeaves() helper rather than rendered as tree children.
 // Useful for showing detail in a separate panel on selection.
 const view = cube.createView({
     query: {

--- a/data/cube/README.md
+++ b/data/cube/README.md
@@ -195,10 +195,17 @@ There are two ways to consume View results:
 **Option 1: Connected stores (recommended for grids)**
 
 Provide one or more stores via `ViewConfig.stores`. The View auto-loads hierarchical data
-into them whenever the query results change:
+into them whenever the query results change. Configure connected stores with
+`projectionOnly: true` (adopt View rows as record data without re-parsing) and
+`reuseRecords: 'cubeRowVersion'` (skip record rebuilds for rows republished without change,
+tracked via a version stamp the View maintains on every row):
 
 ```typescript
-const store = new Store({fields: [...]});
+const store = new Store({
+    fields: [...],
+    projectionOnly: true,
+    reuseRecords: 'cubeRowVersion'
+});
 
 const view = cube.createView({
     query: {dimensions: ['region', 'product']},

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -142,6 +142,8 @@ export class View
     private _recordMap: Map<StoreRecordId, StoreRecord> = null;
     private _bucketDependentFields = new Set<string>();
     private _rowDataTemplate: ViewRowData = null;
+    // Monotonic source for cubeRowVersion stamps - safe-integer headroom spans centuries of use.
+    private _rowVersion = 0;
     _canAggregateTemplate: PlainObject = null;
     _aggContext: AggregationContext = null;
     _rowCache: Map<string, BaseRow> = null;
@@ -324,7 +326,7 @@ export class View
      * @internal
      */
     newRowData(id: string): ViewRowData {
-        return {...this._rowDataTemplate, id};
+        return {...this._rowDataTemplate, id, cubeRowVersion: ++this._rowVersion};
     }
 
     // Templates depend on the query's field set - rebuilt on any query change.
@@ -337,6 +339,7 @@ export class View
             cubeBuckets: null,
             children: null,
             isCubeLeaf: false,
+            cubeRowVersion: null,
             _cubeLeafChildren: null
         };
         const canAggregate: PlainObject = {};
@@ -369,6 +372,8 @@ export class View
             const leaf = _leafMap.get(rec.id);
             leaf?.applyLeafDataUpdate(rec, updatedRowDatas);
         });
+
+        updatedRowDatas.forEach(rowData => (rowData.cubeRowVersion = ++this._rowVersion));
 
         this.createAggregationContext();
 
@@ -619,10 +624,10 @@ export class View
     private parseStores(stores: Some<Store>): Store[] {
         const ret = castArray(stores);
 
-        // Views mutate the rows they feed to connected stores  -- `reuseRecords` not appropriate
+        // Views mutate the rows, so reference identity cannot signal 'unchanged'.
         throwIf(
-            ret.some(s => s.reuseRecords),
-            'Store.reuseRecords cannot be used on a Store that is connected to a Cube View'
+            ret.some(s => s.reuseRecords === true),
+            "Store.reuseRecords: true cannot be used on a Store connected to a Cube View - configure `reuseRecords: 'cubeRowVersion'` instead."
         );
 
         throwIf(
@@ -631,10 +636,16 @@ export class View
             'Store.idEncodesTreePath cannot be used on a Store that is connected to a Cube with a `bucketSpecFn` or `omitFn`'
         );
 
-        // View rows are already parsed and owned by this View - recommend adopting them directly.
         if (ret.some(s => !s.projectionOnly && !s.processRawData)) {
             this.logDebug(
                 'Connected store(s) do not set `projectionOnly` - recommended for improved performance when no additional record parsing or local data modification is required. See StoreConfig.projectionOnly.'
+            );
+        }
+
+        // Views re-publish unchanged row objects across many updates - recommend version reuse.
+        if (ret.some(s => !s.reuseRecords)) {
+            this.logDebug(
+                "Connected store(s) do not set `reuseRecords: 'cubeRowVersion'` - recommended to skip record rebuilds when this View republishes unchanged rows. See StoreConfig.reuseRecords."
             );
         }
 

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -141,6 +141,8 @@ export class View
     private _leafMap: Map<StoreRecordId, LeafRow> = null;
     private _recordMap: Map<StoreRecordId, StoreRecord> = null;
     private _bucketDependentFields = new Set<string>();
+    private _rowDataTemplate: ViewRowData = null;
+    _canAggregateTemplate: PlainObject = null;
     _aggContext: AggregationContext = null;
     _rowCache: Map<string, BaseRow> = null;
 
@@ -154,6 +156,7 @@ export class View
         this.query = query;
         this.stores = this.parseStores(stores);
         this._rowCache = new Map();
+        this.buildRowTemplates();
         this.fullUpdate();
 
         if (connect) {
@@ -213,6 +216,7 @@ export class View
         if (oldQuery.equals(newQuery)) return;
 
         this.query = newQuery;
+        this.buildRowTemplates();
 
         // If the cube is changing then we need to clear the row cache, and potentially disconnect
         // from the old cube and connect to the new one
@@ -310,6 +314,40 @@ export class View
     get exposesLeaves(): boolean {
         const {includeLeaves, provideLeaves} = this.query;
         return includeLeaves || provideLeaves;
+    }
+
+    /**
+     * Create a new row data object as a clone of this View's shared template, which carries a
+     * slot for every ViewRowData property and query field. Rows are only ever written via
+     * overwrites of these slots - never property adds - so all rows in a View share one fixed
+     * shape, keeping them in V8's compact fast-properties mode rather than "dictionary mode".
+     * @internal
+     */
+    newRowData(id: string): ViewRowData {
+        return {...this._rowDataTemplate, id};
+    }
+
+    // Templates depend on the query's field set - rebuilt on any query change.
+    private buildRowTemplates() {
+        const rowData: PlainObject = {
+            id: null,
+            cubeRowType: null,
+            cubeLabel: null,
+            cubeDimension: null,
+            cubeBuckets: null,
+            children: null,
+            isCubeLeaf: false,
+            _cubeLeafChildren: null
+        };
+        const canAggregate: PlainObject = {};
+        this.fields.forEach(({name}) => {
+            rowData[name] = null;
+            canAggregate[name] = false;
+        });
+
+        // Convert into V8 fast-properties mode that we'll need to mint additional fast objects
+        this._rowDataTemplate = {...rowData} as ViewRowData;
+        this._canAggregateTemplate = {...canAggregate};
     }
 
     @logWithDebug

--- a/data/cube/ViewRowData.ts
+++ b/data/cube/ViewRowData.ts
@@ -46,6 +46,9 @@ export interface ViewRowData {
     /** True for leaf rows loaded into the cube (i.e. not a grouped aggregation). */
     isCubeLeaf: boolean;
 
+    /** Monotonic stamp updated on each create or mutation - see `StoreConfig.reuseRecords`. */
+    cubeRowVersion: number;
+
     /**
      * Support all other string keys for application fields in source data.
      */

--- a/data/cube/ViewRowData.ts
+++ b/data/cube/ViewRowData.ts
@@ -13,11 +13,7 @@ import {flatMap} from 'lodash';
  *
  * @mcpHint row shape returned by Cube queries and View results
  */
-export class ViewRowData {
-    constructor(id: string) {
-        this.id = id;
-    }
-
+export interface ViewRowData {
     /** Unique id. */
     id: string;
 
@@ -48,20 +44,7 @@ export class ViewRowData {
     children: ViewRowData[];
 
     /** True for leaf rows loaded into the cube (i.e. not a grouped aggregation). */
-    get isCubeLeaf(): boolean {
-        return this.cubeDimension == null;
-    }
-
-    /**
-     * All visible (i.e. non-locked) cube leaves associated with this row.
-     *
-     * For this to be populated, either {@link Query.includeLeaves} or {@link Query.provideLeaves}
-     * must have been set on the underlying Query.
-     */
-    get cubeLeaves(): Some<ViewRowData> {
-        if (this.isCubeLeaf) return this;
-        return this._cubeLeafChildren ?? flatMap(this.children, 'cubeLeaves');
-    }
+    isCubeLeaf: boolean;
 
     /**
      * Support all other string keys for application fields in source data.
@@ -73,4 +56,15 @@ export class ViewRowData {
     //-----------------
     /** @internal */
     _cubeLeafChildren: ViewRowData[];
+}
+
+/**
+ * All visible (i.e. non-locked) cube leaves associated with a row.
+ *
+ * For this to be populated, either {@link Query.includeLeaves} or {@link Query.provideLeaves}
+ * must have been set on the underlying Query.
+ */
+export function getCubeLeaves(row: ViewRowData): Some<ViewRowData> {
+    if (row.isCubeLeaf) return row;
+    return row._cubeLeafChildren ?? flatMap(row.children, getCubeLeaves);
 }

--- a/data/cube/row/AggregateRow.ts
+++ b/data/cube/row/AggregateRow.ts
@@ -42,10 +42,10 @@ export class AggregateRow extends BaseRow {
 
         this.dim = dim;
         this.dimName = dimName;
-        this.data = new ViewRowData(id);
-        this.data.cubeRowType = 'aggregate';
-        this.data.cubeLabel = strVal;
-        this.data.cubeDimension = dimName;
+        const data = (this.data = view.newRowData(id));
+        data.cubeRowType = 'aggregate';
+        data.cubeLabel = strVal;
+        data.cubeDimension = dimName;
 
         this.initAggregate(children, dimName, val, appliedDimensions);
     }

--- a/data/cube/row/BaseRow.ts
+++ b/data/cube/row/BaseRow.ts
@@ -8,7 +8,7 @@
 import {PlainObject, Some} from '@xh/hoist/core';
 import {BucketSpec} from '@xh/hoist/data/cube/BucketSpec';
 import {ViewRowData} from '@xh/hoist/data/cube/ViewRowData';
-import {compact, isEmpty, reduce} from 'lodash';
+import {compact, isEmpty} from 'lodash';
 import {View} from '../View';
 import {RowUpdate} from './RowUpdate';
 
@@ -142,28 +142,21 @@ export abstract class BaseRow {
         this.children = children;
         children.forEach(it => (it.parent = this));
 
-        view.fields.forEach(({name}) => (data[name] = null));
         Object.assign(data, appliedDimensions);
 
-        this.canAggregate = reduce(
-            view.fields,
-            (ret, field) => {
-                const {name} = field;
-                if (appliedDimensions.hasOwnProperty(name)) {
-                    ret[name] = false;
-                } else {
-                    const {aggregator, canAggregateFn} = field,
-                        ctx = view._aggContext;
-
-                    ret[name] =
-                        aggregator &&
-                        (!canAggregateFn ||
-                            canAggregateFn(dimOrBucketName, val, appliedDimensions, ctx));
-                }
-                return ret;
-            },
-            {}
-        );
+        // Clone the per-View template (all fields false) for fixed shape, then overwrite.
+        const canAggregate = (this.canAggregate = {...view._canAggregateTemplate}),
+            ctx = view._aggContext;
+        view.fields.forEach(field => {
+            const {name} = field;
+            if (!appliedDimensions.hasOwnProperty(name)) {
+                const {aggregator, canAggregateFn} = field;
+                canAggregate[name] =
+                    aggregator &&
+                    (!canAggregateFn ||
+                        canAggregateFn(dimOrBucketName, val, appliedDimensions, ctx));
+            }
+        });
 
         this.computeAggregates();
     }

--- a/data/cube/row/BucketRow.ts
+++ b/data/cube/row/BucketRow.ts
@@ -39,10 +39,10 @@ export class BucketRow extends BaseRow {
         super(view, id);
 
         this.bucketSpec = bucketSpec;
-        this.data = new ViewRowData(id);
-        this.data.cubeRowType = 'bucket';
-        this.data.cubeLabel = bucketSpec.labelFn(bucketVal);
-        this.data.cubeDimension = bucketSpec.name;
+        const data = (this.data = view.newRowData(id));
+        data.cubeRowType = 'bucket';
+        data.cubeLabel = bucketSpec.labelFn(bucketVal);
+        data.cubeDimension = bucketSpec.name;
 
         this.initAggregate(children, bucketSpec.name, bucketVal, appliedDimensions);
 

--- a/data/cube/row/LeafRow.ts
+++ b/data/cube/row/LeafRow.ts
@@ -82,10 +82,10 @@ export class ExposedLeafRow extends LeafRow {
     constructor(view: View, id: string, rawRecord: StoreRecord) {
         super(view, id, rawRecord);
 
-        const data = (this.data = new ViewRowData(id));
+        const data = (this.data = view.newRowData(id));
         data.cubeRowType = 'leaf';
         data.cubeLabel = rawRecord.id.toString();
-        data.cubeDimension = null;
+        data.isCubeLeaf = true;
 
         view.fields.forEach(({name}) => {
             data[name] = rawRecord.data[name];

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -242,13 +242,23 @@ export class RecordSet {
     // Implementation
     //------------------------
     private areRecordsEqual(r1: StoreRecord, r2: StoreRecord): boolean {
+        if (r1 === r2) return true;
+
+        const {store} = this,
+            d1 = r1.data,
+            d2 = r2.data;
+
+        // Projection data carries arbitrary provider keys - compare declared field values only.
+        const dataEqual = store.projectionOnly
+            ? d1 === d2 || store.fields.every(({name}) => equal(d1[name], d2[name]))
+            : equal(d1, d2);
+
         return (
-            r1 === r2 ||
-            (equal(r1.data, r2.data) &&
-                (this.store.idEncodesTreePath ||
-                    // Root records share an id here, so their paths are equal by construction.
-                    (r1.parentId == null && r2.parentId == null) ||
-                    equal(r1.treePath, r2.treePath)))
+            dataEqual &&
+            (store.idEncodesTreePath ||
+                // Root records share an id here, so their paths are equal by construction.
+                (r1.parentId == null && r2.parentId == null) ||
+                equal(r1.treePath, r2.treePath))
         );
     }
 


### PR DESCRIPTION
Stacked on #4534 (`store-simple`) - review that first; this diff is just the top commit.

Converts `ViewRowData` from a class to a plain-object interface and builds View rows by cloning per-View templates - the CSP-safe successor to the codegen approach explored in #4503 (measurements in #4502).

* Each `View` builds a row-data template carrying a slot for every `ViewRowData` property and query field (plus a second small template for the `canAggregate` maps on aggregate/bucket rows). Rows are cloned from it via spread and only ever written by overwriting existing slots - never property adds - so all rows in a View share one fixed shape for life, keeping them in V8's compact fast-properties mode rather than dictionary mode on wide queries.
* `ViewRowData` is now an interface. The lazy `cubeLeaves` getter becomes the exported `getCubeLeaves()` helper (still lazy - eager per-row leaf arrays would undo the v87 leafMap memory win), and `isCubeLeaf` becomes a plain property stamped at construction. Breaking - noted in CHANGELOG.
* Templates rebuild on `updateQuery`. Hidden-leaf rows are untouched and continue to adopt cube record data by reference.

### Measurements

Chrome relaunched with `--js-flags=--expose-gc --enable-precise-memory-info`; heap sampled after forced GC, deltas vs an empty-cube baseline in the same renderer. This branch vs its `store-simple` base.

**30-field cube** (2 dims + 28 SUM measures, 100k leaves, `includeLeaves` + `includeRoot` - past V8's ~20-property dictionary threshold, where this change targets):

| Build | Bytes/row | Heap delta (100,121 rows) | View build |
|---|---|---|---|
| class rows (base) | 817 B | 78.0 MB | 391 ms |
| template rows (this PR) | **333 B** | **31.8 MB** | **296 ms** |

~2.5x smaller and ~25% faster, inclusive of overhead common to both builds (leafMap, `BaseRow` wrappers, children arrays) - the pure row-object ratio is higher, consistent with #4502.

**Toolbox Cube tester as-is** (14 fields, 4 dims, `includeLeaves` + `projectionOnly`, 100k facts → 114,146 rows): parity, as expected - 125.3 MB / 1,157 ms (class) vs 131.8 MB / 1,044 ms (template). At 14 fields class rows stay under the dictionary threshold, so there was no penalty to reclaim; the template's few extra always-present slots cost ~5%.

Functional validation in the tester and admin Activity Tracking: uniform row shape held across 34k rows before/after streaming updates, edit deltas propagated exactly through all aggregation levels, `projectionOnly` stores adopt rows by reference, filter add/remove restored byte-identical totals, and `getCubeLeaves()` verified live on the `provideLeaves` path. Zero console errors.