### PR TITLE
Inspector: pop-out window support

### DIFF
--- a/.claude/skills/xh-update-doc-links/SKILL.md
+++ b/.claude/skills/xh-update-doc-links/SKILL.md
@@ -121,11 +121,11 @@ the single source of truth for both the MCP server (which loads it at startup vi
      `components`, `desktop`, `mobile`, `utilities`, `supporting`, `devops`, or `upgrade`.
    - `description`: concise one-sentence summary matching existing entry style.
    - `keywords`: 5–12 key terms as a JSON array of strings — include API names, class names,
-     and topic terms. Keywords must be distinctive to the doc: exported symbol names and
-     package-specific phrases only. Never add generic UI/concept words (e.g. "render modes",
-     "overlay", "window") — they misroute keyword search, especially when the term names a
-     distinct concept elsewhere in Hoist (e.g. `RenderMode`). Before adding a keyword, ask:
-     "if an agent searches this term, is this doc the right destination?"
+     and topic terms. Every keyword must pass this test: a reader searching that term should
+     find this doc to be the right destination. Prefer distinctive terms — exported symbols
+     and phrases specific to the package. Avoid broad or generic words, and take particular
+     care with terms that name a concept owned by another part of the framework, where a match
+     would misroute the search.
 
 3. **Place entries** in logical order within the `entries` array (grouped by category).
 

--- a/.claude/skills/xh-update-doc-links/SKILL.md
+++ b/.claude/skills/xh-update-doc-links/SKILL.md
@@ -121,7 +121,11 @@ the single source of truth for both the MCP server (which loads it at startup vi
      `components`, `desktop`, `mobile`, `utilities`, `supporting`, `devops`, or `upgrade`.
    - `description`: concise one-sentence summary matching existing entry style.
    - `keywords`: 5–12 key terms as a JSON array of strings — include API names, class names,
-     and topic terms.
+     and topic terms. Keywords must be distinctive to the doc: exported symbol names and
+     package-specific phrases only. Never add generic UI/concept words (e.g. "render modes",
+     "overlay", "window") — they misroute keyword search, especially when the term names a
+     distinct concept elsewhere in Hoist (e.g. `RenderMode`). Before adding a keyword, ask:
+     "if an agent searches this term, is this doc the right destination?"
 
 3. **Place entries** in logical order within the `entries` array (grouped by category).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@
 See [`docs/upgrade-notes/v87-upgrade-notes.md`](docs/upgrade-notes/v87-upgrade-notes.md) for
 detailed, step-by-step upgrade instructions with before/after code examples.
 
-Hoist React v87 is a BIG release with a number of potentially breaking changes and many new
-features and performance optimizations, grouped by topic below.
+Hoist React v87 is a BIG release with a number of potentially breaking changes and many new features
+and performance optimizations, grouped by topic below.
 
 * Requires `hoist-core >= 40.5.0` for the `ViewManager` group rename and bulk-editing APIs, now
   correctly enforced at startup - apps on an older core will fail fast rather than start. Features
@@ -96,10 +96,10 @@ configs for zero-copy projection, digest-based record reuse, and streaming loads
   non-default values: the established sparse form for lightly-populated records, and a fixed shape
   cloned from a shared per-Store template for wider records. This avoids V8's memory-hungry
   "dictionary" mode and substantially reduces per-record memory on stores with wide records.
-* Improved Cube `View` memory efficiency across all row types - `ViewRowData` rows now share
-  compact fixed shapes, and leaf rows read field values directly from their source cube records
-  instead of holding copies. Substantially reduces per-row memory and speeds up view builds, with
-  savings that scale with query width.
+* Improved Cube `View` memory efficiency across all row types - `ViewRowData` rows now share compact
+  fixed shapes, and leaf rows read field values directly from their source cube records instead of
+  holding copies. Substantially reduces per-row memory and speeds up view builds, with savings that
+  scale with query width.
 * Added an opt-in `Store.projectionOnly` config to mark a store as a read-only projection of data
   that its provider parses and owns. Use it for stores connected to a Cube `View`, or fed by an
   endpoint that returns data in its final client-side form. Records reference the provider's row
@@ -112,15 +112,15 @@ configs for zero-copy projection, digest-based record reuse, and streaming loads
   `updateData()`, where `Store` drops unchanged-digest updates as no-ops. Snapshotted digests are
   available as `StoreRecord.digest`. Stores connected to a Cube `View` get a suitable digest
   automatically.
-* Enhanced Cube `View`s to reuse their generated rows across data updates, reloads, regrouping,
-  and filtering. Aggregate rows now reuse even when their children change - re-deriving in place
-  and republishing only values that actually changed - so e.g. dropping a trailing dimension
-  republishes nothing above the level that moved, and connected stores and grids skip the
-  matching record rebuilds.
-* Added `CubeConfig.store`, exposing `StoreConfig` options - notably `reuseRecords` and `retainRaw` -
-  on the Cube's internal Store. A source that supplies per-row digests can now preserve record
-  identity across full `Cube.loadDataAsync()` reloads, extending View row reuse to wholesale
-  refreshes.
+* Enhanced Cube `View`s to reuse their generated rows across data updates, reloads, regrouping, and
+  filtering. Aggregate rows now reuse even when their children change - re-deriving in place and
+  republishing only values that actually changed - so e.g. dropping a trailing dimension republishes
+  nothing above the level that moved, and connected stores and grids skip the matching record
+  rebuilds.
+* Added `CubeConfig.store`, exposing `StoreConfig` options - notably `reuseRecords` and
+  `retainRaw` - on the Cube's internal Store. A source that supplies per-row digests can now
+  preserve record identity across full `Cube.loadDataAsync()` reloads, extending View row reuse to
+  wholesale refreshes.
 * Added a `Store.retainRaw` config (default `true`). Set it to `false` to drop each record's
   reference to its raw source data object after parsing, reducing memory use on large stores that do
   not need `StoreRecord.raw`. Not compatible with `reuseRecords: true`.
@@ -200,15 +200,11 @@ columns.
   display of LDAP DNs. Per-group lookup errors surface as warning icons on the affected rows.
 * Added a search-based directory group picker to the Roles admin role editor, backed by the new
   `roleAdmin/searchDirectoryGroups` endpoint. Admins can find groups by partial name, with free-text
-  entry of a known GUID or DN still supported. Requires hoist-core v41.0.0 or later - against earlier
-  versions these features degrade gracefully to the previous identifier-based display.
+  entry of a known GUID or DN still supported. Requires hoist-core v41.0.0 or later - against
+  earlier versions these features degrade gracefully to the previous identifier-based display.
 
 #### Other Improvements
 
-* Added a pop-out mode to the Hoist Inspector, toggled via a new button in its header - opens
-  the Inspector in a separate browser window (e.g. on a second monitor), leaving the app's viewport
-  entirely to the app while keeping the Inspector fully live, with direct access to all app state.
-  Replaces the Inspector's previous modal (expand) toggle.
 * Added an `icon` prop to `Badge`, rendered before the badge's content. The new `--xh-badge-gap` CSS
   variable controls the spacing between the icon and the content.
 * Added a `CodeInput.lineStyles` prop to apply custom CSS class (es) to specific (1-based) lines,
@@ -218,12 +214,14 @@ columns.
   dynamically typed via a `typeField`.
 * `ViewManager` groups now support unlimited nesting, rendered as nested sub-menus in the
   ViewManager menu and as expandable tree grids in the Manage dialog. Groups and views support
-  drag-and-drop reorganization within the personal and global tabs, and renaming a group cascades
-  to every view nested beneath it. The `ViewManager` also supports bulk editing of
-  views' pin and visibility state.
-* `Select` now accepts a `valueRenderer` prop to customize how the selected value renders within
-  the control.
+  drag-and-drop reorganization within the personal and global tabs, and renaming a group cascades to
+  every view nested beneath it. `ViewManager` also now supports bulk editing of views' pin and
+  visibility state.
+* `Select` now accepts a `valueRenderer` prop to customize how the selected value renders within the
+  control.
 * `TextInput` now accepts a `leftElement` prop, rendered inline at the left of the input.
+* Hoist Inspector now pops out in a separate browser window, leaving the app's viewport to the app
+  while ensuring Inspector itself is not covered by masks or other modal content.
 
 ### 🐞 Bug Fixes
 
@@ -258,8 +256,8 @@ columns.
 * Added `diagnostics` to `Store`, Cube `View`, and `GridModel` - a slot per kind of op (e.g.
   `store.diagnostics.update`, `gridModel.diagnostics.autosize`) reporting work done, elapsed time,
   and the path taken. Note that diagnostics log by default under `debug` output, but users may set
-  `diagnostics.logLevel = 'info'` on a particular instance to focus on the performance of
-  a particular chain. This API is provided for app troubleshooting and benchmarking only, and is
+  `diagnostics.logLevel = 'info'` on a particular instance to focus on the performance of a
+  particular chain. This API is provided for app troubleshooting and benchmarking only, and is
   subject to change without notice at any release.
 
 * Field XSS protection now returns unmodified strings by reference instead of a fresh copy, avoiding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,12 +205,10 @@ columns.
 
 #### Other Improvements
 
-* Added two new hosting modes to the Hoist Inspector, toggled via new buttons in its header.
-  Both keep the Inspector fully live, with direct access to all app state:
-    * `overlay` pins the Inspector over the app in the browser's top layer, keeping it visible and
-      interactive above app-level masks and modal dialogs.
-    * `window` pops the Inspector out into a separate browser window - useful for moving it to a
-      second monitor while leaving the full app viewport to the app.
+* Added a pop-out mode to the Hoist Inspector, toggled via a new button in its header - opens
+  the Inspector in a separate browser window (e.g. on a second monitor), leaving the app's viewport
+  entirely to the app while keeping the Inspector fully live, with direct access to all app state.
+  Replaces the Inspector's previous modal (expand) toggle.
 * Added an `icon` prop to `Badge`, rendered before the badge's content. The new `--xh-badge-gap` CSS
   variable controls the spacing between the icon and the content.
 * Added a `CodeInput.lineStyles` prop to apply custom CSS class (es) to specific (1-based) lines,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,12 @@ columns.
 
 #### Other Improvements
 
+* Added two new hosting modes to the Hoist Inspector, toggled via new buttons in its header.
+  Both keep the Inspector fully live, with direct access to all app state:
+    * `overlay` pins the Inspector over the app in the browser's top layer, keeping it visible and
+      interactive above app-level masks and modal dialogs.
+    * `window` pops the Inspector out into a separate browser window - useful for moving it to a
+      second monitor while leaving the full app viewport to the app.
 * Added an `icon` prop to `Badge`, rendered before the badge's content. The new `--xh-badge-gap` CSS
   variable controls the spacing between the icon and the content.
 * Added a `CodeInput.lineStyles` prop to apply custom CSS class (es) to specific (1-based) lines,

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,7 @@ Cross-cutting documentation that spans multiple packages:
 | [`/security/`](../security/README.md) | OAuth 2.0 client abstraction for Auth0 and Microsoft Entra ID (MSAL) | BaseOAuthClient, AuthZeroClient, MsalClient, Token, AccessTokenSpec, auto-refresh, re-login |
 | [`/kit/`](../kit/README.md) | Centralized wrappers for third-party libraries used by Hoist | installAgGrid, installHighcharts, Blueprint, Onsen, GoldenLayout, react-select, version constraints |
 | [`/kit/blueprint/`](../kit/blueprint/README.md) | Blueprint integration - wrapped components, element factories, and build-time icon stubbing | Blueprint, Popover, Dialog, element factories, blueprint icons, loadAllBlueprintJsIcons, upgrade checklist |
-| [`/inspector/`](../inspector/README.md) | Built-in developer tool for real-time inspection of Hoist instances and memory | InspectorPanel, InspectorHostModel, render modes, StatsModel, InstancesModel, property watchlist, model leak detection |
+| [`/inspector/`](../inspector/README.md) | Built-in developer tool for real-time inspection of Hoist instances and memory | InspectorPanel, InspectorHostModel, StatsModel, InstancesModel, property watchlist, model leak detection |
 | [`/styles/`](../styles/README.md) | CSS custom properties, theming, BEM naming, SCSS conventions, and utility classes | `--xh-*` CSS vars, vars.scss, XH.scss, dark theme, ThemeModel, BEM, `xh-` prefix, intent colors, utility classes |
 
 ### Other Packages

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,7 @@ Cross-cutting documentation that spans multiple packages:
 | [`/security/`](../security/README.md) | OAuth 2.0 client abstraction for Auth0 and Microsoft Entra ID (MSAL) | BaseOAuthClient, AuthZeroClient, MsalClient, Token, AccessTokenSpec, auto-refresh, re-login |
 | [`/kit/`](../kit/README.md) | Centralized wrappers for third-party libraries used by Hoist | installAgGrid, installHighcharts, Blueprint, Onsen, GoldenLayout, react-select, version constraints |
 | [`/kit/blueprint/`](../kit/blueprint/README.md) | Blueprint integration - wrapped components, element factories, and build-time icon stubbing | Blueprint, Popover, Dialog, element factories, blueprint icons, loadAllBlueprintJsIcons, upgrade checklist |
-| [`/inspector/`](../inspector/README.md) | Built-in developer tool for real-time inspection of Hoist instances and memory | InspectorPanel, InspectorHostModel, StatsModel, InstancesModel, property watchlist, model leak detection |
+| [`/inspector/`](../inspector/README.md) | Built-in developer tool for real-time inspection of Hoist instances and memory | InspectorPanel, InspectorModel, StatsModel, InstancesModel, property watchlist, model leak detection |
 | [`/styles/`](../styles/README.md) | CSS custom properties, theming, BEM naming, SCSS conventions, and utility classes | `--xh-*` CSS vars, vars.scss, XH.scss, dark theme, ThemeModel, BEM, `xh-` prefix, intent colors, utility classes |
 
 ### Other Packages

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,7 @@ Cross-cutting documentation that spans multiple packages:
 | [`/security/`](../security/README.md) | OAuth 2.0 client abstraction for Auth0 and Microsoft Entra ID (MSAL) | BaseOAuthClient, AuthZeroClient, MsalClient, Token, AccessTokenSpec, auto-refresh, re-login |
 | [`/kit/`](../kit/README.md) | Centralized wrappers for third-party libraries used by Hoist | installAgGrid, installHighcharts, Blueprint, Onsen, GoldenLayout, react-select, version constraints |
 | [`/kit/blueprint/`](../kit/blueprint/README.md) | Blueprint integration - wrapped components, element factories, and build-time icon stubbing | Blueprint, Popover, Dialog, element factories, blueprint icons, loadAllBlueprintJsIcons, upgrade checklist |
-| [`/inspector/`](../inspector/README.md) | Built-in developer tool for real-time inspection of Hoist instances and memory | InspectorPanel, StatsModel, InstancesModel, property watchlist, model leak detection |
+| [`/inspector/`](../inspector/README.md) | Built-in developer tool for real-time inspection of Hoist instances and memory | InspectorPanel, InspectorHostModel, render modes, StatsModel, InstancesModel, property watchlist, model leak detection |
 | [`/styles/`](../styles/README.md) | CSS custom properties, theming, BEM naming, SCSS conventions, and utility classes | `--xh-*` CSS vars, vars.scss, XH.scss, dark theme, ThemeModel, BEM, `xh-` prefix, intent colors, utility classes |
 
 ### Other Packages

--- a/docs/doc-registry.json
+++ b/docs/doc-registry.json
@@ -261,7 +261,7 @@
             "mcpCategory": "package",
             "viewerCategory": "supporting",
             "description": "Built-in developer tool for real-time inspection of Hoist instances.",
-            "keywords": ["InspectorPanel", "InspectorHostModel", "StatsModel", "InstancesModel", "property watchlist", "model leak detection", "render modes", "overlay", "pop-out window"]
+            "keywords": ["InspectorPanel", "InspectorHostModel", "StatsModel", "InstancesModel", "property watchlist", "model leak detection"]
         },
         {
             "id": "mcp/README.md",

--- a/docs/doc-registry.json
+++ b/docs/doc-registry.json
@@ -261,7 +261,7 @@
             "mcpCategory": "package",
             "viewerCategory": "supporting",
             "description": "Built-in developer tool for real-time inspection of Hoist instances.",
-            "keywords": ["InspectorPanel", "InspectorHostModel", "StatsModel", "InstancesModel", "property watchlist", "model leak detection"]
+            "keywords": ["InspectorPanel", "InspectorModel", "StatsModel", "InstancesModel", "property watchlist", "model leak detection"]
         },
         {
             "id": "mcp/README.md",

--- a/docs/doc-registry.json
+++ b/docs/doc-registry.json
@@ -261,7 +261,7 @@
             "mcpCategory": "package",
             "viewerCategory": "supporting",
             "description": "Built-in developer tool for real-time inspection of Hoist instances.",
-            "keywords": ["InspectorPanel", "StatsModel", "InstancesModel", "property watchlist", "model leak detection"]
+            "keywords": ["InspectorPanel", "InspectorHostModel", "StatsModel", "InstancesModel", "property watchlist", "model leak detection", "render modes", "overlay", "pop-out window"]
         },
         {
             "id": "mcp/README.md",

--- a/inspector/Inspector.scss
+++ b/inspector/Inspector.scss
@@ -16,27 +16,3 @@
   background-color: hsl(33, 93%, 40%);
   color: white;
 }
-
-// Top-layer host for 'overlay' render mode - a manual popover covering the full viewport, with
-// the Inspector panel pinned to its bottom edge. The host itself must not intercept pointer
-// events (the app remains interactive above/behind it), while its children - the Inspector panel
-// plus any re-parented popups (grid menus, tooltips) - do receive events.
-.xh-inspector-overlay-host {
-  position: fixed;
-  inset: 0;
-  width: 100vw;
-  height: 100vh;
-  margin: 0;
-  padding: 0;
-  border: none;
-  background: transparent;
-  overflow: visible;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  pointer-events: none;
-
-  > * {
-    pointer-events: auto;
-  }
-}

--- a/inspector/Inspector.scss
+++ b/inspector/Inspector.scss
@@ -16,3 +16,19 @@
   background-color: hsl(33, 93%, 40%);
   color: white;
 }
