### PR TITLE
Do not add newly-released columns to user-curated grid views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
     * The `popperOptions` escape-hatch prop has been removed from the mobile `Popover`.
 * `View.result.leafMap` is now null unless the `Query` sets `includeLeaves` or `provideLeaves`. Set
      either flag if an aggregate-only view needs leaf access, or read source records from `Cube.store`.
+* Grid columns newly added to the code are now initially hidden when column state is persisted to a
+  `ViewManagerModel` or `DashViewModel`, ensuring a software release does not add columns to views
+  users have curated and named. They remain available via the column chooser. Set the new
+  `GridModelPersistOptions.hideNewColumns` config to `false` to restore the prior behavior.
 
 ### 🎁 New Features
 

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -114,6 +114,7 @@ import {managedRenderer} from './impl/Utils';
 import {
     ColChooserConfig,
     ColumnState,
+    ColumnStateOptions,
     GridModelPersistOptions,
     GroupRowRenderer,
     RowClassFn,
@@ -1244,6 +1245,15 @@ export class GridModel extends HoistModel {
         this.store.clear();
     }
 
+    /**
+     * Replace the columns for this grid, rebuilding all `Column` instances from the configs
+     * provided.
+     *
+     * Note this resets all column state - visibility, width, order, and pinning - to the defaults
+     * specified by the new configs. For a grid with persistence enabled, that reset is itself
+     * persisted, discarding any state the user had saved. Use {@link setColumnState} or
+     * {@link updateColumnState} to change how the *existing* columns are displayed.
+     */
     @action
     setColumns(colConfigs: ColumnOrGroupSpec[]) {
         colConfigs = this.enhanceColConfigsFromStore(colConfigs);
@@ -1255,8 +1265,15 @@ export class GridModel extends HoistModel {
         this.columnState = this.getLeafColumns().map(it => this.getDefaultStateForColumn(it));
     }
 
-    setColumnState(colState: ColumnState[]) {
-        this.columnState = this.cleanColumnState(colState);
+    /**
+     * Replace the current column state wholesale with the state provided.
+     *
+     * Note that any columns missing from `colState` will be restored to their in-code default
+     * state, or hidden if `opts.hideNewColumns` is set - this method does not patch the existing
+     * state. Use {@link updateColumnState} to apply targeted changes to particular columns.
+     */
+    setColumnState(colState: ColumnState[], opts?: ColumnStateOptions) {
+        this.columnState = this.cleanColumnState(colState, opts);
     }
 
     showColChooser() {
@@ -1794,7 +1811,7 @@ export class GridModel extends HoistModel {
         );
     }
 
-    private cleanColumnState(columnState) {
+    private cleanColumnState(columnState, opts?: ColumnStateOptions) {
         const gridCols = this.getLeafColumns();
 
         // REMOVE any state columns that are no longer found in the grid. These were likely saved
@@ -1805,7 +1822,15 @@ export class GridModel extends HoistModel {
         // Insert these columns in position based on the index at which they are defined.
         gridCols.forEach((col, idx) => {
             if (!find(ret, {colId: col.colId})) {
-                ret.splice(idx, 0, this.getDefaultStateForColumn(col));
+                const state = this.getDefaultStateForColumn(col);
+
+                // Hide new columns if so requested - but never those the app requires to be shown,
+                // or that a user could not restore for themselves via the column chooser.
+                if (opts?.hideNewColumns && col.hideable && !col.excludeFromChooser) {
+                    state.hidden = true;
+                }
+
+                ret.splice(idx, 0, state);
             }
         });
 

--- a/cmp/grid/Types.ts
+++ b/cmp/grid/Types.ts
@@ -41,6 +41,19 @@ export interface ColumnState {
     pinned?: HSide;
 }
 
+/** Options for {@link GridModel.setColumnState}. */
+export interface ColumnStateOptions {
+    /**
+     * True to hide any columns missing from the provided state, regardless of their in-code
+     * `hidden` config. Default false, respecting that config.
+     *
+     * Columns configured with `hideable: false` or `excludeFromChooser: true` are never hidden by
+     * this option, as the app has indicated that they must be displayed and/or cannot be restored
+     * by the user.
+     */
+    hideNewColumns?: boolean;
+}
+
 /**
  * Comparator for custom grid group sorting, provided to GridModel.
  * @param groupAVal - first group value to be compared.
@@ -88,6 +101,23 @@ export interface GridModelPersistOptions extends PersistOptions {
     persistSort?: boolean | PersistOptions;
     /** True (default) to include expanded level state or provide expanded level-specific PersistOptions.  */
     persistExpandToLevel?: boolean | PersistOptions;
+    /**
+     * True to force columns newly added to the code - and therefore missing from any previously
+     * persisted state - to be initially hidden, regardless of their in-code `hidden` config. False
+     * to respect that config, allowing new columns to appear automatically.
+     *
+     * Defaults to true when persisting to a user-curated, named view - i.e. a `ViewManagerModel`
+     * or `DashViewModel`, per the resolved `persistColumns` options - as a release should not add
+     * columns to views users have deliberately composed. Defaults to false for all other
+     * providers, where state records a user's last-used layout and new columns aid discovery of
+     * newly released data. The in-code default view of a `ViewManagerModel` always follows the
+     * code - set this config to true to force-hide new columns there as well.
+     *
+     * Affects initial visibility only - new columns are always added to state and remain available
+     * via the column chooser. Columns with `hideable: false` or `excludeFromChooser: true` are
+     * never force-hidden, as the app requires them shown and/or users could not restore them.
+     */
+    hideNewColumns?: boolean;
 }
 
 /**

--- a/cmp/grid/impl/InitPersist.ts
+++ b/cmp/grid/impl/InitPersist.ts
@@ -4,7 +4,14 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {PersistableState, PersistenceProvider, persistOptions} from '@xh/hoist/core';
+import {
+    DashViewProvider,
+    PersistableState,
+    PersistenceProvider,
+    persistOptions,
+    PersistOptions,
+    ViewManagerProvider
+} from '@xh/hoist/core';
 import {isEqual, isObject} from 'lodash';
 import {runInAction} from 'mobx';
 import {GridModel} from '../GridModel';
@@ -21,23 +28,31 @@ export function initPersist(
         persistGrouping = true,
         persistSort = true,
         persistExpandToLevel = true,
+        hideNewColumns,
         path = 'grid',
         ...rootPersistWith
     }: GridModelPersistOptions
 ) {
     if (persistColumns) {
+        const colPersistOptions = persistOptions(
+            {path: `${path}.columns`},
+            rootPersistWith,
+            isObject(persistColumns) ? persistColumns : null
+        );
+
         PersistenceProvider.create({
-            persistOptions: persistOptions(
-                {path: `${path}.columns`},
-                rootPersistWith,
-                isObject(persistColumns) ? persistColumns : null
-            ),
+            persistOptions: colPersistOptions,
             target: {
                 getPersistableState: () =>
                     new PersistableColumnState(gridModel.persistableColumnState),
                 setPersistableState: ({value}) =>
                     runInAction(() => {
-                        gridModel.setColumnState(value);
+                        gridModel.setColumnState(value, {
+                            // Resolved on each read, as the answer can change with the current
+                            // ViewManager view.
+                            hideNewColumns:
+                                hideNewColumns ?? persistsToCuratedView(colPersistOptions)
+                        });
                         if (gridModel.autosizeOptions.mode === 'managed') {
                             const columns = gridModel.columnState
                                 .filter(it => !it.manuallySized)
@@ -95,6 +110,29 @@ export function initPersist(
             owner: gridModel
         });
     }
+}
+
+/**
+ * Is the state described by these options persisted as part of a user-curated, named view - i.e.
+ * a ViewManager view or a dashboard widget? Users compose these views deliberately, in contrast to
+ * providers such as prefs or localStorage, where persisted state is an implicit record of a user's
+ * last-used layout.
+ *
+ * Note the special "default" view of a ViewManager is *not* considered curated - it represents the
+ * in-code state active when no saved view is selected.
+ */
+function persistsToCuratedView(opts: PersistOptions): boolean {
+    const providerClass = PersistenceProvider.parseProviderClass(opts);
+    if (isSubclassOf(providerClass, DashViewProvider)) return true;
+    if (isSubclassOf(providerClass, ViewManagerProvider)) {
+        // Note view can be null if still initializing - treat as curated, the safer assumption.
+        return !opts.viewManagerModel.view?.isDefault;
+    }
+    return false;
+}
+
+function isSubclassOf(cls: any, base: any): boolean {
+    return cls === base || cls.prototype instanceof base;
 }
 
 class PersistableColumnState extends PersistableState<ColumnState[]> {

--- a/cmp/viewmanager/README.md
+++ b/cmp/viewmanager/README.md
@@ -391,15 +391,20 @@ class PortfolioGridModel extends HoistModel {
             persistWith: {
                 viewManagerModel: XH.appModel.portfolioGridViewManager,
                 path: 'grid',
+                persistColumns: true,
                 persistSort: true,
-                persistGrouping: true,
-                persistFilter: true,
-                persistColumns: {hidden: true, width: true, order: true}
+                persistGrouping: true
             }
         });
     }
 }
 ```
+
+Note that columns added to the code after a view was saved are hidden by default when persisting
+to a ViewManager, so that a software release does not add columns to views users have curated.
+They remain available via the column chooser, and the in-code default view continues to show them.
+See [Newly Added Columns](../../docs/persistence.md#newly-added-columns) to adjust this behavior
+via `hideNewColumns`.
 
 ### React to View Changes
 

--- a/core/persist/PersistenceProvider.ts
+++ b/core/persist/PersistenceProvider.ts
@@ -213,7 +213,18 @@ export abstract class PersistenceProvider<S = any> {
         return null;
     }
 
-    private static parseProviderClass<S>(
+    /**
+     * Resolve the PersistenceProvider class that the given options would produce, applying the
+     * same precedence used by {@link create}. Throws if the options do not resolve to a known
+     * provider.
+     *
+     * Useful for callers that must adapt their behavior to the kind of backing store in play -
+     * e.g. {@link GridModel} treats state persisted to a user-curated view differently from state
+     * persisted as an implicit record of a user's last-used layout.
+     *
+     * @internal - not intended for application use.
+     */
+    static parseProviderClass<S>(
         opts: PersistOptions
     ): Class<PersistenceProvider<S>, [PersistenceProviderConfig<S>]> {
         // 1) Recognize shortcut form

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -220,19 +220,57 @@ The most sophisticated built-in persistence, with four independently configurabl
 | `persistGrouping` | `grid.groupBy` | Row grouping columns |
 | `persistExpandToLevel` | `grid.expandLevel` | Expand level for grouped/tree data |
 
-Each aspect can be `true` (use root `persistWith`), `false` (skip), or a `PersistOptions` object
-to override the provider for that aspect:
+Each aspect is specified within the grid's `persistWith` config - a `GridModelPersistOptions` - and
+can be `true` (use the root options), `false` (skip), or a `PersistOptions` object to override the
+provider for that aspect:
 
 ```typescript
 new GridModel({
-    persistWith: {viewManagerModel: myViewManager},
-    persistColumns: true,           // Use viewManagerModel (the default)
-    persistSort: false,             // Do not persist - default sort should always be restored
-    persistGrouping: true,          // Use viewManagerModel
-    persistExpandToLevel: {localStorageKey: 'orderGridExpandLevel'},  // Override: use localStorage
+    persistWith: {
+        viewManagerModel: myViewManager,
+        persistColumns: true,       // Use viewManagerModel (the default)
+        persistSort: false,         // Do not persist - default sort should always be restored
+        persistGrouping: true,      // Use viewManagerModel
+        persistExpandToLevel: {localStorageKey: 'orderGridExpandLevel'}  // Override: localStorage
+    },
     columns: [...]
 });
 ```
+
+#### Newly Added Columns
+
+Columns added to the code after a user's state was saved are always added to that state, in the
+position at which they are defined. Whether they are initially *visible* depends on the backing
+store, via the `hideNewColumns` option:
+
+- **`viewManager` and `dashView`** - defaults to `true`, so new columns are hidden. Persisted state
+  here is a named view the user curated deliberately, often to capture a specific report, and a
+  release should not add columns to it.
+- **All other providers** - defaults to `false`, so new columns follow their in-code `hidden`
+  config. Persisted state here is an implicit record of the user's last-used layout, and surfacing
+  new columns helps users discover data added by a release.
+
+Set `hideNewColumns` explicitly to override:
+
+```typescript
+persistWith: {
+    viewManagerModel: myViewManager,
+    hideNewColumns: false       // Opt in to legacy behavior - new columns appear in saved views
+}
+```
+
+Two exceptions apply in all cases, as the app has indicated these columns must be displayed and/or
+could not be restored by a user: columns configured with `hideable: false` (which includes tree
+columns by default) or `excludeFromChooser: true` are never force-hidden.
+
+Note also that the ViewManager "default" view - the in-code state active when no saved view is
+selected - always follows the columns as defined in code, as it is not a curated artifact. Apps
+that disable that view in favor of a globally-shared default get the curated behavior throughout,
+with new columns surfacing only when an admin adds and saves them. Set `hideNewColumns: true`
+explicitly to force-hide new columns in the default view as well.
+
+Hidden or not, new columns remain available to users via the column chooser. Newly hidden columns
+also do not mark a saved view as dirty, so users are not prompted to save a change they cannot see.
 
 ### FormModel
 


### PR DESCRIPTION
Columns added to the code after a user saved grid state are always merged into that state. Whether they arrive **visible** was governed solely by their in-code `hidden` config. That is right for state recording a user's last-used layout, but wrong for a named view the user curated deliberately, often to capture a specific report.

New columns are now initially **hidden** when column state is persisted to a `ViewManagerModel` or `DashViewModel`, and unchanged everywhere else.

| Provider | New column visibility |
|---|---|
| `viewManager`, `dashView` | Hidden |
| All others | Follows in-code `hidden` config (unchanged) |

## Changes

* Added `GridModelPersistOptions.hideNewColumns`, defaulted from the provider resolved for `persistColumns` (falling back to the root options). Set `false` to restore the prior behavior.
* New columns remain available in the column chooser, and do not mark a view dirty - the existing `PersistableColumnState.equals` override already excludes hidden columns from that comparison.
* Columns with `hideable: false` (including tree columns) or `excludeFromChooser: true` are never force-hidden, as the app requires them shown and/or a user could not restore them.
* A ViewManager's in-code default view still follows the code. Apps that disable it in favor of a globally-shared default get the curated behavior throughout, with new columns surfacing only once an admin adds and saves them.
* `GridModel.setColumnState` accepts an optional `ColumnStateOptions`. Documented its wholesale-replace contract, and documented that `setColumns` resets column state.
* Exposed `PersistenceProvider.parseProviderClass` as `@internal`, so callers can resolve the provider a set of options would produce without duplicating that precedence.

## Verification

Run against Toolbox with hoist inline, driving the Portfolio example app: positions grid on a ViewManager, orders grid on a `DashViewModel` nested in that same ViewManager.

* Both grids hide new columns on a saved view, leave the stored view untouched, and stay clean (`isValueDirty: false`) - including with auto-save enabled and on a runtime view switch, the path that does write.
* New columns appear in the chooser's available list.
* The in-code default view surfaces new visible columns, including when it carries unsaved changes from before the release.
* `hideable: false` and `excludeFromChooser: true` columns arrive visible.
* A localStorage-backed grid surfaces new visible columns while preserving saved widths and hidden state.
* `hideNewColumns: false` on a ViewManager restores the prior behavior.

## Not in scope

Testing surfaced a pre-existing inconsistency in when a newly visible column marks a view dirty: a runtime view switch writes and dirties, while a cold load directly onto a saved view does not, because `PersistenceProvider.bindToTarget` installs its reaction after applying persisted state. Unrelated to this change, and moot under the new default.
