### PR TITLE
Use raw fields when cloning to drop stale dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@
 * Fixed `Grid` retaining an extra generation of records in memory indefinitely - ag-Grid's stored
   `rowData` pinned the record array from the last load into an empty grid, along with every
   `StoreRecord`, `data`, and retained `raw` object in it.
+* Fixed `Query.clone()` retaining dimensions dropped by a dimension-only update within its `fields`.
+  Cube `View`s changing dimensions via `updateQuery()` accumulated these stale fields, aggregating
+  each one on every aggregate row despite nothing having requested or displayed them.
 
 ### ⚙️ Technical
 

--- a/data/cube/Query.ts
+++ b/data/cube/Query.ts
@@ -166,7 +166,6 @@ export class Query {
         omitFn = cube.omitFn
     }: QueryConfig) {
         this.cube = cube;
-        // Retained for the life of this Query and its clones - copy to insulate from the caller.
         this._rawFields = fields?.slice();
         this.dimensions = this.parseDimensions(dimensions);
         this.fields = uniq([...this.parseFields(fields), ...(this.dimensions ?? [])]);
@@ -186,8 +185,7 @@ export class Query {
     clone(overrides: Partial<QueryConfig>) {
         const conf = {
             dimensions: this.dimensions,
-            // use the un-augmented fields list to drop potentially stale dimensions
-            fields: this._rawFields,
+            fields: this._rawFields, // NOT this.fields - would retain stale dimensions
             filter: this.filter,
             includeRoot: this.includeRoot,
             includeLeaves: this.includeLeaves,
@@ -249,8 +247,7 @@ export class Query {
 
     private parseDimensions(raw: CubeField[] | string[]): CubeField[] {
         if (!raw) return null;
-        // Copy - `dimensions` is public and passed back through here by `clone()`.
-        if (raw[0] instanceof CubeField) return (raw as CubeField[]).slice();
+        if (raw[0] instanceof CubeField) return raw.slice() as CubeField[]; // force clone, we retain.
         const {fields} = this.cube;
         return raw.map(name => {
             const field = find(fields, {name});

--- a/data/cube/Query.ts
+++ b/data/cube/Query.ts
@@ -149,6 +149,7 @@ export class Query {
     readonly bucketSpecFn: BucketSpecFn;
     readonly omitFn: OmitFn;
 
+    private readonly _rawFields: string[] | CubeField[];
     private readonly _testFn: FilterTestFn;
 
     constructor({
@@ -165,6 +166,7 @@ export class Query {
         omitFn = cube.omitFn
     }: QueryConfig) {
         this.cube = cube;
+        this._rawFields = fields;
         this.dimensions = this.parseDimensions(dimensions);
         this.fields = uniq([...this.parseFields(fields), ...(this.dimensions ?? [])]);
         this.includeRoot = includeRoot;
@@ -183,7 +185,8 @@ export class Query {
     clone(overrides: Partial<QueryConfig>) {
         const conf = {
             dimensions: this.dimensions,
-            fields: this.fields,
+            // use the un-augmented fields list to drop potentially stale dimensions
+            fields: this._rawFields,
             filter: this.filter,
             includeRoot: this.includeRoot,
             includeLeaves: this.includeLeaves,

--- a/data/cube/Query.ts
+++ b/data/cube/Query.ts
@@ -166,7 +166,8 @@ export class Query {
         omitFn = cube.omitFn
     }: QueryConfig) {
         this.cube = cube;
-        this._rawFields = fields;
+        // Retained for the life of this Query and its clones - copy to insulate from the caller.
+        this._rawFields = fields?.slice();
         this.dimensions = this.parseDimensions(dimensions);
         this.fields = uniq([...this.parseFields(fields), ...(this.dimensions ?? [])]);
         this.includeRoot = includeRoot;
@@ -248,7 +249,8 @@ export class Query {
 
     private parseDimensions(raw: CubeField[] | string[]): CubeField[] {
         if (!raw) return null;
-        if (raw[0] instanceof CubeField) return raw as CubeField[];
+        // Copy - `dimensions` is public and passed back through here by `clone()`.
+        if (raw[0] instanceof CubeField) return (raw as CubeField[]).slice();
         const {fields} = this.cube;
         return raw.map(name => {
             const field = find(fields, {name});


### PR DESCRIPTION
Fixes #4548 

```typescript
import {Cube, Query} from '@xh/hoist/data';

const cube = new Cube({
    idSpec: 'id',
    fields: [
        {name: 'region', isDimension: true, aggregator: 'UNIQUE'},
        {name: 'trader', isDimension: true, aggregator: 'UNIQUE'},
        {name: 'pnl', aggregator: 'SUM'}
    ],
    data: [
        {id: 1, region: 'EMEA', trader: 'ann', pnl: 100},
        {id: 2, region: 'EMEA', trader: 'ann', pnl: 200},
        {id: 3, region: 'APAC', trader: 'bob', pnl: 50}
    ]
});

// 1. The stranded field.
const q = new Query({cube, dimensions: ['region'], fields: ['pnl']});
console.log(q.fields.map(f => f.name));                       // ['pnl', 'region']

const q2 = q.clone({dimensions: ['trader']});
console.log(q2.fields.map(f => f.name));
//   BEFORE: ['pnl', 'region', 'trader']   <- 'region' is no longer a dimension
//   AFTER:  ['pnl', 'trader']

// 2. It isn't inert - the stale field is aggregated on every row.
const view = cube.createView({query: {dimensions: ['region'], fields: ['pnl']}});
view.updateQuery({dimensions: ['trader']});

const annRow = view.result.rows.find(it => it.cubeLabel === 'ann');
console.log('region' in annRow, annRow.region);
//   BEFORE: true 'EMEA'    <- UNIQUE ran across every child, for a field nothing requested
//   AFTER:  false undefined
```

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

