### PR TITLE
Store/Grid: RecordSet delta provenance - incremental refilter, grid delta sync, loadData reuse deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,11 @@
 
 ### ⚙️ Technical
 
+* Improved `Store` performance for incremental changes to large datasets. Transactions and
+  reloads now record the record-level changes they apply, letting a filtered Store re-test only
+  the changed records (flat data) and letting bound grids sync ag-Grid without a full-list diff.
+  Reloads found to change nothing preserve the Store's record collections outright, skipping all
+  downstream work - a common case for apps that poll for data on a timer.
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped
   Popper.js onto Floating UI for React 19 compatibility. Updated the Hoist `Popover` components
   (mobile and desktop) so apps require no call-site changes.
@@ -141,6 +146,8 @@
 
 ### ⚙️ Typescript API Adjustments
 
+* Added the exported `RecordTransaction` interface - the record-level counterpart to the raw-data
+  `StoreTransaction`. `StoreChangeLog` now extends it, with no change to its shape.
 * Retyped `BaseRow.data` from `ViewRowData` to `PlainObject`, reflecting that custom `Aggregator`
   implementations may only rely on queried field values - not `ViewRowData` metadata - when reading
   row data. Use row-level getters such as `BaseRow.isLeaf` in place of `data.cubeRowType`.

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -658,6 +658,21 @@ export class GridLocalModel extends HoistModel {
     genTransaction(newRs, prevRs) {
         if (!prevRs) return {add: newRs.list};
 
+        // Fast path - a RecordSet derived directly from prevRs carries its own delta, avoiding
+        // the full-list diff below on (typically small) incremental transactions. Any other
+        // derivation (full loads, filter changes, multi-step) falls through to the full diff.
+        const {delta} = newRs;
+        if (delta && delta.prevId === prevRs.xhId) {
+            const ret: any = {};
+            if (!isEmpty(delta.update)) ret.update = delta.update;
+            if (!isEmpty(delta.add)) ret.add = delta.add;
+            if (!isEmpty(delta.remove)) {
+                const remove = delta.remove.map(id => prevRs.getById(id)).filter(r => r != null);
+                if (!isEmpty(remove)) ret.remove = remove;
+            }
+            return ret;
+        }
+
         const newList = newRs.list,
             prevList = prevRs.list;
 

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -275,13 +275,22 @@ export interface StoreTransaction {
 }
 
 /**
- * Collection of changes made to a Store's RecordSet. Unlike `StoreTransaction` which is used to
- * specify changes, this object is used to report the actual changes made in a single transaction.
+ * A set of record-level changes to a Store's RecordSet - the shared shape of
+ * {@link StoreChangeLog}, RecordSet transactions, and the internal deltas RecordSets record
+ * about their own derivation. Contrast with {@link StoreTransaction}, which specifies changes
+ * as *raw* data.
  */
-export interface StoreChangeLog {
+export interface RecordTransaction {
     update?: StoreRecord[];
     add?: StoreRecord[];
     remove?: StoreRecordId[];
+}
+
+/**
+ * Collection of changes made to a Store's RecordSet. Unlike `StoreTransaction` which is used to
+ * specify changes, this object is used to report the actual changes made in a single transaction.
+ */
+export interface StoreChangeLog extends RecordTransaction {
     summaryRecords?: StoreRecord[];
 }
 
@@ -403,6 +412,10 @@ export class Store
     // Last parent pair verified position-equal by positionUnchanged().
     private _verifiedCachedParent: StoreRecord = null;
     private _verifiedNewParent: StoreRecord = null;
+
+    // xhId of the _current RecordSet from which _filtered was last built - the delta linkage
+    // gating incremental refiltering. See rebuildFiltered().
+    private _filteredSourceId: number = null;
 
     // Scratch state shared by parseRaw/parseUpdate - the first `n` entries of the parallel
     // name/value buffers are the current record's non-default fields, filled and fully consumed
@@ -527,9 +540,16 @@ export class Store
             ? castArray(rawSummaryData).map(it => this.createRecord(it, null, true))
             : null;
 
-        const records = this.createRecords(rawData, null);
-        this._committed = this._current = this._committed.withNewRecords(records);
-        this.rebuildFiltered();
+        const records = this.createRecords(rawData, null),
+            {_committed} = this,
+            newCommitted = _committed.withNewRecords(records);
+
+        // withNewRecords returns the same instance when a reload changes nothing - common in
+        // polling apps. Skip the swap + refilter entirely, unless discarding local mods.
+        if (newCommitted !== _committed || this._current !== _committed) {
+            this._committed = this._current = newCommitted;
+            this.rebuildFiltered();
+        }
 
         this.lastLoaded = this.lastUpdated = Date.now();
     }
@@ -571,8 +591,12 @@ export class Store
 
         runInAction(() => {
             this.summaryRecords = null;
-            this._committed = this._current = this._committed.withNewRecords(recordMap);
-            this.rebuildFiltered();
+            const {_committed} = this,
+                newCommitted = _committed.withNewRecords(recordMap);
+            if (newCommitted !== _committed || this._current !== _committed) {
+                this._committed = this._current = newCommitted;
+                this.rebuildFiltered();
+            }
             this.lastLoaded = this.lastUpdated = Date.now();
         });
     }
@@ -683,11 +707,7 @@ export class Store
         }
 
         // 3) Apply changes
