### PR TITLE
Getter-based row data for exposed Cube View leaves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ configs for zero-copy projection, digest-based record reuse, and streaming loads
 * Improved Cube `View` memory efficiency across all row types - `ViewRowData` rows now share
   compact fixed shapes, and leaf rows read field values directly from their source cube records
   instead of holding copies. Substantially reduces per-row memory and speeds up view builds, with
-  savings that scale with query width - see related Breaking Changes.
+  savings that scale with query width.
 * Added an opt-in `Store.projectionOnly` config to mark a store as a read-only projection of data
   that its provider parses and owns. Use it for stores connected to a Cube `View`, or fed by an
   endpoint that returns data in its final client-side form. Records reference the provider's row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,6 @@ features and performance optimizations, grouped by topic below.
   `JSON.stringify()` on this object does not reliably see default field values. Use
   `StoreRecord.getValues()` or `getModifiedValues()` instead. This never worked reliably, but the
   new memory optimizations in this release make it much more likely to cause a problem.
-* Leaf rows exposed by Cube `View`s (via `Query.includeLeaves` or `provideLeaves`) now read their
-  field values through generated prototype getters over the source cube record's data. Read values
-  by field name only - spreading or calling `JSON.stringify()` on a leaf row no longer captures
-  field values, and leaf field keys are now read-only.
 * `StoreChangeLog.remove` (returned by `Store.updateData()`) now holds the removed `StoreRecord`s
   instead of their ids. Removed records cannot be resolved against the Store after the fact, so the
   records themselves are the more useful report. Read `record.id` where you need ids.
@@ -79,17 +75,10 @@ configs for zero-copy projection, digest-based record reuse, and streaming loads
   non-default values: the established sparse form for lightly-populated records, and a fixed shape
   cloned from a shared per-Store template for wider records. This avoids V8's memory-hungry
   "dictionary" mode and substantially reduces per-record memory on stores with wide records.
-* Improved Cube `View` memory efficiency - each `View` now clones its `ViewRowData` rows from a
-  shared template, so all rows in a View share one compact, fixed shape. This substantially reduces
-  per-row memory and speeds up view builds, especially for queries with many fields.
-* Cube `View`s no longer copy leaf row data when their results do not expose leaves (neither
-  `includeLeaves` nor `provideLeaves` set). Leaf rows read directly from cube records, which
-  eliminates per-View leaf data objects and speeds up view builds for aggregate-only views over
-  large datasets. Such views no longer publish a `View.result.leafMap` - see Breaking Changes.
-* Improved Cube `View` memory efficiency for views that do expose leaf rows - leaf `ViewRowData`
-  now reads field values directly from its source cube record via generated prototype getters,
-  eliminating the per-leaf copy of queried field values. Substantially reduces View memory - with
-  savings that scale with query width - and speeds up view builds. See Breaking Changes.
+* Improved Cube `View` memory efficiency across all row types - `ViewRowData` rows now share
+  compact fixed shapes, and leaf rows read field values directly from their source cube records
+  instead of holding copies. Substantially reduces per-row memory and speeds up view builds, with
+  savings that scale with query width - see related Breaking Changes.
 * Added an opt-in `Store.projectionOnly` config to mark a store as a read-only projection of data
   that its provider parses and owns. Use it for stores connected to a Cube `View`, or fed by an
   endpoint that returns data in its final client-side form. Records reference the provider's row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ features and performance optimizations, grouped by topic below.
   `JSON.stringify()` on this object does not reliably see default field values. Use
   `StoreRecord.getValues()` or `getModifiedValues()` instead. This never worked reliably, but the
   new memory optimizations in this release make it much more likely to cause a problem.
+* Leaf rows exposed by Cube `View`s (via `Query.includeLeaves` or `provideLeaves`) now read their
+  field values through generated prototype getters over the source cube record's data. Read values
+  by field name only - spreading or calling `JSON.stringify()` on a leaf row no longer captures
+  field values, and leaf field keys are now read-only.
 * `StoreChangeLog.remove` (returned by `Store.updateData()`) now holds the removed `StoreRecord`s
   instead of their ids. Removed records cannot be resolved against the Store after the fact, so the
   records themselves are the more useful report. Read `record.id` where you need ids.
