### PR TITLE
RecordSet diff contract + encapsulation - early extraction from #4560

### DIFF
--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -662,7 +662,7 @@ export class GridLocalModel extends HoistModel {
         const ret: any = {};
         if (!isEmpty(add)) ret.add = add;
         if (!isEmpty(update)) ret.update = update;
-        if (!isEmpty(remove)) ret.remove = remove.map(id => prevRs.getById(id));
+        if (!isEmpty(remove)) ret.remove = remove;
         return ret;
     }
 

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -47,7 +47,18 @@ import {wait} from '@xh/hoist/promise';
 import {consumeEvent, isDisplayed, logWithDebug} from '@xh/hoist/utils/js';
 import {composeRefs, createObservableRef, getLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
-import {compact, debounce, isBoolean, isEmpty, isEqual, isNil, max, maxBy, merge} from 'lodash';
+import {
+    compact,
+    debounce,
+    isBoolean,
+    isEmpty,
+    isEqual,
+    isNil,
+    max,
+    maxBy,
+    merge,
+    omitBy
+} from 'lodash';
 import {type MouseEvent} from 'react';
 import {PartialDeep} from 'type-fest';
 import './Grid.scss';
@@ -656,14 +667,8 @@ export class GridLocalModel extends HoistModel {
 
     @logWithDebug
     genTransaction(newRs, prevRs) {
-        const {update, add, remove} = newRs.diffFrom(prevRs);
-
-        // Only include lists in transaction if non-empty (ag-grid is not internally optimized)
-        const ret: any = {};
-        if (!isEmpty(add)) ret.add = add;
-        if (!isEmpty(update)) ret.update = update;
-        if (!isEmpty(remove)) ret.remove = remove;
-        return ret;
+        // Skip empty props -- ag-grid is not internally optimized
+        return omitBy(newRs.diffFrom(prevRs), isEmpty);
     }
 
     @logWithDebug

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -656,32 +656,16 @@ export class GridLocalModel extends HoistModel {
 
     @logWithDebug
     genTransaction(newRs, prevRs) {
-        if (!prevRs) return {add: newRs.list};
-
-        const newList = newRs.list,
-            prevList = prevRs.list;
-
-        let add = [],
-            update = [],
-            remove = [];
-        newList.forEach(rec => {
-            const existing = prevRs.getById(rec.id);
-            if (!existing) {
-                add.push(rec);
-            } else if (existing !== rec) {
-                update.push(rec);
-            }
-        });
-
-        if (newList.length !== prevList.length + add.length) {
-            remove = prevList.filter(rec => !newRs.getById(rec.id));
-        }
+        const {update, add, remove} = newRs.diffFrom(prevRs);
 
         // Only include lists in transaction if non-empty (ag-grid is not internally optimized)
         const ret: any = {};
         if (!isEmpty(add)) ret.add = add;
         if (!isEmpty(update)) ret.update = update;
-        if (!isEmpty(remove)) ret.remove = remove;
+        if (!isEmpty(remove)) {
+            const removeRecs = remove.map(id => prevRs.getById(id)).filter(r => r != null);
+            if (!isEmpty(removeRecs)) ret.remove = removeRecs;
+        }
         return ret;
     }
 

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -662,10 +662,7 @@ export class GridLocalModel extends HoistModel {
         const ret: any = {};
         if (!isEmpty(add)) ret.add = add;
         if (!isEmpty(update)) ret.update = update;
-        if (!isEmpty(remove)) {
-            const removeRecs = remove.map(id => prevRs.getById(id)).filter(r => r != null);
-            if (!isEmpty(removeRecs)) ret.remove = removeRecs;
-        }
+        if (!isEmpty(remove)) ret.remove = remove.map(id => prevRs.getById(id));
         return ret;
     }
 

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -404,11 +404,6 @@ export class Store
     private _verifiedCachedParent: StoreRecord = null;
     private _verifiedNewParent: StoreRecord = null;
 
-    // The _current RecordSet from which _filtered was last built - passed as the previous-state
-    // hint on the next rebuild, letting RecordSet implementations refilter incrementally.
-    // See rebuildFiltered().
-    private _filteredSource: RecordSet = null;
-
     // Scratch state shared by parseRaw/parseUpdate - the first `n` entries of the parallel
     // name/value buffers are the current record's non-default fields, filled and fully consumed
     // within a single call to avoid allocation during parsing. See buildData(). Not reentrant -
@@ -1286,7 +1281,6 @@ export class Store
     @action
     private resetRecords() {
         this._committed = this._current = this._filtered = new RecordSet(this);
-        this._filteredSource = null;
         this.summaryRecords = null;
     }
 
@@ -1321,9 +1315,7 @@ export class Store
 
     @action
     private rebuildFiltered() {
-        const {filter, _current, _filtered} = this;
-        this._filtered = _current.withFilter(filter, _filtered, this._filteredSource);
-        this._filteredSource = _current;
+        this._filtered = this._current.withFilter(this.filter, this._filtered);
     }
 
     //---------------------------------------

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -404,6 +404,11 @@ export class Store
     private _verifiedCachedParent: StoreRecord = null;
     private _verifiedNewParent: StoreRecord = null;
 
+    // The _current RecordSet from which _filtered was last built - passed as the previous-state
+    // hint on the next rebuild, letting RecordSet implementations refilter incrementally.
+    // See rebuildFiltered().
+    private _filteredSource: RecordSet = null;
+
     // Scratch state shared by parseRaw/parseUpdate - the first `n` entries of the parallel
     // name/value buffers are the current record's non-default fields, filled and fully consumed
     // within a single call to avoid allocation during parsing. See buildData(). Not reentrant -
@@ -1281,6 +1286,7 @@ export class Store
     @action
     private resetRecords() {
         this._committed = this._current = this._filtered = new RecordSet(this);
+        this._filteredSource = null;
         this.summaryRecords = null;
     }
 
@@ -1315,7 +1321,9 @@ export class Store
 
     @action
     private rebuildFiltered() {
-        this._filtered = this._current.withFilter(this.filter);
+        const {filter, _current, _filtered} = this;
+        this._filtered = _current.withFilter(filter, _filtered, this._filteredSource);
+        this._filteredSource = _current;
     }
 
     //---------------------------------------
@@ -1379,7 +1387,7 @@ export class Store
     ): StoreRecord {
         const refMode = this.reuseRecords === true;
         if (!refMode && digest == null) return null;
-        const cached = this._committed?.recordMap.get(id);
+        const cached = this._committed?.getById(id);
         return cached &&
             (refMode ? cached.raw === raw : cached.digest === digest) &&
             this.positionUnchanged(cached.parent, parent)

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -18,14 +18,14 @@ type ChildRecordMap = Map<StoreRecordId, StoreRecord[]>;
 /**
  * Changes deriving one RecordSet from another, as computed by {@link RecordSet.diffFrom}.
  * Unlike a transaction used to *specify* changes, `remove` here holds the full set of removed
- * ids, including cascaded descendants - consumers apply it verbatim. Every removed id is
- * guaranteed present in the diffed-from instance, an invariant any implementation must uphold.
+ * records (as they exist in the diffed-from instance), including cascaded descendants -
+ * consumers apply it verbatim.
  * @internal
  */
 export interface RecordSetDelta {
     update: StoreRecord[];
     add: StoreRecord[];
-    remove: StoreRecordId[];
+    remove: StoreRecord[];
 }
 
 /**
@@ -111,7 +111,7 @@ export class RecordSet {
 
         if (this.count !== prev.count + add.length) {
             prev._recordMap.forEach((rec, id) => {
-                if (!this.getById(id)) remove.push(id);
+                if (!this.getById(id)) remove.push(rec);
             });
         }
 

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -18,7 +18,8 @@ type ChildRecordMap = Map<StoreRecordId, StoreRecord[]>;
 /**
  * Changes deriving one RecordSet from another, as computed by {@link RecordSet.diffFrom}.
  * Unlike a transaction used to *specify* changes, `remove` here holds the full set of removed
- * ids, including cascaded descendants - consumers apply it verbatim.
+ * ids, including cascaded descendants - consumers apply it verbatim. Every removed id is
+ * guaranteed present in the diffed-from instance, an invariant any implementation must uphold.
  * @internal
  */
 export interface RecordSetDelta {

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -16,6 +16,18 @@ type StoreRecordMap = Map<StoreRecordId, StoreRecord>;
 type ChildRecordMap = Map<StoreRecordId, StoreRecord[]>;
 
 /**
+ * Changes deriving one RecordSet from another, as computed by {@link RecordSet.diffFrom}.
+ * Unlike a transaction used to *specify* changes, `remove` here holds the full set of removed
+ * ids, including cascaded descendants - consumers apply it verbatim.
+ * @internal
+ */
+export interface RecordSetDelta {
+    update: StoreRecord[];
+    add: StoreRecord[];
+    remove: StoreRecordId[];
+}
+
+/**
  * Internal container for StoreRecord management within a Store.
  * Note this is an immutable object; its update and filtering APIs return new instances as required.
  *
@@ -23,10 +35,10 @@ type ChildRecordMap = Map<StoreRecordId, StoreRecord[]>;
  */
 export class RecordSet {
     store: Store;
-    recordMap: StoreRecordMap; // Map of all Records by id
     count: number;
     rootCount: number;
 
+    private _recordMap: StoreRecordMap; // Map of all Records by id
     private _childrenMap: ChildRecordMap; // children by parentId
     private _list: StoreRecord[]; // all records.
     private _rootList: StoreRecord[]; // root records.
@@ -34,7 +46,7 @@ export class RecordSet {
 
     constructor(store: Store, recordMap: StoreRecordMap = new Map()) {
         this.store = store;
-        this.recordMap = recordMap;
+        this._recordMap = recordMap;
         this.count = recordMap.size;
         this.rootCount = this.countRoots(recordMap);
     }
@@ -44,7 +56,7 @@ export class RecordSet {
     }
 
     getById(id: StoreRecordId): StoreRecord {
-        return this.recordMap.get(id);
+        return this._recordMap.get(id);
     }
 
     getDescendantsById(id: StoreRecordId): StoreRecord[] {
@@ -67,11 +79,42 @@ export class RecordSet {
     isEqual(other: RecordSet): boolean {
         if (this.count !== other.count) return false;
 
-        for (const [id, rec] of this.recordMap) {
-            if (rec !== other.recordMap.get(id)) return false;
+        for (const [id, rec] of this._recordMap) {
+            if (rec !== other.getById(id)) return false;
         }
 
         return true;
+    }
+
+    /**
+     * Changes that would derive this RecordSet from `prev` - the delta contract consumed by
+     * Grid to sync ag-Grid transactionally and by incremental refiltering. Computed here by a
+     * full scan of both sets - implementations with knowledge of their own derivation may
+     * answer far more cheaply.
+     */
+    diffFrom(prev: RecordSet): RecordSetDelta {
+        const update = [],
+            add = [],
+            remove = [];
+
+        if (!prev) return {update, add: this.list, remove};
+
+        this._recordMap.forEach((rec, id) => {
+            const existing = prev.getById(id);
+            if (!existing) {
+                add.push(rec);
+            } else if (existing !== rec) {
+                update.push(rec);
+            }
+        });
+
+        if (this.count !== prev.count + add.length) {
+            prev._recordMap.forEach((rec, id) => {
+                if (!this.getById(id)) remove.push(id);
+            });
+        }
+
+        return {update, add, remove};
     }
 
     //----------------------------------------------------------
@@ -80,12 +123,12 @@ export class RecordSet {
     // clients will never ask for list or tree representations.
     //----------------------------------------------------------
     get childrenMap(): ChildRecordMap {
-        if (!this._childrenMap) this._childrenMap = this.computeChildrenMap(this.recordMap);
+        if (!this._childrenMap) this._childrenMap = this.computeChildrenMap(this._recordMap);
         return this._childrenMap;
     }
 
     get list(): StoreRecord[] {
-        if (!this._list) this._list = Array.from(this.recordMap.values());
+        if (!this._list) this._list = Array.from(this._recordMap.values());
         return this._list;
     }
 
@@ -113,7 +156,15 @@ export class RecordSet {
         return this.isEqual(target) ? target : this;
     }
 
-    withFilter(filter: Filter): RecordSet {
+    /**
+     * Filtered projection of this RecordSet.
+     *
+     * The optional previous filtered state - `prevFiltered` (the last filtered projection) and
+     * `prevSource` (the instance it was projected from) - is unused by this full-pass
+     * implementation, but lets implementations that can diff themselves against `prevSource`
+     * derive the new filtered set incrementally.
+     */
+    withFilter(filter: Filter, prevFiltered?: RecordSet, prevSource?: RecordSet): RecordSet {
         if (!filter) return this;
         const {store} = this,
             includeChildren = store.filterIncludesChildren,
@@ -137,7 +188,7 @@ export class RecordSet {
                 });
             };
         }
-        this.recordMap.forEach(rec => {
+        this._recordMap.forEach(rec => {
             if (!isMarked(rec) && test(rec)) {
                 mark(rec);
                 if (includeChildren) markChildren(rec);
@@ -184,8 +235,7 @@ export class RecordSet {
         const {update, add, remove} = t;
 
         // Be sure to finalize any new records that are accepted.
-        const {recordMap} = this,
-            newRecords = new Map(recordMap);
+        const newRecords = new Map(this._recordMap);
 
         let missingRemoves = 0,
             missingUpdates = 0;

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -89,9 +89,7 @@ export class RecordSet {
 
     /**
      * Changes that would derive this RecordSet from `prev` - the delta contract consumed by
-     * Grid to sync ag-Grid transactionally and by incremental refiltering. Computed here by a
-     * full scan of both sets - implementations with knowledge of their own derivation may
-     * answer far more cheaply.
+     * Grid to sync ag-Grid transactionally.
      */
     diffFrom(prev: RecordSet): RecordSetDelta {
         const update = [],
@@ -157,15 +155,8 @@ export class RecordSet {
         return this.isEqual(target) ? target : this;
     }
 
-    /**
-     * Filtered projection of this RecordSet.
-     *
-     * The optional previous filtered state - `prevFiltered` (the last filtered projection) and
-     * `prevSource` (the instance it was projected from) - is unused by this full-pass
-     * implementation, but lets implementations that can diff themselves against `prevSource`
-     * derive the new filtered set incrementally.
-     */
-    withFilter(filter: Filter, prevFiltered?: RecordSet, prevSource?: RecordSet): RecordSet {
+    withFilter(filter: Filter, prevFiltered: RecordSet): RecordSet {
+        // `prevFiltered` (the previous projection) is unused by this full-pass implementation.
         if (!filter) return this;
         const {store} = this,
             includeChildren = store.filterIncludesChildren,


### PR DESCRIPTION
Early extraction from #4560, moving the RecordSet contract changes to develop ahead of the experimental `PatchableRecordSet` itself. Internal APIs only - no behavior change, no changelog entry. After this, #4560 reduces to the new class plus its opt-in flag.

- **`RecordSet.diffFrom(prev)`** is now part of the RecordSet contract - the record-set delta computation previously inlined in `Grid.genTransaction`. The returned `RecordSetDelta` holds records throughout (`remove` included - both implementations have them in hand), so `genTransaction` collapses to `omitBy(newRs.diffFrom(prevRs), isEmpty)`, with the empty-key stripping staying grid-side as an ag-Grid concern. An implementation that knows its own derivation (the patch-based class in #4560) answers at O(changes) instead of O(n), and the Grid-side difference between the two evaporates.
- **`recordMap` is now private** (`_recordMap`) - `Store` reads individual records via `getById()`, closing off the one external access.
- **`withFilter(filter, prevFiltered)`** - `Store.rebuildFiltered` passes the previous filtered projection. Unused by the full-pass implementation; an incremental implementation stamps each projection with the source it was built from and patches `prevFiltered` with the diff. No further `Store` or `RecordSet` signature changes when #4560 merges.

Verified with a `diffFrom` parity smoke test (brute-force diff cross-check over ticks, adds/removes in one transaction, reloads, filter on/off transitions, null-prev, and self-diff) plus the full store bench at develop parity.
