### PR TITLE
Tiered ag-Grid transaction handling for large-grid update performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ and performance optimizations, grouped by topic below.
   Set the new `GridModelPersistOptions.hideNewColumns` config to `false` to restore the previous
   behavior.
 
+#### Grid - Data Update Timing
+
+* Grids now always apply `Store` data changes to ag-Grid in a fresh macrotask - pending UI
+  updates (e.g. load masks) paint first, and rapid changes coalesce. This strengthens an existing
+  requirement: grid reads after a data change were already subject to a minimal async debounce
+  and should already route through `GridModel.whenReadyAsync()`, which now provides a hard
+  guarantee that all store data has been applied to ag-Grid.
+
 ### 🎁 New Features
 
 #### Data - Store and Records
@@ -184,12 +192,9 @@ columns.
   minimum amount required.
 * Improved `Grid` data update performance with tiered ag-Grid transaction handling. Update
   transactions that provably cannot affect row order, grouping, or tree structure now skip
-  ag-Grid's model refresh (sort/filter/group/flatten) entirely, and smaller transactions that do
-  reorder re-sort only their changed rows via ag-Grid delta sorting. Streaming updates into large
-  sorted grids apply up to ~100x faster, with no configuration required.
-* Added `GridConfig.streamingSortInterval` to amortize re-sorting on rapidly-updating grids - cell
-  values update immediately while row order is restored at most once per interval. New records
-  still sort into place immediately.
+  ag-Grid's model refresh entirely, and transactions that would re-order rows apply their cell
+  values immediately, with row order restored by a managed, idle-scheduled re-sort. New records
+  still sort into place on arrival.
 * Added `StoreTransaction.changedFields`, letting data producers assert exactly which fields a
   value-only update touched. Cube `View`s supply this automatically, extending the no-re-sort
   Grid fast path to view-connected stores. See the data package README for details.
@@ -273,8 +278,12 @@ columns.
 
 ### ⚙️ Technical
 
-* Removed `GridExperimentalFlags.deltaSort` - Hoist now manages ag-Grid delta sorting
-  automatically per transaction. See the Grid transaction handling entry under New Features.
+* Replaced `GridExperimentalFlags.deltaSort` with `deltaSortRatio` - Hoist now manages ag-Grid
+  delta sorting automatically, using it for re-sorts touching fewer than this percentage of rows
+  (default 50). See the Grid transaction handling entry under New Features.
+* Added `GridExperimentalFlags.deferredSortFactor` to tune the pacing of the managed re-sort on
+  updating grids - a re-sort costing E ms defers the next for `E * factor` (default 4). Set 0 to
+  disable deferral and re-sort synchronously on every change.
 * Added `diagnostics` to `Store`, Cube `View`, and `GridModel` - a slot per kind of op (e.g.
   `store.diagnostics.update`, `gridModel.diagnostics.autosize`) reporting work done, elapsed time,
   and the path taken. Note that diagnostics log by default under `debug` output, but users may set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,17 @@ columns.
   `ensureSelectionVisibleAsync()`, and `selectAsync()`. Callers can now request that a row be
   scrolled to the `top`, `middle`, or `bottom` of the viewport, instead of scrolling only the
   minimum amount required.
+* Improved `Grid` data update performance with tiered ag-Grid transaction handling. Update
+  transactions that provably cannot affect row order, grouping, or tree structure now skip
+  ag-Grid's model refresh (sort/filter/group/flatten) entirely, and smaller transactions that do
+  reorder re-sort only their changed rows via ag-Grid delta sorting. Streaming updates into large
+  sorted grids apply up to ~100x faster, with no configuration required.
+* Added `GridConfig.streamingSortInterval` to amortize re-sorting on rapidly-updating grids - cell
+  values update immediately while row order is restored at most once per interval. New records
+  still sort into place immediately.
+* Added `StoreTransaction.changedFields`, letting data producers assert exactly which fields a
+  value-only update touched. Cube `View`s supply this automatically, extending the no-re-sort
+  Grid fast path to view-connected stores. See the data package README for details.
 
 #### Admin Console
 
@@ -251,6 +262,8 @@ columns.
 
 ### ⚙️ Technical
 
+* Removed `GridExperimentalFlags.deltaSort` - Hoist now manages ag-Grid delta sorting
+  automatically per transaction. See the Grid transaction handling entry under New Features.
 * Added `diagnostics` to `Store`, Cube `View`, and `GridModel` - a slot per kind of op (e.g.
   `store.diagnostics.update`, `gridModel.diagnostics.autosize`) reporting work done, elapsed time,
   and the path taken. Note that diagnostics log by default under `debug` output, but users may set

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -25,6 +25,7 @@ import {
     uses,
     XH
 } from '@xh/hoist/core';
+import type {StoreRecord} from '@xh/hoist/data';
 import {GridTransactionManager} from '@xh/hoist/cmp/grid/impl/GridTransactionManager';
 import {
     colChooser as desktopColChooser,
@@ -488,18 +489,26 @@ export class GridLocalModel extends HoistModel {
         );
     }
 
-    applyScrollOptimization() {
-        if (!this.useScrollOptimization) return;
+    applyScrollOptimization(added?: StoreRecord[]) {
+        if (!this.useScrollOptimization || (added && !added.length)) return;
 
         const {agApi} = this.model,
             {getRowHeight} = this.agOptions,
-            params = {api: agApi, context: null} as any;
+            params = {api: agApi, context: null} as any,
+            setHeight = node => {
+                params.node = node;
+                params.data = node.data;
+                node.setRowHeight(getRowHeight(params));
+            };
 
-        agApi.forEachNode(node => {
-            params.node = node;
-            params.data = node.data;
-            node.setRowHeight(getRowHeight(params));
-        });
+        if (added) {
+            added.forEach(rec => {
+                const node = agApi.getRowNode(rec.agId);
+                if (node) setHeight(node);
+            });
+        } else {
+            agApi.forEachNode(setHeight);
+        }
         agApi.onRowHeightChanged();
     }
 
@@ -728,7 +737,7 @@ export class GridLocalModel extends HoistModel {
         }
 
         model._syncedRs = newRs;
-        this.applyScrollOptimization();
+        this.applyScrollOptimization(transaction.add);
 
         model.diagnostics.noteApplyTransaction(transaction, newRs, applyStart);
     }

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -25,7 +25,6 @@ import {
     uses,
     XH
 } from '@xh/hoist/core';
