### PR TITLE
Fix SumAggregator inconsistency between replace and full rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,9 @@
 * Fixed `Grid` retaining an extra generation of records in memory indefinitely - ag-Grid's stored
   `rowData` pinned the record array from the last load into an empty grid, along with every
   `StoreRecord`, `data`, and retained `raw` object in it.
+* Fixed `SumAggregator.replace` reporting `0` instead of `null` once the last non-null contributor
+  to an aggregate went null, leaving an incremental Cube `View` update disagreeing with a full
+  rebuild over the same data.
 
 ### ⚙️ Technical
 

--- a/data/cube/aggregate/SumAggregator.ts
+++ b/data/cube/aggregate/SumAggregator.ts
@@ -19,8 +19,15 @@ export class SumAggregator extends Aggregator {
     }
 
     override replace(rows, currAgg, update, context) {
-        if (update.oldValue != null) currAgg -= update.oldValue;
-        if (update.newValue != null) currAgg += update.newValue;
-        return currAgg;
+        const {oldValue, newValue, field} = update;
+        if (oldValue != null) currAgg -= oldValue;
+        if (newValue != null) return currAgg + newValue;
+
+        // A delta cannot tell "sums to zero" from "nothing left to sum".
+        const {name} = field;
+        for (const row of rows) {
+            if (row.data[name] != null) return currAgg;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Fixes #4540 

Resolve the agg value to `null` instead of `0` when the final non-null row becomes `null`

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

