### PR TITLE
RecordSet.deltaFrom probe + StoreChangeLog.remove as records - extraction from #4560

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
   `ViewManagerModel` or `DashViewModel`, ensuring a software release does not add columns to views
   users have curated and named. They remain available via the column chooser. Set the new
   `GridModelPersistOptions.hideNewColumns` config to `false` to restore the prior behavior.
+* `StoreChangeLog.remove` (returned by `Store.updateData()`) now holds the removed `StoreRecord`s
+  rather than their ids - removed records cannot be resolved against the Store after the fact,
+  making the records themselves the more useful report. Read `record.id` where ids are needed.
 
 ### 🎁 New Features
 

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -278,11 +278,11 @@ export interface StoreTransaction {
 /**
  * Collection of changes made to a Store's RecordSet. Unlike `StoreTransaction` which is used to
  * specify changes, this object is used to report the actual changes made in a single transaction.
+ * Removed records are as they existed prior to removal - no longer resolvable by id.
  */
 export interface StoreChangeLog {
     update?: StoreRecord[];
     add?: StoreRecord[];
-    /** Removed records as they existed prior to removal - no longer resolvable by id. */
     remove?: StoreRecord[];
     summaryRecords?: StoreRecord[];
 }
@@ -705,10 +705,11 @@ export class Store
         if (!isEmpty(remove)) rsTransaction.remove = remove;
 
         if (!isEmpty(rsTransaction)) {
-            // Resolve removed records for the changelog up front - unresolvable post-removal.
-            const removeRecs = rsTransaction.remove
-                ? compact(rsTransaction.remove.map(id => this.getById(id)))
-                : null;
+            // Prepare changelog up front - removed records are unresolvable post-removal.
+            const {update, add, remove: removeIds} = rsTransaction;
+            if (update) changeLog.update = update;
+            if (add) changeLog.add = add;
+            if (removeIds) changeLog.remove = compact(removeIds.map(id => this.getById(id)));
 
             // Apply updates to the committed RecordSet - these changes are considered to be
             // sourced from the server / source of record and are coming in as committed.
@@ -728,7 +729,6 @@ export class Store
             }
 
             this.rebuildFiltered();
-            Object.assign(changeLog, rsTransaction, removeRecs ? {remove: removeRecs} : null);
         }
 
         if (!isEmpty(changeLog)) {

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -28,6 +28,7 @@ import {logWithDebug, throwIf, warnIf} from '@xh/hoist/utils/js';
 import equal from 'fast-deep-equal';
 import {
     castArray,
+    compact,
     defaultsDeep,
     differenceBy,
     first,
@@ -281,7 +282,8 @@ export interface StoreTransaction {
 export interface StoreChangeLog {
     update?: StoreRecord[];
     add?: StoreRecord[];
-    remove?: StoreRecordId[];
+    /** Removed records as they existed prior to removal - no longer resolvable by id. */
+    remove?: StoreRecord[];
     summaryRecords?: StoreRecord[];
 }
 
@@ -703,6 +705,11 @@ export class Store
         if (!isEmpty(remove)) rsTransaction.remove = remove;
 
         if (!isEmpty(rsTransaction)) {
+            // Resolve removed records for the changelog up front - unresolvable post-removal.
+            const removeRecs = rsTransaction.remove
+                ? compact(rsTransaction.remove.map(id => this.getById(id)))
+                : null;
+
             // Apply updates to the committed RecordSet - these changes are considered to be
             // sourced from the server / source of record and are coming in as committed.
             this._committed = this._committed.withTransaction(rsTransaction);
@@ -721,7 +728,7 @@ export class Store
             }
 
             this.rebuildFiltered();
-            Object.assign(changeLog, rsTransaction);
+            Object.assign(changeLog, rsTransaction, removeRecs ? {remove: removeRecs} : null);
         }
 
         if (!isEmpty(changeLog)) {

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -8,8 +8,10 @@
 import {AnyIterable, HoistBase, managed, PlainObject, Some} from '@xh/hoist/core';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {forEachAsync} from '@xh/hoist/utils/async';
+import {throwIf} from '@xh/hoist/utils/js';
 import {defaultsDeep, isArray, isEmpty} from 'lodash';
 import {RecordDigest, Store, StoreRecordIdSpec, StoreTransaction} from '../Store';
+import {RecordSetDelta} from '../impl/RecordSet';
 import {StoreRecord} from '../StoreRecord';
 import {BucketSpec} from './BucketSpec';
 import {CubeField, CubeFieldSpec} from './CubeField';
@@ -314,10 +316,12 @@ export class Cube extends HoistBase {
         }
         this.setInfo(info);
 
-        // No-change loads need only an info/timestamp sync on views - skip row regeneration.
-        const unchanged = store._filtered === prevRecords;
+        // Sync views incrementally on no-change loads and cheaply derivable deltas - see deltaFrom.
+        const {_filtered} = store,
+            unchanged = _filtered === prevRecords,
+            delta = unchanged ? null : _filtered.deltaFrom(prevRecords);
         await forEachAsync(this._connectedViews, v =>
-            unchanged ? v.noteCubeUpdated(null) : v.noteCubeLoaded()
+            unchanged || delta ? v.noteCubeUpdated(delta) : v.noteCubeLoaded()
         );
     }
 
@@ -336,6 +340,11 @@ export class Cube extends HoistBase {
         rawData: PlainObject[] | StoreTransaction,
         infoUpdates: PlainObject = {}
     ): Promise<void> {
+        throwIf(
+            !isArray(rawData) && rawData.rawSummaryData,
+            'Cubes do not support summary records - remove rawSummaryData from this transaction.'
+        );
+
         // 1) Process data
         const changeLog = this.store.updateData(rawData);
 
@@ -345,7 +354,9 @@ export class Cube extends HoistBase {
 
         // 3) Notify connected views
         if (changeLog || hasInfoUpdates) {
-            await forEachAsync(this._connectedViews, v => v.noteCubeUpdated(changeLog));
+            await forEachAsync(this._connectedViews, v =>
+                v.noteCubeUpdated(changeLog as RecordSetDelta)
+            );
         }
     }
 
@@ -365,7 +376,9 @@ export class Cube extends HoistBase {
         const changeLog = this.store.modifyRecords(modifications);
 
         if (changeLog) {
-            await forEachAsync(this._connectedViews, v => v.noteCubeUpdated(changeLog));
+            await forEachAsync(this._connectedViews, v =>
+                v.noteCubeUpdated(changeLog as RecordSetDelta)
+            );
         }
     }
 

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -340,11 +340,6 @@ export class Cube extends HoistBase {
         rawData: PlainObject[] | StoreTransaction,
         infoUpdates: PlainObject = {}
     ): Promise<void> {
-        throwIf(
-            !isArray(rawData) && rawData.rawSummaryData,
-            'Cubes do not support summary records - remove rawSummaryData from this transaction.'
-        );
-
         // 1) Process data
         const changeLog = this.store.updateData(rawData);
 

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -17,7 +17,6 @@ import {
     Query,
     QueryConfig,
     Store,
-    StoreChangeLog,
     StoreRecord,
     StoreRecordId
 } from '@xh/hoist/data';
@@ -30,6 +29,7 @@ import {RowCache} from './impl/RowCache';
 import {BaseRow} from './row/BaseRow';
 import {ExposedLeafRow, HiddenLeafRow, LeafRow} from './row/LeafRow';
 import {AggregateRow, BucketRow} from './row/ParentRow';
+import {RecordSetDelta} from '../impl/RecordSet';
 
 /**
  * Configuration for a {@link View} - a query result from a {@link Cube} that can optionally
@@ -278,14 +278,20 @@ export class View
     //-----------------------
     // Entry point for cube
     //-----------------------
+    /** Full rebuild against current cube data. @internal - called by this View's Cube. */
     @action
     noteCubeLoaded() {
         this.fullUpdate();
     }
 
+    /**
+     * Incremental sync from a report of record-level changes, or null to sync `info` and
+     * timestamps alone.
+     * @internal - called by this View's Cube.
+     */
     @action
-    noteCubeUpdated(changeLog: StoreChangeLog) {
-        const simpleUpdates = this.getSimpleUpdates(changeLog);
+    noteCubeUpdated(changes: RecordSetDelta) {
+        const simpleUpdates = this.getSimpleUpdates(changes);
 
         if (!simpleUpdates) {
             this.fullUpdate();
@@ -598,7 +604,7 @@ export class View
 
     // return a list of simple data updates we can apply to leaves.
     // false if leaf population changing, or aggregations are complex
-    private getSimpleUpdates(t: StoreChangeLog): StoreRecord[] | false {
+    private getSimpleUpdates(t: RecordSetDelta): StoreRecord[] | false {
         if (!t) return [];
         if (!this.aggregatorsAreSimple) return false;
         const {_leafMap, query} = this;
@@ -613,7 +619,7 @@ export class View
         // 2) Examine, accounting for filter
         // 2a) Relevant adds or removes fail us
         if (t.add?.some(rec => query.test(rec))) return false;
-        if (t.remove?.some(r => _leafMap.has(r.id))) return false;
+        if (t.remove?.some(rec => _leafMap.has(rec.id))) return false;
 
         // 2b) Examine updates, if they change w.r.t. filter then fail otherwise take relevant
         const ret = [];

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -613,7 +613,7 @@ export class View
         // 2) Examine, accounting for filter
         // 2a) Relevant adds or removes fail us
         if (t.add?.some(rec => query.test(rec))) return false;
-        if (t.remove?.some(id => _leafMap.has(id))) return false;
+        if (t.remove?.some(r => _leafMap.has(r.id))) return false;
 
         // 2b) Examine updates, if they change w.r.t. filter then fail otherwise take relevant
         const ret = [];

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -278,17 +278,11 @@ export class View
     //-----------------------
     // Entry point for cube
     //-----------------------
-    /** Full rebuild against current cube data. @internal - called by this View's Cube. */
     @action
     noteCubeLoaded() {
         this.fullUpdate();
     }
 
-    /**
-     * Incremental sync from a report of record-level changes, or null to sync `info` and
-     * timestamps alone.
-     * @internal - called by this View's Cube.
-     */
     @action
     noteCubeUpdated(changes: RecordSetDelta) {
         const simpleUpdates = this.getSimpleUpdates(changes);

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -116,6 +116,16 @@ export class RecordSet {
         return {update, add, remove};
     }
 
+    /**
+     * Changes deriving this RecordSet from `prev` when cheaply derivable, null otherwise -
+     * directing consumers to their full fallback paths. Contrast with `diffFrom`, which always
+     * answers, at full-scan cost if needed. Implementations sharing structure across related
+     * instances can answer at O(changes).
+     */
+    deltaFrom(prev: RecordSet): RecordSetDelta {
+        return null;
+    }
+
     //----------------------------------------------------------
     // Lazy getters
     // Avoid memory allocation and work -- in many cases

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -117,10 +117,8 @@ export class RecordSet {
     }
 
     /**
-     * Changes deriving this RecordSet from `prev` when cheaply derivable, null otherwise -
-     * directing consumers to their full fallback paths. Contrast with `diffFrom`, which always
-     * answers, at full-scan cost if needed. Implementations sharing structure across related
-     * instances can answer at O(changes).
+     * As `diffFrom`, but null unless cheaply derivable (i.e. without a full scan) - directing
+     * consumers to their full fallback paths. Always null for this implementation.
      */
     deltaFrom(prev: RecordSet): RecordSetDelta {
         return null;

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -117,8 +117,8 @@ export class RecordSet {
     }
 
     /**
-     * As `diffFrom`, but null unless cheaply derivable (i.e. without a full scan) - directing
-     * consumers to their full fallback paths. Always null for this implementation.
+     * As `diffFrom`, but only provided if cheaply derivable (i.e. without a full scan).
+     * Always null for this implementation.
      */
     deltaFrom(prev: RecordSet): RecordSetDelta {
         return null;


### PR DESCRIPTION
Third early extraction from #4560 - the delta contract and its consumers, ready for develop on their own:

- **`RecordSet.deltaFrom(prev)`** - as `diffFrom`, but null unless cheaply derivable (i.e. without a full scan), directing consumers to their full fallback paths. Always null for the classic full-scan implementation; the patch-based class in #4560 answers at O(changes) when instances share a base.

- **`Cube.loadDataAsync` routes reload deltas to connected `View`s** - loads with cheaply derivable record-level changes sync views through the same incremental path as `updateDataAsync`, falling back to `noteCubeLoaded` otherwise. Dormant on develop (classic `deltaFrom` always answers null - behavior byte-identical today); lights up under #4560's experimental flag, where mostly-unchanged polled reloads stop regenerating every view's rows.

- **View entry points hardened**: `noteCubeLoaded`/`noteCubeUpdated` marked `@internal` and typed on `RecordSetDelta` - cube data never carries summary records, now stated by the type. `updateDataAsync` rejects `rawSummaryData` outright (previously a latent crash deep in View).

- **`StoreChangeLog.remove` now holds the removed `StoreRecord`s rather than their ids.** Removed records cannot be resolved against the Store after the fact, making the records themselves the more useful report. The changelog is now prepared in one block up front in `updateData`; ids requested for records that did not exist are no longer echoed back. Breaking for apps reading `changeLog.remove` - adapt via `record.id` - noted in the v87 changelog.

Verified with the `diffFrom` brute-force parity smoke and a mode-aware cube smoke asserting the classic (dormant) behavior end-to-end: value-only/add/identical/big reloads all take their expected paths with correct aggregates.
