### PR TITLE
Fix O(n²) option merge in async Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,10 @@ columns.
   with Hoist's other constraints. Pair the two rules if a value must be present.
 * Fixed `CodeInput` with `autoFormat` committing reformatted text back to its bound value, leaving
   forms dirty after a reset.
+* Fixed an `O(n²)` option merge in async `Select` (v86.3.0 regression) that could block the main
+  thread for seconds on large `queryFn` results. `Select` now retains only the queried options plus
+  any selected options not among them, instead of accumulating and de-duping the full query history,
+  and skips retaining results superseded by later input.
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,9 +260,8 @@ columns.
 * Fixed `CodeInput` with `autoFormat` committing reformatted text back to its bound value, leaving
   forms dirty after a reset.
 * Fixed an `O(n²)` option merge in async `Select` (v86.3.0 regression) that could block the main
-  thread for seconds on large `queryFn` results. `Select` now retains only the queried options plus
-  any selected options not among them, instead of accumulating and de-duping the full query history,
-  and skips retaining results superseded by later input.
+  thread for seconds on large `queryFn` results. `Select` no longer accumulates and de-dupes the
+  full query history.
 
 ### ⚙️ Technical
 

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -534,7 +534,8 @@ class SelectInputModel extends HoistInputModel {
     //------------------------
     // Async
     //------------------------
-    // Bumped for each query issued by react-select, to identify superseded results below.
+    // Bumped on each loadOptions call from react-select - i.e. per input change, not per query
+    // actually issued - so the debounced query below can detect results superseded by later input.
     private queryGeneration = 0;
 
     doQueryAsync = query => {

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -199,13 +199,18 @@ export interface SelectProps extends HoistProps, HoistInputProps, LayoutProps {
     valueField?: string;
 
     /**
-     * Function to generate a `SelectOption` for a (non-null) selected value not present in the
-     * current options list. Return null to fall back to the default value-as-label behavior.
+     * Fallback function to look up the `SelectOption` for a (non-null) selected value that is not
+     * present in the current options. Return null to accept the default value-as-label behavior.
      *
-     * Useful with queryFn-based selects, readonly forms, or any case where options may not be
-     * loaded when a value is set, ensuring the value renders with its proper label.
+     * Intended for values that already exist but whose option is simply out of view - e.g. an
+     * initial value on a `queryFn`-based select, where the control is bound to the value alone and
+     * no query has yet run to supply its label. Useful where value-as-label would never be
+     * meaningful to the user, such as an object select that should always render the object's name
+     * rather than its id value.
+     *
+     * Note this is not capable of "creating" new values via `enableCreate`.
      */
-    generateOptionFn?: (value: any) => SelectOption;
+    generateOptionFn?: (value: any) => SelectOption | null;
 }
 
 /**
@@ -301,7 +306,7 @@ class SelectInputModel extends HoistInputModel {
 
     override onLinked() {
         const queryBuffer = withDefault(this.componentProps.queryBuffer, 300);
-        if (queryBuffer) this.queryAsync = debouncePromise(this.queryAsync, queryBuffer);
+        if (queryBuffer) this.doQueryAsync = debouncePromise(this.doQueryAsync, queryBuffer);
 
         this.addReaction({
             track: () => this.componentProps.options,
@@ -450,10 +455,7 @@ class SelectInputModel extends HoistInputModel {
         return regex.test(opt.label);
     };
 
-    // Convert external value into option object(s). Options created if missing - this takes the
-    // external value from the model, and we will respect that even if we don't know about it.
-    // (Exception for a null value, which is never synthesized - accepted only if provided via
-    // options.)
+    // Convert external value (which may be a primitive string or number) into option object(s).
     override toInternal(external) {
         if (this.multiMode) {
             if (external == null || isEqual(external, this.emptyValue)) external = []; // avoid [null]
@@ -475,8 +477,14 @@ class SelectInputModel extends HoistInputModel {
 
         if (!createIfNotFound) return null;
 
-        // Value not among options - let the app generate an option for it, else synthesize one.
-        return this.componentProps.generateOptionFn?.(value) ?? this.valueToOption(value);
+        return (
+            // Attempts to find the option in internalValue.
+            this.selectedOptions.find(it => isEqual(it.value, value)) ??
+            // Attempts to call the generateOptionFn function to get the option for this value.
+            this.componentProps.generateOptionFn?.(value) ??
+            // All else failing, converts the value into an option.
+            this.valueToOption(value)
+        );
     }
 
     override toExternal(internal) {
@@ -534,33 +542,9 @@ class SelectInputModel extends HoistInputModel {
     //------------------------
     // Async
     //------------------------
-    // Bumped on each loadOptions call from react-select - i.e. per input change, not per query
-    // actually issued - so the debounced query below can detect results superseded by later input.
-    private queryGeneration = 0;
-
-    doQueryAsync = query => {
-        this.queryGeneration++;
-        return this.queryAsync(query);
-    };
-
-    // Debounced within onLinked(), per the queryBuffer prop.
-    private queryAsync = async query => {
-        const generation = this.queryGeneration,
-            rawOpts = await this.componentProps.queryFn(query),
-            matchOpts = this.normalizeOptions(rawOpts);
-
-        // Retain the queried options, plus any selected options not among them, to allow our value
-        // converters to continue to resolve all selected values in multiMode. Skipped if superseded
-        // by later input, as react-select discards such results.
-        if (generation === this.queryGeneration) {
-            const extraOpts = this.selectedOptions.filter(
-                it => !this.findOption(it.value, false, matchOpts)
-            );
-            this.internalOptions = [...matchOpts, ...extraOpts];
-        }
-
-        // But only return the matching options back to the combo.
-        return matchOpts;
+    doQueryAsync = async query => {
+        const rawOpts = await this.componentProps.queryFn(query);
+        return this.normalizeOptions(rawOpts);
     };
 
     // Option(s) backing the current selection, as produced by toInternal() above.

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -210,7 +210,7 @@ export interface SelectProps extends HoistProps, HoistInputProps, LayoutProps {
      *
      * Note this is not capable of "creating" new values via `enableCreate`.
      */
-    generateOptionFn?: (value: any) => SelectOption | null;
+    generateOptionFn?: (value: any) => SelectOption;
 }
 
 /**
@@ -478,11 +478,8 @@ class SelectInputModel extends HoistInputModel {
         if (!createIfNotFound) return null;
 
         return (
-            // Attempts to find the option in internalValue.
             this.selectedOptions.find(it => isEqual(it.value, value)) ??
-            // Attempts to call the generateOptionFn function to get the option for this value.
             this.componentProps.generateOptionFn?.(value) ??
-            // All else failing, converts the value into an option.
             this.valueToOption(value)
         );
     }

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -31,7 +31,7 @@ import {debouncePromise, wait} from '@xh/hoist/promise';
 import {elemWithin, getTestId, mergeDeep, TEST_ID, throwIf, withDefault} from '@xh/hoist/utils/js';
 import {createObservableRef, getLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
-import {castArray, escapeRegExp, isEmpty, isEqual, isNil, isPlainObject, unionWith} from 'lodash';
+import {castArray, escapeRegExp, isEmpty, isEqual, isNil, isPlainObject} from 'lodash';
 import {ReactElement, ReactNode} from 'react';
 import {components} from 'react-select';
 import {calcWindowedMenuWidth} from './impl/CalcWindowedMenuWidth';
@@ -301,7 +301,7 @@ class SelectInputModel extends HoistInputModel {
 
     override onLinked() {
         const queryBuffer = withDefault(this.componentProps.queryBuffer, 300);
-        if (queryBuffer) this.doQueryAsync = debouncePromise(this.doQueryAsync, queryBuffer);
+        if (queryBuffer) this.queryAsync = debouncePromise(this.queryAsync, queryBuffer);
 
         this.addReaction({
             track: () => this.componentProps.options,
@@ -534,19 +534,39 @@ class SelectInputModel extends HoistInputModel {
     //------------------------
     // Async
     //------------------------
-    doQueryAsync = async query => {
-        const rawOpts = await this.componentProps.queryFn(query),
+    // Bumped for each query issued by react-select, to identify superseded results below.
+    private queryGeneration = 0;
+
+    doQueryAsync = query => {
+        this.queryGeneration++;
+        return this.queryAsync(query);
+    };
+
+    // Debounced within onLinked(), per the queryBuffer prop.
+    private queryAsync = async query => {
+        const generation = this.queryGeneration,
+            rawOpts = await this.componentProps.queryFn(query),
             matchOpts = this.normalizeOptions(rawOpts);
 
-        // Carry forward and add to any existing internalOpts to allow our value
-        // converters to continue all selected values in multiMode.
-        this.internalOptions = unionWith(matchOpts, this.internalOptions, (a, b) =>
-            isEqual(a.value, b.value)
-        );
+        // Retain the queried options, plus any selected options not among them, to allow our value
+        // converters to continue to resolve all selected values in multiMode. Skipped if superseded
+        // by later input, as react-select discards such results.
+        if (generation === this.queryGeneration) {
+            const extraOpts = this.selectedOptions.filter(
+                it => !this.findOption(it.value, false, matchOpts)
+            );
+            this.internalOptions = [...matchOpts, ...extraOpts];
+        }
 
         // But only return the matching options back to the combo.
         return matchOpts;
     };
+
+    // Option(s) backing the current selection, as produced by toInternal() above.
+    private get selectedOptions(): SelectOption[] {
+        const {internalValue} = this;
+        return isNil(internalValue) ? [] : castArray(internalValue).filter(it => !isNil(it));
+    }
 
     loadingMessageFn = params => {
         const {loadingMessageFn} = this.componentProps,

--- a/mobile/cmp/input/Select.ts
+++ b/mobile/cmp/input/Select.ts
@@ -457,7 +457,8 @@ class SelectInputModel extends HoistInputModel {
     //------------------------
     // Async
     //------------------------
-    // Bumped for each query issued by react-select, to identify superseded results below.
+    // Bumped on each loadOptions call from react-select - i.e. per input change, not per query
+    // actually issued - so the debounced query below can detect results superseded by later input.
     private queryGeneration = 0;
 
     doQueryAsync = query => {

--- a/mobile/cmp/input/Select.ts
+++ b/mobile/cmp/input/Select.ts
@@ -159,13 +159,18 @@ export interface SelectProps extends HoistProps, HoistInputProps, LayoutProps {
     valueField?: string;
 
     /**
-     * Function to generate a `SelectOption` for a (non-null) selected value not present in the
-     * current options list. Return null to fall back to the default value-as-label behavior.
+     * Fallback function to look up the `SelectOption` for a (non-null) selected value that is not
+     * present in the current options. Return null to accept the default value-as-label behavior.
      *
-     * Useful with queryFn-based selects, readonly forms, or any case where options may not be
-     * loaded when a value is set, ensuring the value renders with its proper label.
+     * Intended for values that already exist but whose option is simply out of view - e.g. an
+     * initial value on a `queryFn`-based select, where the control is bound to the value alone and
+     * no query has yet run to supply its label. Useful where value-as-label would never be
+     * meaningful to the user, such as an object select that should always render the object's name
+     * rather than its id value.
+     *
+     * Note this is not capable of "creating" new values via `enableCreate`.
      */
-    generateOptionFn?: (value: any) => SelectOption;
+    generateOptionFn?: (value: any) => SelectOption | null;
 }
 
 /**
@@ -240,7 +245,7 @@ class SelectInputModel extends HoistInputModel {
 
     override onLinked() {
         const queryBuffer = withDefault(this.componentProps.queryBuffer, 300);
-        if (queryBuffer) this.queryAsync = debouncePromise(this.queryAsync, queryBuffer);
+        if (queryBuffer) this.doQueryAsync = debouncePromise(this.doQueryAsync, queryBuffer);
 
         this.addReaction({
             track: () => this.componentProps.options,
@@ -384,10 +389,7 @@ class SelectInputModel extends HoistInputModel {
         return regex.test(opt.label);
     };
 
-    // Convert external value into option object(s). Options created if missing - this takes the
-    // external value from the model, and we will respect that even if we don't know about it.
-    // (Exception for a null value, which is never synthesized - accepted only if provided via
-    // options.)
+    // Convert external value (which may be a primitive string or number) into option object(s).
     override toInternal(external) {
         return this.findOption(external, !isNil(external));
     }
@@ -405,8 +407,14 @@ class SelectInputModel extends HoistInputModel {
 
         if (!createIfNotFound) return null;
 
-        // Value not among options - let the app generate an option for it, else synthesize one.
-        return this.componentProps.generateOptionFn?.(value) ?? this.valueToOption(value);
+        return (
+            // Attempts to find the option in internalValue.
+            this.selectedOptions.find(it => isEqual(it.value, value)) ??
+            // Attempts to call the generateOptionFn function to get the option for this value.
+            this.componentProps.generateOptionFn?.(value) ??
+            // All else failing, converts the value into an option.
+            this.valueToOption(value)
+        );
     }
 
     override toExternal(internal) {
@@ -457,37 +465,10 @@ class SelectInputModel extends HoistInputModel {
     //------------------------
     // Async
     //------------------------
-    // Bumped on each loadOptions call from react-select - i.e. per input change, not per query
-    // actually issued - so the debounced query below can detect results superseded by later input.
-    private queryGeneration = 0;
-
     doQueryAsync = query => {
-        this.queryGeneration++;
-        return this.queryAsync(query);
-    };
-
-    // Debounced within onLinked(), per the queryBuffer prop.
-    private queryAsync = query => {
-        const generation = this.queryGeneration;
         return this.componentProps
             .queryFn(query)
-            .then(rawOpts => {
-                // Normalize query return.
-                const matchOpts = this.normalizeOptions(rawOpts);
-
-                // Retain the queried options, plus the selected option if not among them, to allow
-                // our value converters to continue to resolve it. Skipped if superseded by later
-                // input, as react-select discards such results.
-                if (generation === this.queryGeneration) {
-                    const extraOpts = this.selectedOptions.filter(
-                        it => !this.findOption(it.value, false, matchOpts)
-                    );
-                    this.internalOptions = [...matchOpts, ...extraOpts];
-                }
-
-                // But only return the matching options back to the combo.
-                return matchOpts;
-            })
+            .then(rawOpts => this.normalizeOptions(rawOpts))
             .catch(e => {
                 this.logError(e);
                 throw e;

--- a/mobile/cmp/input/Select.ts
+++ b/mobile/cmp/input/Select.ts
@@ -170,7 +170,7 @@ export interface SelectProps extends HoistProps, HoistInputProps, LayoutProps {
      *
      * Note this is not capable of "creating" new values via `enableCreate`.
      */
