### PR TITLE
Add Query.autoIncludeDimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ configs for zero-copy projection, digest-based record reuse, and streaming loads
   and republishing only values that actually changed - so e.g. dropping a trailing dimension
   republishes nothing above the level that moved, and connected stores and grids skip the
   matching record rebuilds.
+* Added `QueryConfig.autoIncludeDimensions` (default `true`, the established behavior). Set
+  `false` to keep an explicit `fields` list exactly as specified: dimension values are then not
+  published on row data, so row shape no longer varies with grouping and every leaf survives any
+  regroup. If you set this flag and need these values for grid columns or in your
+  `lockFn`/`omitFn`/`bucketSpecFn`, specify your dimension explicitly in `fields`.
 * Added `CubeConfig.reuseRecords`, passed through to the Cube's internal Store. A source that
   supplies per-row digests can now preserve record identity across full `Cube.loadDataAsync()`
   reloads, extending View row reuse to wholesale refreshes.

--- a/data/cube/Query.ts
+++ b/data/cube/Query.ts
@@ -56,6 +56,17 @@ export interface QueryConfig {
     dimensions?: string[] | CubeField[];
 
     /**
+     * True (default) to automatically include `dimensions` in `fields`, publishing each applied
+     * dimension's value on the row data of its aggregate rows and leaves.
+     *
+     * False to leave `fields` exactly as specified - dimension values are then not published on
+     * row data at all, with grouping expressed only via tree structure, row ids and
+     * `cubeLabel`/`cubeDimension`. Note `fields` defaults to all Cube fields when unspecified,
+     * so an explicit `fields` list is required for this option to have any effect.
+     */
+    autoIncludeDimensions?: boolean;
+
+    /**
      * Filters to apply to leaf data, or configs to create. Note that leaf data will be filtered
      * and then aggregated - i.e. the filters provided here will filter in/out the lowest level
      * facts and _won't_ operate directly on any aggregates.
@@ -137,10 +148,12 @@ export interface QueryConfig {
  */
 export class Query {
     /**
-     * Queried fields, sorted by name. Includes `dimensions`, added here if not already present.
+     * Queried fields, sorted by name. Includes `dimensions`, added here if not already present,
+     * unless `autoIncludeDimensions` was set to false.
      */
     readonly fields: CubeField[];
     readonly dimensions: CubeField[];
+    readonly autoIncludeDimensions: boolean;
     readonly filter: Filter;
     readonly hasFilter: boolean;
     readonly includeRoot: boolean;
@@ -159,6 +172,7 @@ export class Query {
         cube,
         fields,
         dimensions,
+        autoIncludeDimensions = true,
         filter = null,
         includeRoot = false,
         includeLeaves = false,
@@ -171,9 +185,13 @@ export class Query {
         this.cube = cube;
         this._rawFields = fields?.slice();
         this.dimensions = this.parseDimensions(dimensions);
+        this.autoIncludeDimensions = autoIncludeDimensions;
         // Ensure canonical field order so equivalent queries compare equal
         this.fields = sortBy(
-            uniq([...this.parseFields(fields), ...(this.dimensions ?? [])]),
+            uniq([
+                ...this.parseFields(fields),
+                ...(autoIncludeDimensions ? (this.dimensions ?? []) : [])
+            ]),
             'name'
         );
         this.includeRoot = includeRoot;
@@ -193,6 +211,7 @@ export class Query {
         const conf = {
             dimensions: this.dimensions,
             fields: this._rawFields, // NOT this.fields - would retain stale dimensions
+            autoIncludeDimensions: this.autoIncludeDimensions,
             filter: this.filter,
             includeRoot: this.includeRoot,
             includeLeaves: this.includeLeaves,
@@ -230,6 +249,7 @@ export class Query {
         return (
             isEqual(this.fields, other.fields) &&
             isEqual(this.dimensions, other.dimensions) &&
+            this.autoIncludeDimensions === other.autoIncludeDimensions &&
             this.cube === other.cube &&
             this.includeRoot === other.includeRoot &&
             this.includeLeaves === other.includeLeaves &&

--- a/data/cube/README.md
+++ b/data/cube/README.md
@@ -169,7 +169,12 @@ view.setFilter({field: 'year', op: '=', value: 2025});
 
 Query updates are highly incremental - the View caches its generated rows and republishes
 unchanged rows (and their record-reuse digests) across regrouping, refiltering, and field
-changes, so connected stores and grids only process rows that actually changed.
+changes, so connected stores and grids only process rows that actually changed. Note that
+`dimensions` are auto-included in `fields` by default, which makes the published row shape a
+function of the current grouping. Queries with an explicit `fields` list can set
+`autoIncludeDimensions: false` to keep row shape fully grouping-independent - maximizing reuse
+across regroups - in exchange for dimension values not being published on row data at all. See
+`QueryConfig.autoIncludeDimensions` for the trade-offs.
 
 **One-shot queries with `executeQuery`:**
 

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -246,9 +246,13 @@ export class View
 
     /** Gather all unique values for each dimension field in the query. */
     getDimensionValues(): DimensionValue[] {
-        const ret = this.query.fields
-            .filter(it => it.isDimension)
-            .map(field => ({field, values: new Set<any>()}));
+        // Applied dimensions are appended for queries that do not auto-include them in fields.
+        const {query} = this,
+            dimFields = uniq([
+                ...query.fields.filter(it => it.isDimension),
+                ...(query.dimensions ?? [])
+            ]),
+            ret = dimFields.map(field => ({field, values: new Set<any>()}));
 
         this._leafMap.forEach(leaf => {
             const {data} = leaf.cubeRecord;

--- a/data/cube/row/ParentRow.ts
+++ b/data/cube/row/ParentRow.ts
@@ -7,7 +7,7 @@
 
 import {PlainObject} from '@xh/hoist/core';
 import {shallowEqualArrays} from '@xh/hoist/utils/impl';
-import {isEmpty} from 'lodash';
+import {forEach, isEmpty} from 'lodash';
 import {BucketSpec} from '../BucketSpec';
 import {CubeField} from '../CubeField';
 import {View} from '../View';
@@ -51,7 +51,9 @@ export abstract class ParentRow extends BaseRow {
         this.children = children;
         children.forEach(it => (it.parent = this));
 
-        Object.assign(this.data, appliedDimensions);
+        forEach(appliedDimensions, (v, name) => {
+            if (name in this.data) this.data[name] = v;
+        });
         this.depth = depth;
 
         // Needed to re-evaluate any `canAggregateFn` - clone, as the View mutates its copy as it
@@ -216,9 +218,12 @@ export class AggregateRow extends ParentRow {
         return this.dimName;
     }
 
-    // Value of `dim` on `data`, never aggregated over - or 'Total' for a dimension-less summary.
+    // Value of `dim` at this row - or 'Total' for a dimension-less summary. Read from the
+    // retained `appliedDimensions` rather than `data`, where the value may not be published -
+    // see Query.autoIncludeDimensions. Only consumed by a `canAggregateFn` (via
+    // evalCanAggregate), exactly the condition under which `appliedDimensions` is retained.
     protected get dimOrBucketVal(): any {
-        return this.dim ? this.data[this.dimName] : this.dimName;
+        return this.dim ? this.appliedDimensions[this.dimName] : this.dimName;
     }
 
     constructor(


### PR DESCRIPTION
Pulled out of #4570 before that merged, to land after the v78 release.

Adds `QueryConfig.autoIncludeDimensions` (default `true`, the established behavior). Set `false` to keep an explicit `fields` list exactly as specified: dimension values are then not published on row data, so row shape no longer varies with grouping and every leaf survives any regroup - maximizing View row reuse across regroups.

If you set this flag and need dimension values for grid columns or in a `lockFn`/`omitFn`/`bucketSpecFn`, list the dimension explicitly in `fields`.