@@ -82,6 +86,10 @@ configs for zero-copy projection, digest-based record reuse, and streaming loads
   `includeLeaves` nor `provideLeaves` set). Leaf rows read directly from cube records, which
   eliminates per-View leaf data objects and speeds up view builds for aggregate-only views over
   large datasets. Such views no longer publish a `View.result.leafMap` - see Breaking Changes.
+* Improved Cube `View` memory efficiency for views that do expose leaf rows - leaf `ViewRowData`
+  now reads field values directly from its source cube record via generated prototype getters,
+  eliminating the per-leaf copy of queried field values. Substantially reduces View memory - with
+  savings that scale with query width - and speeds up view builds. See Breaking Changes.
 * Added an opt-in `Store.projectionOnly` config to mark a store as a read-only projection of data
   that its provider parses and owns. Use it for stores connected to a Cube `View`, or fed by an
   endpoint that returns data in its final client-side form. Records reference the provider's row

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -27,6 +27,7 @@ import {throwIf} from '@xh/hoist/utils/js';
 import {castArray, find, forEach, groupBy, isEmpty, isNil, map, uniq} from 'lodash';
 import {AggregationContext} from './aggregate/AggregationContext';
 import {RowCache} from './impl/RowCache';
+import {RowDataGenerator} from './impl/RowDataGenerator';
 import {BaseRow} from './row/BaseRow';
 import {ExposedLeafRow, HiddenLeafRow, LeafRow} from './row/LeafRow';
 import {AggregateRow, BucketRow} from './row/ParentRow';
@@ -144,7 +145,7 @@ export class View
     private _leafMap: Map<StoreRecordId, LeafRow> = null;
     _records: RecordSet = null; // cube records passing this view's filter
     private _bucketDependentFields = new Set<string>();
-    private _rowDataTemplate: ViewRowData = null;
+    _rowDataGenerator: RowDataGenerator = null;
     // Monotonic source for cubeRowDigest stamps - safe-integer headroom spans centuries of use.
     _rowDigest = 0;
     // Fields eligible for aggregation at each level of the query - i.e. those with an aggregator
@@ -168,7 +169,8 @@ export class View
         this.query = query;
         this.stores = this.parseStores(stores);
         this._rowCache = new RowCache(this);
-        this.buildRowTemplates();
+        this._rowDataGenerator = new RowDataGenerator(this);
+        this.buildAggFields();
         this.fullUpdate('query', start);
 
         if (connect) {
@@ -229,7 +231,8 @@ export class View
         if (oldQuery.equals(newQuery)) return;
 
         this.query = newQuery;
-        this.buildRowTemplates();
+        this._rowDataGenerator.onQueryChange();
+        this.buildAggFields();
 
         // If the cube is changing potentially disconnect from the old cube and connect to the new
         const {cube: oldCube} = oldQuery,
@@ -322,39 +325,30 @@ export class View
     }
 
     /**
-     * Create a new row data object as a clone of this View's shared template, which carries a
-     * slot for every ViewRowData property and query field. Rows are only ever written via
-     * overwrites of these slots - never property adds - so rows minted for a given query share
-     * one fixed shape, keeping them in V8's compact fast-properties mode rather than
-     * "dictionary mode".
+     * Create a new aggregate or bucket row data object.
      * @internal
      */
