### PR TITLE
Store/Cube quick perf wins: clean-store validator short-circuit + no-change cube reload skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,7 @@
       `FetchService` can also share interned values across successive fetches of the same logical
       dataset, which the app identifies with a required key, per a configurable `retainMode`. Skip
       known high-cardinality fields (e.g. UUID columns) via `excludeFields`.
-    * `Store.loadData()` calls found to change nothing now preserve the Store's record collections
-       outright, skipping all downstream work.
+    * `Store.loadData()` and `Cube.loadDataAsync` calls have been optimized to skip all downstream work.
 
 * Added an `icon` prop to `Badge`, rendered before the badge's content. Spacing between the icon and
   content is controlled by the new `--xh-badge-gap` CSS variable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,11 @@
 
 ### ⚙️ Technical
 
+* Improved `Cube.loadDataAsync()` to skip regenerating rows on connected `View`s when a reload is
+  found to change no records - views sync their `info` and timestamps only, making polled reloads
+  of unchanged cube data near-free.
+* Improved `Store` validation bookkeeping to skip an all-records scan previously run on every data
+  change - now short-circuited for the common case of a store with no uncommitted records.
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped
   Popper.js onto Floating UI for React 19 compatibility. Updated the Hoist `Popover` components
   (mobile and desktop) so apps require no call-site changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,11 +129,6 @@
 
 ### ⚙️ Technical
 
-* Improved `Cube.loadDataAsync()` to skip regenerating rows on connected `View`s when a reload is
-  found to change no records - views sync their `info` and timestamps only, making polled reloads
-  of unchanged cube data near-free.
-* Improved `Store` validation bookkeeping to skip an all-records scan previously run on every data
-  change - now short-circuited for the common case of a store with no uncommitted records.
 * Moved both desktop and mobile popover implementations off the deprecated, React-18-capped
   Popper.js onto Floating UI for React 19 compatibility. Updated the Hoist `Popover` components
   (mobile and desktop) so apps require no call-site changes.

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -314,8 +314,7 @@ export class Cube extends HoistBase {
         }
         this.setInfo(info);
 
-        // Loads found to change nothing preserve the store's record collections outright -
-        // sync each view's info/timestamp only, skipping the full regeneration of its rows.
+        // No-change loads need only an info/timestamp sync on views - skip row regeneration.
         const unchanged = store._filtered === prevRecords;
         await forEachAsync(this._connectedViews, v =>
             unchanged ? v.noteCubeUpdated(null) : v.noteCubeLoaded()

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -305,13 +305,21 @@ export class Cube extends HoistBase {
         rawData: PlainObject[] | AnyIterable<PlainObject>,
         info: PlainObject = {}
     ): Promise<void> {
+        const {store} = this,
+            prevRecords = store._filtered;
         if (isArray(rawData)) {
-            this.store.loadData(rawData);
+            store.loadData(rawData);
         } else {
-            await this.store.loadDataAsync(rawData);
+            await store.loadDataAsync(rawData);
         }
         this.setInfo(info);
-        await forEachAsync(this._connectedViews, v => v.noteCubeLoaded());
+
+        // Loads found to change nothing preserve the store's record collections outright -
+        // sync each view's info/timestamp only, skipping the full regeneration of its rows.
+        const unchanged = store._filtered === prevRecords;
+        await forEachAsync(this._connectedViews, v =>
+            unchanged ? v.noteCubeUpdated(null) : v.noteCubeLoaded()
+        );
     }
 
     /**

--- a/data/impl/StoreValidator.ts
+++ b/data/impl/StoreValidator.ts
@@ -125,9 +125,6 @@ export class StoreValidator extends HoistBase {
     // Implementation
     //---------------------------------------
     private get uncommittedRecords() {
-        // A clean store holds committed records only - answer without touching the (potentially
-        // very large) record list. Keeps the tracking reaction O(1) per transaction for the
-        // common case of a read-only store.
         const {store} = this;
         return store.isDirty ? store.allRecords.filter(it => !it.isCommitted) : [];
     }

--- a/data/impl/StoreValidator.ts
+++ b/data/impl/StoreValidator.ts
@@ -125,7 +125,11 @@ export class StoreValidator extends HoistBase {
     // Implementation
     //---------------------------------------
     private get uncommittedRecords() {
-        return this.store.allRecords.filter(it => !it.isCommitted);
+        // A clean store holds committed records only - answer without touching the (potentially
+        // very large) record list. Keeps the tracking reaction O(1) per transaction for the
+        // common case of a read-only store.
+        const {store} = this;
+        return store.isDirty ? store.allRecords.filter(it => !it.isCommitted) : [];
     }
 
     private async syncValidatorsAsync() {


### PR DESCRIPTION
Two small, standalone perf wins for large / frequently-refreshed datasets, extracted from ongoing RecordSet work (#4560):

- **`StoreValidator`**: its `uncommittedRecords` tracking reaction materialized and filtered the full record list on *every* transaction, for every store - a per-tick O(n) cost even on read-only stores. A store with no uncommitted records (`Store.isDirty` false, O(1)) can only hold committed records, so it now short-circuits to an empty result. Profiling a 200k-record store showed this as one of the largest fixed per-update costs.

- **`Cube.loadDataAsync`**: reloads that `Store.loadData` finds to change nothing (its existing no-change short-circuit, which preserves the record collections outright) no longer force a `fullUpdate` on every connected `View`. Views sync their `info` and `cubeUpdated` timestamp only (via the same `noteCubeUpdated(null)` path used by `Cube.updateInfo`), so apps polling cube data pay ~zero when nothing changed. Changed reloads behave exactly as before.

Verified with a node smoke test: no-change reloads preserve `View.result` identity with `info`/timestamps synced (incl. the `connectView` staleness check); changed reloads still fully regenerate with correct aggregates.