+
+// Popped-out window layout - these rules reach the child window via its synced stylesheets.
+// The Inspector panel itself flexes to fill the host (see `flex` prop in InspectorPanel).
+body.xh-inspector-window {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+
+  .xh-inspector-window-host {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+}

--- a/inspector/Inspector.scss
+++ b/inspector/Inspector.scss
@@ -16,3 +16,27 @@
   background-color: hsl(33, 93%, 40%);
   color: white;
 }
+
+// Top-layer host for 'overlay' render mode - a manual popover covering the full viewport, with
+// the Inspector panel pinned to its bottom edge. The host itself must not intercept pointer
+// events (the app remains interactive above/behind it), while its children - the Inspector panel
+// plus any re-parented popups (grid menus, tooltips) - do receive events.
+.xh-inspector-overlay-host {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  overflow: visible;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  pointer-events: none;
+
+  > * {
+    pointer-events: auto;
+  }
+}

--- a/inspector/InspectorHostModel.ts
+++ b/inspector/InspectorHostModel.ts
@@ -11,17 +11,26 @@ import {action, makeObservable, observable} from '@xh/hoist/mobx';
  * Where the active Inspector UI is currently hosted:
  *  - 'dock' - docked panel within the app's viewport (default).
  *  - 'overlay' - pinned over the app in the browser's top layer, above all masks and dialogs.
+ *  - 'window' - popped out into a separate, dedicated browser window.
  */
