### PR TITLE
Identify the offending aggregator in AggregationContext.filteredRecords error

### DIFF
--- a/data/cube/aggregate/AggregationContext.ts
+++ b/data/cube/aggregate/AggregationContext.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 
-import {throwIf} from '@xh/hoist/utils/js';
+import {XH} from '@xh/hoist/core';
 import {StoreRecord} from '../../StoreRecord';
 import {View} from '../View';
 
@@ -27,24 +27,44 @@ export class AggregationContext {
     appData: any;
 
     /**
+     * Name of the field currently being aggregated - set by row implementations immediately before
+     * each call into an aggregator, and used to identify the aggregator in error messages.
+     * @internal
+     */
+    activeFieldName: string = null;
+
+    /**
      * All records currently meeting the filter for this view.
      *
-     * Available only when an aggregator on the view declares
-     * {@link Aggregator.dependsOnChildrenOnly} as false - the View then rebuilds its filtered
-     * records before every aggregation pass. Views with children-only aggregators update
+     * Available only when an aggregator on the view overrides
+     * {@link Aggregator.dependsOnChildrenOnly} to return false - the View then rebuilds its
+     * filtered records before every aggregation pass. Views with children-only aggregators update
      * incrementally without refreshing that collection, so reading it here throws.
      */
     get filteredRecords(): StoreRecord[] {
         const {view} = this;
-        throwIf(
-            view.aggregatorsAreSimple,
-            'filteredRecords is available only when an aggregator declares `dependsOnChildrenOnly` as false - aggregators depending on records beyond their own children must do so.'
-        );
+        // Note error message built lazily - this getter is called throughout aggregation.
+        if (view.aggregatorsAreSimple) {
+            throw XH.exception(
+                `${this.activeAggregatorDescription} read \`filteredRecords\` but does not override \`dependsOnChildrenOnly\` to return false. ` +
+                    'Aggregators reading records beyond their own children must do so.'
+            );
+        }
         return view._records.list;
     }
 
     constructor(view: View) {
         this.view = view;
         this.appData = {};
+    }
+
+    /** Identify the in-progress aggregator by its class + field, for error reporting. */
+    private get activeAggregatorDescription(): string {
+        const {activeFieldName, view} = this,
+            aggregator = activeFieldName ? view.getField(activeFieldName)?.aggregator : null;
+
+        return aggregator
+            ? `${aggregator.constructor.name} for the ${activeFieldName} field`
+            : 'An aggregator on this Cube View';
     }
 }

--- a/data/cube/aggregate/AggregationContext.ts
+++ b/data/cube/aggregate/AggregationContext.ts
@@ -7,8 +7,10 @@
 
 import {XH} from '@xh/hoist/core';
 import {StoreRecord} from '../../StoreRecord';
+import type {CubeField} from '../CubeField';
+import type {BaseRow} from '../row/BaseRow';
+import type {RowUpdate} from '../row/RowUpdate';
 import {View} from '../View';
-import {CubeField} from '@xh/hoist/data';
 
 /**
  * Context provided to aggregators.
@@ -28,8 +30,7 @@ export class AggregationContext {
     appData: any;
 
     /**
-     * The cube field currently being aggregated - set by row implementations immediately before
-     * each call into an aggregator, and used to identify the aggregator in error messages.
+     * Field currently being aggregated, or null if not within a call to an aggregator.
      * @internal
      */
     activeField: CubeField = null;
