### PR TITLE
Fix GridModel.leafColumnMap staleness

### DIFF
--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -550,6 +550,12 @@ export class GridModel extends HoistModel {
     @observable.ref groupBy: string[] = null;
     @observable expandLevel: number = 0;
 
+    // Kept alive, as the primary reader `getColumn()` is often called outside of a reaction.
+    @computed({keepAlive: true})
+    private get leafColumnMap(): Map<string, Column> {
+        return new Map(this.getLeafColumns().map(it => [it.colId, it]));
+    }
+
     @computed.struct
     get persistableColumnState(): ColumnState[] {
         return this.cleanColumnState(this.columnState);
@@ -1151,7 +1157,7 @@ export class GridModel extends HoistModel {
     setGroupBy(colIds: Some<string>) {
         colIds = isNil(colIds) ? [] : castArray(colIds);
 
-        const invalidColIds = colIds.filter(it => !this.findColumn(this.columns, it));
+        const invalidColIds = colIds.filter(it => !this.getColumn(it));
         if (invalidColIds.length) {
             this.logWarn(
                 'Unknown colId specified in groupBy - grid will not be grouped.',
@@ -1237,7 +1243,7 @@ export class GridModel extends HoistModel {
 
         // Allow sorts associated with Hoist columns as well as ag-Grid dynamic grouping columns
         const invalidSorters = newSorters.filter(
-            it => !it.colId?.startsWith('ag-Grid') && !this.findColumn(this.columns, it.colId)
+            it => !it.colId?.startsWith('ag-Grid') && !this.getColumn(it.colId)
         );
         if (invalidSorters.length) {
             this.logWarn('GridSorter colId not found in grid columns', invalidSorters);
@@ -1305,7 +1311,7 @@ export class GridModel extends HoistModel {
     noteAgColumnStateChanged(agColState: AgColumnState[]) {
         const colStateChanges: Partial<ColumnState>[] = agColState.map(
             ({colId, width, hide, pinned}) => {
-                const col = this.findColumn(this.columns, colId);
+                const col = this.getColumn(colId);
                 if (!col) return null;
                 return {
                     colId,
@@ -1345,7 +1351,7 @@ export class GridModel extends HoistModel {
     }
 
     noteColumnManuallySized(colId, width) {
-        const col = this.findColumn(this.columns, colId);
+        const col = this.getColumn(colId);
         if (!width || !col || col.flex) return;
         const colStateChanges = [{colId, width, manuallySized: true}];
         this.updateColumnState(colStateChanges);
@@ -1385,7 +1391,7 @@ export class GridModel extends HoistModel {
         });
 
         // 2) If the changes provided is a full list of leaf columns, synchronize the sort order
-        if (colStateChanges.length === this.getLeafColumns().length) {
+        if (colStateChanges.length === this.leafColumnMap.size) {
             columnState = colStateChanges.map(c => find(columnState, {colId: c.colId}));
         }
 
@@ -1395,7 +1401,7 @@ export class GridModel extends HoistModel {
     }
 
     getColumn(colId: string): Column {
-        return this.findColumn(this.columns, colId);
+        return this.leafColumnMap.get(colId) ?? null;
     }
 
     getColumnGroup(groupId: string): ColumnGroup {
@@ -1838,7 +1844,7 @@ export class GridModel extends HoistModel {
 
         // REMOVE any state columns that are no longer found in the grid. These were likely saved
         // under a prior release of the app and have since been removed from the code.
-        let ret = columnState.filter(({colId}) => this.findColumn(gridCols, colId));
+        let ret = columnState.filter(({colId}) => this.getColumn(colId));
 
         // ADD any grid columns that are not found in state. These are newly added to the code.
         // Insert these columns in position based on the index at which they are defined.
@@ -1857,7 +1863,7 @@ export class GridModel extends HoistModel {
         });
 
         ret = ret.map(state => {
-            const col = this.findColumn(gridCols, state.colId);
+            const col = this.getColumn(state.colId);
 
             // Remove the width from any non-resizable column - we don't want to track those widths as
             // they are set programmatically (e.g. fixed / action columns), and saved state should not


### PR DESCRIPTION
Follow-up to #4409, which introduced `leafColumnMap` as a field rebuilt alongside `columns` in `setColumns()`.

`columns` is public and writable, so any `gridModel.columns = [...]` outside `setColumns()` leaves the map stale, and `getColumn()` then returns `null` for every column - silently breaking `setGroupBy` (rejects valid colIds as unknown), `setSortBy` (drops all sorters), `noteAgColumnStateChanged` (skips every column), and `cleanColumnState` (discards saved state as no longer in the grid).

Deriving the map as a `@computed` over `columns` keeps the O(1) lookup and removes the invariant entirely.

Marked `keepAlive` because `getColumn()` has hot callers outside any reaction - notably `cleanColumnState()`, which calls it once per column. An unobserved computed rebuilds on every read, which would turn that loop back into O(n²) and give back the win #4409 set out to get. That's a new pattern in this repo, so worth a look.