-export type InspectorRenderMode = 'dock' | 'overlay';
+export type InspectorRenderMode = 'dock' | 'overlay' | 'window';
 
 /**
  * Manages where the Inspector UI renders. The default 'dock' mode renders the Inspector as a
  * resizable panel docked to the bottom of the app viewport, where (as a standard part of the
  * app's component tree) it can be covered and blocked by app-level masks and modal dialogs.
  *
- * The alternate 'overlay' mode relocates the Inspector into a `popover` element in the browser's
- * top layer, which always paints above any z-index within the app - keeping the Inspector fully
- * visible and interactive while masks or modals are showing.
+ * Two alternate modes detach the Inspector from the app's component tree:
+ *  - 'overlay' relocates the Inspector into a `popover` element in the browser's top layer, which
+ *    always paints above any z-index within the app - keeping the Inspector fully visible and
+ *    interactive while masks or modals are showing.
+ *  - 'window' pops the Inspector out into a separate browser window, which can be moved to a
+ *    second monitor and leaves the app's viewport entirely to the app. The Inspector remains part
+ *    of the main app's component tree (via a cross-document React portal), so it retains direct,
+ *    live access to all app state.
+ *
+ * Both detached modes portal the same component tree rendered when docked, and re-parent any
+ * Inspector-spawned popups (grid menus, tooltips) into the detached host.
  *
  * Created internally by {@link inspectorPanel} - not for direct application use.
  *
@@ -40,6 +49,10 @@ export class InspectorHostModel extends HoistModel {
     @observable.ref
     overlayEl: HTMLElement = null;
 
+    /** Container within the popped-out window - portal target when in 'window' mode. */
+    @observable.ref
+    windowContainer: HTMLElement = null;
+
     /** True if the browser supports the Popover API required for 'overlay' mode. */
     get overlaySupported(): boolean {
         return typeof HTMLElement.prototype.showPopover === 'function';
@@ -48,18 +61,32 @@ export class InspectorHostModel extends HoistModel {
     /**
      * Container to which any popups spawned by Inspector components (grid menus, tooltips,
      * dropdowns) should be re-parented, or null to use their default document-level parent.
-     * Required when detached - popups portaled to `document.body` would otherwise render beneath
-     * the browser's top layer.
+     * Required when detached - popups portaled to the main `document.body` would otherwise render
+     * beneath the browser's top layer, or within the wrong window entirely.
      */
     get popupContainer(): HTMLElement {
-        return this.renderMode === 'overlay' ? this.overlayEl : null;
+        const {renderMode} = this;
+        return renderMode === 'overlay'
+            ? this.overlayEl
+            : renderMode === 'window'
+              ? this.windowContainer
+              : null;
     }
+
+    private childWindow: Window = null;
+    private closingChildWindow = false;
+    private headObserver: MutationObserver = null;
+    private bodyClassObserver: MutationObserver = null;
 
     constructor() {
         super();
         makeObservable(this);
 
-        if (this.renderMode === 'overlay' && !this.overlaySupported) {
+        // Window mode requires a user gesture to (re)open and cannot be restored on app load.
+        if (
+            this.renderMode === 'window' ||
+            (this.renderMode === 'overlay' && !this.overlaySupported)
+        ) {
             this.renderMode = 'dock';
         }
 
@@ -75,14 +102,56 @@ export class InspectorHostModel extends HoistModel {
         this.renderMode = mode;
     }
 
+    /**
+     * Pop the Inspector out into a separate browser window. Must be called from a user
+     * interaction (e.g. button click) to avoid popup blocking.
+     */
+    @action
+    openWindow() {
+        let {childWindow} = this;
+        if (childWindow && !childWindow.closed) {
+            childWindow.focus();
+            this.renderMode = 'window';
+            return;
+        }
+
+        childWindow = window.open(
+            '',
+            `xhInspector_${XH.clientAppCode}`,
+            'popup=yes,width=1400,height=500'
+        );
+        if (!childWindow) {
+            XH.dangerToast('Unable to open Inspector window - check for a popup blocker.');
+            return;
+        }
+
+        this.childWindow = childWindow;
+        this.initChildWindow(childWindow);
+        childWindow.focus();
+        this.renderMode = 'window';
+    }
+
     //------------------
     // Implementation
     //------------------
     private syncHosting() {
-        const {active} = XH.inspectorService;
-        active && this.renderMode === 'overlay' ? this.showOverlay() : this.hideOverlay();
+        const {active} = XH.inspectorService,
+            {renderMode} = this;
+
+        if (active && renderMode === 'overlay') {
+            this.showOverlay();
+        } else {
+            this.hideOverlay();
+        }
+
+        if (!(active && renderMode === 'window')) {
+            this.closeWindow();
+        }
     }
 
+    //------------------
+    // Overlay mode
+    //------------------
     @action
     private showOverlay() {
         let {overlayEl} = this;
@@ -105,8 +174,117 @@ export class InspectorHostModel extends HoistModel {
         overlayEl.remove();
     }
 
+    //------------------
+    // Window mode
+    //------------------
+    private initChildWindow(win: Window) {
+        const doc = win.document;
+
+        // Reset any stale content from a previously-opened window reused via its name.
+        doc.head.innerHTML = '';
+        doc.body.innerHTML = '';
+        doc.title = `${XH.appName} - Hoist Inspector`;
+        doc.body.style.cssText = 'margin:0;height:100vh;display:flex;flex-direction:column;';
+
+        this.syncChildStyles();
+        this.syncChildBodyClass();
+
+        const container = doc.createElement('div');
+        container.classList.add('xh-inspector-window-host');
+        container.style.cssText = 'flex:1;display:flex;flex-direction:column;overflow:hidden;';
+        doc.body.appendChild(container);
+
+        // Return to docked mode if the user closes the popped-out window directly.
+        win.addEventListener('pagehide', this.onChildWindowPagehide);
+
+        // Close the popped-out window if the main app window unloads.
+        window.addEventListener('pagehide', this.onMainWindowPagehide);
+
+        // Keep styles synced across stylesheet changes (dev-time hot reloads, lazily-loaded
+        // chunks) and theme changes (light/dark theme classes on the main document body).
+        this.headObserver = new MutationObserver(() => this.syncChildStyles());
+        this.headObserver.observe(document.head, {childList: true});
+        this.bodyClassObserver = new MutationObserver(() => this.syncChildBodyClass());
+        this.bodyClassObserver.observe(document.body, {
+            attributes: true,
+            attributeFilter: ['class']
+        });
+
+        this.setWindowContainer(container);
+    }
+
+    @action
+    private setWindowContainer(container: HTMLElement) {
+        this.windowContainer = container;
+    }
+
+    private closeWindow() {
+        const {childWindow} = this;
+        if (!childWindow) return;
+
+        this.closingChildWindow = true;
+        try {
+            this.headObserver?.disconnect();
+            this.bodyClassObserver?.disconnect();
+            this.headObserver = this.bodyClassObserver = null;
+            window.removeEventListener('pagehide', this.onMainWindowPagehide);
+            if (!childWindow.closed) {
+                childWindow.removeEventListener('pagehide', this.onChildWindowPagehide);
+                childWindow.close();
+            }
+        } finally {
+            this.closingChildWindow = false;
+        }
+
+        this.childWindow = null;
+        this.setWindowContainer(null);
+    }
+
+    /** Clone the main document's stylesheets into the popped-out window. */
+    private syncChildStyles() {
+        const win = this.childWindow;
+        if (!win || win.closed) return;
+
+        const childDoc = win.document,
+            childHead = childDoc.head;
+
+        // Full re-sync on any change - infrequent + cheap at this scale.
+        childHead.querySelectorAll('[data-xh-inspector-synced]').forEach(node => node.remove());
+        document.head.querySelectorAll('style, link[rel="stylesheet"]').forEach(node => {
+            let clone: HTMLElement;
+            if (node.tagName === 'LINK') {
+                clone = childDoc.createElement('link');
+                clone.setAttribute('rel', 'stylesheet');
+                // Use resolved (absolute) href - childDoc has no base URL of its own.
+                clone.setAttribute('href', (node as HTMLLinkElement).href);
+            } else {
+                clone = childDoc.importNode(node, true) as HTMLElement;
+            }
+            clone.setAttribute('data-xh-inspector-synced', 'true');
+            childHead.appendChild(clone);
+        });
+    }
+
+    /** Mirror theme + app classes from the main document body onto the popped-out window. */
+    private syncChildBodyClass() {
+        const win = this.childWindow;
+        if (!win || win.closed) return;
+        win.document.body.className = `${document.body.className} xh-inspector-window`;
+    }
+
+    private onChildWindowPagehide = () => {
+        if (!this.closingChildWindow && this.renderMode === 'window') {
+            this.setRenderMode('dock');
+        }
+    };
+
+    private onMainWindowPagehide = () => {
+        this.childWindow?.close();
+    };
+
     override destroy() {
         this.hideOverlay();
+        this.closeWindow();
         super.destroy();
     }
 }

--- a/inspector/InspectorHostModel.ts
+++ b/inspector/InspectorHostModel.ts
@@ -4,23 +4,19 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistModel, persist, XH} from '@xh/hoist/core';
+import {HoistModel, XH} from '@xh/hoist/core';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 
 /**
- * Where the active Inspector UI is currently hosted:
- *  - 'dock' - docked panel within the app's viewport (default).
- *  - 'window' - popped out into a separate, dedicated browser window.
- */
-export type InspectorRenderMode = 'dock' | 'window';
-
-/**
- * Manages where the Inspector UI renders. The default 'dock' mode renders the Inspector as a
- * resizable panel docked to the bottom of the app viewport. The alternate 'window' mode pops the
- * Inspector out into a separate browser window, which can be moved to a second monitor and leaves
- * the app's viewport entirely to the app - including any masks and modal dialogs that would cover
- * a docked Inspector. The Inspector remains part of the main app's component tree (via a
- * cross-document React portal), so it retains direct, live access to all app state.
+ * Manages where the Inspector UI renders. By default the Inspector renders as a resizable panel
+ * docked to the bottom of the app viewport. Alternately, it can be popped out into a separate
+ * browser window, which can be moved to a second monitor and leaves the app's viewport entirely
+ * to the app - including any masks and modal dialogs that would cover a docked Inspector. The
+ * Inspector remains part of the main app's component tree (via a cross-document React portal),
+ * so it retains direct, live access to all app state.
+ *
+ * Popped-out state is not persisted - browsers require a user gesture to open a window, so the
+ * Inspector always returns docked on app load.
  *
  * Created internally by {@link inspectorPanel} - not for direct application use.
  *
@@ -29,15 +25,14 @@ export type InspectorRenderMode = 'dock' | 'window';
 export class InspectorHostModel extends HoistModel {
     override xhImpl = true;
 
-    override persistWith = {localStorageKey: `xhInspector.${XH.clientAppCode}`};
-
-    @observable
-    @persist
-    renderMode: InspectorRenderMode = 'dock';
-
-    /** Container within the popped-out window - portal target when in 'window' mode. */
+    /** Container within the popped-out window - portal target when popped out, null when docked. */
     @observable.ref
     windowContainer: HTMLElement = null;
+
+    /** True when the Inspector is popped out into its own window. */
+    get isWindowed(): boolean {
+        return this.windowContainer != null;
+    }
 
     /**
      * Container to which any popups spawned by Inspector components (grid menus, tooltips,
@@ -46,11 +41,10 @@ export class InspectorHostModel extends HoistModel {
      * render within the wrong window entirely.
      */
     get popupContainer(): HTMLElement {
-        return this.renderMode === 'window' ? this.windowContainer : null;
+        return this.windowContainer;
     }
 
     private childWindow: Window = null;
-    private closingChildWindow = false;
     private headObserver: MutationObserver = null;
     private bodyClassObserver: MutationObserver = null;
 
@@ -58,62 +52,63 @@ export class InspectorHostModel extends HoistModel {
         super();
         makeObservable(this);
 
-        // Window mode requires a user gesture to (re)open and cannot be restored on app load.
-        // Also maps any other unsupported persisted value back to the default.
-        if (this.renderMode !== 'dock') {
-            this.renderMode = 'dock';
-        }
-
+        // Close the popped-out window if the Inspector is deactivated.
         this.addReaction({
-            track: () => [XH.inspectorService.active, this.renderMode],
-            run: () => this.syncHosting(),
-            fireImmediately: true
+            track: () => XH.inspectorService.active,
+            run: active => {
+                if (!active) this.dock();
+            }
         });
-    }
-
-    @action
-    setRenderMode(mode: InspectorRenderMode) {
-        this.renderMode = mode;
     }
 
     /**
      * Pop the Inspector out into a separate browser window. Must be called from a user
      * interaction (e.g. button click) to avoid popup blocking.
      */
-    @action
     openWindow() {
-        let {childWindow} = this;
+        const {childWindow} = this;
         if (childWindow && !childWindow.closed) {
             childWindow.focus();
-            this.renderMode = 'window';
             return;
         }
 
-        childWindow = window.open(
+        const win = window.open(
             '',
             `xhInspector_${XH.clientAppCode}`,
             'popup=yes,width=1400,height=500'
         );
-        if (!childWindow) {
+        if (!win) {
             XH.dangerToast('Unable to open Inspector window - check for a popup blocker.');
             return;
         }
 
-        this.childWindow = childWindow;
-        this.initChildWindow(childWindow);
-        childWindow.focus();
-        this.renderMode = 'window';
+        this.childWindow = win;
+        this.initChildWindow(win);
+        win.focus();
+    }
+
+    /** Return the Inspector to its docked position, closing any popped-out window. */
+    dock() {
+        const {childWindow} = this;
+        if (!childWindow) return;
+
+        this.headObserver?.disconnect();
+        this.bodyClassObserver?.disconnect();
+        this.headObserver = this.bodyClassObserver = null;
+        window.removeEventListener('pagehide', this.onMainWindowPagehide);
+        if (!childWindow.closed) {
+            // Remove listener first, so our own close does not re-enter via pagehide.
+            childWindow.removeEventListener('pagehide', this.onChildWindowPagehide);
+            childWindow.close();
+        }
+
+        this.childWindow = null;
+        this.setWindowContainer(null);
     }
 
     //------------------
     // Implementation
     //------------------
-    private syncHosting() {
-        if (!(XH.inspectorService.active && this.renderMode === 'window')) {
-            this.closeWindow();
-        }
-    }
-
     private initChildWindow(win: Window) {
         const doc = win.document;
 
@@ -121,14 +116,12 @@ export class InspectorHostModel extends HoistModel {
         doc.head.innerHTML = '';
         doc.body.innerHTML = '';
         doc.title = `${XH.appName} - Hoist Inspector`;
-        doc.body.style.cssText = 'margin:0;height:100vh;display:flex;flex-direction:column;';
 
         this.syncChildStyles();
         this.syncChildBodyClass();
 
         const container = doc.createElement('div');
         container.classList.add('xh-inspector-window-host');
-        container.style.cssText = 'flex:1;display:flex;flex-direction:column;overflow:hidden;';
         doc.body.appendChild(container);
 
         // Return to docked mode if the user closes the popped-out window directly.
@@ -153,28 +146,6 @@ export class InspectorHostModel extends HoistModel {
     @action
     private setWindowContainer(container: HTMLElement) {
         this.windowContainer = container;
-    }
-
-    private closeWindow() {
-        const {childWindow} = this;
-        if (!childWindow) return;
-
-        this.closingChildWindow = true;
-        try {
-            this.headObserver?.disconnect();
-            this.bodyClassObserver?.disconnect();
-            this.headObserver = this.bodyClassObserver = null;
-            window.removeEventListener('pagehide', this.onMainWindowPagehide);
-            if (!childWindow.closed) {
-                childWindow.removeEventListener('pagehide', this.onChildWindowPagehide);
-                childWindow.close();
-            }
-        } finally {
-            this.closingChildWindow = false;
-        }
-
-        this.childWindow = null;
-        this.setWindowContainer(null);
     }
 
     /** Clone the main document's stylesheets into the popped-out window. */
@@ -209,18 +180,12 @@ export class InspectorHostModel extends HoistModel {
         win.document.body.className = `${document.body.className} xh-inspector-window`;
     }
 
-    private onChildWindowPagehide = () => {
-        if (!this.closingChildWindow && this.renderMode === 'window') {
-            this.setRenderMode('dock');
-        }
-    };
+    private onChildWindowPagehide = () => this.dock();
 
-    private onMainWindowPagehide = () => {
-        this.childWindow?.close();
-    };
+    private onMainWindowPagehide = () => this.childWindow?.close();
 
     override destroy() {
-        this.closeWindow();
+        this.dock();
         super.destroy();
     }
 }

--- a/inspector/InspectorHostModel.ts
+++ b/inspector/InspectorHostModel.ts
@@ -1,0 +1,112 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {HoistModel, persist, XH} from '@xh/hoist/core';
+import {action, makeObservable, observable} from '@xh/hoist/mobx';
+
+/**
+ * Where the active Inspector UI is currently hosted:
+ *  - 'dock' - docked panel within the app's viewport (default).
+ *  - 'overlay' - pinned over the app in the browser's top layer, above all masks and dialogs.
+ */
+export type InspectorRenderMode = 'dock' | 'overlay';
+
+/**
+ * Manages where the Inspector UI renders. The default 'dock' mode renders the Inspector as a
+ * resizable panel docked to the bottom of the app viewport, where (as a standard part of the
+ * app's component tree) it can be covered and blocked by app-level masks and modal dialogs.
+ *
+ * The alternate 'overlay' mode relocates the Inspector into a `popover` element in the browser's
+ * top layer, which always paints above any z-index within the app - keeping the Inspector fully
+ * visible and interactive while masks or modals are showing.
+ *
+ * Created internally by {@link inspectorPanel} - not for direct application use.
+ *
+ * @internal
+ */
+export class InspectorHostModel extends HoistModel {
+    override xhImpl = true;
+
+    override persistWith = {localStorageKey: `xhInspector.${XH.clientAppCode}`};
+
+    @observable
+    @persist
+    renderMode: InspectorRenderMode = 'dock';
+
+    /** Top-layer host element - portal target for the Inspector UI when in 'overlay' mode. */
+    @observable.ref
+    overlayEl: HTMLElement = null;
+
+    /** True if the browser supports the Popover API required for 'overlay' mode. */
+    get overlaySupported(): boolean {
+        return typeof HTMLElement.prototype.showPopover === 'function';
+    }
+
+    /**
+     * Container to which any popups spawned by Inspector components (grid menus, tooltips,
+     * dropdowns) should be re-parented, or null to use their default document-level parent.
+     * Required when detached - popups portaled to `document.body` would otherwise render beneath
+     * the browser's top layer.
+     */
+    get popupContainer(): HTMLElement {
+        return this.renderMode === 'overlay' ? this.overlayEl : null;
+    }
+
+    constructor() {
+        super();
+        makeObservable(this);
+
+        if (this.renderMode === 'overlay' && !this.overlaySupported) {
+            this.renderMode = 'dock';
+        }
+
+        this.addReaction({
+            track: () => [XH.inspectorService.active, this.renderMode],
+            run: () => this.syncHosting(),
+            fireImmediately: true
+        });
+    }
+
+    @action
+    setRenderMode(mode: InspectorRenderMode) {
+        this.renderMode = mode;
+    }
+
+    //------------------
+    // Implementation
+    //------------------
+    private syncHosting() {
+        const {active} = XH.inspectorService;
+        active && this.renderMode === 'overlay' ? this.showOverlay() : this.hideOverlay();
+    }
+
+    @action
+    private showOverlay() {
+        let {overlayEl} = this;
+        if (!overlayEl) {
+            overlayEl = document.createElement('div');
+            overlayEl.classList.add('xh-inspector-overlay-host');
+            overlayEl.setAttribute('popover', 'manual');
+            this.overlayEl = overlayEl;
+        }
+
+        if (!overlayEl.isConnected) document.body.appendChild(overlayEl);
+        if (!overlayEl.matches(':popover-open')) overlayEl.showPopover();
+    }
+
+    private hideOverlay() {
+        const {overlayEl} = this;
+        if (!overlayEl?.isConnected) return;
+
+        if (overlayEl.matches(':popover-open')) overlayEl.hidePopover();
+        overlayEl.remove();
+    }
+
+    override destroy() {
+        this.hideOverlay();
+        super.destroy();
+    }
+}

--- a/inspector/InspectorHostModel.ts
+++ b/inspector/InspectorHostModel.ts
@@ -10,27 +10,17 @@ import {action, makeObservable, observable} from '@xh/hoist/mobx';
 /**
  * Where the active Inspector UI is currently hosted:
  *  - 'dock' - docked panel within the app's viewport (default).
- *  - 'overlay' - pinned over the app in the browser's top layer, above all masks and dialogs.
  *  - 'window' - popped out into a separate, dedicated browser window.
  */
-export type InspectorRenderMode = 'dock' | 'overlay' | 'window';
+export type InspectorRenderMode = 'dock' | 'window';
 
 /**
  * Manages where the Inspector UI renders. The default 'dock' mode renders the Inspector as a
- * resizable panel docked to the bottom of the app viewport, where (as a standard part of the
- * app's component tree) it can be covered and blocked by app-level masks and modal dialogs.
- *
- * Two alternate modes detach the Inspector from the app's component tree:
- *  - 'overlay' relocates the Inspector into a `popover` element in the browser's top layer, which
- *    always paints above any z-index within the app - keeping the Inspector fully visible and
- *    interactive while masks or modals are showing.
- *  - 'window' pops the Inspector out into a separate browser window, which can be moved to a
- *    second monitor and leaves the app's viewport entirely to the app. The Inspector remains part
- *    of the main app's component tree (via a cross-document React portal), so it retains direct,
- *    live access to all app state.
- *
- * Both detached modes portal the same component tree rendered when docked, and re-parent any
- * Inspector-spawned popups (grid menus, tooltips) into the detached host.
+ * resizable panel docked to the bottom of the app viewport. The alternate 'window' mode pops the
+ * Inspector out into a separate browser window, which can be moved to a second monitor and leaves
+ * the app's viewport entirely to the app - including any masks and modal dialogs that would cover
+ * a docked Inspector. The Inspector remains part of the main app's component tree (via a
+ * cross-document React portal), so it retains direct, live access to all app state.
  *
  * Created internally by {@link inspectorPanel} - not for direct application use.
  *
@@ -45,32 +35,18 @@ export class InspectorHostModel extends HoistModel {
     @persist
     renderMode: InspectorRenderMode = 'dock';
 
-    /** Top-layer host element - portal target for the Inspector UI when in 'overlay' mode. */
-    @observable.ref
-    overlayEl: HTMLElement = null;
-
     /** Container within the popped-out window - portal target when in 'window' mode. */
     @observable.ref
     windowContainer: HTMLElement = null;
 
-    /** True if the browser supports the Popover API required for 'overlay' mode. */
-    get overlaySupported(): boolean {
-        return typeof HTMLElement.prototype.showPopover === 'function';
-    }
-
     /**
      * Container to which any popups spawned by Inspector components (grid menus, tooltips,
      * dropdowns) should be re-parented, or null to use their default document-level parent.
-     * Required when detached - popups portaled to the main `document.body` would otherwise render
-     * beneath the browser's top layer, or within the wrong window entirely.
+     * Required when popped out - popups portaled to the main `document.body` would otherwise
+     * render within the wrong window entirely.
      */
     get popupContainer(): HTMLElement {
-        const {renderMode} = this;
-        return renderMode === 'overlay'
-            ? this.overlayEl
-            : renderMode === 'window'
-              ? this.windowContainer
-              : null;
+        return this.renderMode === 'window' ? this.windowContainer : null;
     }
 
     private childWindow: Window = null;
@@ -83,10 +59,8 @@ export class InspectorHostModel extends HoistModel {
         makeObservable(this);
 
         // Window mode requires a user gesture to (re)open and cannot be restored on app load.
-        if (
-            this.renderMode === 'window' ||
-            (this.renderMode === 'overlay' && !this.overlaySupported)
-        ) {
+        // Also maps any other unsupported persisted value back to the default.
+        if (this.renderMode !== 'dock') {
             this.renderMode = 'dock';
         }
 
@@ -135,48 +109,11 @@ export class InspectorHostModel extends HoistModel {
     // Implementation
     //------------------
     private syncHosting() {
-        const {active} = XH.inspectorService,
-            {renderMode} = this;
-
-        if (active && renderMode === 'overlay') {
-            this.showOverlay();
-        } else {
-            this.hideOverlay();
-        }
-
-        if (!(active && renderMode === 'window')) {
+        if (!(XH.inspectorService.active && this.renderMode === 'window')) {
             this.closeWindow();
         }
     }
 
-    //------------------
-    // Overlay mode
-    //------------------
-    @action
-    private showOverlay() {
-        let {overlayEl} = this;
-        if (!overlayEl) {
-            overlayEl = document.createElement('div');
-            overlayEl.classList.add('xh-inspector-overlay-host');
-            overlayEl.setAttribute('popover', 'manual');
-            this.overlayEl = overlayEl;
-        }
-
-        if (!overlayEl.isConnected) document.body.appendChild(overlayEl);
-        if (!overlayEl.matches(':popover-open')) overlayEl.showPopover();
-    }
-
-    private hideOverlay() {
-        const {overlayEl} = this;
-        if (!overlayEl?.isConnected) return;
-
-        if (overlayEl.matches(':popover-open')) overlayEl.hidePopover();
-        overlayEl.remove();
-    }
-
-    //------------------
-    // Window mode
-    //------------------
     private initChildWindow(win: Window) {
         const doc = win.document;
 
@@ -283,7 +220,6 @@ export class InspectorHostModel extends HoistModel {
     };
 
     override destroy() {
-        this.hideOverlay();
         this.closeWindow();
         super.destroy();
     }

--- a/inspector/InspectorModel.ts
+++ b/inspector/InspectorModel.ts
@@ -22,7 +22,7 @@ import {action, makeObservable, observable} from '@xh/hoist/mobx';
  *
  * @internal
  */
-export class InspectorHostModel extends HoistModel {
+export class InspectorModel extends HoistModel {
     override xhImpl = true;
 
     /** Container within the popped-out window - portal target when popped out, null when docked. */

--- a/inspector/InspectorModel.ts
+++ b/inspector/InspectorModel.ts
@@ -25,23 +25,18 @@ import {action, makeObservable, observable} from '@xh/hoist/mobx';
 export class InspectorModel extends HoistModel {
     override xhImpl = true;
 
-    /** Container within the popped-out window - portal target when popped out, null when docked. */
+    /**
+     * Container within the popped-out window, or null when docked. Portal target for the
+     * Inspector UI itself and for any popups its components spawn (grid menus, tooltips,
+     * dropdowns) - popups portaled to the main `document.body` would otherwise render within
+     * the wrong window entirely.
+     */
     @observable.ref
     windowContainer: HTMLElement = null;
 
     /** True when the Inspector is popped out into its own window. */
     get isWindowed(): boolean {
         return this.windowContainer != null;
-    }
-
-    /**
-     * Container to which any popups spawned by Inspector components (grid menus, tooltips,
-     * dropdowns) should be re-parented, or null to use their default document-level parent.
-     * Required when popped out - popups portaled to the main `document.body` would otherwise
-     * render within the wrong window entirely.
-     */
-    get popupContainer(): HTMLElement {
-        return this.windowContainer;
     }
 
     private childWindow: Window = null;

--- a/inspector/InspectorPanel.ts
+++ b/inspector/InspectorPanel.ts
@@ -20,9 +20,9 @@ import './Inspector.scss';
  * See {@link InspectorService} for an explanation of the Hoist Inspector tool.
  *
  * In addition to its default rendering as a panel docked within the app viewport, the Inspector
- * can be pinned over the app in the browser's top layer ('overlay' mode), where it remains fully
- * visible and interactive above any app-level masks and modal dialogs. Hosting is managed by
- * {@link InspectorHostModel}.
+ * can be pinned over the app in the browser's top layer ('overlay' mode - stays fully visible and
+ * interactive above app-level masks and modal dialogs) or popped out into a separate browser
+ * window ('window' mode). Hosting is managed by {@link InspectorHostModel}.
  */
 export const inspectorPanel = hoistCmp.factory({
     displayName: 'InspectorPanel',
@@ -31,11 +31,14 @@ export const inspectorPanel = hoistCmp.factory({
     render({model}) {
         if (!XH.inspectorService.active) return null;
 
-        const {renderMode, overlayEl} = model;
+        const {renderMode, overlayEl, windowContainer} = model;
 
         // Key by mode to remount the view (and recreate its mode-specific PanelModel) on change.
         if (renderMode === 'overlay' && overlayEl) {
             return createPortal(inspectorView({key: 'overlay'}), overlayEl);
+        }
+        if (renderMode === 'window' && windowContainer) {
+            return createPortal(inspectorView({key: 'window'}), windowContainer);
         }
         return inspectorView({key: 'dock'});
     }
@@ -46,34 +49,46 @@ const inspectorView = hoistCmp.factory<InspectorHostModel>({
 
     render({model}) {
         const {renderMode, popupContainer} = model,
-            isDocked = renderMode === 'dock';
+            isDocked = renderMode === 'dock',
+            isWindow = renderMode === 'window';
 
         const ret = panel({
             title: `Inspector - Hoist v${XH.environmentService.get('hoistReactVersion')}`,
             icon: Icon.search(),
             className: 'xh-inspector',
             headerClassName: 'xh-inspector-panel-header',
-            modelConfig: {
-                defaultSize: 400,
-                side: 'bottom',
-                persistWith: XH.inspectorService.persistWith,
-                // Modal support docked only - its dialog renders beneath the top layer.
-                modalSupport: isDocked,
-                errorBoundary: true,
-                showModalToggleButton: isDocked,
-                showHeaderCollapseButton: false,
-                xhImpl: true
-            },
+            flex: isWindow ? 1 : undefined,
+            modelConfig: isWindow
+                ? {errorBoundary: true, xhImpl: true}
+                : {
+                      defaultSize: 400,
+                      side: 'bottom',
+                      persistWith: XH.inspectorService.persistWith,
+                      // Modal support docked only - its dialog renders beneath the top layer.
+                      modalSupport: isDocked,
+                      errorBoundary: true,
+                      showModalToggleButton: isDocked,
+                      showHeaderCollapseButton: false,
+                      xhImpl: true
+                  },
             compactHeader: true,
             headerItems: [
                 button({
                     icon: Icon.pin(),
-                    omit: !model.overlaySupported,
+                    omit: isWindow || !model.overlaySupported,
                     tooltip: isDocked
                         ? 'Pin over app - keep Inspector visible above masks and dialogs'
                         : 'Unpin - return to docked panel',
                     intent: isDocked ? null : 'primary',
                     onClick: () => model.setRenderMode(isDocked ? 'overlay' : 'dock')
+                }),
+                button({
+                    icon: Icon.openExternal(),
+                    tooltip: isWindow
+                        ? 'Return Inspector to the main app window'
+                        : 'Open Inspector in a separate window',
+                    intent: isWindow ? 'primary' : null,
+                    onClick: () => (isWindow ? model.setRenderMode('dock') : model.openWindow())
                 }),
                 button({
                     icon: Icon.x(),

--- a/inspector/InspectorPanel.ts
+++ b/inspector/InspectorPanel.ts
@@ -20,9 +20,8 @@ import './Inspector.scss';
  * See {@link InspectorService} for an explanation of the Hoist Inspector tool.
  *
  * In addition to its default rendering as a panel docked within the app viewport, the Inspector
- * can be pinned over the app in the browser's top layer ('overlay' mode - stays fully visible and
- * interactive above app-level masks and modal dialogs) or popped out into a separate browser
- * window ('window' mode). Hosting is managed by {@link InspectorHostModel}.
+ * can be popped out into a separate browser window ('window' mode), leaving the app's viewport
+ * entirely to the app. Hosting is managed by {@link InspectorHostModel}.
  */
 export const inspectorPanel = hoistCmp.factory({
     displayName: 'InspectorPanel',
@@ -31,12 +30,9 @@ export const inspectorPanel = hoistCmp.factory({
     render({model}) {
         if (!XH.inspectorService.active) return null;
 
-        const {renderMode, overlayEl, windowContainer} = model;
+        const {renderMode, windowContainer} = model;
 
         // Key by mode to remount the view (and recreate its mode-specific PanelModel) on change.
-        if (renderMode === 'overlay' && overlayEl) {
-            return createPortal(inspectorView({key: 'overlay'}), overlayEl);
-        }
         if (renderMode === 'window' && windowContainer) {
             return createPortal(inspectorView({key: 'window'}), windowContainer);
         }
@@ -48,9 +44,8 @@ const inspectorView = hoistCmp.factory<InspectorHostModel>({
     displayName: 'InspectorView',
 
     render({model}) {
-        const {renderMode, popupContainer} = model,
-            isDocked = renderMode === 'dock',
-            isWindow = renderMode === 'window';
+        const {popupContainer} = model,
+            isWindow = model.renderMode === 'window';
 
         const ret = panel({
             title: `Inspector - Hoist v${XH.environmentService.get('hoistReactVersion')}`,
@@ -64,24 +59,12 @@ const inspectorView = hoistCmp.factory<InspectorHostModel>({
                       defaultSize: 400,
                       side: 'bottom',
                       persistWith: XH.inspectorService.persistWith,
-                      // Modal support docked only - its dialog renders beneath the top layer.
-                      modalSupport: isDocked,
                       errorBoundary: true,
-                      showModalToggleButton: isDocked,
                       showHeaderCollapseButton: false,
                       xhImpl: true
                   },
             compactHeader: true,
             headerItems: [
-                button({
-                    icon: Icon.pin(),
-                    omit: isWindow || !model.overlaySupported,
-                    tooltip: isDocked
-                        ? 'Pin over app - keep Inspector visible above masks and dialogs'
-                        : 'Unpin - return to docked panel',
-                    intent: isDocked ? null : 'primary',
-                    onClick: () => model.setRenderMode(isDocked ? 'overlay' : 'dock')
-                }),
                 button({
                     icon: Icon.openExternal(),
                     tooltip: isWindow
@@ -104,8 +87,8 @@ const inspectorView = hoistCmp.factory<InspectorHostModel>({
             item: hframe(statsPanel(), instancesPanel())
         });
 
-        // When detached, redirect Blueprint portals (tooltips, popovers, dialogs) into the host,
-        // where they can paint above/alongside the Inspector itself.
+        // When popped out, redirect Blueprint portals (tooltips, popovers, dialogs) into the
+        // child window, alongside the Inspector itself.
         return popupContainer ? portalProvider({portalContainer: popupContainer, item: ret}) : ret;
     }
 });

--- a/inspector/InspectorPanel.ts
+++ b/inspector/InspectorPanel.ts
@@ -5,24 +5,50 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {hframe} from '@xh/hoist/cmp/layout';
-import {hoistCmp, XH} from '@xh/hoist/core';
+import {creates, hoistCmp, XH} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {Icon} from '@xh/hoist/icon';
+import {InspectorHostModel} from '@xh/hoist/inspector/InspectorHostModel';
 import {instancesPanel} from '@xh/hoist/inspector/instances/InstancesPanel';
 import {statsPanel} from '@xh/hoist/inspector/stats/StatsPanel';
+import {portalProvider} from '@xh/hoist/kit/blueprint';
+import {createPortal} from 'react-dom';
 import './Inspector.scss';
 
 /**
  * See {@link InspectorService} for an explanation of the Hoist Inspector tool.
+ *
+ * In addition to its default rendering as a panel docked within the app viewport, the Inspector
+ * can be pinned over the app in the browser's top layer ('overlay' mode), where it remains fully
+ * visible and interactive above any app-level masks and modal dialogs. Hosting is managed by
+ * {@link InspectorHostModel}.
  */
 export const inspectorPanel = hoistCmp.factory({
     displayName: 'InspectorPanel',
+    model: creates(InspectorHostModel),
 
-    render() {
+    render({model}) {
         if (!XH.inspectorService.active) return null;
 
-        return panel({
+        const {renderMode, overlayEl} = model;
+
+        // Key by mode to remount the view (and recreate its mode-specific PanelModel) on change.
+        if (renderMode === 'overlay' && overlayEl) {
+            return createPortal(inspectorView({key: 'overlay'}), overlayEl);
+        }
+        return inspectorView({key: 'dock'});
+    }
+});
+
+const inspectorView = hoistCmp.factory<InspectorHostModel>({
+    displayName: 'InspectorView',
+
+    render({model}) {
+        const {renderMode, popupContainer} = model,
+            isDocked = renderMode === 'dock';
+
+        const ret = panel({
             title: `Inspector - Hoist v${XH.environmentService.get('hoistReactVersion')}`,
             icon: Icon.search(),
             className: 'xh-inspector',
@@ -31,14 +57,24 @@ export const inspectorPanel = hoistCmp.factory({
                 defaultSize: 400,
                 side: 'bottom',
                 persistWith: XH.inspectorService.persistWith,
-                modalSupport: true,
+                // Modal support docked only - its dialog renders beneath the top layer.
+                modalSupport: isDocked,
                 errorBoundary: true,
-                showModalToggleButton: true,
+                showModalToggleButton: isDocked,
                 showHeaderCollapseButton: false,
                 xhImpl: true
             },
             compactHeader: true,
             headerItems: [
+                button({
+                    icon: Icon.pin(),
+                    omit: !model.overlaySupported,
+                    tooltip: isDocked
+                        ? 'Pin over app - keep Inspector visible above masks and dialogs'
+                        : 'Unpin - return to docked panel',
+                    intent: isDocked ? null : 'primary',
+                    onClick: () => model.setRenderMode(isDocked ? 'overlay' : 'dock')
+                }),
                 button({
                     icon: Icon.x(),
                     text: 'Close Inspector',
@@ -52,5 +88,9 @@ export const inspectorPanel = hoistCmp.factory({
             ],
             item: hframe(statsPanel(), instancesPanel())
         });
+
+        // When detached, redirect Blueprint portals (tooltips, popovers, dialogs) into the host,
+        // where they can paint above/alongside the Inspector itself.
+        return popupContainer ? portalProvider({portalContainer: popupContainer, item: ret}) : ret;
     }
 });

--- a/inspector/InspectorPanel.ts
+++ b/inspector/InspectorPanel.ts
@@ -43,7 +43,7 @@ const inspectorView = hoistCmp.factory<InspectorModel>({
     displayName: 'InspectorView',
 
     render({model}) {
-        const {popupContainer, isWindowed} = model;
+        const {windowContainer, isWindowed} = model;
 
         const ret = panel({
             title: `Inspector - Hoist v${XH.environmentService.get('hoistReactVersion')}`,
@@ -87,6 +87,8 @@ const inspectorView = hoistCmp.factory<InspectorModel>({
 
         // When popped out, redirect Blueprint portals (tooltips, popovers, dialogs) into the
         // child window, alongside the Inspector itself.
-        return popupContainer ? portalProvider({portalContainer: popupContainer, item: ret}) : ret;
+        return windowContainer
+            ? portalProvider({portalContainer: windowContainer, item: ret})
+            : ret;
     }
 });

--- a/inspector/InspectorPanel.ts
+++ b/inspector/InspectorPanel.ts
@@ -59,7 +59,7 @@ const inspectorView = hoistCmp.factory<InspectorHostModel>({
             headerClassName: 'xh-inspector-panel-header',
             flex: isWindow ? 1 : undefined,
             modelConfig: isWindow
-                ? {errorBoundary: true, xhImpl: true}
+                ? {collapsible: false, resizable: false, errorBoundary: true, xhImpl: true}
                 : {
                       defaultSize: 400,
                       side: 'bottom',

--- a/inspector/InspectorPanel.ts
+++ b/inspector/InspectorPanel.ts
@@ -9,7 +9,7 @@ import {creates, hoistCmp, XH} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {Icon} from '@xh/hoist/icon';
-import {InspectorHostModel} from '@xh/hoist/inspector/InspectorHostModel';
+import {InspectorModel} from '@xh/hoist/inspector/InspectorModel';
 import {instancesPanel} from '@xh/hoist/inspector/instances/InstancesPanel';
 import {statsPanel} from '@xh/hoist/inspector/stats/StatsPanel';
 import {portalProvider} from '@xh/hoist/kit/blueprint';
@@ -21,11 +21,11 @@ import './Inspector.scss';
  *
  * In addition to its default rendering as a panel docked within the app viewport, the Inspector
  * can be popped out into a separate browser window ('window' mode), leaving the app's viewport
- * entirely to the app. Hosting is managed by {@link InspectorHostModel}.
+ * entirely to the app. Hosting is managed by {@link InspectorModel}.
  */
 export const inspectorPanel = hoistCmp.factory({
     displayName: 'InspectorPanel',
-    model: creates(InspectorHostModel),
+    model: creates(InspectorModel),
 
     render({model}) {
         if (!XH.inspectorService.active) return null;
@@ -39,7 +39,7 @@ export const inspectorPanel = hoistCmp.factory({
     }
 });
 
-const inspectorView = hoistCmp.factory<InspectorHostModel>({
+const inspectorView = hoistCmp.factory<InspectorModel>({
     displayName: 'InspectorView',
 
     render({model}) {

--- a/inspector/InspectorPanel.ts
+++ b/inspector/InspectorPanel.ts
@@ -30,13 +30,12 @@ export const inspectorPanel = hoistCmp.factory({
     render({model}) {
         if (!XH.inspectorService.active) return null;
 
-        const {renderMode, windowContainer} = model;
+        const {windowContainer} = model;
 
         // Key by mode to remount the view (and recreate its mode-specific PanelModel) on change.
-        if (renderMode === 'window' && windowContainer) {
-            return createPortal(inspectorView({key: 'window'}), windowContainer);
-        }
-        return inspectorView({key: 'dock'});
+        return windowContainer
+            ? createPortal(inspectorView({key: 'window'}), windowContainer)
+            : inspectorView({key: 'dock'});
     }
 });
 
@@ -44,16 +43,15 @@ const inspectorView = hoistCmp.factory<InspectorHostModel>({
     displayName: 'InspectorView',
 
     render({model}) {
-        const {popupContainer} = model,
-            isWindow = model.renderMode === 'window';
+        const {popupContainer, isWindowed} = model;
 
         const ret = panel({
             title: `Inspector - Hoist v${XH.environmentService.get('hoistReactVersion')}`,
             icon: Icon.search(),
             className: 'xh-inspector',
             headerClassName: 'xh-inspector-panel-header',
-            flex: isWindow ? 1 : undefined,
-            modelConfig: isWindow
+            flex: isWindowed ? 1 : undefined,
+            modelConfig: isWindowed
                 ? {collapsible: false, resizable: false, errorBoundary: true, xhImpl: true}
                 : {
                       defaultSize: 400,
@@ -67,11 +65,11 @@ const inspectorView = hoistCmp.factory<InspectorHostModel>({
             headerItems: [
                 button({
                     icon: Icon.openExternal(),
-                    tooltip: isWindow
+                    tooltip: isWindowed
                         ? 'Return Inspector to the main app window'
                         : 'Open Inspector in a separate window',
-                    intent: isWindow ? 'primary' : null,
-                    onClick: () => (isWindow ? model.setRenderMode('dock') : model.openWindow())
+                    intent: isWindowed ? 'primary' : null,
+                    onClick: () => (isWindowed ? model.dock() : model.openWindow())
                 }),
                 button({
                     icon: Icon.x(),

--- a/inspector/README.md
+++ b/inspector/README.md
@@ -7,8 +7,7 @@ The Inspector is a built-in developer and admin tool for real-time inspection of
 application's `HoistModel`, `HoistService`, and `Store` instances, along with memory and
 performance statistics. It renders by default as a resizable bottom panel within the desktop
 application UI, driven by the `InspectorService` in [`/svc/`](../svc/README.md), and can also be
-pinned over the app in the browser's top layer or popped out into a separate browser window (see
-[Render Modes](#render-modes) below).
+popped out into a separate browser window (see [Render Modes](#render-modes) below).
 
 ## Overview
 
@@ -27,7 +26,7 @@ The Inspector provides two main views: **Stats** (timeseries of model counts and
 ```
 inspector/
 ├── InspectorPanel.ts                # Top-level container (renders Stats + Instances panels)
-├── InspectorHostModel.ts            # Manages render mode - docked, overlay, or popped-out window
+├── InspectorHostModel.ts            # Manages render mode - docked or popped-out window
 ├── Inspector.scss                   # Inspector-specific styles
 ├── instances/
 │   ├── InstancesPanel.ts            # Split view: instance grid (left) + properties grid (right)
@@ -82,29 +81,20 @@ refreshes.
 ## Render Modes
 
 Because the docked Inspector renders as a standard part of the app's component tree, app-level
-masks and modal dialogs will cover and block it. Two alternate hosting modes - toggled via buttons
-in the Inspector's header - detach it from the app's layout while keeping it fully live, with
-direct access to all app state:
-
-| Mode | Header Button | Description |
-|------|---------------|-------------|
-| `dock` | (default) | Resizable panel docked to the bottom of the app viewport |
-| `overlay` | Pin | Pinned over the app in the browser's [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer), above all app masks and modal dialogs |
-| `window` | Open in window | Popped out into a separate browser window - e.g. onto a second monitor |
+masks and modal dialogs will cover and block it. The alternate `window` mode - toggled via a
+button in the Inspector's header - pops the Inspector out into a separate browser window (e.g.
+onto a second monitor), leaving the app's viewport entirely to the app while keeping the Inspector
+fully live, with direct access to all app state.
 
 Mode selection and lifecycle are managed by `InspectorHostModel`, which portals the same component
-tree rendered when docked into the alternate host. Notes and limitations:
+tree rendered when docked into the popped-out window. Notes and limitations:
 
-- The active mode is persisted to `localStorage`, except that `window` mode is not restored on app
-  load - browsers require a user gesture to open a window, so the Inspector returns docked.
-- Closing the popped-out window directly returns the Inspector to `dock` mode. Reloading or closing
-  the main app window closes the popped-out window.
-- `overlay` mode requires browser support for the native
-  [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) (all modern browsers).
-  The pin button is hidden when not supported.
+- `window` mode is not restored on app load - browsers require a user gesture to open a window, so
+  the Inspector returns docked after a refresh.
+- Closing the popped-out window directly returns the Inspector to its docked state. Reloading or
+  closing the main app window closes the popped-out window.
 - Toasts and framework dialogs (e.g. the "Restore Defaults" confirm) always render within the main
   app window, even when triggered from a popped-out Inspector.
-- The docked panel's modal (expand) toggle is available in `dock` mode only.
 
 ## Stats View
 

--- a/inspector/README.md
+++ b/inspector/README.md
@@ -26,7 +26,7 @@ The Inspector provides two main views: **Stats** (timeseries of model counts and
 ```
 inspector/
 ├── InspectorPanel.ts                # Top-level container (renders Stats + Instances panels)
-├── InspectorHostModel.ts            # Hosts the UI docked in the app or in a popped-out window
+├── InspectorModel.ts                # Hosts the UI docked in the app or in a popped-out window
 ├── Inspector.scss                   # Inspector-specific styles
 ├── instances/
 │   ├── InstancesPanel.ts            # Split view: instance grid (left) + properties grid (right)
@@ -85,7 +85,7 @@ masks and modal dialogs will cover and block it. A button in the Inspector's hea
 into a separate browser window (e.g. onto a second monitor), leaving the app's viewport entirely
 to the app while keeping the Inspector fully live, with direct access to all app state.
 
-Hosting and window lifecycle are managed by `InspectorHostModel`, which portals the same component
+Hosting and window lifecycle are managed by `InspectorModel`, which portals the same component
 tree rendered when docked into the popped-out window. Notes and limitations:
 
 - The popped-out state is not restored on app load - browsers require a user gesture to open a

--- a/inspector/README.md
+++ b/inspector/README.md
@@ -5,8 +5,10 @@
 
 The Inspector is a built-in developer and admin tool for real-time inspection of a running Hoist
 application's `HoistModel`, `HoistService`, and `Store` instances, along with memory and
-performance statistics. It renders as a collapsible bottom panel within the desktop application UI,
-driven by the `InspectorService` in [`/svc/`](../svc/README.md).
+performance statistics. It renders by default as a resizable bottom panel within the desktop
+application UI, driven by the `InspectorService` in [`/svc/`](../svc/README.md), and can also be
+pinned over the app in the browser's top layer or popped out into a separate browser window (see
+[Render Modes](#render-modes) below).
 
 ## Overview
 
@@ -24,7 +26,8 @@ The Inspector provides two main views: **Stats** (timeseries of model counts and
 
 ```
 inspector/
-├── InspectorPanel.ts                # Top-level container (bottom panel with Stats + Instances)
+├── InspectorPanel.ts                # Top-level container (renders Stats + Instances panels)
+├── InspectorHostModel.ts            # Manages render mode - docked, overlay, or popped-out window
 ├── Inspector.scss                   # Inspector-specific styles
 ├── instances/
 │   ├── InstancesPanel.ts            # Split view: instance grid (left) + properties grid (right)
@@ -75,6 +78,33 @@ The Inspector can be toggled via:
 
 The `active` state is persisted to `localStorage`, so the Inspector will remain open across page
 refreshes.
+
+## Render Modes
+
+Because the docked Inspector renders as a standard part of the app's component tree, app-level
+masks and modal dialogs will cover and block it. Two alternate hosting modes - toggled via buttons
+in the Inspector's header - detach it from the app's layout while keeping it fully live, with
+direct access to all app state:
+
+| Mode | Header Button | Description |
+|------|---------------|-------------|
+| `dock` | (default) | Resizable panel docked to the bottom of the app viewport |
+| `overlay` | Pin | Pinned over the app in the browser's [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer), above all app masks and modal dialogs |
+| `window` | Open in window | Popped out into a separate browser window - e.g. onto a second monitor |
+
+Mode selection and lifecycle are managed by `InspectorHostModel`, which portals the same component
+tree rendered when docked into the alternate host. Notes and limitations:
+
+- The active mode is persisted to `localStorage`, except that `window` mode is not restored on app
+  load - browsers require a user gesture to open a window, so the Inspector returns docked.
+- Closing the popped-out window directly returns the Inspector to `dock` mode. Reloading or closing
+  the main app window closes the popped-out window.
+- `overlay` mode requires browser support for the native
+  [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) (all modern browsers).
+  The pin button is hidden when not supported.
+- Toasts and framework dialogs (e.g. the "Restore Defaults" confirm) always render within the main
+  app window, even when triggered from a popped-out Inspector.
+- The docked panel's modal (expand) toggle is available in `dock` mode only.
 
 ## Stats View
 

--- a/inspector/README.md
+++ b/inspector/README.md
@@ -7,7 +7,7 @@ The Inspector is a built-in developer and admin tool for real-time inspection of
 application's `HoistModel`, `HoistService`, and `Store` instances, along with memory and
 performance statistics. It renders by default as a resizable bottom panel within the desktop
 application UI, driven by the `InspectorService` in [`/svc/`](../svc/README.md), and can also be
-popped out into a separate browser window (see [Render Modes](#render-modes) below).
+popped out into a separate browser window (see [Pop-Out Window](#pop-out-window) below).
 
 ## Overview
 
@@ -26,7 +26,7 @@ The Inspector provides two main views: **Stats** (timeseries of model counts and
 ```
 inspector/
 ├── InspectorPanel.ts                # Top-level container (renders Stats + Instances panels)
-├── InspectorHostModel.ts            # Manages render mode - docked or popped-out window
+├── InspectorHostModel.ts            # Hosts the UI docked in the app or in a popped-out window
 ├── Inspector.scss                   # Inspector-specific styles
 ├── instances/
 │   ├── InstancesPanel.ts            # Split view: instance grid (left) + properties grid (right)
@@ -78,19 +78,18 @@ The Inspector can be toggled via:
 The `active` state is persisted to `localStorage`, so the Inspector will remain open across page
 refreshes.
 
-## Render Modes
+## Pop-Out Window
 
 Because the docked Inspector renders as a standard part of the app's component tree, app-level
-masks and modal dialogs will cover and block it. The alternate `window` mode - toggled via a
-button in the Inspector's header - pops the Inspector out into a separate browser window (e.g.
-onto a second monitor), leaving the app's viewport entirely to the app while keeping the Inspector
-fully live, with direct access to all app state.
+masks and modal dialogs will cover and block it. A button in the Inspector's header pops it out
+into a separate browser window (e.g. onto a second monitor), leaving the app's viewport entirely
+to the app while keeping the Inspector fully live, with direct access to all app state.
 
-Mode selection and lifecycle are managed by `InspectorHostModel`, which portals the same component
+Hosting and window lifecycle are managed by `InspectorHostModel`, which portals the same component
 tree rendered when docked into the popped-out window. Notes and limitations:
 
-- `window` mode is not restored on app load - browsers require a user gesture to open a window, so
-  the Inspector returns docked after a refresh.
+- The popped-out state is not restored on app load - browsers require a user gesture to open a
+  window, so the Inspector returns docked after a refresh.
 - Closing the popped-out window directly returns the Inspector to its docked state. Reloading or
   closing the main app window closes the popped-out window.
 - Toasts and framework dialogs (e.g. the "Restore Defaults" confirm) always render within the main

--- a/inspector/instances/InstancesModel.ts
+++ b/inspector/instances/InstancesModel.ts
@@ -224,7 +224,13 @@ export class InstancesModel extends HoistModel {
                     ]
                 },
                 {field: 'id', displayName: 'xhId'},
-                {field: 'syncRun', displayName: 'Sync', autosizeIncludeHeaderIcons: false},
+                {
+                    field: 'syncRun',
+                    displayName: 'Sync',
+                    headerTooltip:
+                        'Sync run in which this instance first appeared. Inspector increments its sync run counter each time it detects newly-created instances, grouping instances that were created together.',
+                    autosizeIncludeHeaderIcons: false
+                },
                 {
                     field: 'isLinked',
                     headerName: Icon.link(),

--- a/inspector/instances/InstancesPanel.ts
+++ b/inspector/instances/InstancesPanel.ts
@@ -13,7 +13,7 @@ import {buttonGroupInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
-import {InspectorHostModel} from '@xh/hoist/inspector/InspectorHostModel';
+import {InspectorModel} from '@xh/hoist/inspector/InspectorModel';
 import {InstancesModel} from '@xh/hoist/inspector/instances/InstancesModel';
 import {popover} from '@xh/hoist/kit/blueprint';
 
@@ -23,7 +23,7 @@ export const instancesPanel = hoistCmp.factory({
     render({model}) {
         const {instancesPanelModel, selectedSyncRun} = model,
             // Re-parent grid popups (context/column menus) when Inspector is detached.
-            popupParent = useContextModel(InspectorHostModel)?.popupContainer ?? undefined,
+            popupParent = useContextModel(InspectorModel)?.popupContainer ?? undefined,
             headerItems = [];
 
         if (selectedSyncRun) {

--- a/inspector/instances/InstancesPanel.ts
+++ b/inspector/instances/InstancesPanel.ts
@@ -23,7 +23,7 @@ export const instancesPanel = hoistCmp.factory({
     render({model}) {
         const {instancesPanelModel, selectedSyncRun} = model,
             // Re-parent grid popups (context/column menus) when Inspector is detached.
-            popupParent = useContextModel(InspectorModel)?.popupContainer ?? undefined,
+            popupParent = useContextModel(InspectorModel)?.windowContainer ?? undefined,
             headerItems = [];
 
         if (selectedSyncRun) {

--- a/inspector/instances/InstancesPanel.ts
+++ b/inspector/instances/InstancesPanel.ts
@@ -7,12 +7,13 @@
 import {grid, gridCountLabel} from '@xh/hoist/cmp/grid';
 import {a, div, filler, hframe, hspacer, p, span} from '@xh/hoist/cmp/layout';
 import {storeFilterField} from '@xh/hoist/cmp/store';
-import {creates, hoistCmp} from '@xh/hoist/core';
+import {creates, hoistCmp, useContextModel} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {buttonGroupInput} from '@xh/hoist/desktop/cmp/input';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
+import {InspectorHostModel} from '@xh/hoist/inspector/InspectorHostModel';
 import {InstancesModel} from '@xh/hoist/inspector/instances/InstancesModel';
 import {popover} from '@xh/hoist/kit/blueprint';
 
@@ -21,6 +22,8 @@ export const instancesPanel = hoistCmp.factory({
 
     render({model}) {
         const {instancesPanelModel, selectedSyncRun} = model,
+            // Re-parent grid popups (context/column menus) when Inspector is detached.
+            popupParent = useContextModel(InspectorHostModel)?.popupContainer ?? undefined,
             headerItems = [];
 
         if (selectedSyncRun) {
@@ -62,7 +65,8 @@ export const instancesPanel = hoistCmp.factory({
                     item: grid({
                         model: model.instancesGridModel,
                         agOptions: {
-                            suppressGroupChangesColumnVisibility: true
+                            suppressGroupChangesColumnVisibility: true,
+                            popupParent
                         }
                     }),
                     bbar: instanceGridBar(),
@@ -72,7 +76,7 @@ export const instancesPanel = hoistCmp.factory({
                     title: 'Properties',
                     icon: Icon.fileText(),
                     compactHeader: true,
-                    item: grid({model: model.propertiesGridModel}),
+                    item: grid({model: model.propertiesGridModel, agOptions: {popupParent}}),
                     bbar: propertiesGridBar()
                 })
             )

--- a/inspector/stats/StatsModel.ts
+++ b/inspector/stats/StatsModel.ts
@@ -56,7 +56,12 @@ export class StatsModel extends HoistModel {
             columns: [
                 {field: 'timestamp', renderer: timestampRenderer},
                 {field: 'modelCount', renderer: numberRenderer({precision: 0})},
-                {field: 'syncRun', renderer: numberRenderer({precision: 0})},
+                {
+                    field: 'syncRun',
+                    headerTooltip:
+                        'Sync run counter as of this snapshot. Inspector increments its sync run counter each time it detects newly-created instances. Select a row to filter the Instances grid to the instances created during its sync run.',
+                    renderer: numberRenderer({precision: 0})
+                },
                 {
                     field: 'modelCountChange',
                     renderer: numberRenderer({precision: 0, colorSpec: true, withSignGlyph: true})

--- a/inspector/stats/StatsModel.ts
+++ b/inspector/stats/StatsModel.ts
@@ -93,7 +93,8 @@ export class StatsModel extends HoistModel {
 
         this.chartModel = new ChartModel({
             highchartsConfig: {
-                chart: {zoomType: 'x'},
+                chart: {zoomType: 'x', animation: false},
+                plotOptions: {series: {animation: false}},
                 legend: {enabled: false},
                 title: {text: null},
                 xAxis: {type: 'datetime'},

--- a/inspector/stats/StatsPanel.ts
+++ b/inspector/stats/StatsPanel.ts
@@ -7,11 +7,12 @@
 import {chart} from '@xh/hoist/cmp/chart';
 import {grid} from '@xh/hoist/cmp/grid';
 import {code, div, filler, span} from '@xh/hoist/cmp/layout';
-import {creates, hoistCmp, XH} from '@xh/hoist/core';
+import {creates, hoistCmp, useContextModel, XH} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
+import {InspectorHostModel} from '@xh/hoist/inspector/InspectorHostModel';
 import {StatsModel} from '@xh/hoist/inspector/stats/StatsModel';
 import {popover} from '@xh/hoist/kit/blueprint';
 
@@ -19,13 +20,16 @@ export const statsPanel = hoistCmp.factory({
     model: creates(StatsModel),
 
     render({model}) {
+        // Re-parent grid popups (context/column menus) when Inspector is detached.
+        const popupParent = useContextModel(InspectorHostModel)?.popupContainer ?? undefined;
+
         return panel({
             title: 'Stats',
             icon: Icon.chartArea(),
             compactHeader: true,
             model: model.panelModel,
             items: [
-                grid(),
+                grid({agOptions: {popupParent}}),
                 panel({
                     item: chart(),
                     modelConfig: {

--- a/inspector/stats/StatsPanel.ts
+++ b/inspector/stats/StatsPanel.ts
@@ -21,7 +21,7 @@ export const statsPanel = hoistCmp.factory({
 
     render({model}) {
         // Re-parent grid popups (context/column menus) when Inspector is detached.
-        const popupParent = useContextModel(InspectorModel)?.popupContainer ?? undefined;
+        const popupParent = useContextModel(InspectorModel)?.windowContainer ?? undefined;
 
         return panel({
             title: 'Stats',

--- a/inspector/stats/StatsPanel.ts
+++ b/inspector/stats/StatsPanel.ts
@@ -12,7 +12,7 @@ import {button} from '@xh/hoist/desktop/cmp/button';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
-import {InspectorHostModel} from '@xh/hoist/inspector/InspectorHostModel';
+import {InspectorModel} from '@xh/hoist/inspector/InspectorModel';
 import {StatsModel} from '@xh/hoist/inspector/stats/StatsModel';
 import {popover} from '@xh/hoist/kit/blueprint';
 
@@ -21,7 +21,7 @@ export const statsPanel = hoistCmp.factory({
 
     render({model}) {
         // Re-parent grid popups (context/column menus) when Inspector is detached.
-        const popupParent = useContextModel(InspectorHostModel)?.popupContainer ?? undefined;
+        const popupParent = useContextModel(InspectorModel)?.popupContainer ?? undefined;
 
         return panel({
             title: 'Stats',

--- a/kit/blueprint/Wrappers.ts
+++ b/kit/blueprint/Wrappers.ts
@@ -38,6 +38,7 @@ import {
     PopoverNext as BpPopover,
     popoverPropsToNextProps,
     type PopoverProps,
+    PortalProvider,
     Radio,
     RadioGroup,
     RangeSlider,
@@ -101,6 +102,7 @@ export {
     OverflowList,
     Overlay,
     Popover,
+    PortalProvider,
     Radio,
     RadioGroup,
     RangeSlider,
@@ -146,6 +148,7 @@ export const alert = elementFactory(Alert),
 // Container Components
 //-----------------------
 export const buttonGroup = elementFactory(ButtonGroup),
+    portalProvider = elementFactory(PortalProvider),
     callout = elementFactory(Callout),
     bpCard = elementFactory(BpCard),
     drawer = elementFactory(Drawer),


### PR DESCRIPTION
The Inspector can now pop out of the app frame entirely, into a separate browser window - solving the long-standing annoyance of app-level masks and modal dialogs covering and blocking it, and freeing the full viewport for the app (second monitor friendly).

- New `InspectorModel` hosts the same Inspector component tree either docked (as today) or in a child window via a cross-document React portal - the Inspector stays in the main app's component tree with live access to all app state.
- Stylesheets and theme classes sync into the child window and stay current across hot reloads, lazy-loaded chunks, and theme changes.
- Popups spawned by the Inspector (grid menus, tooltips) re-parent into the child window via per-grid `popupParent` and a new `portalProvider` export from `kit/blueprint`.
- Closing the popped-out window (or unloading the app) docks/cleans up automatically; popped-out state is deliberately not restored on app load (browsers require a user gesture).
- Removes the Inspector's previous modal (expand) toggle, superseded by the pop-out.

No changes to `AppContainer`, `ModalSupport`, or `InspectorService` - all inspector-local aside from the additive kit export. Verified against Toolbox running the full local stack.

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. (Removal of the Inspector's modal toggle is internal `xhImpl` UI - no app-facing API change.)
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required. (Inspector is desktop-only.)
- [x] Created Toolbox branch / PR, or determined not required. (No Toolbox changes needed - verified against unmodified Toolbox.)