-import {RecordSet} from '@xh/hoist/data/impl/RecordSet';
 import {GridTransactionManager} from '@xh/hoist/cmp/grid/impl/GridTransactionManager';
 import {
     colChooser as desktopColChooser,
@@ -46,7 +45,7 @@ import type {
     GridReadyEvent,
     ProcessCellForExportParams
 } from '@xh/hoist/kit/ag-grid';
-import {computed, observer} from '@xh/hoist/mobx';
+import {computed, observer, runInAction} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 import {consumeEvent, isDisplayed} from '@xh/hoist/utils/js';
 import {useComposedRefs, createObservableRef, getLayoutProps} from '@xh/hoist/utils/react';
@@ -181,7 +180,6 @@ export class GridLocalModel extends HoistModel {
     agOptions: GridOptions;
     viewRef = createObservableRef<HTMLElement>();
     private rowKeyNavSupport: RowKeyNavSupport;
-    private prevRs: RecordSet;
     @managed private transactionMgr: GridTransactionManager;
 
     /** @returns true if any root-level records have children */
@@ -204,6 +202,9 @@ export class GridLocalModel extends HoistModel {
     }
 
     override onLinked() {
+        // This mount's ag instance starts empty, regardless of what a prior mount applied.
+        runInAction(() => (this.model._syncedRs = null));
+
         this.rowKeyNavSupport = XH.isDesktop ? new RowKeyNavSupport(this.model) : null;
         this.addReaction(
             this.selectionReaction(),
@@ -380,8 +381,10 @@ export class GridLocalModel extends HoistModel {
         return {
             track: () => [model.isReady, store._filtered, model.showSummary, store.summaryRecords],
             run: () => {
-                if (model.isReady) this.syncData();
-            }
+                if (!this.isDestroyed && model.isReady) this.syncData();
+            },
+            // Sync in a fresh macrotask - lets pending UI paint first and coalesces rapid arrivals.
+            debounce: 0
         };
     }
 
@@ -677,7 +680,7 @@ export class GridLocalModel extends HoistModel {
         const {model} = this,
             {agGridModel, store, agApi} = model,
             newRs = store._filtered,
-            prevRs = this.prevRs;
+            prevRs = model._syncedRs;
 
         const start = performance.now(),
             transaction = newRs.diffFrom(prevRs);
@@ -687,9 +690,7 @@ export class GridLocalModel extends HoistModel {
         if (!this.transactionIsEmpty(transaction)) {
             this.transactionMgr.apply(transaction, prevRs, newRs);
         } else if (!prevRs) {
-            // First sync with an empty store yields an empty transaction, but AG Grid must still
-            // be handed rowData to exit its initial loading state - otherwise a grid mounted over
-            // an empty store shows its loading overlay indefinitely instead of `emptyText`.
+            // AG Grid needs rowData (even if empty) to exit its initial loading state.
             agApi.updateGridOptions({rowData: []});
         }
 
@@ -726,7 +727,7 @@ export class GridLocalModel extends HoistModel {
             model.noteAgExpandStateChange();
         }
 
-        this.prevRs = newRs;
+        model._syncedRs = newRs;
         this.applyScrollOptimization();
 
         model.diagnostics.noteApplyTransaction(transaction, newRs, applyStart);

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -17,6 +17,7 @@ import {
     HoistProps,
     LayoutProps,
     lookup,
+    managed,
     PlainObject,
     ReactionSpec,
     TestSupportProps,
@@ -25,6 +26,7 @@ import {
     XH
 } from '@xh/hoist/core';
 import {RecordSet} from '@xh/hoist/data/impl/RecordSet';
+import {GridTransactionManager} from '@xh/hoist/cmp/grid/impl/GridTransactionManager';
 import {
     colChooser as desktopColChooser,
     colChooserPanel as desktopColChooserPanel,
@@ -180,6 +182,7 @@ export class GridLocalModel extends HoistModel {
     viewRef = createObservableRef<HTMLElement>();
     private rowKeyNavSupport: RowKeyNavSupport;
     private prevRs: RecordSet;
+    @managed private transactionMgr: GridTransactionManager;
 
     /** @returns true if any root-level records have children */
     @computed
@@ -217,14 +220,14 @@ export class GridLocalModel extends HoistModel {
         );
 
         this.agOptions = merge(this.createDefaultAgOptions(), this.componentProps.agOptions || {});
+        this.transactionMgr = new GridTransactionManager(this.model, !!this.agOptions.deltaSort);
     }
 
     private createDefaultAgOptions(): GridOptions {
         const {model} = this,
-            {clicksToEdit, selModel, deltaSort} = model;
+            {clicksToEdit, selModel} = model;
 
         let ret: GridOptions = {
-            deltaSort,
             animateRows: false,
             suppressColumnVirtualisation: !model.useVirtualColumns,
             getRowId: ({data}) => data.agId,
@@ -682,7 +685,7 @@ export class GridLocalModel extends HoistModel {
 
         const applyStart = performance.now();
         if (!this.transactionIsEmpty(transaction)) {
-            agApi.applyTransaction(transaction);
+            this.transactionMgr.apply(transaction, prevRs, newRs);
         } else if (!prevRs) {
             // First sync with an empty store yields an empty transaction, but AG Grid must still
             // be handed rowData to exit its initial loading state - otherwise a grid mounted over

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -220,7 +220,7 @@ export class GridLocalModel extends HoistModel {
         );
 
         this.agOptions = merge(this.createDefaultAgOptions(), this.componentProps.agOptions || {});
-        this.transactionMgr = new GridTransactionManager(this.model, !!this.agOptions.deltaSort);
+        this.transactionMgr = new GridTransactionManager(this.model);
     }
 
     private createDefaultAgOptions(): GridOptions {

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -372,6 +372,16 @@ export interface GridConfig {
     externalSort?: boolean;
 
     /**
+     * Interval (ms) at which to re-sort this grid while streaming updates are arriving, or null
+     * (default) to re-sort on every change. When set, update-only transactions are applied
+     * without re-running ag-Grid's sort/filter/group stages - cell values update immediately
+     * while row order is restored by a managed re-sort at most once per interval. New records
+     * (adds) still sort into position immediately. Intended for grids over large, rapidly
+     * updating datasets, where a per-transaction re-sort is both costly and visually noisy.
+     */
+    streamingSortInterval?: number;
+
+    /**
      * Set to true to highlight a row on click. Intended to provide feedback to users in grids
      * without selection. Note this setting overrides the styling used by Column.highlightOnChange,
      * and is not recommended for use alongside that feature. Default true for mobiles,
@@ -400,14 +410,6 @@ export interface GridConfig {
 }
 
 interface GridExperimentalFlags {
-    /**
-     * Set to true to enable more optimal row sorting in cases where only small subsets of rows are
-     * updated in configurations where rows have many siblings.
-     * See https://www.ag-grid.com/javascript-data-grid/grid-options/#reference-sort-deltaSort for
-     * more details on where this option may improve (or degrade) performance.
-     */
-    deltaSort?: boolean;
-
     /**
      * Set to true to disable scroll optimization for large grids, where we proactively update the
      * row heights in ag-grid whenever the data changes to avoid hitching while quickly scrolling
@@ -528,6 +530,7 @@ export class GridModel extends HoistModel {
     enableExport: boolean;
     enableFullWidthScroll: boolean;
     externalSort: boolean;
+    streamingSortInterval: number;
     exportOptions: ExportOptions;
     useVirtualColumns: boolean;
     autosizeOptions: GridAutosizeOptions;
@@ -644,6 +647,7 @@ export class GridModel extends HoistModel {
             groupBy = null,
             showGroupRowCounts = GridModel.defaults.showGroupRowCounts,
             externalSort = false,
+            streamingSortInterval = null,
             persistWith,
             sizingMode = GridModel.defaults.sizingMode,
             showHover = GridModel.defaults.showHover,
@@ -707,6 +711,7 @@ export class GridModel extends HoistModel {
             contextMenu === false ? [] : withDefault(contextMenu, GridModel.defaults.contextMenu);
         this.useVirtualColumns = useVirtualColumns;
         this.externalSort = externalSort;
+        this.streamingSortInterval = streamingSortInterval;
         this.enableFullWidthScroll = enableFullWidthScroll;
         this.autosizeOptions = defaults(
             {...autosizeOptions},
@@ -1735,11 +1740,6 @@ export class GridModel extends HoistModel {
         if (b === '') return -1;
         return a.localeCompare(b);
     };
-
-    /** @internal */
-    get deltaSort() {
-        return !!this.experimental.deltaSort;
-    }
 
     /** @internal */
     get disableScrollOptimization() {

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -66,6 +66,7 @@ import {
     RowClickedEvent,
     RowDoubleClickedEvent
 } from '@xh/hoist/kit/ag-grid';
+import type {RecordSet} from '@xh/hoist/data/impl/RecordSet';
 import {action, bindable, makeObservable, observable, when} from '@xh/hoist/mobx';
 import {wait, waitFor} from '@xh/hoist/promise';
 import {ExportOptions} from '@xh/hoist/svc/GridExportService';
@@ -372,16 +373,6 @@ export interface GridConfig {
     externalSort?: boolean;
 
     /**
-     * Interval (ms) at which to re-sort this grid while streaming updates are arriving, or null
-     * (default) to re-sort on every change. When set, update-only transactions are applied
-     * without re-running ag-Grid's sort/filter/group stages - cell values update immediately
-     * while row order is restored by a managed re-sort at most once per interval. New records
-     * (adds) still sort into position immediately. Intended for grids over large, rapidly
-     * updating datasets, where a per-transaction re-sort is both costly and visually noisy.
-     */
-    streamingSortInterval?: number;
-
-    /**
      * Set to true to highlight a row on click. Intended to provide feedback to users in grids
      * without selection. Note this setting overrides the styling used by Column.highlightOnChange,
      * and is not recommended for use alongside that feature. Default true for mobiles,
@@ -416,6 +407,22 @@ interface GridExperimentalFlags {
      * through large grids.
      */
     disableScrollOptimization?: boolean;
+
+    /**
+     * Percentage [0-90] of changed rows above which a managed re-sort runs a full sort rather
+     * than an ag-Grid delta sort. Delta cost is ~linear in changed rows while full cost is ~flat
+     * in them, with measured break-even near 55% on nested cube grids - erring toward delta
+     * yields smaller, smoother chunks. Default 50.
+     */
+    deltaSortRatio?: number;
+
+    /**
+     * Multiplier pacing the managed re-sort of updating grids - a re-sort costing E ms defers
+     * the next for `E * factor`, bounding sort work to a fraction of main-thread time regardless
+     * of grid size or hardware. Set 0 to disable deferral entirely and re-sort synchronously on
+     * every change. Default 4.
+     */
+    deferredSortFactor?: number;
 }
 
 export interface GridModelDefaults {
@@ -530,7 +537,6 @@ export class GridModel extends HoistModel {
     enableExport: boolean;
     enableFullWidthScroll: boolean;
     externalSort: boolean;
-    streamingSortInterval: number;
     exportOptions: ExportOptions;
     useVirtualColumns: boolean;
     autosizeOptions: GridAutosizeOptions;
@@ -567,6 +573,9 @@ export class GridModel extends HoistModel {
     @observable.ref sortBy: GridSorter[] = [];
     @observable.ref groupBy: string[] = null;
     @observable expandLevel: number = 0;
+
+    /** @internal - latest RecordSet applied to ag-Grid, maintained by the Grid component. */
+    @observable.ref _syncedRs: RecordSet = null;
 
     // Kept alive, as the primary reader `getColumn()` is often called outside of a reaction.
     @computed({keepAlive: true})
@@ -647,7 +656,6 @@ export class GridModel extends HoistModel {
             groupBy = null,
             showGroupRowCounts = GridModel.defaults.showGroupRowCounts,
             externalSort = false,
-            streamingSortInterval = null,
             persistWith,
             sizingMode = GridModel.defaults.sizingMode,
             showHover = GridModel.defaults.showHover,
@@ -711,7 +719,6 @@ export class GridModel extends HoistModel {
             contextMenu === false ? [] : withDefault(contextMenu, GridModel.defaults.contextMenu);
         this.useVirtualColumns = useVirtualColumns;
         this.externalSort = externalSort;
-        this.streamingSortInterval = streamingSortInterval;
         this.enableFullWidthScroll = enableFullWidthScroll;
         this.autosizeOptions = defaults(
             {...autosizeOptions},
@@ -1712,21 +1719,26 @@ export class GridModel extends HoistModel {
      *   within this class re-check `isReady` directly. We have observed this method returning
      *   to its caller as true when the ag-grid/API has in fact dismounted and is no longer ready.
      *
-     * This method will introduce a minimal delay for all calls.  This is useful to ensure
-     * that the grid has had the opportunity to process any pending data updates, which are also
-     * subject to a minimal async debounce.
+     * This method also waits for all current (filtered) Store data to be applied to the
+     * underlying ag-Grid - data changes apply in their own macrotask - and introduces a minimal
+     * delay for all calls.
      *
      * @param timeout - timeout in ms
      */
     async whenReadyAsync(timeout: number = 3 * SECONDS): Promise<boolean> {
         try {
-            await when(() => this.isReady, {timeout});
+            await when(() => this.isReady && this.isDataSynced, {timeout});
         } catch (ignored) {
-            this.logDebug(`Grid failed to enter ready state after waiting ${timeout}ms`);
+            this.logDebug(`Grid not ready with data applied after waiting ${timeout}ms`);
         }
         await wait();
 
         return this.isReady;
+    }
+
+    /** True when the Store's current data has been fully applied to ag-Grid. */
+    get isDataSynced(): boolean {
+        return this._syncedRs === this.store._filtered;
     }
 
     /**

--- a/cmp/grid/impl/ColumnHeader.ts
+++ b/cmp/grid/impl/ColumnHeader.ts
@@ -80,12 +80,14 @@ export const columnHeader = hoistCmp.factory<ColumnHeaderProps>({
         };
 
         const expandCollapseIcon = () => {
-            const {xhColumn} = model;
+            const {xhColumn} = model,
+                {store} = model.gridModel;
             if (
                 !xhColumn ||
                 !xhColumn.isTreeColumn ||
                 !xhColumn.headerHasExpandCollapse ||
-                !model.rootsWithChildren
+                // Any non-root record implies at least one expandable root.
+                store.count === store.rootCount
             ) {
                 return null;
             }
@@ -239,14 +241,9 @@ class ColumnHeaderModel extends HoistModel {
     };
 
     @computed
-    get rootsWithChildren() {
-        return filter(this.gridModel.store.rootRecords, it => !isEmpty(it.children)).length;
-    }
-
-    @computed
     get majorityIsExpanded() {
-        const {expandState} = this.gridModel;
-        return !isEmpty(expandState) && size(expandState) > this.rootsWithChildren / 2;
+        const {expandState, store} = this.gridModel;
+        return !isEmpty(expandState) && size(expandState) > store.rootCount / 2;
     }
 
     // Desktop click handling

--- a/cmp/grid/impl/GridModelDiagnostics.ts
+++ b/cmp/grid/impl/GridModelDiagnostics.ts
@@ -20,6 +20,7 @@ import type {GridModel} from '@xh/hoist/cmp/grid';
 export class GridModelDiagnostics extends BaseDiagnostics<GridModel> {
     @observable.ref genTransaction: GridOpStats = this.emptyStats();
     @observable.ref applyTransaction: GridOpStats = this.emptyStats();
+    @observable.ref sortFlush: SortFlushOpStats = this.emptyStats();
     @observable.ref autosize: AutosizeOpStats = this.emptyStats();
 
     constructor(owner: GridModel) {
@@ -55,6 +56,20 @@ export class GridModelDiagnostics extends BaseDiagnostics<GridModel> {
     }
 
     @action
+    noteSortFlush(type: SortFlushOp['type'], pending: number, total: number, start: number) {
+        const op: SortFlushOp = {
+            type,
+            pending,
+            total,
+            elapsed: performance.now() - start,
+            timestamp: Date.now()
+        };
+        const {count, elapsed} = this.sortFlush;
+        this.sortFlush = {last: op, count: count + 1, elapsed: elapsed + op.elapsed};
+        this.logOp('sortFlush', op, `pending ${op.pending} of ${op.total}`);
+    }
+
+    @action
     noteAutosize(type: AutosizeOp['type'], columns: number, records: number, start: number) {
         const op: AutosizeOp = {
             type,
@@ -73,6 +88,7 @@ export class GridModelDiagnostics extends BaseDiagnostics<GridModel> {
     reset() {
         this.genTransaction = this.emptyStats();
         this.applyTransaction = this.emptyStats();
+        this.sortFlush = this.emptyStats();
         this.autosize = this.emptyStats();
     }
 
@@ -115,6 +131,20 @@ export interface AutosizeOpStats {
     last: AutosizeOp;
     count: number;
     elapsed: number;
+}
+
+export interface SortFlushOpStats {
+    last: SortFlushOp;
+    count: number;
+    elapsed: number;
+}
+
+export interface SortFlushOp {
+    type: 'delta' | 'full';
+    pending: number;
+    total: number;
+    elapsed: number;
+    timestamp: number;
 }
 
 export interface AutosizeOp {

--- a/cmp/grid/impl/GridTransactionManager.ts
+++ b/cmp/grid/impl/GridTransactionManager.ts
@@ -43,17 +43,15 @@ const DELTA_SORT_MAX_RATIO = 0.2;
  */
 export class GridTransactionManager extends HoistBase {
     private model: GridModel;
-    private currentDeltaSort: boolean;
     private sortDirty = false;
     @managed private sortTimer: Timer;
 
     // Cached provable sort paths - undefined = stale, null = sort not provably value-based.
     private _sortPaths: Array<Some<string>> | null | undefined;
 
-    constructor(model: GridModel, initialDeltaSort: boolean) {
+    constructor(model: GridModel) {
         super();
         this.model = model;
-        this.currentDeltaSort = initialDeltaSort;
 
         this.addReaction({
             track: () => [model.sortBy, model.columns],
@@ -68,19 +66,23 @@ export class GridTransactionManager extends HoistBase {
 
     apply(transaction: RecordSetDelta, prevRs: RecordSet, newRs: RecordSet) {
         const {agApi} = this.model,
-            mode = this.getRefreshMode(transaction, prevRs, newRs);
+            mode = this.getRefreshMode(transaction, prevRs, newRs),
+            suppress = mode === 'suppress';
 
-        if (mode === 'suppress') {
-            agApi.setGridOption('suppressModelUpdateAfterUpdateTransaction', true);
-        } else {
-            this.syncDeltaSort(mode === 'delta');
-        }
-        agApi.applyTransaction(transaction);
-        if (mode === 'suppress') {
-            agApi.setGridOption('suppressModelUpdateAfterUpdateTransaction', false);
-        } else {
+        // Set both options explicitly per transaction - each apply is self-contained, with no
+        // dependence on state left by a prior pass. Same-value writes are no-ops within ag-Grid.
+        agApi.setGridOption('suppressModelUpdateAfterUpdateTransaction', suppress);
+        agApi.setGridOption('deltaSort', mode === 'delta');
+        try {
+            agApi.applyTransaction(transaction);
             // Any un-suppressed pass re-sorted (delta implies a clean starting order - see below).
-            this.sortDirty = false;
+            if (!suppress) this.sortDirty = false;
+        } finally {
+            // Never leave suppression on - transactions applied outside this manager (or after an
+            // exception above) must get ag-Grid's full default refresh behavior.
+            if (suppress) {
+                agApi.setGridOption('suppressModelUpdateAfterUpdateTransaction', false);
+            }
         }
     }
 
@@ -174,15 +176,6 @@ export class GridTransactionManager extends HoistBase {
             ret.push(path);
         }
         return ret;
-    }
-
-    // Delta sort is managed per-transaction. Only touch the ag option when the desired state
-    // actually changes.
-    private syncDeltaSort(desired: boolean) {
-        if (desired !== this.currentDeltaSort) {
-            this.model.agApi.setGridOption('deltaSort', desired);
-            this.currentDeltaSort = desired;
-        }
     }
 
     private flushPendingSort() {

--- a/cmp/grid/impl/GridTransactionManager.ts
+++ b/cmp/grid/impl/GridTransactionManager.ts
@@ -69,20 +69,17 @@ export class GridTransactionManager extends HoistBase {
             mode = this.getRefreshMode(transaction, prevRs, newRs),
             suppress = mode === 'suppress';
 
-        // Set both options explicitly per transaction - each apply is self-contained, with no
-        // dependence on state left by a prior pass. Same-value writes are no-ops within ag-Grid.
-        agApi.setGridOption('suppressModelUpdateAfterUpdateTransaction', suppress);
-        agApi.setGridOption('deltaSort', mode === 'delta');
+        agApi.updateGridOptions({
+            suppressModelUpdateAfterUpdateTransaction: suppress,
+            deltaSort: mode === 'delta'
+        });
         try {
             agApi.applyTransaction(transaction);
-            // Any un-suppressed pass re-sorted (delta implies a clean starting order - see below).
             if (!suppress) this.sortDirty = false;
         } finally {
-            // Never leave suppression on - transactions applied outside this manager (or after an
-            // exception above) must get ag-Grid's full default refresh behavior.
-            if (suppress) {
-                agApi.setGridOption('suppressModelUpdateAfterUpdateTransaction', false);
-            }
+            // Never leave suppression on - transactions applied outside this manager must get
+            // ag-Grid's full default refresh behavior.
+            agApi.setGridOption('suppressModelUpdateAfterUpdateTransaction', false);
         }
     }
 
@@ -116,8 +113,7 @@ export class GridTransactionManager extends HoistBase {
             }
         }
 
-        // Once order is stale only a full sort restores it - deltaSort merges changed rows into
-        // the existing (stale) order.
+        // deltaSort not possible if we let the sort lapse.
         if (this.sortDirty) return 'full';
 
         const changedCount = update.length + add.length + remove.length;

--- a/cmp/grid/impl/GridTransactionManager.ts
+++ b/cmp/grid/impl/GridTransactionManager.ts
@@ -77,9 +77,7 @@ export class GridTransactionManager extends HoistBase {
             agApi.applyTransaction(transaction);
             if (!suppress) this.sortDirty = false;
         } finally {
-            // Never leave suppression on - transactions applied outside this manager must get
-            // ag-Grid's full default refresh behavior.
-            agApi.setGridOption('suppressModelUpdateAfterUpdateTransaction', false);
+            agApi.updateGridOptions({suppressModelUpdateAfterUpdateTransaction: false});
         }
     }
 

--- a/cmp/grid/impl/GridTransactionManager.ts
+++ b/cmp/grid/impl/GridTransactionManager.ts
@@ -4,10 +4,12 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistBase, managed, Some} from '@xh/hoist/core';
-import {StoreRecord} from '@xh/hoist/data';
+import {HoistBase, Some} from '@xh/hoist/core';
+import {StoreRecord, StoreRecordId} from '@xh/hoist/data';
 import {RecordSet, RecordSetDelta} from '@xh/hoist/data/impl/RecordSet';
-import {Timer} from '@xh/hoist/utils/async';
+import {wait} from '@xh/hoist/promise';
+import {runWhenIdle} from '@xh/hoist/utils/async';
+import {SECONDS} from '@xh/hoist/utils/datetime';
 import {get, isArray, isEmpty, isEqual, isFunction} from 'lodash';
 import type {GridModel} from '../GridModel';
 
@@ -21,9 +23,9 @@ import type {GridModel} from '../GridModel';
  */
 type RefreshMode = 'suppress' | 'delta' | 'full';
 
-// Transactions changing less than this fraction of rows sort via deltaSort - above it, merging
-// changed rows into the existing order stops beating a full sort.
-const DELTA_SORT_MAX_RATIO = 0.2;
+// Ceiling (ms) on the total deferral of a pending re-sort - pacing floor plus idle wait
+// combined - so row order can never go stale for longer than this.
+const MAX_DEFERRED_SORT = 10 * SECONDS;
 
 /**
  * Applies Store transactions to ag-Grid on behalf of Grid, minimizing the portion of ag-Grid's
@@ -35,16 +37,26 @@ const DELTA_SORT_MAX_RATIO = 0.2;
  * sorted field values record-by-record against the prior RecordSet otherwise. Smaller
  * transactions that miss that bar sort via ag-Grid `deltaSort`; the rest run a full sort.
  *
- * With {@link GridModel.streamingSortInterval} set, update-only transactions that would require
- * a re-sort are also applied suppressed - cell values update immediately while row order goes
- * briefly stale - and a managed timer restores sort order at most once per interval.
+ * Update-only transactions that would require a re-sort are also applied suppressed - cell
+ * values update immediately while row order goes briefly stale - and the touched rows
+ * accumulate for a managed flush that restores order.
+ * Flushes pace adaptively off their own measured cost (see the `deferredSortFactor`
+ * experimental flag), bounding sort work to a fraction of main-thread time. The flush lands at the browser's next
+ * idle moment, deadline-bounded, and re-applies the touched rows under ag-Grid `deltaSort` when
+ * few enough are pending, falling back to a full re-sort.
  *
  * @internal
  */
 export class GridTransactionManager extends HoistBase {
     private model: GridModel;
-    private sortDirty = false;
-    @managed private sortTimer: Timer;
+    private flushQueued = false;
+
+    // Rows updated by suppressed transactions since the last sort - null when order is current.
+    private pendingSortIds: Set<StoreRecordId> = null;
+
+    // Earliest performance.now() at which the next flush may start - set from the last flush's
+    // measured cost and any configured interval floor.
+    private nextFlushAllowed = 0;
 
     // Cached provable sort paths - undefined = stale, null = sort not provably value-based.
     private _sortPaths: Array<Some<string>> | null | undefined;
@@ -56,11 +68,6 @@ export class GridTransactionManager extends HoistBase {
         this.addReaction({
             track: () => [model.sortBy, model.columns],
             run: () => (this._sortPaths = undefined)
-        });
-
-        this.sortTimer = Timer.create({
-            runFn: () => this.flushPendingSort(),
-            interval: () => model.streamingSortInterval ?? -1
         });
     }
 
@@ -75,7 +82,8 @@ export class GridTransactionManager extends HoistBase {
         });
         try {
             agApi.applyTransaction(transaction);
-            if (!suppress) this.sortDirty = false;
+            // Any non-suppressed refresh re-sorts everything, resolving pending staleness.
+            if (!suppress) this.pendingSortIds = null;
         } finally {
             agApi.updateGridOptions({suppressModelUpdateAfterUpdateTransaction: false});
         }
@@ -102,20 +110,20 @@ export class GridTransactionManager extends HoistBase {
             if (structureStable) {
                 if (this.sortUnchanged(update, prevRs, changedFields)) return 'suppress';
 
-                // Streaming mode: suppress anyway, leaving order stale until the next
-                // interval flush.
-                if (model.streamingSortInterval > 0) {
-                    this.sortDirty = true;
+                // Suppress even when order is affected, leaving it stale until the pending flush.
+                if (this.deferredSortFactor > 0) {
+                    this.notePendingSort(update);
                     return 'suppress';
                 }
             }
         }
 
-        // deltaSort not possible if we let the sort lapse.
-        if (this.sortDirty) return 'full';
+        // With a flush pending, current order is stale - a delta merge would preserve the
+        // staleness, so any refresh must be full (which resolves the pending flush, per apply).
+        if (this.pendingSortIds) return 'full';
 
         const changedCount = update.length + add.length + remove.length;
-        return newRs.count > 0 && changedCount / newRs.count < DELTA_SORT_MAX_RATIO
+        return newRs.count > 0 && changedCount / newRs.count < this.deltaSortRatio
             ? 'delta'
             : 'full';
     }
@@ -172,10 +180,68 @@ export class GridTransactionManager extends HoistBase {
         return ret;
     }
 
+    // Changed-row fraction above which a full sort beats a delta sort - see the experimental
+    // flag's doc for the cost model.
+    private get deltaSortRatio(): number {
+        return (this.model.experimental.deltaSortRatio ?? 50) / 100;
+    }
+
+    private get deferredSortFactor(): number {
+        return this.model.experimental.deferredSortFactor ?? 4;
+    }
+
+    private notePendingSort(updates: StoreRecord[]) {
+        const ids = (this.pendingSortIds ??= new Set());
+        updates.forEach(rec => ids.add(rec.id));
+        this.scheduleFlushAsync();
+    }
+
+    // Decides *when* the pending flush runs. Two stages: a floor (see nextFlushAllowed), then
+    // idle placement - with MAX_DEFERRED_SORT bounding the two combined, so a busy main thread
+    // cannot defer the flush indefinitely.
+    private async scheduleFlushAsync() {
+        if (this.flushQueued || !this.pendingSortIds) return;
+        this.flushQueued = true;
+
+        const deadline = performance.now() + MAX_DEFERRED_SORT,
+            floor = this.nextFlushAllowed - performance.now();
+        if (floor > 0) await wait(floor);
+        runWhenIdle(
+            () => {
+                this.flushQueued = false;
+                this.flushPendingSort();
+            },
+            {timeout: Math.max(1, deadline - performance.now())}
+        );
+    }
+
     private flushPendingSort() {
-        const {model, sortDirty} = this;
-        if (!sortDirty || !model.isReady) return;
-        this.sortDirty = false;
-        model.agApi.refreshClientSideRowModel('sort');
+        const {model, pendingSortIds} = this,
+            latestRs = model._syncedRs;
+        if (!pendingSortIds || !latestRs || !model.isReady) return;
+        this.pendingSortIds = null;
+
+        const start = performance.now(),
+            {agApi} = model,
+            update = [];
+        pendingSortIds.forEach(id => {
+            const rec = latestRs.getById(id);
+            if (rec) update.push(rec);
+        });
+
+        if (update.length && update.length / latestRs.count < this.deltaSortRatio) {
+            agApi.updateGridOptions({deltaSort: true});
+            agApi.applyTransaction({update});
+            model.diagnostics.noteSortFlush('delta', update.length, latestRs.count, start);
+        } else {
+            agApi.refreshClientSideRowModel('sort');
+            model.diagnostics.noteSortFlush('full', update.length, latestRs.count, start);
+        }
+
+        this.nextFlushAllowed = performance.now() + this.backoffFor(performance.now() - start);
+    }
+
+    private backoffFor(elapsed: number): number {
+        return Math.min(elapsed * this.deferredSortFactor, MAX_DEFERRED_SORT);
     }
 }

--- a/cmp/grid/impl/GridTransactionManager.ts
+++ b/cmp/grid/impl/GridTransactionManager.ts
@@ -82,10 +82,12 @@ export class GridTransactionManager extends HoistBase {
         });
         try {
             agApi.applyTransaction(transaction);
-            // Any non-suppressed refresh re-sorts everything, resolving pending staleness.
             if (!suppress) this.pendingSortIds = null;
         } finally {
-            agApi.updateGridOptions({suppressModelUpdateAfterUpdateTransaction: false});
+            agApi.updateGridOptions({
+                suppressModelUpdateAfterUpdateTransaction: false,
+                deltaSort: false
+            });
         }
     }
 
@@ -173,9 +175,10 @@ export class GridTransactionManager extends HoistBase {
             if (!col || col.comparator || col.getValueFn !== col.defaultGetValueFn) return null;
             const {sortValue} = col;
             if (isFunction(sortValue)) return null;
-            const path = sortValue ?? col.fieldPath;
-            if (path == null) return null;
-            ret.push(path);
+            // A string sortValue falls back to the column's own value when nullish per-record.
+            const paths = sortValue != null ? [sortValue, col.fieldPath] : [col.fieldPath];
+            if (paths.some(p => p == null)) return null;
+            ret.push(...paths);
         }
         return ret;
     }
@@ -216,8 +219,10 @@ export class GridTransactionManager extends HoistBase {
     }
 
     private flushPendingSort() {
+        if (this.isDestroyed) return;
         const {model, pendingSortIds} = this,
             latestRs = model._syncedRs;
+        // Not ready - leave ids pending; the next transaction will run 'full' and resolve them.
         if (!pendingSortIds || !latestRs || !model.isReady) return;
         this.pendingSortIds = null;
 
@@ -231,7 +236,11 @@ export class GridTransactionManager extends HoistBase {
 
         if (update.length && update.length / latestRs.count < this.deltaSortRatio) {
             agApi.updateGridOptions({deltaSort: true});
-            agApi.applyTransaction({update});
+            try {
+                agApi.applyTransaction({update});
+            } finally {
+                agApi.updateGridOptions({deltaSort: false});
+            }
             model.diagnostics.noteSortFlush('delta', update.length, latestRs.count, start);
         } else {
             agApi.refreshClientSideRowModel('sort');

--- a/cmp/grid/impl/GridTransactionManager.ts
+++ b/cmp/grid/impl/GridTransactionManager.ts
@@ -1,0 +1,194 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {HoistBase, managed, Some} from '@xh/hoist/core';
+import {StoreRecord} from '@xh/hoist/data';
+import {RecordSet, RecordSetDelta} from '@xh/hoist/data/impl/RecordSet';
+import {Timer} from '@xh/hoist/utils/async';
+import {get, isArray, isEmpty, isEqual, isFunction} from 'lodash';
+import type {GridModel} from '../GridModel';
+
+/**
+ * How much of ag-Grid's client-side model refresh a transaction requires:
+ *   'suppress' - skip the sort/filter/group/flatten stages entirely - just a row data swap and
+ *                cell refresh.
+ *   'delta'    - full refresh, but sort only the changed rows and merge them into the existing
+ *                sorted order (ag-Grid `deltaSort`).
+ *   'full'     - full refresh with a full sort.
+ */
+type RefreshMode = 'suppress' | 'delta' | 'full';
+
+// Transactions changing less than this fraction of rows sort via deltaSort - above it, merging
+// changed rows into the existing order stops beating a full sort.
+const DELTA_SORT_MAX_RATIO = 0.2;
+
+/**
+ * Applies Store transactions to ag-Grid on behalf of Grid, minimizing the portion of ag-Grid's
+ * client-side model refresh each transaction actually runs.
+ *
+ * Pure updates provably unable to affect row order, grouping, or tree structure suppress the
+ * model refresh entirely. The proof comes from {@link RecordSetDelta.changedFields} when the
+ * producing transaction supplied them (e.g. cube View streaming updates), or from comparing
+ * sorted field values record-by-record against the prior RecordSet otherwise. Smaller
+ * transactions that miss that bar sort via ag-Grid `deltaSort`; the rest run a full sort.
+ *
+ * With {@link GridModel.streamingSortInterval} set, update-only transactions that would require
+ * a re-sort are also applied suppressed - cell values update immediately while row order goes
+ * briefly stale - and a managed timer restores sort order at most once per interval.
+ *
+ * @internal
+ */
+export class GridTransactionManager extends HoistBase {
+    private model: GridModel;
+    private currentDeltaSort: boolean;
+    private sortDirty = false;
+    @managed private sortTimer: Timer;
+
+    // Cached provable sort paths - undefined = stale, null = sort not provably value-based.
+    private _sortPaths: Array<Some<string>> | null | undefined;
+
+    constructor(model: GridModel, initialDeltaSort: boolean) {
+        super();
+        this.model = model;
+        this.currentDeltaSort = initialDeltaSort;
+
+        this.addReaction({
+            track: () => [model.sortBy, model.columns],
+            run: () => (this._sortPaths = undefined)
+        });
+
+        this.sortTimer = Timer.create({
+            runFn: () => this.flushPendingSort(),
+            interval: () => model.streamingSortInterval ?? -1
+        });
+    }
+
+    apply(transaction: RecordSetDelta, prevRs: RecordSet, newRs: RecordSet) {
+        const {agApi} = this.model,
+            mode = this.getRefreshMode(transaction, prevRs, newRs);
+
+        if (mode === 'suppress') {
+            agApi.setGridOption('suppressModelUpdateAfterUpdateTransaction', true);
+        } else {
+            this.syncDeltaSort(mode === 'delta');
+        }
+        agApi.applyTransaction(transaction);
+        if (mode === 'suppress') {
+            agApi.setGridOption('suppressModelUpdateAfterUpdateTransaction', false);
+        } else {
+            // Any un-suppressed pass re-sorted (delta implies a clean starting order - see below).
+            this.sortDirty = false;
+        }
+    }
+
+    //------------------------
+    // Implementation
+    //------------------------
+    private getRefreshMode(t: RecordSetDelta, prevRs: RecordSet, newRs: RecordSet): RefreshMode {
+        const {model} = this,
+            {update, add, remove, changedFields} = t,
+            updatesOnly = isEmpty(add) && isEmpty(remove);
+
+        if (updatesOnly && isEmpty(model.groupBy) && !model.agApi.isAnyFilterPresent()) {
+            // changedFields carries its producer's assertion that structure is untouched -
+            // otherwise verify each record kept its place in the tree.
+            const structureStable = changedFields
+                ? true
+                : update.every(rec => {
+                      const prev = prevRs.getById(rec.id);
+                      return prev && (!model.treeMode || isEqual(rec.treePath, prev.treePath));
+                  });
+
+            if (structureStable) {
+                if (this.sortUnchanged(update, prevRs, changedFields)) return 'suppress';
+
+                // Streaming mode: suppress anyway, leaving order stale until the next
+                // interval flush.
+                if (model.streamingSortInterval > 0) {
+                    this.sortDirty = true;
+                    return 'suppress';
+                }
+            }
+        }
+
+        // Once order is stale only a full sort restores it - deltaSort merges changed rows into
+        // the existing (stale) order.
+        if (this.sortDirty) return 'full';
+
+        const changedCount = update.length + add.length + remove.length;
+        return newRs.count > 0 && changedCount / newRs.count < DELTA_SORT_MAX_RATIO
+            ? 'delta'
+            : 'full';
+    }
+
+    // True if this update provably cannot reorder any row.
+    private sortUnchanged(
+        updates: StoreRecord[],
+        prevRs: RecordSet,
+        changedFields: Set<string>
+    ): boolean {
+        const sortPaths = this.getSortPaths();
+        if (!sortPaths) return false;
+
+        if (changedFields) {
+            return sortPaths.every(p => !changedFields.has(isArray(p) ? p[0] : p));
+        }
+
+        const getVal = (data, path) => (isArray(path) ? get(data, path) : data[path]);
+        return updates.every(rec => {
+            const prev = prevRs.getById(rec.id);
+            return (
+                prev &&
+                // A record sharing its predecessor's data object (row-reuse stores mutate row
+                // data in place) has already lost its old values - nothing can be proven.
+                prev.data !== rec.data &&
+                sortPaths.every(p => getVal(rec.data, p) === getVal(prev.data, p))
+            );
+        });
+    }
+
+    /**
+     * The raw data path each active sorter provably sorts on, or null if any sort depends on
+     * more than that value (custom comparator, custom getValueFn, or a sortValue function - all
+     * of which can read arbitrary record state). Cached until sortBy or columns change.
+     */
+    private getSortPaths(): Array<Some<string>> | null {
+        let ret = this._sortPaths;
+        if (ret === undefined) ret = this._sortPaths = this.computeSortPaths();
+        return ret;
+    }
+
+    private computeSortPaths(): Array<Some<string>> | null {
+        const {model} = this,
+            ret = [];
+        for (const sorter of model.sortBy) {
+            const col = model.getColumn(sorter.colId);
+            if (!col || col.comparator || col.getValueFn !== col.defaultGetValueFn) return null;
+            const {sortValue} = col;
+            if (isFunction(sortValue)) return null;
+            const path = sortValue ?? col.fieldPath;
+            if (path == null) return null;
+            ret.push(path);
+        }
+        return ret;
+    }
+
+    // Delta sort is managed per-transaction. Only touch the ag option when the desired state
+    // actually changes.
+    private syncDeltaSort(desired: boolean) {
+        if (desired !== this.currentDeltaSort) {
+            this.model.agApi.setGridOption('deltaSort', desired);
+            this.currentDeltaSort = desired;
+        }
+    }
+
+    private flushPendingSort() {
+        const {model, sortDirty} = this;
+        if (!sortDirty || !model.isReady) return;
+        this.sortDirty = false;
+        model.agApi.refreshClientSideRowModel('sort');
+    }
+}

--- a/data/README.md
+++ b/data/README.md
@@ -169,6 +169,23 @@ if (changes) {
 }
 ```
 
+#### Declaring changed fields
+
+A transaction may include `changedFields` - a `Set` of the field names whose values changed across
+its `update` rows:
+
+```typescript
+store.updateData({update: tickingRows, changedFields: new Set(['lastPrice', 'volume'])});
+```
+
+Providing it is an assertion: the updates change record values only (no parent/structural changes),
+and no field outside the set changed. Hoist carries the set through to the `Grid` transaction sync,
+which uses it to prove that an update cannot affect row order and skip ag-Grid's re-sort entirely -
+a major win for high-frequency updates into large sorted grids. Cube `View`s supply `changedFields`
+automatically on streaming updates, so view-connected stores get this for free. Producers that
+cannot cheaply determine the set should simply omit it - the grid falls back to comparing sorted
+field values record-by-record where possible.
+
 **`loadDataAsync(rawData)`** - Streaming counterpart to `loadData()`. It accepts a sync or async
 iterable that yields raw records, and creates records incrementally without buffering the complete
 raw dataset in memory. Use it for very large datasets streamed from the server. Pair it with

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -282,6 +282,14 @@ export interface StoreTransaction {
      *  `update` property.
      */
     rawSummaryData?: Some<PlainObject>;
+
+    /**
+     * Names of every field whose value changed across the `update` rows, when the producer can
+     * supply them cheaply. Providing this asserts that updates change record values only - no
+     * structural/parent changes - and that no field outside the set changed. Enables downstream
+     * consumers (e.g. Grid) to prove a change cannot affect sort order and skip re-sorting.
+     */
+    changedFields?: Set<string>;
 }
 
 /**
@@ -666,7 +674,7 @@ export class Store
             rawTransaction = rawData;
         }
 
-        const {update, add, remove, rawSummaryData, ...other} = rawTransaction;
+        const {update, add, remove, rawSummaryData, changedFields, ...other} = rawTransaction;
         throwIf(!isEmpty(other), 'Unknown argument(s) passed to updateData().');
 
         // 1) Pre-process updates and adds into Records
@@ -723,10 +731,12 @@ export class Store
             update?: StoreRecord[];
             add?: StoreRecord[];
             remove?: StoreRecordId[];
+            changedFields?: Set<string>;
         } = {};
         if (!isEmpty(updateRecs)) rsTransaction.update = updateRecs;
         if (!isEmpty(addRecs)) rsTransaction.add = Array.from(addRecs.values());
         if (!isEmpty(remove)) rsTransaction.remove = remove;
+        if (changedFields && rsTransaction.update) rsTransaction.changedFields = changedFields;
 
         const hasChanges = !isEmpty(rsTransaction),
             prevCurrent = this._current;

--- a/data/StoreSelectionModel.ts
+++ b/data/StoreSelectionModel.ts
@@ -150,11 +150,10 @@ export class StoreSelectionModel extends HoistModel {
     // Implementation
     //------------------------
     private cullSelectionReaction() {
-        // Remove recs from selection if they are no longer in store. Cleanup array in place without
-        // modifying observable -- the 'records' getter provides all observable state.
+        // Remove recs from selection if they are no longer in store.
         const {store} = this;
         return {
-            track: () => store.records,
+            track: () => store._filtered,
             run: () => remove(this._ids, id => !store.getById(id, true))
         };
     }

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -398,12 +398,13 @@ export class View
 
     private dataOnlyUpdate(updates: StoreRecord[], start: number) {
         const {_leafMap, stores} = this,
-            updatedRowDatas = new Set<ViewRowData>();
+            updatedRowDatas = new Set<ViewRowData>(),
+            changedFields = new Set<string>();
 
         // `_records` left stale by design - simple updates never touch filter/dim/bucket fields.
         updates.forEach(rec => {
             const leaf = _leafMap.get(rec.id);
-            leaf?.applyLeafDataUpdate(rec, updatedRowDatas);
+            leaf?.applyLeafDataUpdate(rec, updatedRowDatas, changedFields);
         });
 
         updatedRowDatas.forEach(rowData => this.assignDigest(rowData));
@@ -415,7 +416,9 @@ export class View
             updatedRowDatas.forEach(rowData => {
                 if (store.getById(rowData.id)) recordUpdates.push(rowData);
             });
-            store.updateData({update: recordUpdates});
+            // Parents only rewrite fields reported changed by leaves, so the leaf-level union
+            // covers every value written - and this path never touches structure.
+            store.updateData({update: recordUpdates, changedFields});
         });
         this.updateResults();
         this.diagnostics.noteUpdate('dataOnly', start);

--- a/data/cube/row/LeafRow.ts
+++ b/data/cube/row/LeafRow.ts
@@ -50,7 +50,11 @@ export abstract class LeafRow extends BaseRow {
         this.cubeRecord = rawRecord;
     }
 
-    applyLeafDataUpdate(newRec: StoreRecord, updatedRowDatas: Set<PlainObject>) {
+    applyLeafDataUpdate(
+        newRec: StoreRecord,
+        updatedRowDatas: Set<PlainObject>,
+        changedFields: Set<string>
+    ) {
         this.cubeRecord = newRec;
         const {view, data} = this,
             newData = newRec.data,
@@ -63,6 +67,7 @@ export abstract class LeafRow extends BaseRow {
                 newValue = newData[name];
             if (oldValue !== newValue) {
                 updates.push(new RowUpdate(field, oldValue, newValue));
+                changedFields.add(name);
             }
         });
 

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -7,7 +7,7 @@
 
 import equal from 'fast-deep-equal';
 import {logWarn, throwIf} from '@xh/hoist/utils/js';
-import {clamp, maxBy, isNil} from 'lodash';
+import {clamp, isEmpty, isNil, maxBy} from 'lodash';
 import {StoreRecord, StoreRecordId} from '../StoreRecord';
 import {Store} from '../Store';
 import {Filter} from '../filter/Filter';
@@ -18,6 +18,9 @@ type ChildRecordMap = Map<StoreRecordId, StoreRecord[]>;
 /** Patch-layer entry marking a base record as removed. */
 const TOMBSTONE = {} as StoreRecord;
 type PatchMap = Map<StoreRecordId, StoreRecord>;
+
+// Source of `RecordSet.ordinal` values - global uniqueness is all that matters.
+let ordinalSeq = 0;
 
 /**
  * Changes deriving one RecordSet from another, as computed by {@link RecordSet.diffFrom}.
@@ -30,6 +33,15 @@ export interface RecordSetDelta {
     update: StoreRecord[];
     add: StoreRecord[];
     remove: StoreRecord[];
+
+    /**
+     * Names of every field whose value changed in `update` records, when known - null when
+     * unknown. Only populated when the delta spans a single value-only transaction that supplied
+     * {@link StoreTransaction.changedFields} - carries that producer's assertion that updates
+     * changed record values only (no structural/parent changes) and touched no field outside
+     * the set. Lets consumers (e.g. Grid) prove a change cannot affect sort order.
+     */
+    changedFields?: Set<string>;
 }
 
 // Default cap on patch size as a fraction of base - 0 disables the patch layer entirely, with
@@ -72,6 +84,17 @@ export class RecordSet {
     readonly base: StoreRecordMap;
     /** Changed entries relative to `base` (TOMBSTONE = removed), or null for a flat set. */
     readonly patch: PatchMap;
+
+    /** Unique id for step-provenance tracking - see `prevOrdinal`. */
+    readonly ordinal: number = ++ordinalSeq;
+    /**
+     * Ordinal of the instance a single-step derivation produced this one from, or null.
+     * With `changedFields`, lets `diffFrom` recognize a one-step diff window and surface the
+     * fields changed within it - identity via ordinals avoids retaining predecessor instances.
+     */
+    private prevOrdinal: number = null;
+    /** Fields changed in that single step, when the producing transaction supplied them. */
+    private changedFields: Set<string> = null;
 
     private _childrenMap: ChildRecordMap; // children by parentId
     private _list: StoreRecord[]; // all records.
@@ -171,6 +194,10 @@ export class RecordSet {
 
         if (!prev) return {update, add: this.list, remove};
 
+        // changedFields is only knowable when the window is exactly the single step that
+        // produced this instance from `prev`.
+        const changedFields = this.prevOrdinal === prev.ordinal ? this.changedFields : null;
+
         const {base, patch} = this,
             prevPatch = prev.patch;
 
@@ -189,7 +216,7 @@ export class RecordSet {
                     if (!this.getById(id)) remove.push(rec);
                 });
             }
-            return {update, add, remove};
+            return {update, add, remove, changedFields};
         }
 
         //... or patch compare
@@ -232,7 +259,7 @@ export class RecordSet {
             });
         }
 
-        return {update, add, remove};
+        return {update, add, remove, changedFields};
     }
 
     /** As `diffFrom`, but only when answerable at O(patch) - null on unrelated instances. */
@@ -426,6 +453,7 @@ export class RecordSet {
         update?: StoreRecord[];
         add?: StoreRecord[];
         remove?: StoreRecordId[];
+        changedFields?: Set<string>;
     }): RecordSet {
         const {update, add, remove} = t,
             {base, patch} = this;
@@ -507,6 +535,10 @@ export class RecordSet {
             add: add?.length ?? 0,
             remove: this.count + (add?.length ?? 0) - count
         };
+        ret.prevOrdinal = this.ordinal;
+        if (t.changedFields && isEmpty(add) && isEmpty(remove)) {
+            ret.changedFields = t.changedFields;
+        }
         return ret;
     }
 
@@ -571,6 +603,11 @@ export class RecordSet {
             add: added,
             remove: removed
         };
+        ret.prevOrdinal = prevFiltered.ordinal;
+        // Fields carry through only when the source delta was itself a single value-only step.
+        if (delta.changedFields && !added && !removed) {
+            ret.changedFields = delta.changedFields;
+        }
         return ret;
     }
 

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -22,6 +22,9 @@ type PatchMap = Map<StoreRecordId, StoreRecord>;
 // Source of `RecordSet.ordinal` values - global uniqueness is all that matters.
 let ordinalSeq = 0;
 
+// Depth without forcing lazy treePath materialization on root records of flat stores.
+const recDepth = (rec: StoreRecord): number => (rec.parentId == null ? 0 : rec.depth);
+
 /**
  * Changes deriving one RecordSet from another, as computed by {@link RecordSet.diffFrom}.
  * Unlike a transaction used to *specify* changes, `remove` here holds the full set of removed
@@ -399,7 +402,9 @@ export class RecordSet {
         // Be sure to finalize any new records that are accepted.
         const changed: StoreRecord[] = []; // accepted new instances - updates and adds
         let adds = 0,
-            rootCount = 0;
+            rootCount = 0,
+            maxChangedDepth = 0,
+            depthLowered = false;
         recordMap.forEach((newRec, id) => {
             const currRec = this.getById(id);
             if (currRec && this.areRecordsEqual(currRec, newRec)) {
@@ -408,6 +413,8 @@ export class RecordSet {
             } else {
                 newRec.finalize();
                 if (!currRec) adds++;
+                else if (recDepth(newRec) < recDepth(currRec)) depthLowered = true;
+                maxChangedDepth = Math.max(maxChangedDepth, recDepth(newRec));
                 changed.push(newRec);
                 if (newRec.parentId == null) rootCount++;
             }
@@ -425,6 +432,13 @@ export class RecordSet {
             changes = changed.length + removedCount,
             counts = {update: changed.length - adds, add: adds, remove: removedCount};
 
+        // Carry maxDepth forward without a scan - safe unless a removed or shallower-moved
+        // record could have held the old max.
+        const newMaxDepth =
+            !isNil(this._maxDepth) && !removedCount && !depthLowered
+                ? Math.max(this._maxDepth, maxChangedDepth)
+                : null;
+
         if (changes <= ratio * count) {
             const newPatch: PatchMap = patch ? new Map(patch) : new Map();
             changed.forEach(rec => newPatch.set(rec.id, rec));
@@ -436,12 +450,14 @@ export class RecordSet {
             if (newPatch.size <= ratio * base.size) {
                 const ret = new RecordSet(store, base, newPatch, count, rootCount);
                 ret.derivation = {type: 'patched', ...counts};
+                ret._maxDepth = newMaxDepth;
                 return ret;
             }
         }
 
         const ret = new RecordSet(store, recordMap, null, count, rootCount);
         ret.derivation = {type: 'full', ...counts};
+        ret._maxDepth = newMaxDepth;
         return ret;
     }
 
@@ -534,6 +550,14 @@ export class RecordSet {
         ret.prevOrdinal = this.ordinal;
         if (t.changedFields && isEmpty(add) && isEmpty(remove)) {
             ret.changedFields = t.changedFields;
+        }
+
+        // Carry maxDepth forward without a scan - only removes can lower it (recompute lazily).
+        if (!isNil(this._maxDepth) && isEmpty(remove)) {
+            ret._maxDepth = (add ?? []).reduce(
+                (m, rec) => Math.max(m, recDepth(rec)),
+                this._maxDepth
+            );
         }
         return ret;
     }

--- a/data/impl/RecordSet.ts
+++ b/data/impl/RecordSet.ts
@@ -87,11 +87,7 @@ export class RecordSet {
 
     /** Unique id for step-provenance tracking - see `prevOrdinal`. */
     readonly ordinal: number = ++ordinalSeq;
-    /**
-     * Ordinal of the instance a single-step derivation produced this one from, or null.
-     * With `changedFields`, lets `diffFrom` recognize a one-step diff window and surface the
-     * fields changed within it - identity via ordinals avoids retaining predecessor instances.
-     */
+    /** Ordinal of the instance a single-step derivation produced this one from, or null. */
     private prevOrdinal: number = null;
     /** Fields changed in that single step, when the producing transaction supplied them. */
     private changedFields: Set<string> = null;
@@ -604,7 +600,6 @@ export class RecordSet {
             remove: removed
         };
         ret.prevOrdinal = prevFiltered.ordinal;
-        // Fields carry through only when the source delta was itself a single value-only step.
         if (delta.changedFields && !added && !removed) {
             ret.changedFields = delta.changedFields;
         }

--- a/utils/async/AsyncUtils.ts
+++ b/utils/async/AsyncUtils.ts
@@ -72,6 +72,21 @@ export async function whileAsync(
     }
 }
 
+/**
+ * Run a function when the browser is next idle, or after `timeout` ms - whichever comes first.
+ *
+ * Intended for low-priority or cosmetic work that should cede the main thread to rendering,
+ * input handling, and other tasks under load. Falls back to a prompt macrotask on browsers
+ * without `requestIdleCallback` support.
+ */
+export function runWhenIdle(fn: () => void, opts: {timeout: number}) {
+    if (typeof window.requestIdleCallback === 'function') {
+        window.requestIdleCallback(() => fn(), opts);
+    } else {
+        setTimeout(fn, 0);
+    }
+}
+
 export interface AsyncLoopOptions {
     /**
      * Interval in ms after which the loop should pause and wait. If the loop completes before


### PR DESCRIPTION
## Overview

Grid data updates now run only as much of ag-Grid's client-side model refresh as each transaction actually requires. A new `GridTransactionManager` (delegated to by Grid's local model) picks one of three modes per transaction:

- **Suppress** - update-only transactions provably unable to affect row order, grouping, or tree structure skip the sort/filter/group/flatten stages entirely (via `suppressModelUpdateAfterUpdateTransaction`): just a row data swap + cell refresh.
- **Delta** - transactions changing fewer than `experimental.deltaSortRatio` percent of rows (default 50 - see appendix) run a full refresh but sort only their changed rows, merging into the existing order (ag-Grid `deltaSort`, now managed dynamically - `experimental.deltaSort` removed).
- **Full** - everything else, unchanged behavior.

Order-stability is proven two ways: a new `StoreTransaction.changedFields` (a producer's assertion of exactly which fields a value-only update touched - Cube `View`s supply it automatically from the per-field diff their dataOnly updates already compute, carried through `RecordSet` and surfaced on the grid's delta), or a per-record comparison of sorted field values against the prior RecordSet. Sorts on custom comparators, custom `getValueFn`s, or `sortValue` functions are never suppressed. Cached sort-path resolution invalidates on `sortBy`/`columns` changes.

Order-affecting updates also apply suppressed (cells tick live), with a managed, idle-scheduled re-sort paced adaptively off its own measured cost - `experimental.deferredSortFactor` tunes the pacing, 0 restoring synchronous re-sorting. New records (adds) always sort into place immediately - ag-Grid ignores suppression for transactions with adds/removes.

## Results

Toolbox cube tester, tree grid (Fund > Trader, leaves), ~550-row update transactions, avg `applyTransaction` time:

| Rows | Suppress | Delta (values changing) | Full |
|---|---|---|---|
| 400k | **10.5ms** | 592ms | 2,237ms |
| 40k | **15.8ms** | 419ms | 1,254ms |

- At 400k rows the previous per-transaction full refresh (~1.4-2.2s) could not keep up with a 1/sec update stream; suppressed applies are ~100x faster and size-independent (dominated by the fixed cell-refresh cost).
- The win holds well down at 40k rows: ~80x vs full for order-stable updates, ~3x for genuinely reordering ones.
- On a commission-sorted 400k grid: all updates applied at ~11ms, with re-sorts amortized off the transaction path and paced to a bounded fraction of main-thread time.
- Verified mode selection live at both scales: order-stable streams suppress on 100% of transactions via `changedFields`; sorting by a field the stream changes correctly drops to delta.

## Notes for review

- `RecordSet` carries `changedFields` via single-step ordinal provenance (no predecessor references retained). `diffFrom` surfaces it only when the diff window is exactly one value-only step - multi-step windows conservatively report unknown.
- Row-reuse stores mutate row data objects in place, so the per-record fallback detects shared data (`prev.data === rec.data`) and declines to suppress - `changedFields` is what enables the fast path for view-connected stores.
- Companion Toolbox commit (local, not yet pushed) removes the cube tester's now-obsolete Delta Sort toggle.

## Appendix: delta vs. full re-sort - measured crossover

The delta/full threshold (`experimental.deltaSortRatio`) was raised from an initial 20% to a default of 50%, from live measurement in the cube tester (fund > trader tree with leaves, n = 20,055, sorted on a streaming field; per-flush timings via the new `sortFlush` diagnostics):

| changed rows (t/n) | delta | full |
|---|---|---|
| 1% | 22ms | ~83ms |
| 18% | 37ms | ~83ms |
| 33% | 51ms | ~83ms |
| 51% | 73ms | ~83ms |
| 98% | 98-141ms | ~83ms |

- Full-sort cost is flat in changed-row count (it re-sorts everything regardless); delta is linear: ~21ms + ~5µs per changed row at this scale. At full coverage delta is ~1.7-3x *slower* than full - it pays a full-sized sort of the changed set plus its own index/merge bookkeeping.
- Measured break-even at t/n ≈ 0.55 matches a comparator-count model (`t·log₂t` vs `n·(log₂n_g − a)`, a ≈ 5, with n_g ≈ 440-row leaf groups here). The crossover rises with leaf-group size - flatter grids favor delta longer - and falls for deeply nested, small-group shapes.
- 0.5 sits just below break-even for this shape, and erring toward delta is the safe side of wrong: modestly more total sort time, but in smaller, smoother chunks - vs. full's single larger block.