-    newRowData(id: string): ViewRowData {
-        return {...this._rowDataTemplate, id, cubeRowDigest: ++this._rowDigest};
+    newParentRowData(id: string): ViewRowData {
+        const ret = this._rowDataGenerator.newParentRowData(id);
+        this.assignDigest(ret);
+        return ret;
     }
 
-    noteRowDataMutated(data: PlainObject) {
+    /**
+     * Create the data object for an exposed leaf row.
+     * @internal
+     */
+    newLeafRowData(id: string, src: PlainObject): ViewRowData {
+        const ret = this._rowDataGenerator.newLeafRowData(id, src);
+        this.assignDigest(ret);
+        return ret;
+    }
+
+    assignDigest(data: ViewRowData) {
         data.cubeRowDigest = ++this._rowDigest;
     }
 
-    // Templates depend on the query's field set - rebuilt on any query change.
-    private buildRowTemplates() {
-        const rowData: PlainObject = {
-            id: null,
-            cubeRowType: null,
-            cubeLabel: null,
-            cubeDimension: null,
-            cubeBuckets: null,
-            children: null,
-            isCubeLeaf: false,
-            cubeRowDigest: null,
-            _cubeLeafChildren: null
-        };
-        this.fields.forEach(({name}) => (rowData[name] = null));
-
-        // Convert into V8 fast-properties mode that we'll need to mint additional fast objects
-        this._rowDataTemplate = {...rowData} as ViewRowData;
-
+    private buildAggFields() {
         // Aggregation eligibility is a function of level alone - dimensions apply in order, and
         // bucket rows share the level of the aggregate row above them. Note depth 0 has no applied
         // dimensions, and so holds the unfiltered superset of each list. Queries need not specify
@@ -404,7 +398,7 @@ export class View
 
     private dataOnlyUpdate(updates: StoreRecord[], start: number) {
         const {_leafMap, stores} = this,
-            updatedRowDatas = new Set<PlainObject>();
+            updatedRowDatas = new Set<ViewRowData>();
 
         // `_records` left stale by design - simple updates never touch filter/dim/bucket fields.
         updates.forEach(rec => {
@@ -412,7 +406,7 @@ export class View
             leaf?.applyLeafDataUpdate(rec, updatedRowDatas);
         });
 
-        updatedRowDatas.forEach(rowData => this.noteRowDataMutated(rowData));
+        updatedRowDatas.forEach(rowData => this.assignDigest(rowData));
 
         this.createAggregationContext();
 

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -145,7 +145,7 @@ export class View
     private _leafMap: Map<StoreRecordId, LeafRow> = null;
     _records: RecordSet = null; // cube records passing this view's filter
     private _bucketDependentFields = new Set<string>();
-    _rowDataGenerator: RowDataGenerator = null;
+    private _rowDataGenerator: RowDataGenerator = null;
     // Monotonic source for cubeRowDigest stamps - safe-integer headroom spans centuries of use.
     _rowDigest = 0;
     // Fields eligible for aggregation at each level of the query - i.e. those with an aggregator

--- a/data/cube/ViewRowData.ts
+++ b/data/cube/ViewRowData.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {PlainObject, Some} from '@xh/hoist/core';
+import {Some} from '@xh/hoist/core';
 import {flatMap} from 'lodash';
 
 /**
@@ -62,13 +62,6 @@ export interface ViewRowData {
     //-----------------
     /** @internal - aggregate rows only, leaf rows omit this key entirely. */
     _cubeLeafChildren?: ViewRowData[];
-
-    /**
-     * Leaf rows only - the underlying cube record data, through which queried field values are
-     * read via prototype getters rather than held as own properties.
-     * @internal
-     */
-    _src?: PlainObject;
 }
 
 /**

--- a/data/cube/ViewRowData.ts
+++ b/data/cube/ViewRowData.ts
@@ -56,12 +56,6 @@ export interface ViewRowData {
      * Support all other string keys for application fields in source data.
      */
     [key: string]: any;
-
-    //------------------
-    // Implementation
-    //-----------------
-    /** @internal - aggregate rows only, leaf rows omit this key entirely. */
-    _cubeLeafChildren?: ViewRowData[];
 }
 
 /**

--- a/data/cube/ViewRowData.ts
+++ b/data/cube/ViewRowData.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {Some} from '@xh/hoist/core';
+import {PlainObject, Some} from '@xh/hoist/core';
 import {flatMap} from 'lodash';
 
 /**
@@ -60,8 +60,15 @@ export interface ViewRowData {
     //------------------
     // Implementation
     //-----------------
-    /** @internal */
-    _cubeLeafChildren: ViewRowData[];
+    /** @internal - aggregate rows only, leaf rows omit this key entirely. */
+    _cubeLeafChildren?: ViewRowData[];
+
+    /**
+     * Leaf rows only - the underlying cube record data, through which queried field values are
+     * read via prototype getters rather than held as own properties.
+     * @internal
+     */
+    _src?: PlainObject;
 }
 
 /**

--- a/data/cube/impl/RowCache.ts
+++ b/data/cube/impl/RowCache.ts
@@ -132,8 +132,8 @@ export class RowCache {
             bucketsRemoved = oldQuery.bucketSpecFn && !query.bucketSpecFn;
 
         // 1) Leaf-mode flips, field gains on exposed leaves, and bucket removal invalidate
-        // wholesale - gained fields hold null/stale values on existing rows. (Dropped fields do
-        // NOT invalidate: their slots remain, stop updating, and are out of contract.)
+        // wholesale - existing rows' data was minted without the gained fields. (Dropped fields
+        // do NOT invalidate: they remain readable on existing rows, but are out of contract.)
         if (oldExposed !== newExposed || (newExposed && fieldsGained) || bucketsRemoved) {
             this.rows.clear();
             return;

--- a/data/cube/impl/RowDataGenerator.ts
+++ b/data/cube/impl/RowDataGenerator.ts
@@ -1,0 +1,144 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+
+import {PlainObject} from '@xh/hoist/core';
+import {isEqual} from 'lodash';
+import type {View} from '../View';
+import {ViewRowData} from '../ViewRowData';
+
+/**
+ * Generates the `ViewRowData` objects published by a View. Owned by its View, with
+ * query-dependent templates rebuilt when the query's field set or leaf exposure changes. The
+ * View stamps each minted or mutated row with its monotonic `cubeRowDigest` post-construction -
+ * every row is minted with a `cubeRowDigest` slot so the stamp is an overwrite, never a
+ * shape-changing property add.
+ *
+ * Row shapes are fixed per query, keeping them in V8's compact fast-properties mode rather than
+ * "dictionary mode":
+ *  - Aggregate and bucket row data is cloned from a shared template carrying a slot for every
+ *    ViewRowData property and query field. Rows are only ever written via overwrites of these
+ *    slots - never property adds.
+ *  - Exposed-leaf row data holds no per-leaf copy of field values - queried fields are read
+ *    through prototype getters over an own `_src` reference to the leaf's cube record data. One
+ *    generated class per query keeps all leaf datas on a single shape with monomorphic,
+ *    inlinable reads.
+ *
+ * @internal
+ */
+export class RowDataGenerator {
+    private view: View;
+    private fieldNames: string[];
+    private exposesLeaves: boolean;
+    private parentDataTemplate: ViewRowData = null;
+    private leafDataClass: LeafDataClass = null;
+
+    constructor(view: View) {
+        this.view = view;
+        this.init();
+    }
+
+    /** Create a new aggregate or bucket row data object as a clone of the shared template. */
+    newParentRowData(id: string): ViewRowData {
+        return {...this.parentDataTemplate, id};
+    }
+
+    /** Create an exposed-leaf data object - fields read via prototype getters over `src`. */
+    newLeafRowData(id: string, src: PlainObject): ViewRowData {
+        return new this.leafDataClass(id, src);
+    }
+
+    //------------------
+    // Implementation
+    //------------------
+    onQueryChange() {
+        const {view} = this;
+        if (
+            !isEqual(view.fieldNames, this.fieldNames) ||
+            view.exposesLeaves !== this.exposesLeaves
+        ) {
+            this.init();
+        }
+    }
+
+    private init() {
+        this.fieldNames = this.view.fieldNames;
+        this.exposesLeaves = this.view.exposesLeaves;
+        this.parentDataTemplate = this.buildParentDataTemplate();
+        this.leafDataClass = this.buildLeafDataClass();
+    }
+
+    private buildParentDataTemplate(): ViewRowData {
+        const rowData: PlainObject = {
+            id: null,
+            cubeRowType: null,
+            cubeLabel: null,
+            cubeDimension: null,
+            cubeBuckets: null,
+            children: null,
+            isCubeLeaf: false,
+            cubeRowDigest: null,
+            _cubeLeafChildren: null
+        };
+        this.view.fields.forEach(({name}) => (rowData[name] = null));
+
+        // Convert into V8 fast-properties mode that we'll need to mint additional fast objects
+        return {...rowData} as ViewRowData;
+    }
+
+    private buildLeafDataClass(): LeafDataClass {
+        if (!this.exposesLeaves) return null;
+
+        class LeafRowData extends BaseLeafRowData {}
+        this.view.fields.forEach(({name}) => {
+            Object.defineProperty(LeafRowData.prototype, name, {
+                get(this: PlainObject) {
+                    return this._src[name];
+                },
+                enumerable: true
+            });
+        });
+        return LeafRowData;
+    }
+}
+
+/**
+ * Fixed portion of a View's exposed-leaf data class - `buildLeafDataClass` extends this with
+ * per-query field getters reading through the own `_src` reference to the leaf's cube record
+ * data.
+ */
+class BaseLeafRowData implements ViewRowData {
+    id: string;
+    cubeLabel: string = null;
+    cubeBuckets: PlainObject = null;
+    cubeRowDigest: number = null;
+    _src: PlainObject;
+
+    // Type-only, erased: the interface's index signature.
+    [key: string]: any;
+
+    // Constants for all leaves - no own slots, and non-enumerable like all class accessors:
+    // enumerating consumers (e.g. Store.parseRaw) care only about queried fields.
+    get cubeRowType(): 'leaf' {
+        return 'leaf';
+    }
+    get isCubeLeaf(): boolean {
+        return true;
+    }
+    get cubeDimension(): string {
+        return null;
+    }
+    get children(): ViewRowData[] {
+        return null;
+    }
+
+    constructor(id: string, src: PlainObject) {
+        this.id = id;
+        this._src = src;
+    }
+}
+
+type LeafDataClass = new (id: string, src: PlainObject) => ViewRowData;

--- a/data/cube/row/BaseRow.ts
+++ b/data/cube/row/BaseRow.ts
@@ -52,7 +52,6 @@ export abstract class BaseRow {
 
         if (!shallowEqualObjects(data.cubeBuckets, buckets)) {
             data.cubeBuckets = buckets;
-            // Safe cast - hidden leaves, the only rows with non-ViewRowData data, no-op this walk.
             this.view.assignDigest(data as ViewRowData);
         }
 

--- a/data/cube/row/BaseRow.ts
+++ b/data/cube/row/BaseRow.ts
@@ -52,7 +52,8 @@ export abstract class BaseRow {
 
         if (!shallowEqualObjects(data.cubeBuckets, buckets)) {
             data.cubeBuckets = buckets;
-            this.view.noteRowDataMutated(data);
+            // Safe cast - hidden leaves, the only rows with non-ViewRowData data, no-op this walk.
+            this.view.assignDigest(data as ViewRowData);
         }
 
         this.children?.forEach(it => it.syncBuckets(buckets));

--- a/data/cube/row/LeafRow.ts
+++ b/data/cube/row/LeafRow.ts
@@ -41,9 +41,6 @@ export abstract class LeafRow extends BaseRow {
         return true;
     }
 
-    // Leaves publish no children - skip BaseRow's child wiring, whose null writes would add own
-    // `children`/`_cubeLeafChildren` slots to exposed leaf data (`children` reads null off its
-    // prototype; the internal `_cubeLeafChildren` is simply absent).
     override getVisibleDatas(): ViewRowData {
         return this.data as ViewRowData;
     }
@@ -106,8 +103,6 @@ export class ExposedLeafRow extends LeafRow {
         newData: PlainObject,
         updatedRowDatas: Set<PlainObject>
     ) {
-        // Always swap the getter source to avoid retaining the old record's data - register with
-        // consumers only on genuine change.
         this.data._src = newData;
         if (!isEmpty(updates)) updatedRowDatas.add(this.data);
     }
@@ -131,8 +126,6 @@ export class HiddenLeafRow extends LeafRow {
     override syncBuckets() {}
 
     protected override applyUpdatedData(updates: RowUpdate[], newData: PlainObject) {
-        // Always swap reference to avoid retaining the old record. Never registered in
-        // updatedRowDatas - hidden leaves are not published to stores or results.
         this.data = newData;
     }
 }

--- a/data/cube/row/LeafRow.ts
+++ b/data/cube/row/LeafRow.ts
@@ -41,6 +41,13 @@ export abstract class LeafRow extends BaseRow {
         return true;
     }
 
+    // Leaves publish no children - skip BaseRow's child wiring, whose null writes would add own
+    // `children`/`_cubeLeafChildren` slots to exposed leaf data (`children` reads null off its
+    // prototype; the internal `_cubeLeafChildren` is simply absent).
+    override getVisibleDatas(): ViewRowData {
+        return this.data as ViewRowData;
+    }
+
     constructor(view: View, id: string, rawRecord: StoreRecord) {
         super(view, id);
         this.cubeRecord = rawRecord;
@@ -80,8 +87,9 @@ export abstract class LeafRow extends BaseRow {
 
 /**
  * Leaf row exposed on results - i.e. when the Query sets {@link Query.includeLeaves} or
- * {@link Query.provideLeaves}. Holds a per-View {@link ViewRowData} copy of its source record's
- * data, limited to the queried fields.
+ * {@link Query.provideLeaves}. Holds a per-View {@link ViewRowData} whose queried field values
+ * are read through prototype getters over an own `_src` reference to the source record's data,
+ * avoiding a per-leaf copy. See {@link View.newLeafRowData}.
  */
 export class ExposedLeafRow extends LeafRow {
     declare data: ViewRowData;
@@ -89,14 +97,8 @@ export class ExposedLeafRow extends LeafRow {
     constructor(view: View, id: string, rawRecord: StoreRecord) {
         super(view, id, rawRecord);
 
-        const data = (this.data = view.newRowData(id));
-        data.cubeRowType = 'leaf';
+        const data = (this.data = view.newLeafRowData(id, rawRecord.data));
         data.cubeLabel = rawRecord.id.toString();
-        data.isCubeLeaf = true;
-
-        view.fields.forEach(({name}) => {
-            data[name] = rawRecord.data[name];
-        });
     }
 
     protected override applyUpdatedData(
@@ -104,9 +106,10 @@ export class ExposedLeafRow extends LeafRow {
         newData: PlainObject,
         updatedRowDatas: Set<PlainObject>
     ) {
-        const {data} = this;
-        updates.forEach(({field, newValue}) => (data[field.name] = newValue));
-        if (!isEmpty(updates)) updatedRowDatas.add(data);
+        // Always swap the getter source to avoid retaining the old record's data - register with
+        // consumers only on genuine change.
+        this.data._src = newData;
+        if (!isEmpty(updates)) updatedRowDatas.add(this.data);
     }
 }
 

--- a/data/cube/row/ParentRow.ts
+++ b/data/cube/row/ParentRow.ts
@@ -132,7 +132,7 @@ export abstract class ParentRow extends BaseRow {
             changed = this.recomputeAggregatesForContextChange(this.recomputeCanAggregate());
         }
 
-        if (changed) view.noteRowDataMutated(this.data);
+        if (changed) view.assignDigest(this.data);
         return this;
     }
 
@@ -235,7 +235,7 @@ export class AggregateRow extends ParentRow {
 
         this.dim = dim;
         this.dimName = dimName;
-        const data = (this.data = view.newRowData(id));
+        const data = (this.data = view.newParentRowData(id));
         data.cubeRowType = 'aggregate';
         data.cubeLabel = strVal;
         data.cubeDimension = dimName;
@@ -277,7 +277,7 @@ export class BucketRow extends ParentRow {
 
         this.bucketSpec = bucketSpec;
         this.bucketVal = bucketVal;
-        const data = (this.data = view.newRowData(id));
+        const data = (this.data = view.newParentRowData(id));
         data.cubeRowType = 'bucket';
         data.cubeLabel = bucketSpec.labelFn(bucketVal);
         data.cubeDimension = bucketSpec.name;


### PR DESCRIPTION
Exposed-leaf `ViewRowData` no longer copies queried field values onto each row - a per-View generated class reads them through prototype getters over an own `_src` reference to the leaf's cube record data.

**Key changes**

- New internal `RowDataGenerator` (`data/cube/impl`) owns row-data minting - parent template clones plus the generated leaf class - rebuilt only when the query's field set or leaf exposure changes, keeping all of a view's leaf rows on one V8 shape. `View` delegates minting and stamps `cubeRowDigest` post-construction.
- Static `BaseLeafRowData` carries the fixed leaf shape: own slots (`id`, `cubeLabel`, `cubeBuckets`, `cubeRowDigest`, `_src`) plus non-enumerable constant getters (`cubeRowType`, `isCubeLeaf`, `cubeDimension`, `children`). The generated subclass adds only the per-query field getters, which stay enumerable for classic (non-`projectionOnly`) stores whose `parseRaw` enumerates fields.
- `ExposedLeafRow` updates reduce to swapping the `_src` reference; digest-based record reuse in connected stores is unaffected. Leaves skip `BaseRow`'s child wiring via a `getVisibleDatas` override, and `ViewRowData._cubeLeafChildren` is now optional (absent on leaves).
- Renamed `View.noteRowDataMutated` → `assignDigest`, `newRowData` → `newParentRowData`.

**Behavior note (see CHANGELOG)**: leaf field values must be read by name - spreading or `JSON.stringify`-ing a leaf row no longer captures them, and leaf field keys are read-only. Complements the existing v87 `StoreRecord.data` read-by-name guidance.

**Validation**: benched at ~21% less View+store heap (100k leaves × 14 fields, projection store) with ~35% faster view creation and neutral regen/tick times - savings scale with query width. Validated in the Toolbox cube tester across projection and classic stores, live ticks, regroups, and query changes; node smoke suite covers getter reads, aggregation, both store parse paths, updates, reuse, and shape invariants.