-        let rsTransaction: {
-            update?: StoreRecord[];
-            add?: StoreRecord[];
-            remove?: StoreRecordId[];
-        } = {};
+        let rsTransaction: RecordTransaction = {};
         if (!isEmpty(updateRecs)) rsTransaction.update = updateRecs;
         if (!isEmpty(addRecs)) rsTransaction.add = Array.from(addRecs.values());
         if (!isEmpty(remove)) rsTransaction.remove = remove;
@@ -1305,7 +1325,18 @@ export class Store
 
     @action
     private rebuildFiltered() {
-        this._filtered = this._current.withFilter(this.filter);
+        const {filter, _current, _filtered} = this;
+
+        // Patch the previous filtered set incrementally when possible - a full refilter tests
+        // every record on every transaction, however small. The delta linkage check within
+        // ensures this only applies when _current was derived from _filtered's source by a
+        // single transaction with this same filter - any other path (new/changed filter,
+        // refreshFilter(), full loads) falls through to the full pass.
+        const patched = filter
+            ? _current.withFilterIncremental(filter, _filtered, this._filteredSourceId)
+            : null;
+        this._filtered = patched ?? _current.withFilter(filter);
+        this._filteredSourceId = _current.xhId;
     }
 
     //---------------------------------------

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -9,11 +9,31 @@ import equal from 'fast-deep-equal';
 import {logWarn, throwIf} from '@xh/hoist/utils/js';
 import {maxBy, isNil} from 'lodash';
 import {StoreRecord, StoreRecordId} from '../StoreRecord';
-import {Store} from '../Store';
+import {RecordTransaction, Store} from '../Store';
 import {Filter} from '../filter/Filter';
 
 type StoreRecordMap = Map<StoreRecordId, StoreRecord>;
 type ChildRecordMap = Map<StoreRecordId, StoreRecord[]>;
+
+// Monotonic source for RecordSet.xhId - identifies instances for delta linkage.
+let nextXhId = 0;
+
+// Attach a load delta (see withNewRecords) only when reuse dominates - a large delta costs
+// consumers more to apply than their full-rebuild fallbacks.
+const MAX_LOAD_DELTA_RATIO = 0.25;
+
+/**
+ * Changes applied to a source RecordSet (identified by `prevId`) to produce a derived one.
+ * Unlike a RecordTransaction used to *specify* changes, `remove` here holds the full expanded
+ * set of removed ids, including cascaded descendants - consumers apply it verbatim.
+ * @internal
+ */
+export interface RecordSetDelta extends RecordTransaction {
+    prevId: number;
+    update: StoreRecord[];
+    add: StoreRecord[];
+    remove: StoreRecordId[];
+}
 
 /**
  * Internal container for StoreRecord management within a Store.
@@ -27,16 +47,28 @@ export class RecordSet {
     count: number;
     rootCount: number;
 
+    /** Unique instance id, identifying this set as the source of derived sets' `delta`s. */
+    readonly xhId: number = ++nextXhId;
+
+    /**
+     * Changes that produced this RecordSet from the instance identified by `delta.prevId` -
+     * populated when derived via `withTransaction` or an incremental filter patch, null when
+     * built any other way (full load, full filter). Lets consumers (e.g. Grid) sync small
+     * changes without a full-list diff.
+     */
+    readonly delta: RecordSetDelta = null;
+
     private _childrenMap: ChildRecordMap; // children by parentId
     private _list: StoreRecord[]; // all records.
     private _rootList: StoreRecord[]; // root records.
     private _maxDepth: number;
 
