### PR TITLE
Fix golden-layout padding regression in DashContainer sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 86.4.1 - 2026-08-07
+
+### 🐞 Bug Fixes
+
+* Fixed `DashContainer` sizing regression introduced with the golden-layout fork in v86.0.0. CSS
+  padding applied to the container element was incorrectly counted as available layout space,
+  causing dashboard content to render oversized and cut off.
+
 ## 86.4.0 - 2026-07-15
 
 ### 🎁 New Features

--- a/kit/golden-layout/impl/js/LayoutManager.js
+++ b/kit/golden-layout/impl/js/LayoutManager.js
@@ -210,8 +210,8 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 			this.width = width;
 			this.height = height;
 		} else {
-			this.width = containerNode.clientWidth;
-			this.height = containerNode.clientHeight;
+			this.width = lm.utils.contentWidth( containerNode );
+			this.height = lm.utils.contentHeight( containerNode );
 		}
 
 		if( this.isInitialised === true ) {
@@ -219,8 +219,8 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 
 			if( this._maximisedItem ) {
 				var maxNode = this._maximisedItem.element;
-				maxNode.style.width = containerNode.clientWidth + 'px';
-				maxNode.style.height = containerNode.clientHeight + 'px';
+				maxNode.style.width = lm.utils.contentWidth( containerNode ) + 'px';
+				maxNode.style.height = lm.utils.contentHeight( containerNode ) + 'px';
 				this._maximisedItem.callDownwards( 'setSize' );
 			}
 
@@ -379,8 +379,8 @@ lm.utils.copy( lm.LayoutManager.prototype, {
 		itemNode.classList.add( 'lm_maximised' );
 		itemNode.after( placeholderNode );
 		rootNode.prepend( itemNode );
-		itemNode.style.width = containerNode.clientWidth + 'px';
-		itemNode.style.height = containerNode.clientHeight + 'px';
+		itemNode.style.width = lm.utils.contentWidth( containerNode ) + 'px';
+		itemNode.style.height = lm.utils.contentHeight( containerNode ) + 'px';
 		contentItem.callDownwards( 'setSize' );
 		this._maximisedItem.emit( 'maximised' );
 		this.emit( 'stateChanged' );

--- a/kit/golden-layout/impl/js/controls/DragProxy.js
+++ b/kit/golden-layout/impl/js/controls/DragProxy.js
@@ -62,8 +62,8 @@ lm.controls.DragProxy = function( x, y, dragListener, layoutManager, contentItem
 
 	this._minX = containerRect.left + window.scrollX;
 	this._minY = containerRect.top + window.scrollY;
-	this._maxX = containerNode.clientWidth + this._minX;
-	this._maxY = containerNode.clientHeight + this._minY;
+	this._maxX = lm.utils.contentWidth(containerNode) + this._minX;
+	this._maxY = lm.utils.contentHeight(containerNode) + this._minY;
 	this._width = this.element.clientWidth;
 	this._height = this.element.clientHeight;
 

--- a/kit/golden-layout/impl/js/items/Root.js
+++ b/kit/golden-layout/impl/js/items/Root.js
@@ -29,8 +29,8 @@ lm.utils.copy( lm.items.Root.prototype, {
 
 	setSize: function( width, height ) {
 		var containerNode = this._containerElement;
-		width = ( typeof width === 'undefined' ) ? containerNode.clientWidth : width;
-		height = ( typeof height === 'undefined' ) ? containerNode.clientHeight : height;
+		width = ( typeof width === 'undefined' ) ? lm.utils.contentWidth( containerNode ) : width;
+		height = ( typeof height === 'undefined' ) ? lm.utils.contentHeight( containerNode ) : height;
 
 		this.element.style.width = width + 'px';
 		this.element.style.height = height + 'px';

--- a/kit/golden-layout/impl/js/utils/utils.js
+++ b/kit/golden-layout/impl/js/utils/utils.js
@@ -160,6 +160,20 @@ lm.utils.getUniqueId = function() {
 };
 
 /**
+ * Content-box dimensions - equivalent to jQuery's .width()/.height(),
+ * which the pre-fork code used. clientWidth/Height include CSS padding.
+ */
+lm.utils.contentWidth = function( node ) {
+	var style = getComputedStyle( node );
+	return node.clientWidth - parseFloat( style.paddingLeft ) - parseFloat( style.paddingRight );
+};
+
+lm.utils.contentHeight = function( node ) {
+	var style = getComputedStyle( node );
+	return node.clientHeight - parseFloat( style.paddingTop ) - parseFloat( style.paddingBottom );
+};
+
+/**
  * A basic XSS filter. It is ultimately up to the
  * implementing developer to make sure their particular
  * applications and usecases are save from cross site scripting attacks


### PR DESCRIPTION
The fork (v86+) replaced jQuery .width()/.height() with clientWidth/clientHeight, which include CSS padding. Apps with padding on .xh-dash-container saw content render oversized and cut off.

Add contentWidth/contentHeight helpers to restore jQuery semantics (content-box measurement, padding excluded) at all four sites that measure the container: updateSize(), maximized item sizing, Root.setSize(), and drag-proxy bounds.

Fixes #4546

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [ ] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