-    generateOptionFn?: (value: any) => SelectOption | null;
+    generateOptionFn?: (value: any) => SelectOption;
 }
 
 /**
@@ -408,11 +408,8 @@ class SelectInputModel extends HoistInputModel {
         if (!createIfNotFound) return null;
 
         return (
-            // Attempts to find the option in internalValue.
             this.selectedOptions.find(it => isEqual(it.value, value)) ??
-            // Attempts to call the generateOptionFn function to get the option for this value.
             this.componentProps.generateOptionFn?.(value) ??
-            // All else failing, converts the value into an option.
             this.valueToOption(value)
         );
     }

--- a/mobile/cmp/input/Select.ts
+++ b/mobile/cmp/input/Select.ts
@@ -21,7 +21,7 @@ import {action, bindable, makeObservable, observable, override} from '@xh/hoist/
 import {debouncePromise, wait} from '@xh/hoist/promise';
 import {throwIf, withDefault, mergeDeep} from '@xh/hoist/utils/js';
 import {createObservableRef, getLayoutProps} from '@xh/hoist/utils/react';
-import {escapeRegExp, isEqual, isNil, isPlainObject, unionWith} from 'lodash';
+import {escapeRegExp, isEqual, isNil, isPlainObject} from 'lodash';
 import {Children, ReactNode, ReactPortal} from 'react';
 import ReactDom from 'react-dom';
 import './Select.scss';
@@ -240,7 +240,7 @@ class SelectInputModel extends HoistInputModel {
 
     override onLinked() {
         const queryBuffer = withDefault(this.componentProps.queryBuffer, 300);
-        if (queryBuffer) this.doQueryAsync = debouncePromise(this.doQueryAsync, queryBuffer);
+        if (queryBuffer) this.queryAsync = debouncePromise(this.queryAsync, queryBuffer);
 
         this.addReaction({
             track: () => this.componentProps.options,
@@ -328,7 +328,7 @@ class SelectInputModel extends HoistInputModel {
         super.noteFocused();
     }
 
-    selectText() {
+    private selectText() {
         const {reactSelect} = this;
         if (!reactSelect) return;
 
@@ -392,7 +392,7 @@ class SelectInputModel extends HoistInputModel {
         return this.findOption(external, !isNil(external));
     }
 
-    findOption(value, createIfNotFound, options = this.internalOptions) {
+    private findOption(value, createIfNotFound, options = this.internalOptions) {
         // Do a depth-first search of options
         for (const option of options) {
             if (option.options) {
@@ -413,7 +413,7 @@ class SelectInputModel extends HoistInputModel {
         return isNil(internal) ? null : internal.value;
     }
 
-    normalizeOptions(options, depth = 0) {
+    private normalizeOptions(options, depth = 0) {
         throwIf(depth > 1, 'Grouped select options support only one-deep nesting.');
 
         options = options || [];
@@ -423,11 +423,11 @@ class SelectInputModel extends HoistInputModel {
     // Normalize / clone a single source value into a normalized option object. Supports Strings
     // and Objects. Objects are validated/defaulted to ensure a label+value or label+options sublist,
     // with other fields brought along to support Selects emitting value objects with ad hoc properties.
-    toOption(src, depth) {
+    private toOption(src, depth) {
         return isPlainObject(src) ? this.objectToOption(src, depth) : this.valueToOption(src);
     }
 
-    objectToOption(src, depth) {
+    private objectToOption(src, depth) {
         const {componentProps} = this,
             labelField = withDefault(componentProps.labelField, 'label'),
             valueField = withDefault(componentProps.valueField, 'value');
@@ -450,25 +450,39 @@ class SelectInputModel extends HoistInputModel {
               };
     }
 
-    valueToOption(src) {
+    private valueToOption(src) {
         return {label: src != null ? src.toString() : '-null-', value: src};
     }
 
     //------------------------
     // Async
     //------------------------
+    // Bumped for each query issued by react-select, to identify superseded results below.
+    private queryGeneration = 0;
+
     doQueryAsync = query => {
+        this.queryGeneration++;
+        return this.queryAsync(query);
+    };
+
+    // Debounced within onLinked(), per the queryBuffer prop.
+    private queryAsync = query => {
+        const generation = this.queryGeneration;
         return this.componentProps
             .queryFn(query)
-            .then(matchOpts => {
+            .then(rawOpts => {
                 // Normalize query return.
-                matchOpts = this.normalizeOptions(matchOpts);
+                const matchOpts = this.normalizeOptions(rawOpts);
 
-                // Carry forward and add to any existing internalOpts to allow our value
-                // converters to continue all selected values in multiMode.
-                this.internalOptions = unionWith(matchOpts, this.internalOptions, (a, b) =>
-                    isEqual(a.value, b.value)
-                );
+                // Retain the queried options, plus the selected option if not among them, to allow
+                // our value converters to continue to resolve it. Skipped if superseded by later
+                // input, as react-select discards such results.
+                if (generation === this.queryGeneration) {
+                    const extraOpts = this.selectedOptions.filter(
+                        it => !this.findOption(it.value, false, matchOpts)
+                    );
+                    this.internalOptions = [...matchOpts, ...extraOpts];
+                }
 
                 // But only return the matching options back to the combo.
                 return matchOpts;
@@ -478,6 +492,12 @@ class SelectInputModel extends HoistInputModel {
                 throw e;
             });
     };
+
+    // Option backing the current selection, as produced by toInternal() above.
+    private get selectedOptions(): SelectOption[] {
+        const {internalValue} = this;
+        return isNil(internalValue) ? [] : [internalValue];
+    }
 
     loadingMessageFn = params => {
         if (!params) return '';
@@ -502,7 +522,7 @@ class SelectInputModel extends HoistInputModel {
         return optionRenderer(opt);
     };
 
-    optionRenderer = opt => {
+    private optionRenderer = opt => {
         if (this.hideSelectedOptionCheck) {
             return div(opt.label);
         }
@@ -524,7 +544,7 @@ class SelectInputModel extends HoistInputModel {
     //------------------------
     // Fullscreen mode
     //------------------------
-    fullscreenReaction() {
+    private fullscreenReaction() {
         return {
             track: () => this.fullscreen,
             run: fullscreen => {


### PR DESCRIPTION
Fixes #4589.

In async (`queryFn`) mode, `SelectInputModel` merged every query result into `internalOptions` with `unionWith(..., (a, b) => isEqual(a.value, b.value))`. lodash cannot hash a custom comparator, so the merge fell back to a nested scan - O(n²), with a deep-equality call per pair, including de-duping each incoming result against itself. This was O(n) before 86.3.0, when `c4696b6` swapped a `keyBy` hash for `unionWith` to fix object-valued options colliding under `keyBy`.

## Approach

Rather than making that cache faster - hashed `Set`s for primitive values, a generation counter to skip results react-select had already discarded - this fixes the issue at its source by not maintaining the cache at all. The point of the original change was to make it convenient to hydrate non-value-as-label fields; it simply does not need to store every record it has ever encountered to achieve that.

`doQueryAsync` now normalizes the query result and returns it, full stop. Label resolution for a selected value falls back, in order, to the option already backing the current `internalValue`, then `generateOptionFn`, then value-as-label - so an option chosen from query results keeps its label across external-value round-trips with no query history retained.

## Changes

* `doQueryAsync` no longer accumulates into `internalOptions` on either platform - `internalOptions` is now sourced solely from the `options` prop.
* `findOption` consults the option(s) backing the current selection before falling back to `generateOptionFn` / value-as-label.
* Reworked the `generateOptionFn` doc comment to describe it as a fallback lookup for a value whose option is simply out of view, and noted that it cannot "create" values via `enableCreate`.
* Marked the remaining internal members of the mobile `SelectInputModel` `private`, matching its desktop counterpart.

Two things fall out of this for free: superseded query results cost nothing, since nothing is merged; and grouped options stop colliding in async mode - they carry no `value`, so `isEqual(undefined, undefined)` was true and all but the first group was dropped from `internalOptions`.

## Verification

`pnpm typecheck`, `pnpm lint`, and `prettier --check` pass.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.