-    constructor(store: Store, recordMap: StoreRecordMap = new Map()) {
+    constructor(store: Store, recordMap: StoreRecordMap = new Map(), delta: RecordSetDelta = null) {
         this.store = store;
         this.recordMap = recordMap;
         this.count = recordMap.size;
         this.rootCount = this.countRoots(recordMap);
+        this.delta = delta;
     }
 
     get empty(): boolean {
@@ -161,31 +193,47 @@ export class RecordSet {
         // Reuse existing StoreRecord object instances where possible.  See Store.loadData().
         // Be sure to finalize any new records that are accepted.
         if (this.empty) {
+            if (!recordMap.size) return this;
             recordMap.forEach(r => r.finalize());
-        } else {
-            recordMap.forEach((newRec, id) => {
-                const currRec = this.getById(id);
-                if (currRec && this.areRecordsEqual(currRec, newRec)) {
-                    recordMap.set(id, currRec);
-                } else {
-                    newRec.finalize();
-                }
-            });
+            return new RecordSet(this.store, recordMap);
         }
 
-        return new RecordSet(this.store, recordMap);
+        // Classify against the incumbents while reusing - reused records are no-ops, the rest
+        // form this set's delta from its predecessor.
+        const delta: RecordSetDelta = {prevId: this.xhId, update: [], add: [], remove: []};
+        recordMap.forEach((newRec, id) => {
+            const currRec = this.getById(id);
+            if (currRec && this.areRecordsEqual(currRec, newRec)) {
+                recordMap.set(id, currRec);
+            } else {
+                newRec.finalize();
+                (currRec ? delta.update : delta.add).push(newRec);
+            }
+        });
+
+        // Reload changed nothing - preserve instance identity outright, letting the Store skip
+        // its refilter and downstream consumers skip all sync. Common in polling apps.
+        const removedCount = this.count - (recordMap.size - delta.add.length);
+        if (!removedCount && !delta.update.length && !delta.add.length) return this;
+
+        if (removedCount) {
+            for (const id of this.recordMap.keys()) {
+                if (!recordMap.has(id)) delta.remove.push(id);
+            }
+        }
+
+        const changes = delta.update.length + delta.add.length + delta.remove.length,
+            attachDelta = changes <= MAX_LOAD_DELTA_RATIO * recordMap.size;
+        return new RecordSet(this.store, recordMap, attachDelta ? delta : null);
     }
 
-    withTransaction(t: {
-        update?: StoreRecord[];
-        add?: StoreRecord[];
-        remove?: StoreRecordId[];
-    }): RecordSet {
+    withTransaction(t: RecordTransaction): RecordSet {
         const {update, add, remove} = t;
 
         // Be sure to finalize any new records that are accepted.
         const {recordMap} = this,
-            newRecords = new Map(recordMap);
+            newRecords = new Map(recordMap),
+            delta: RecordSetDelta = {prevId: this.xhId, update: [], add: [], remove: []};
 
         let missingRemoves = 0,
             missingUpdates = 0;
@@ -203,6 +251,7 @@ export class RecordSet {
                 this.gatherDescendantIds(id, allRemoves);
             });
             allRemoves.forEach(it => newRecords.delete(it));
+            delta.remove = Array.from(allRemoves);
         }
 
         // 1) Updates
@@ -217,6 +266,7 @@ export class RecordSet {
                 }
                 newRecords.set(id, rec);
                 rec.finalize();
+                delta.update.push(rec);
             });
         }
 
@@ -227,6 +277,7 @@ export class RecordSet {
                 throwIf(newRecords.has(id), `Attempted to insert duplicate record: ${id}`);
                 newRecords.set(id, rec);
                 rec.finalize();
+                delta.add.push(rec);
             });
         }
 
@@ -235,7 +286,63 @@ export class RecordSet {
         if (missingUpdates > 0)
             logWarn(`Failed to update ${missingUpdates} records not found by id`, this);
 
-        return new RecordSet(this.store, newRecords);
+        return new RecordSet(this.store, newRecords, delta);
+    }
+
+    /**
+     * Filtered projection of this RecordSet, built by patching the previous filtered set with
+     * this set's delta rather than re-testing every record. Applicable only when this set was
+     * derived from `prevFiltered`'s source (identified by `prevSourceId`) via a single
+     * transaction, and both states are flat - hierarchy-aware marking (ancestors of passing
+     * records, optionally their children) requires the full `withFilter` pass.
+     *
+     * Returns `prevFiltered` itself when the changes turn out not to touch the filtered set at
+     * all (e.g. updates only to filtered-out records), and null when not applicable - callers
+     * must then fall back to `withFilter`.
+     */
+    withFilterIncremental(
+        filter: Filter,
+        prevFiltered: RecordSet,
+        prevSourceId: number
+    ): RecordSet {
+        const {delta, store} = this;
+        if (
+            !delta ||
+            delta.prevId !== prevSourceId ||
+            this.count !== this.rootCount ||
+            prevFiltered.count !== prevFiltered.rootCount
+        ) {
+            return null;
+        }
+
+        const test = filter.getTestFn(store),
+            newMap = new Map(prevFiltered.recordMap),
+            fDelta: RecordSetDelta = {prevId: prevFiltered.xhId, update: [], add: [], remove: []};
+
+        delta.remove.forEach(id => {
+            if (newMap.delete(id)) fDelta.remove.push(id);
+        });
+        delta.update.forEach(rec => {
+            const {id} = rec,
+                present = newMap.has(id);
+            if (test(rec)) {
+                newMap.set(id, rec);
+                (present ? fDelta.update : fDelta.add).push(rec);
+            } else if (present) {
+                newMap.delete(id);
+                fDelta.remove.push(id);
+            }
+        });
+        delta.add.forEach(rec => {
+            if (test(rec)) {
+                newMap.set(rec.id, rec);
+                fDelta.add.push(rec);
+            }
+        });
+
+        return fDelta.update.length || fDelta.add.length || fDelta.remove.length
+            ? new RecordSet(store, newMap, fDelta)
+            : prevFiltered;
     }
 
     //------------------------