@@ -39,14 +40,14 @@ export class AggregationContext {
      *
      * Available only when an aggregator on the view overrides
      * {@link Aggregator.dependsOnChildrenOnly} to return false.
+     * Views with children-only aggregators update incrementally without
+     * refreshing that collection, so reading it here throws.
      */
     get filteredRecords(): StoreRecord[] {
-        const {activeField, view} = this,
-            agg = activeField?.aggregator;
-        if (agg?.dependsOnChildrenOnly) {
-            const label = `${agg.constructor.name} for the ${activeField.name} field`;
+        const {activeField, view} = this;
+        if (activeField?.aggregator.dependsOnChildrenOnly) {
             throw XH.exception(
-                `${label} read \`filteredRecords\` but does not override \`dependsOnChildrenOnly\` to return false. `
+                `The aggregator for the '${activeField.name}' field read \`filteredRecords\`, but does not override \`dependsOnChildrenOnly\` to return false - aggregators depending on records beyond their own children must do so.`
             );
         }
         return view._records.list;
@@ -55,5 +56,33 @@ export class AggregationContext {
     constructor(view: View) {
         this.view = view;
         this.appData = {};
+    }
+
+    /**
+     * Aggregate the given rows for a field, tracking the field as active for the duration.
+     * @internal
+     */
+    aggregate(rows: BaseRow[], field: CubeField): any {
+        this.activeField = field;
+        try {
+            return field.aggregator.aggregate(rows, field.name, this);
+        } finally {
+            this.activeField = null;
+        }
+    }
+
+    /**
+     * Adjust an aggregated value for a single child update, tracking the updated field as active
+     * for the duration.
+     * @internal
+     */
+    replace(rows: BaseRow[], currVal: any, update: RowUpdate): any {
+        const {field} = update;
+        this.activeField = field;
+        try {
+            return field.aggregator.replace(rows, currVal, update, this);
+        } finally {
+            this.activeField = null;
+        }
     }
 }

--- a/data/cube/aggregate/AggregationContext.ts
+++ b/data/cube/aggregate/AggregationContext.ts
@@ -8,6 +8,7 @@
 import {XH} from '@xh/hoist/core';
 import {StoreRecord} from '../../StoreRecord';
 import {View} from '../View';
+import {CubeField} from '@xh/hoist/data';
 
 /**
  * Context provided to aggregators.
@@ -27,27 +28,25 @@ export class AggregationContext {
     appData: any;
 
     /**
-     * Name of the field currently being aggregated - set by row implementations immediately before
+     * The cube field currently being aggregated - set by row implementations immediately before
      * each call into an aggregator, and used to identify the aggregator in error messages.
      * @internal
      */
-    activeFieldName: string = null;
+    activeField: CubeField = null;
 
     /**
      * All records currently meeting the filter for this view.
      *
      * Available only when an aggregator on the view overrides
-     * {@link Aggregator.dependsOnChildrenOnly} to return false - the View then rebuilds its
-     * filtered records before every aggregation pass. Views with children-only aggregators update
-     * incrementally without refreshing that collection, so reading it here throws.
+     * {@link Aggregator.dependsOnChildrenOnly} to return false.
      */
     get filteredRecords(): StoreRecord[] {
-        const {view} = this;
-        // Note error message built lazily - this getter is called throughout aggregation.
-        if (view.aggregatorsAreSimple) {
+        const {activeField, view} = this,
+            agg = activeField?.aggregator;
+        if (agg?.dependsOnChildrenOnly) {
+            const label = `${agg.constructor.name} for the ${activeField.name} field`;
             throw XH.exception(
-                `${this.activeAggregatorDescription} read \`filteredRecords\` but does not override \`dependsOnChildrenOnly\` to return false. ` +
-                    'Aggregators reading records beyond their own children must do so.'
+                `${label} read \`filteredRecords\` but does not override \`dependsOnChildrenOnly\` to return false. `
             );
         }
         return view._records.list;
@@ -56,15 +55,5 @@ export class AggregationContext {
     constructor(view: View) {
         this.view = view;
         this.appData = {};
-    }
-
-    /** Identify the in-progress aggregator by its class + field, for error reporting. */
-    private get activeAggregatorDescription(): string {
-        const {activeFieldName, view} = this,
-            aggregator = activeFieldName ? view.getField(activeFieldName)?.aggregator : null;
-
-        return aggregator
-            ? `${aggregator.constructor.name} for the ${activeFieldName} field`
-            : 'An aggregator on this Cube View';
     }
 }

--- a/data/cube/aggregate/Aggregator.ts
+++ b/data/cube/aggregate/Aggregator.ts
@@ -30,6 +30,8 @@ export abstract class Aggregator {
      * By default this property returns true, indicating to the cube that if all children of a
      * given node are the same, the node does not need to be re-aggregated.  Aggregators that
      * depend on global values (e.g. % of total) should return false for this value.
+     *
+     * Aggregators that delegate to other aggregators must all agree on this setting.
      */
     get dependsOnChildrenOnly(): boolean {
         return true;

--- a/data/cube/row/ParentRow.ts
+++ b/data/cube/row/ParentRow.ts
@@ -66,6 +66,7 @@ export abstract class ParentRow extends BaseRow {
             ctx = view._aggContext;
         view._aggFieldsByDepth[this.depth].forEach(({aggregator, name}) => {
             if (canAggResults?.[name] !== false) {
+                ctx.activeFieldName = name;
                 data[name] = aggregator.aggregate(children, name, ctx);
             }
         });
@@ -83,6 +84,7 @@ export abstract class ParentRow extends BaseRow {
             const {field} = update,
                 {name} = field;
             if (aggFieldNames.has(name) && canAggResults?.[name] !== false) {
+                ctx.activeFieldName = name;
                 const oldValue = data[name],
                     newValue = field.aggregator.replace(children, oldValue, update, ctx);
                 update.oldValue = oldValue;
@@ -140,10 +142,11 @@ export abstract class ParentRow extends BaseRow {
     private recomputeAggregate(field: CubeField): boolean {
         const {children, data, view} = this,
             {aggregator, name} = field,
-            val =
-                this.canAggResults?.[name] !== false
-                    ? aggregator.aggregate(children, name, view._aggContext)
-                    : null;
+            ctx = view._aggContext;
+
+        ctx.activeFieldName = name;
+        const val =
+            this.canAggResults?.[name] !== false ? aggregator.aggregate(children, name, ctx) : null;
 
         if (data[name] === val) return false;
 

--- a/data/cube/row/ParentRow.ts
+++ b/data/cube/row/ParentRow.ts
@@ -64,11 +64,10 @@ export abstract class ParentRow extends BaseRow {
         // initial computation of aggregates
         const {data, canAggResults} = this,
             ctx = view._aggContext;
-        view._aggFieldsByDepth[this.depth].forEach(f => {
-            const {aggregator, name} = f;
+        view._aggFieldsByDepth[this.depth].forEach(field => {
+            const {name} = field;
             if (canAggResults?.[name] !== false) {
-                ctx.activeField = f;
-                data[name] = aggregator.aggregate(children, name, ctx);
+                data[name] = ctx.aggregate(children, field);
             }
         });
     }
@@ -85,9 +84,8 @@ export abstract class ParentRow extends BaseRow {
             const {field} = update,
                 {name} = field;
             if (aggFieldNames.has(name) && canAggResults?.[name] !== false) {
-                ctx.activeField = field;
                 const oldValue = data[name],
-                    newValue = field.aggregator.replace(children, oldValue, update, ctx);
+                    newValue = ctx.replace(children, oldValue, update);
                 update.oldValue = oldValue;
                 update.newValue = newValue;
                 myUpdates.push(update);
@@ -142,12 +140,11 @@ export abstract class ParentRow extends BaseRow {
     // Re-aggregate a single field in place, returning true if its value changed.
     private recomputeAggregate(field: CubeField): boolean {
         const {children, data, view} = this,
-            {aggregator, name} = field,
-            ctx = view._aggContext;
-
-        ctx.activeField = field;
-        const val =
-            this.canAggResults?.[name] !== false ? aggregator.aggregate(children, name, ctx) : null;
+            {name} = field,
+            val =
+                this.canAggResults?.[name] !== false
+                    ? view._aggContext.aggregate(children, field)
+                    : null;
 
         if (data[name] === val) return false;
 

--- a/data/cube/row/ParentRow.ts
+++ b/data/cube/row/ParentRow.ts
@@ -64,9 +64,10 @@ export abstract class ParentRow extends BaseRow {
         // initial computation of aggregates
         const {data, canAggResults} = this,
             ctx = view._aggContext;
-        view._aggFieldsByDepth[this.depth].forEach(({aggregator, name}) => {
+        view._aggFieldsByDepth[this.depth].forEach(f => {
+            const {aggregator, name} = f;
             if (canAggResults?.[name] !== false) {
-                ctx.activeFieldName = name;
+                ctx.activeField = f;
                 data[name] = aggregator.aggregate(children, name, ctx);
             }
         });
@@ -84,7 +85,7 @@ export abstract class ParentRow extends BaseRow {
             const {field} = update,
                 {name} = field;
             if (aggFieldNames.has(name) && canAggResults?.[name] !== false) {
-                ctx.activeFieldName = name;
+                ctx.activeField = field;
                 const oldValue = data[name],
                     newValue = field.aggregator.replace(children, oldValue, update, ctx);
                 update.oldValue = oldValue;
@@ -144,7 +145,7 @@ export abstract class ParentRow extends BaseRow {
             {aggregator, name} = field,
             ctx = view._aggContext;
 
-        ctx.activeFieldName = name;
+        ctx.activeField = field;
         const val =
             this.canAggResults?.[name] !== false ? aggregator.aggregate(children, name, ctx) : null;
 


### PR DESCRIPTION
The throw raised when an aggregator reads `filteredRecords` without overriding `dependsOnChildrenOnly` now names the aggregator class and the field being aggregated, making it actionable from a user-reported screenshot alone.

Before:
> filteredRecords is available only when an aggregator declares `dependsOnChildrenOnly` as false - aggregators depending on records beyond their own children must do so.

After:
> ProportionAggregator for the pctTotalBillings field read `filteredRecords` but does not override `dependsOnChildrenOnly` to return false. Aggregators reading records beyond their own children must do so.

* Added an internal `AggregationContext.activeFieldName`, set by `ParentRow` immediately before each call into an aggregator - the three sites in `ParentRow` are the only entry points into `Aggregator.aggregate()`/`replace()`. Falls back to a generic message if unset.
* Message is now built lazily on the error path only, as this getter runs throughout aggregation.

No changelog entry - the throw itself is new in the unreleased v87 cycle and this only sharpens its message.