### PR DESCRIPTION
> **Status: draft pending Toolbox validation.** For stores using `reuseRecords` digests - including all Cube View-connected stores, typically an app's largest - digests already remove the parse cost on reloads, leaving the refilter and grid diff as the dominant remaining terms. Those are exactly what this PR removes: a 1%-changed reload on a filtered 200k-record digest store drops **322ms → 159ms (−50%)** store-side, with the grid's full-list diff additionally eliminated in-browser. For digest-less stores the win is smaller in relative terms, as record parsing dominates (tracked separately). The delta bookkeeping is also the natural foundation for a future overlay/copy-on-write RecordSet that would remove the remaining `withTransaction` map-copy floor.

Store transactions and reloads now record the record-level changes they apply as a *delta* on the derived RecordSet, letting downstream consumers apply exactly those changes instead of rediscovering them with full O(n) passes.

## Key changes

- **`RecordSet` delta provenance** - each instance carries a monotonic `xhId`; `withTransaction` and `withNewRecords` record `{prevId, update, add, remove}` on the sets they derive. Linkage is by id, not reference: no retention chains, and any other derivation (full builds, filter changes, `refreshFilter()`, `normalize()` swaps, multi-step) fails the linkage check and falls back to today's full-pass behavior. Correctness never depends on the fast path applying.
- **Incremental refiltering** - with a filter active, `Store.rebuildFiltered` patches the previous filtered set, re-testing only changed records (flat stores; tree marking semantics still take the full pass). Ticks that don't intersect the filter preserve the filtered instance - no downstream reactions at all.
- **Grid delta sync** - `genTransaction` consumes the delta directly when linked, eliminating the full-list diff on every incremental change.
- **`loadData` reuse deltas** - `withNewRecords` classifies against incumbents during its existing reuse walk, attaching a delta when changes stay under 25% of the dataset. (The no-change-reload identity preservation originally in this PR was extracted and shipped separately on develop - this branch's classification subsumes it.)
- **`RecordTransaction`** - new exported interface, the record-level counterpart to raw-data `StoreTransaction`; `StoreChangeLog` extends it unchanged. Note the delta's `remove` holds the fully-expanded id set (incl. cascaded descendants), unlike transaction input.

## Benchmarks

Node, digest-less flat store, 200k records × 15 fields, median of 5 (store-side only - grid diffs are additionally eliminated in-browser). Filter = compound AND of a text `like` + numeric bound, as a `StoreFilterField` produces:

| Scenario | develop | this PR |
|---|---|---|
| updateData: 100-row tick, filter active | 122.2 ms | **68.2 ms (−44%)** |
| reload: identical payload, filter active | 364.8 ms | **311.7 ms (−15%)** |
| reload: 1% changed, filter active | 356.1 ms | 340.4 ms |
| updateData: 100-row tick, no filter | 70.2 ms | 73.4 ms (noise - the map-copy floor) |

Digest-store profile (`reuseRecords: 'seq'`, the expensive-recordset case - parse already skipped by digests):

| Scenario | develop | this PR |
|---|---|---|
| DIGEST reload: 1% changed, filter active | 322.6 ms | **159.5 ms (−50%)** |
| DIGEST reload: identical, filter active | 125.3 ms | 125.3 ms (short-circuited on both by the previously-extracted no-change reload check) |

The refilter term is eliminated nearly in full; remaining tick cost is the immutable map copy, remaining digest-less reload cost is record parsing (tracked separately).

Also verified programmatically: incremental filtered sets match a full refilter record-for-record; identical reloads preserve instance identity end-to-end; out-of-filter ticks produce zero filtered-set churn. Remaining reload cost is record parsing (tracked separately); remaining tick floor is the transaction map copy.
