### PR TITLE
Inspector: Cube/View tracking and data-pipeline Diagnostics panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,12 @@ columns.
 * `TextInput` now accepts a `leftElement` prop, rendered inline at the left of the input.
 * Hoist Inspector now pops out in a separate browser window, leaving the app's viewport to the app
   while ensuring Inspector itself is not covered by masks or other modal content.
+* Hoist Inspector now tracks `Cube` and cube `View` instances alongside models, services, and
+  stores, and adds a Diagnostics panel - a live readout of the data-pipeline `diagnostics`
+  published by selected Stores, Cube Views, and GridModels, with controls to reset counters and
+  stream ops to the devtools console.
+* Added `XH.getCubes()` and `XH.getViews()` to enumerate all active `Cube` and `View` instances,
+  now registered with Hoist's instance registry.
 
 ### 🐞 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,8 +224,8 @@ columns.
   while ensuring Inspector itself is not covered by masks or other modal content.
 * Hoist Inspector now tracks `Cube` and cube `View` instances alongside models, services, and
   stores, and adds a Diagnostics panel - a live readout of the data-pipeline `diagnostics`
-  published by selected Stores, Cube Views, and GridModels, with controls to reset counters and
-  stream ops to the devtools console.
+  published by selected Stores, Cubes, Cube Views, and GridModels, with controls to reset counters
+  and stream ops to the devtools console.
 * Added `XH.getCubes()` and `XH.getViews()` to enumerate all active `Cube` and `View` instances,
   now registered with Hoist's instance registry.
 

--- a/core/XH.ts
+++ b/core/XH.ts
@@ -6,7 +6,7 @@
  */
 import {RouterModel} from '@xh/hoist/appcontainer/RouterModel';
 import {HoistAuthModel} from '@xh/hoist/core/HoistAuthModel';
-import {Store} from '@xh/hoist/data';
+import {Cube, Store, View} from '@xh/hoist/data';
 import {Icon} from '@xh/hoist/icon';
 import {action} from '@xh/hoist/mobx';
 import {never} from '@xh/hoist/promise';
@@ -873,6 +873,16 @@ export class XHApi {
     /** All Stores registered with this application. */
     getStores(): Store[] {
         return Array.from(instanceManager.stores);
+    }
+
+    /** All Cubes registered with this application. */
+    getCubes(): Cube[] {
+        return Array.from(instanceManager.cubes);
+    }
+
+    /** All Cube Views registered with this application. */
+    getViews(): View[] {
+        return Array.from(instanceManager.views);
     }
 
     /**

--- a/core/impl/BaseDiagnostics.ts
+++ b/core/impl/BaseDiagnostics.ts
@@ -5,6 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import type {HoistBase} from '@xh/hoist/core';
+import {observable} from '@xh/hoist/mobx';
 import {logDebug, logInfo} from '@xh/hoist/utils/js';
 
 /**
@@ -19,7 +20,9 @@ export abstract class BaseDiagnostics<T extends HoistBase> {
     /**
      * Level at which each op is logged as it happens. Leave at 'debug' to stream with the rest of
      * the app's debug output, or set to 'info' to follow this object alone at any `XH.logLevel`.
+     * Observable, to support UI toggles (e.g. the Hoist Inspector's Diagnostics panel).
      */
+    @observable
     logLevel: 'info' | 'debug' = 'debug';
 
     protected owner: T;

--- a/core/impl/InstanceManager.ts
+++ b/core/impl/InstanceManager.ts
@@ -7,7 +7,7 @@
 
 import {HoistService, HoistModel} from '../';
 import {isNil} from 'lodash';
-import {Store} from '@xh/hoist/data';
+import type {Cube, Store, View} from '@xh/hoist/data';
 import {observable, makeObservable} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 
@@ -24,6 +24,12 @@ class InstanceManager {
 
     @observable.shallow
     stores: Set<Store> = new Set();
+
+    @observable.shallow
+    cubes: Set<Cube> = new Set();
+
+    @observable.shallow
+    views: Set<View> = new Set();
 
     private modelsByTestId: Map<string, HoistModel> = new Map();
     private testSupportedModels = new Set(['GridModel', 'DataViewModel', 'FormModel', 'TabModel']);
@@ -46,6 +52,22 @@ class InstanceManager {
 
     unregisterStore(s: Store) {
         wait().thenAction(() => this.stores.delete(s));
+    }
+
+    registerCube(c: Cube) {
+        wait().thenAction(() => this.cubes.add(c));
+    }
+
+    unregisterCube(c: Cube) {
+        wait().thenAction(() => this.cubes.delete(c));
+    }
+
+    registerView(v: View) {
+        wait().thenAction(() => this.views.add(v));
+    }
+
+    unregisterView(v: View) {
+        wait().thenAction(() => this.views.delete(v));
     }
 
     registerModelWithTestId(testId: string, m: HoistModel) {

--- a/data/README.md
+++ b/data/README.md
@@ -1081,6 +1081,9 @@ gridModel.diagnostics.logLevel = 'info';
 This API supports app troubleshooting and benchmarking only. It can change without notice at any
 release.
 
+The [Hoist Inspector](../inspector/README.md) provides a built-in UI for these diagnostics - select
+any Store, Cube View, or GridModel in its Instances grid to see a live readout.
+
 ## Common Patterns
 
 ### Processing Raw Data with `processRawData`

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -6,6 +6,7 @@
  */
 
 import {AnyIterable, HoistBase, managed, PlainObject, Some} from '@xh/hoist/core';
+import {instanceManager} from '@xh/hoist/core/impl/InstanceManager';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {forEachAsync} from '@xh/hoist/utils/async';
 import {defaultsDeep, isArray, isEmpty} from 'lodash';
@@ -160,6 +161,12 @@ export type BucketSpecFn = (rows: BaseRow[]) => BucketSpec;
 export class Cube extends HoistBase {
     static RECORD_ID_DELIMITER = '>>';
 
+    static isCube(obj: unknown): obj is Cube {
+        return obj instanceof Cube;
+    }
+
+    _created = Date.now();
+
     @managed store: Store;
     lockFn: LockFn;
     bucketSpecFn: BucketSpecFn;
@@ -197,6 +204,7 @@ export class Cube extends HoistBase {
         this.lockFn = lockFn;
         this.bucketSpecFn = bucketSpecFn;
         this.omitFn = omitFn;
+        instanceManager.registerCube(this);
     }
 
     /** Fields configured for this Cube. */
@@ -434,6 +442,7 @@ export class Cube extends HoistBase {
     }
 
     override destroy() {
+        instanceManager.unregisterCube(this);
         this._connectedViews.forEach(v => v.disconnect());
         super.destroy();
     }

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -7,6 +7,7 @@
 
 import type {GridFilterBindTarget} from '@xh/hoist/cmp/grid';
 import {HoistBase, PlainObject, Some} from '@xh/hoist/core';
+import {instanceManager} from '@xh/hoist/core/impl/InstanceManager';
 import {
     Cube,
     CubeField,
@@ -140,6 +141,8 @@ export class View
     /** @internal */
     readonly diagnostics = new ViewDiagnostics(this);
 
+    _created = Date.now();
+
     // Implementation
     private _rowDatas: ViewRowData[] = null;
     private _leafMap: Map<StoreRecordId, LeafRow> = null;
@@ -176,6 +179,8 @@ export class View
         if (connect) {
             this.cube._connectedViews.add(this);
         }
+
+        instanceManager.registerView(this);
     }
 
     //--------------------
@@ -706,6 +711,7 @@ export class View
     }
 
     override destroy() {
+        instanceManager.unregisterView(this);
         this.disconnect();
         super.destroy();
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,7 +128,7 @@ Cross-cutting documentation that spans multiple packages:
 | [`/security/`](../security/README.md) | OAuth 2.0 client abstraction for Auth0 and Microsoft Entra ID (MSAL) | BaseOAuthClient, AuthZeroClient, MsalClient, Token, AccessTokenSpec, auto-refresh, re-login |
 | [`/kit/`](../kit/README.md) | Centralized wrappers for third-party libraries used by Hoist | installAgGrid, installHighcharts, Blueprint, Onsen, GoldenLayout, react-select, version constraints |
 | [`/kit/blueprint/`](../kit/blueprint/README.md) | Blueprint integration - wrapped components, element factories, and build-time icon stubbing | Blueprint, Popover, Dialog, element factories, blueprint icons, loadAllBlueprintJsIcons, upgrade checklist |
-| [`/inspector/`](../inspector/README.md) | Built-in developer tool for real-time inspection of Hoist instances and memory | InspectorPanel, InspectorModel, StatsModel, InstancesModel, property watchlist, model leak detection |
+| [`/inspector/`](../inspector/README.md) | Built-in developer tool for real-time inspection of Hoist instances and memory | InspectorPanel, InspectorModel, StatsModel, InstancesModel, DiagnosticsModel, property watchlist, model leak detection |
 | [`/styles/`](../styles/README.md) | CSS custom properties, theming, BEM naming, SCSS conventions, and utility classes | `--xh-*` CSS vars, vars.scss, XH.scss, dark theme, ThemeModel, BEM, `xh-` prefix, intent colors, utility classes |
 
 ### Other Packages

--- a/docs/doc-registry.json
+++ b/docs/doc-registry.json
@@ -261,7 +261,7 @@
             "mcpCategory": "package",
             "viewerCategory": "supporting",
             "description": "Built-in developer tool for real-time inspection of Hoist instances.",
-            "keywords": ["InspectorPanel", "InspectorModel", "StatsModel", "InstancesModel", "property watchlist", "model leak detection"]
+            "keywords": ["InspectorPanel", "InspectorModel", "StatsModel", "InstancesModel", "DiagnosticsModel", "property watchlist", "model leak detection"]
         },
         {
             "id": "mcp/README.md",

--- a/inspector/README.md
+++ b/inspector/README.md
@@ -161,9 +161,10 @@ kind with the last op's type (the path taken - e.g. an incremental patch vs. a f
 work done, its timing, and cumulative count/average stats. Selecting a `Cube` reports via its
 internal `Store`, where its data ops actually land.
 
-- **Log ops** — Streams each op performed by the selected instances to the devtools console,
-  by escalating their per-instance `diagnostics.logLevel` - no need to raise the app-wide
-  `XH.logLevel`. Resets when the selection changes.
+- **Log operations to console** — Streams each op performed by the selected instances to the
+  devtools console, by escalating their per-instance `diagnostics.logLevel` - no need to raise the
+  app-wide `XH.logLevel`. Sticky per instance - logging continues when the selection moves
+  elsewhere, and any number of instances can log at once.
 - **Reset** — Clears counts and timings for the selected instances.
 
 Select the instances along a data-change's path - e.g. a Cube's `Store`, a `View` on that cube, and

--- a/inspector/README.md
+++ b/inspector/README.md
@@ -158,7 +158,8 @@ The Instances panel is a split layout with:
 operation they perform - see [Diagnostics](../data/README.md#diagnostics) in the data package
 README. When any selected instance publishes diagnostics, this panel shows one row per operation
 kind with the last op's type (the path taken - e.g. an incremental patch vs. a full rebuild), the
-work done, its timing, and cumulative count/average stats.
+work done, its timing, and cumulative count/average stats. Selecting a `Cube` reports via its
+internal `Store`, where its data ops actually land.
 
 - **Log ops** — Streams each op performed by the selected instances to the devtools console,
   by escalating their per-instance `diagnostics.logLevel` - no need to raise the app-wide

--- a/inspector/README.md
+++ b/inspector/README.md
@@ -30,7 +30,9 @@ inspector/
 ├── Inspector.scss                   # Inspector-specific styles
 ├── instances/
 │   ├── InstancesPanel.ts            # Split view: instance grid (left) + properties grid (right)
-│   └── InstancesModel.ts            # Model managing instance/property grids, watchlist, getters
+│   ├── InstancesModel.ts            # Model managing instance/property grids, watchlist, getters
+│   ├── DiagnosticsPanel.ts          # Data-pipeline diagnostics readout for selected instances
+│   └── DiagnosticsModel.ts          # Model syncing op stats from selected instance diagnostics
 └── stats/
     ├── StatsPanel.ts                # Chart + grid combo for timeseries stats
     └── StatsModel.ts                # Model tracking model count, heap memory, sync runs
@@ -119,10 +121,12 @@ navigation or load action created them.
 
 The Instances panel is a split layout with:
 
-- **Instances grid** (left, resizable) — Lists all live `HoistModel`, `HoistService`, and `Store`
-  instances with their class name, creation time, linked status, and sync run
+- **Instances grid** (left, resizable) — Lists all live `HoistModel`, `HoistService`, `Store`,
+  `Cube`, and `View` instances with their class name, creation time, linked status, and sync run
 - **Properties grid** (right) — Shows properties of the selected instance(s), including observable
   values with live updates
+- **Diagnostics panel** (below properties, collapsible) — Live readout of the data-pipeline
+  `diagnostics` published by selected Stores, Cube Views, and GridModels
 
 ### Instance Grid Features
 
@@ -143,10 +147,27 @@ The Instances panel is a split layout with:
   watched properties across multiple instances
 - **Filtering** — Toggle filters for: own properties only, observable properties only, hide
   underscore-prefixed properties
-- **Navigation** — When a property value is a HoistModel, HoistService, or Store, clicking its
-  value navigates to that instance in the instances grid
+- **Navigation** — When a property value is a HoistModel, HoistService, Store, Cube, or View,
+  clicking its value navigates to that instance in the instances grid
 - **Console logging** — Double-click a property or use the action button to log its value to the
   browser devtools console
+
+### Diagnostics Panel
+
+`Store`, Cube `View`, and `GridModel` publish `diagnostics` reporting on each data-pipeline
+operation they perform - see [Diagnostics](../data/README.md#diagnostics) in the data package
+README. When any selected instance publishes diagnostics, this panel shows one row per operation
+kind with the last op's type (the path taken - e.g. an incremental patch vs. a full rebuild), the
+work done, its timing, and cumulative count/average stats.
+
+- **Log ops** — Streams each op performed by the selected instances to the devtools console,
+  by escalating their per-instance `diagnostics.logLevel` - no need to raise the app-wide
+  `XH.logLevel`. Resets when the selection changes.
+- **Reset** — Clears counts and timings for the selected instances.
+
+Select the instances along a data-change's path - e.g. a Cube's `Store`, a `View` on that cube, and
+the `GridModel` displaying its results - to localize the cost of the change to the stage
+responsible for it.
 
 ### Persistence
 

--- a/inspector/README.md
+++ b/inspector/README.md
@@ -29,7 +29,7 @@ inspector/
 ├── InspectorModel.ts                # Hosts the UI docked in the app or in a popped-out window
 ├── Inspector.scss                   # Inspector-specific styles
 ├── instances/
-│   ├── InstancesPanel.ts            # Split view: instance grid (left) + properties grid (right)
+│   ├── InstancesPanel.ts            # Instance grid (left) + tabbed properties/diagnostics (right)
 │   ├── InstancesModel.ts            # Model managing instance/property grids, watchlist, getters
 │   ├── DiagnosticsPanel.ts          # Data-pipeline diagnostics readout for selected instances
 │   └── DiagnosticsModel.ts          # Model syncing op stats from selected instance diagnostics
@@ -125,7 +125,7 @@ The Instances panel is a split layout with:
   `Cube`, and `View` instances with their class name, creation time, linked status, and sync run
 - **Properties grid** (right) — Shows properties of the selected instance(s), including observable
   values with live updates
-- **Diagnostics panel** (below properties, collapsible) — Live readout of the data-pipeline
+- **Diagnostics panel** (tabbed with properties) — Live readout of the data-pipeline
   `diagnostics` published by selected Stores, Cube Views, and GridModels
 
 ### Instance Grid Features

--- a/inspector/instances/DiagnosticsModel.ts
+++ b/inspector/instances/DiagnosticsModel.ts
@@ -143,7 +143,7 @@ export class DiagnosticsModel extends HoistModel {
     }
 
     private createGridModel(): GridModel {
-        const msRenderer = (v: number) => (v != null ? `${v.toFixed(1)}ms` : null);
+        const msRenderer = numberRenderer({precision: 1, zeroPad: true, label: 'ms'});
 
         return new GridModel({
             persistWith: {...this.parent.persistWith, path: 'diagnosticsGrid'},

--- a/inspector/instances/DiagnosticsModel.ts
+++ b/inspector/instances/DiagnosticsModel.ts
@@ -144,7 +144,6 @@ export class DiagnosticsModel extends HoistModel {
             autosizeOptions: {mode: 'managed'},
             filterModel: true,
             headerMenuDisplay: 'hover',
-            emptyText: 'Select a Store, Cube View, or GridModel to view data-pipeline diagnostics.',
             groupBy: 'instanceDisplayName',
             showGroupRowCounts: false,
             sortBy: 'kind',
@@ -157,7 +156,7 @@ export class DiagnosticsModel extends HoistModel {
                     {name: 'total', displayName: 'Row #', type: 'number'},
                     {name: 'lastElapsedMs', displayName: 'ms', type: 'number'},
                     {name: 'count', displayName: 'n', type: 'number'},
-                    {name: 'avgMs', displayName: 'avg ms', type: 'number'},
+                    {name: 'avgMs', displayName: 'Avg ms', type: 'number'},
                     {name: 'timestamp', displayName: 'Last Run', type: 'number'}
                 ]
             },

--- a/inspector/instances/DiagnosticsModel.ts
+++ b/inspector/instances/DiagnosticsModel.ts
@@ -9,6 +9,7 @@ import {HoistModel, managed, PlainObject} from '@xh/hoist/core';
 import {BaseDiagnostics} from '@xh/hoist/core/impl/BaseDiagnostics';
 import {fmtDate, numberRenderer} from '@xh/hoist/format';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
+import {Cube} from '@xh/hoist/data';
 import {forIn, isFinite} from 'lodash';
 import type {InstancesModel} from './InstancesModel';
 
@@ -16,7 +17,8 @@ import type {InstancesModel} from './InstancesModel';
  * Displays the data-pipeline `diagnostics` published by any currently selected instances that
  * provide them - Stores, Cube Views, and GridModels. Each op-stats slot on a diagnostics object
  * renders as a row reporting the last operation performed (its type, work done, and timing)
- * alongside cumulative count and average timing.
+ * alongside cumulative count and average timing. A selected Cube reports via its internal Store,
+ * where its data ops actually land.
  *
  * Rows are discovered from the shape of each diagnostics object rather than a per-class schema -
  * the diagnostics APIs are internal and deliberately unstable, so this readout adapts to their
@@ -39,9 +41,29 @@ export class DiagnosticsModel extends HoistModel {
 
     /** Diagnostics published by the currently selected instances. */
     get trackedDiagnostics(): BaseDiagnostics<any>[] {
-        return this.parent.selectedInstances
-            .map(inst => (inst as any).diagnostics)
-            .filter(it => it instanceof BaseDiagnostics);
+        return this.diagnosticSources.map(it => it.diag);
+    }
+
+    /**
+     * Selected instances resolved to the diagnostics they publish, with a display label for
+     * each. A Cube resolves to its internal Store's diagnostics, labeled to show the indirection.
+     */
+    private get diagnosticSources(): DiagnosticSource[] {
+        const ret: DiagnosticSource[] = [];
+        this.parent.selectedInstances.forEach(inst => {
+            const label = `${inst.constructor.name} [${inst.xhId}]`,
+                diag = (inst as any).diagnostics;
+            if (diag instanceof BaseDiagnostics) {
+                ret.push({xhId: inst.xhId, diag, label});
+            } else if (Cube.isCube(inst) && inst.store?.diagnostics instanceof BaseDiagnostics) {
+                ret.push({
+                    xhId: inst.xhId,
+                    diag: inst.store.diagnostics,
+                    label: `${label} › Store [${inst.store.xhId}]`
+                });
+            }
+        });
+        return ret;
     }
 
     private escalated: BaseDiagnostics<any>[] = [];
@@ -82,17 +104,13 @@ export class DiagnosticsModel extends HoistModel {
     private syncGrid() {
         const data = [];
 
-        this.parent.selectedInstances.forEach(inst => {
-            const diag = (inst as any).diagnostics;
-            if (!(diag instanceof BaseDiagnostics)) return;
-
-            const instanceDisplayName = `${inst.constructor.name} [${inst.xhId}]`;
+        this.diagnosticSources.forEach(({xhId, diag, label}) => {
             forIn(diag as PlainObject, (stats, kind) => {
                 if (!this.isOpStats(stats)) return;
                 const {last, count, elapsed} = stats;
                 data.push({
-                    id: `${inst.xhId}-${kind}`,
-                    instanceDisplayName,
+                    id: `${xhId}-${kind}`,
+                    instanceDisplayName: label,
                     kind,
                     type: last?.type ?? null,
                     detail: last ? this.opDetail(last) : null,
@@ -210,4 +228,10 @@ export class DiagnosticsModel extends HoistModel {
         this.escalated.forEach(it => (it.logLevel = 'debug'));
         super.destroy();
     }
+}
+
+interface DiagnosticSource {
+    xhId: string;
+    diag: BaseDiagnostics<any>;
+    label: string;
 }

--- a/inspector/instances/DiagnosticsModel.ts
+++ b/inspector/instances/DiagnosticsModel.ts
@@ -1,0 +1,214 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {GridModel} from '@xh/hoist/cmp/grid';
+import {HoistModel, PlainObject, XH} from '@xh/hoist/core';
+import {BaseDiagnostics} from '@xh/hoist/core/impl/BaseDiagnostics';
+import {fmtDate, numberRenderer} from '@xh/hoist/format';
+import {bindable, makeObservable} from '@xh/hoist/mobx';
+import {forIn, isFinite} from 'lodash';
+import type {InstancesModel} from './InstancesModel';
+
+/**
+ * Displays the data-pipeline `diagnostics` published by any currently selected instances that
+ * provide them - Stores, Cube Views, and GridModels. Each op-stats slot on a diagnostics object
+ * renders as a row reporting the last operation performed (its type, work done, and timing)
+ * alongside cumulative count and average timing.
+ *
+ * Rows are discovered from the shape of each diagnostics object rather than a per-class schema -
+ * the diagnostics APIs are internal and deliberately unstable, so this readout adapts to their
+ * current form.
+ *
+ * @internal
+ */
+export class DiagnosticsModel extends HoistModel {
+    override xhImpl = true;
+
+    parent: InstancesModel;
+    gridModel: GridModel;
+
+    /**
+     * True to stream each op performed by the selected instances to the devtools console at
+     * 'info' level, following them without raising the app-wide log level. Reset on selection
+     * change.
+     */
+    @bindable logOps = false;
+
+    /** Diagnostics published by the currently selected instances. */
+    get trackedDiagnostics(): BaseDiagnostics<any>[] {
+        return this.parent.selectedInstances
+            .map(inst => (inst as any).diagnostics)
+            .filter(it => it instanceof BaseDiagnostics);
+    }
+
+    private escalated: BaseDiagnostics<any>[] = [];
+
+    constructor(parent: InstancesModel) {
+        super();
+        makeObservable(this);
+        this.parent = parent;
+        this.gridModel = this.createGridModel();
+
+        this.addAutorun({
+            run: () => this.syncGrid(),
+            delay: 300
+        });
+
+        this.addReaction(
+            {
+                track: () => this.parent.instancesGridModel.selectedIds,
+                run: () => {
+                    this.logOps = false;
+                    this.syncLogging();
+                }
+            },
+            {
+                track: () => this.logOps,
+                run: () => this.syncLogging()
+            }
+        );
+    }
+
+    resetAll() {
+        this.trackedDiagnostics.forEach(it => it.reset());
+    }
+
+    //------------------
+    // Implementation
+    //------------------
+    private syncGrid() {
+        const data = [];
+
+        this.parent.selectedInstances.forEach(inst => {
+            const diag = (inst as any).diagnostics;
+            if (!(diag instanceof BaseDiagnostics)) return;
+
+            const instanceDisplayName = `${inst.constructor.name} [${inst.xhId}]`;
+            forIn(diag as PlainObject, (stats, kind) => {
+                if (!this.isOpStats(stats)) return;
+                const {last, count, elapsed} = stats;
+                data.push({
+                    id: `${inst.xhId}-${kind}`,
+                    instanceDisplayName,
+                    kind,
+                    type: last?.type ?? null,
+                    detail: last ? this.opDetail(last) : null,
+                    total: last?.total ?? null,
+                    lastElapsedMs: last?.elapsed ?? null,
+                    count,
+                    avgMs: count ? elapsed / count : null,
+                    timestamp: last?.timestamp ?? null
+                });
+            });
+        });
+
+        this.gridModel.loadData(data);
+    }
+
+    /** An op-stats slot (last, count, elapsed) vs. other props on the diagnostics object. */
+    private isOpStats(v: unknown): v is PlainObject {
+        return (
+            v != null &&
+            typeof v === 'object' &&
+            'last' in v &&
+            isFinite((v as PlainObject).count) &&
+            isFinite((v as PlainObject).elapsed)
+        );
+    }
+
+    /** Summarize the work an op reported, adapting to the fields present on its shape. */
+    private opDetail(op: PlainObject): string {
+        return op.reused != null
+            ? `reused ${op.reused} · rebuilt ${op.rebuilt} · created ${op.created}`
+            : op.columns != null
+              ? `cols ${op.columns} · recs ${op.records}`
+              : op.update != null
+                ? `upd ${op.update} · add ${op.add} · rem ${op.remove}`
+                : null;
+    }
+
+    private syncLogging() {
+        this.escalated.forEach(it => (it.logLevel = 'debug'));
+        this.escalated = this.logOps ? this.trackedDiagnostics : [];
+        this.escalated.forEach(it => (it.logLevel = 'info'));
+    }
+
+    private createGridModel(): GridModel {
+        const msRenderer = (v: number) => (v != null ? `${v.toFixed(1)}ms` : null);
+
+        return new GridModel({
+            persistWith: {...this.parent.persistWith, path: 'diagnosticsGrid'},
+            autosizeOptions: {mode: 'managed'},
+            emptyText: 'Select a Store, Cube View, or GridModel to view data-pipeline diagnostics.',
+            groupBy: 'instanceDisplayName',
+            showGroupRowCounts: false,
+            sortBy: 'kind',
+            store: {
+                fields: [
+                    {name: 'instanceDisplayName', type: 'string'},
+                    {name: 'kind', displayName: 'Op', type: 'string'},
+                    {name: 'type', type: 'string'},
+                    {name: 'detail', displayName: 'Last Op Detail', type: 'string'},
+                    {name: 'total', type: 'number'},
+                    {name: 'lastElapsedMs', displayName: 'ms', type: 'number'},
+                    {name: 'count', displayName: 'n', type: 'number'},
+                    {name: 'avgMs', displayName: 'avg ms', type: 'number'},
+                    {name: 'timestamp', displayName: 'Last Run', type: 'number'}
+                ]
+            },
+            colDefaults: {autosizeIncludeHeaderIcons: false},
+            columns: [
+                {field: 'instanceDisplayName', hidden: true},
+                {field: 'kind', width: 140},
+                {
+                    field: 'type',
+                    width: 110,
+                    headerTooltip:
+                        'Path the operation took through the data pipeline - e.g. an incremental patch/delta vs. a full rebuild.'
+                },
+                {field: 'detail', minWidth: 180, flex: 1},
+                {
+                    field: 'total',
+                    headerTooltip: 'Total records/rows held after the last operation.',
+                    renderer: numberRenderer({precision: 0}),
+                    highlightOnChange: true
+                },
+                {
+                    field: 'lastElapsedMs',
+                    headerTooltip: 'Time taken by the last operation.',
+                    align: 'right',
+                    renderer: msRenderer,
+                    highlightOnChange: true
+                },
+                {
+                    field: 'count',
+                    headerTooltip: 'Operations performed since activation or last reset.',
+                    renderer: numberRenderer({precision: 0})
+                },
+                {
+                    field: 'avgMs',
+                    headerTooltip:
+                        'Mean time per operation - resolves sub-millisecond ops that report 0ms individually.',
+                    align: 'right',
+                    renderer: msRenderer
+                },
+                {
+                    field: 'timestamp',
+                    align: 'right',
+                    renderer: v => fmtDate(v, {fmt: 'HH:mm:ss.SSS'}),
+                    highlightOnChange: true
+                }
+            ],
+            xhImpl: true
+        });
+    }
+
+    override destroy() {
+        this.escalated.forEach(it => (it.logLevel = 'debug'));
+        XH.safeDestroy(this.gridModel);
+        super.destroy();
+    }
+}

--- a/inspector/instances/DiagnosticsModel.ts
+++ b/inspector/instances/DiagnosticsModel.ts
@@ -8,9 +8,9 @@ import {GridModel} from '@xh/hoist/cmp/grid';
 import {HoistModel, managed, PlainObject} from '@xh/hoist/core';
 import {BaseDiagnostics} from '@xh/hoist/core/impl/BaseDiagnostics';
 import {fmtDate, numberRenderer} from '@xh/hoist/format';
-import {bindable, makeObservable} from '@xh/hoist/mobx';
+import {action, makeObservable} from '@xh/hoist/mobx';
 import {Cube} from '@xh/hoist/data';
-import {forIn, isFinite} from 'lodash';
+import {forIn, isEmpty, isFinite} from 'lodash';
 import type {InstancesModel} from './InstancesModel';
 
 /**
@@ -33,11 +33,15 @@ export class DiagnosticsModel extends HoistModel {
     @managed gridModel: GridModel;
 
     /**
-     * True to stream each op performed by the selected instances to the devtools console at
-     * 'info' level, following them without raising the app-wide log level. Reset on selection
-     * change.
+     * True if every currently selected diagnostics source is streaming its ops to the devtools
+     * console at 'info' level. Derived from (and toggled onto) the per-instance
+     * `diagnostics.logLevel`, so it is sticky per instance - logging continues as the selection
+     * moves elsewhere, and any number of instances can be logging at once.
      */
-    @bindable logOps = false;
+    get logOps(): boolean {
+        const tracked = this.trackedDiagnostics;
+        return !isEmpty(tracked) && tracked.every(it => it.logLevel === 'info');
+    }
 
     /** Diagnostics published by the currently selected instances. */
     get trackedDiagnostics(): BaseDiagnostics<any>[] {
@@ -66,8 +70,6 @@ export class DiagnosticsModel extends HoistModel {
         return ret;
     }
 
-    private escalated: BaseDiagnostics<any>[] = [];
-
     constructor(parent: InstancesModel) {
         super();
         makeObservable(this);
@@ -78,24 +80,16 @@ export class DiagnosticsModel extends HoistModel {
             run: () => this.syncGrid(),
             delay: 300
         });
-
-        this.addReaction(
-            {
-                track: () => this.parent.instancesGridModel.selectedIds,
-                run: () => {
-                    this.logOps = false;
-                    this.syncLogging();
-                }
-            },
-            {
-                track: () => this.logOps,
-                run: () => this.syncLogging()
-            }
-        );
     }
 
     resetAll() {
         this.trackedDiagnostics.forEach(it => it.reset());
+    }
+
+    /** Enable/disable op logging for all currently selected diagnostics sources. */
+    @action
+    setLogOps(logOps: boolean) {
+        this.trackedDiagnostics.forEach(it => (it.logLevel = logOps ? 'info' : 'debug'));
     }
 
     //------------------
@@ -146,12 +140,6 @@ export class DiagnosticsModel extends HoistModel {
               : op.update != null
                 ? `upd ${op.update} · add ${op.add} · rem ${op.remove}`
                 : null;
-    }
-
-    private syncLogging() {
-        this.escalated.forEach(it => (it.logLevel = 'debug'));
-        this.escalated = this.logOps ? this.trackedDiagnostics : [];
-        this.escalated.forEach(it => (it.logLevel = 'info'));
     }
 
     private createGridModel(): GridModel {
@@ -222,11 +210,6 @@ export class DiagnosticsModel extends HoistModel {
             ],
             xhImpl: true
         });
-    }
-
-    override destroy() {
-        this.escalated.forEach(it => (it.logLevel = 'debug'));
-        super.destroy();
     }
 }
 

--- a/inspector/instances/DiagnosticsModel.ts
+++ b/inspector/instances/DiagnosticsModel.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {GridModel} from '@xh/hoist/cmp/grid';
-import {HoistModel, PlainObject, XH} from '@xh/hoist/core';
+import {HoistModel, managed, PlainObject} from '@xh/hoist/core';
 import {BaseDiagnostics} from '@xh/hoist/core/impl/BaseDiagnostics';
 import {fmtDate, numberRenderer} from '@xh/hoist/format';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
@@ -28,7 +28,7 @@ export class DiagnosticsModel extends HoistModel {
     override xhImpl = true;
 
     parent: InstancesModel;
-    gridModel: GridModel;
+    @managed gridModel: GridModel;
 
     /**
      * True to stream each op performed by the selected instances to the devtools console at
@@ -208,7 +208,6 @@ export class DiagnosticsModel extends HoistModel {
 
     override destroy() {
         this.escalated.forEach(it => (it.logLevel = 'debug'));
-        XH.safeDestroy(this.gridModel);
         super.destroy();
     }
 }

--- a/inspector/instances/DiagnosticsModel.ts
+++ b/inspector/instances/DiagnosticsModel.ts
@@ -142,6 +142,8 @@ export class DiagnosticsModel extends HoistModel {
         return new GridModel({
             persistWith: {...this.parent.persistWith, path: 'diagnosticsGrid'},
             autosizeOptions: {mode: 'managed'},
+            filterModel: true,
+            headerMenuDisplay: 'hover',
             emptyText: 'Select a Store, Cube View, or GridModel to view data-pipeline diagnostics.',
             groupBy: 'instanceDisplayName',
             showGroupRowCounts: false,
@@ -152,14 +154,14 @@ export class DiagnosticsModel extends HoistModel {
                     {name: 'kind', displayName: 'Op', type: 'string'},
                     {name: 'type', type: 'string'},
                     {name: 'detail', displayName: 'Last Op Detail', type: 'string'},
-                    {name: 'total', type: 'number'},
+                    {name: 'total', displayName: 'Row #', type: 'number'},
                     {name: 'lastElapsedMs', displayName: 'ms', type: 'number'},
                     {name: 'count', displayName: 'n', type: 'number'},
                     {name: 'avgMs', displayName: 'avg ms', type: 'number'},
                     {name: 'timestamp', displayName: 'Last Run', type: 'number'}
                 ]
             },
-            colDefaults: {autosizeIncludeHeaderIcons: false},
+            colDefaults: {autosizeIncludeHeaderIcons: false, filterable: true},
             columns: [
                 {field: 'instanceDisplayName', hidden: true},
                 {field: 'kind', width: 140},
@@ -190,8 +192,7 @@ export class DiagnosticsModel extends HoistModel {
                 },
                 {
                     field: 'avgMs',
-                    headerTooltip:
-                        'Mean time per operation - resolves sub-millisecond ops that report 0ms individually.',
+                    headerTooltip: 'Mean time per operation.',
                     align: 'right',
                     renderer: msRenderer
                 },

--- a/inspector/instances/DiagnosticsPanel.ts
+++ b/inspector/instances/DiagnosticsPanel.ts
@@ -41,9 +41,10 @@ export const diagnosticsPanel = hoistCmp.factory({
             bbar: toolbar({
                 items: [
                     span({
-                        title: 'Stream each op performed by the selected instances to the devtools console, without raising the app-wide log level.',
+                        title: 'Stream each op performed by the selected instances to the devtools console, without raising the app-wide log level. Sticky per instance - logging continues when the selection moves elsewhere.',
                         item: switchInput({
-                            bind: 'logOps',
+                            value: model.logOps,
+                            onChange: v => model.setLogOps(v),
                             label: 'Log operations to console',
                             disabled: !hasTracked
                         })

--- a/inspector/instances/DiagnosticsPanel.ts
+++ b/inspector/instances/DiagnosticsPanel.ts
@@ -32,16 +32,6 @@ export const diagnosticsPanel = hoistCmp.factory({
             hasTracked = !isEmpty(model.trackedDiagnostics);
 
         return panel({
-            title: 'Diagnostics',
-            icon: Icon.gauge(),
-            compactHeader: true,
-            modelConfig: {
-                side: 'bottom',
-                defaultSize: 250,
-                persistWith: {...model.parent.persistWith, path: 'diagnosticsPanel'},
-                showHeaderCollapseButton: true,
-                xhImpl: true
-            },
             item: grid({model: model.gridModel, agOptions: {popupParent}}),
             bbar: toolbar({
                 items: [

--- a/inspector/instances/DiagnosticsPanel.ts
+++ b/inspector/instances/DiagnosticsPanel.ts
@@ -1,0 +1,67 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {grid} from '@xh/hoist/cmp/grid';
+import {filler, span} from '@xh/hoist/cmp/layout';
+import {hoistCmp, useContextModel, uses} from '@xh/hoist/core';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {switchInput} from '@xh/hoist/desktop/cmp/input';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
+import {Icon} from '@xh/hoist/icon';
+import {DiagnosticsModel} from '@xh/hoist/inspector/instances/DiagnosticsModel';
+import {InspectorModel} from '@xh/hoist/inspector/InspectorModel';
+import {isEmpty} from 'lodash';
+
+/**
+ * Live readout of the data-pipeline `diagnostics` published by selected Stores, Cube Views, and
+ * GridModels. See {@link DiagnosticsModel}.
+ *
+ * @internal
+ */
+export const diagnosticsPanel = hoistCmp.factory({
+    displayName: 'DiagnosticsPanel',
+    model: uses(DiagnosticsModel, {fromContext: false, publishMode: 'none'}),
+
+    render({model}) {
+        // Re-parent grid popups (context/column menus) when Inspector is popped out.
+        const popupParent = useContextModel(InspectorModel)?.windowContainer ?? undefined,
+            hasTracked = !isEmpty(model.trackedDiagnostics);
+
+        return panel({
+            title: 'Diagnostics',
+            icon: Icon.gauge(),
+            compactHeader: true,
+            modelConfig: {
+                side: 'bottom',
+                defaultSize: 250,
+                persistWith: {...model.parent.persistWith, path: 'diagnosticsPanel'},
+                showHeaderCollapseButton: true,
+                xhImpl: true
+            },
+            item: grid({model: model.gridModel, agOptions: {popupParent}}),
+            bbar: toolbar({
+                items: [
+                    span({
+                        title: 'Stream each op performed by the selected instances to the devtools console, without raising the app-wide log level.',
+                        item: switchInput({
+                            bind: 'logOps',
+                            label: 'Log ops',
+                            disabled: !hasTracked
+                        })
+                    }),
+                    filler(),
+                    button({
+                        icon: Icon.reset(),
+                        tooltip: 'Reset op counts and timings for the selected instances',
+                        disabled: !hasTracked,
+                        onClick: () => model.resetAll()
+                    })
+                ]
+            })
+        });
+    }
+});

--- a/inspector/instances/DiagnosticsPanel.ts
+++ b/inspector/instances/DiagnosticsPanel.ts
@@ -36,7 +36,7 @@ export const diagnosticsPanel = hoistCmp.factory({
                 ? grid({model: model.gridModel, agOptions: {popupParent}})
                 : placeholder(
                       Icon.gauge(),
-                      'Select a Store, Cube View, or GridModel to view data-pipeline diagnostics.'
+                      'Select a Store, Cube, Cube View, or GridModel to view data-pipeline diagnostics.'
                   ),
             bbar: toolbar({
                 items: [
@@ -44,7 +44,7 @@ export const diagnosticsPanel = hoistCmp.factory({
                         title: 'Stream each op performed by the selected instances to the devtools console, without raising the app-wide log level.',
                         item: switchInput({
                             bind: 'logOps',
-                            label: 'Log ops',
+                            label: 'Log operations to console',
                             disabled: !hasTracked
                         })
                     }),

--- a/inspector/instances/DiagnosticsPanel.ts
+++ b/inspector/instances/DiagnosticsPanel.ts
@@ -24,7 +24,7 @@ import {isEmpty} from 'lodash';
  */
 export const diagnosticsPanel = hoistCmp.factory({
     displayName: 'DiagnosticsPanel',
-    model: uses(DiagnosticsModel, {fromContext: false, publishMode: 'none'}),
+    model: uses(DiagnosticsModel, {fromContext: false}),
 
     render({model}) {
         // Re-parent grid popups (context/column menus) when Inspector is popped out.

--- a/inspector/instances/DiagnosticsPanel.ts
+++ b/inspector/instances/DiagnosticsPanel.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {grid} from '@xh/hoist/cmp/grid';
-import {filler, span} from '@xh/hoist/cmp/layout';
+import {filler, placeholder, span} from '@xh/hoist/cmp/layout';
 import {hoistCmp, useContextModel, uses} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {switchInput} from '@xh/hoist/desktop/cmp/input';
@@ -32,7 +32,12 @@ export const diagnosticsPanel = hoistCmp.factory({
             hasTracked = !isEmpty(model.trackedDiagnostics);
 
         return panel({
-            item: grid({model: model.gridModel, agOptions: {popupParent}}),
+            item: hasTracked
+                ? grid({model: model.gridModel, agOptions: {popupParent}})
+                : placeholder(
+                      Icon.gauge(),
+                      'Select a Store, Cube View, or GridModel to view data-pipeline diagnostics.'
+                  ),
             bbar: toolbar({
                 items: [
                     span({

--- a/inspector/instances/InstancesModel.ts
+++ b/inspector/instances/InstancesModel.ts
@@ -188,6 +188,9 @@ export class InstancesModel extends HoistModel {
         return new GridModel({
             persistWith: {...this.persistWith, path: 'instancesGrid', persistGrouping: false},
             autosizeOptions: {mode: 'managed'},
+            filterModel: true,
+            headerMenuDisplay: 'hover',
+            colDefaults: {filterable: true},
             emptyText: 'No matching (and alive) instances found.',
             store: {
                 fields: [
@@ -272,6 +275,9 @@ export class InstancesModel extends HoistModel {
         return new GridModel({
             persistWith: {...this.persistWith, path: 'propertiesGrid'},
             autosizeOptions: {mode: 'managed'},
+            filterModel: true,
+            headerMenuDisplay: 'hover',
+            colDefaults: {filterable: true},
             sortBy: 'displayProperty',
             groupBy: 'displayGroup',
             showGroupRowCounts: false,

--- a/inspector/instances/InstancesModel.ts
+++ b/inspector/instances/InstancesModel.ts
@@ -7,7 +7,7 @@
 import {boolCheckCol, ColumnSpec, GridModel} from '@xh/hoist/cmp/grid';
 import {a} from '@xh/hoist/cmp/layout';
 import {HoistBase, hoistCmp, HoistModel, persist, XH} from '@xh/hoist/core';
-import {StoreRecord} from '@xh/hoist/data';
+import {Cube, StoreRecord, View} from '@xh/hoist/data';
 import {actionCol, calcActionColWidth} from '@xh/hoist/desktop/cmp/grid';
 import {PanelModel} from '@xh/hoist/desktop/cmp/panel';
 import {fmtDate} from '@xh/hoist/format';
@@ -172,7 +172,9 @@ export class InstancesModel extends HoistModel {
         return (
             head(XH.getModels(it => it.xhId === xhId)) ??
             XH.getServices().find(it => it.xhId === xhId) ??
-            XH.getStores().find(it => it.xhId === xhId)
+            XH.getStores().find(it => it.xhId === xhId) ??
+            XH.getCubes().find(it => it.xhId === xhId) ??
+            XH.getViews().find(it => it.xhId === xhId)
         );
     }
 
@@ -193,6 +195,8 @@ export class InstancesModel extends HoistModel {
                     {name: 'isHoistService', type: 'bool'},
                     {name: 'isHoistModel', type: 'bool'},
                     {name: 'isStore', type: 'bool'},
+                    {name: 'isCube', type: 'bool'},
+                    {name: 'isView', type: 'bool'},
                     {name: 'isLinked', type: 'bool'},
                     {name: 'isXhImpl', type: 'bool'},
                     {name: 'hasLoadSupport', type: 'bool'},
@@ -288,6 +292,8 @@ export class InstancesModel extends HoistModel {
                     {name: 'isHoistModel', type: 'bool'},
                     {name: 'isHoistService', type: 'bool'},
                     {name: 'isStore', type: 'bool'},
+                    {name: 'isCube', type: 'bool'},
+                    {name: 'isView', type: 'bool'},
                     {name: 'isGetter', type: 'bool'},
                     {name: 'isLoadedGetter', type: 'bool'}
                 ]
@@ -345,7 +351,13 @@ export class InstancesModel extends HoistModel {
                         if (data.isGetter && !data.isLoadedGetter) {
                             return a({item: '(...)', onClick: () => this.loadGetter(record)});
                         }
-                        if (data.isHoistModel || data.isHoistService || data.isStore) {
+                        if (
+                            data.isHoistModel ||
+                            data.isHoistService ||
+                            data.isStore ||
+                            data.isCube ||
+                            data.isView
+                        ) {
                             return a({item: v, onClick: () => this.selectInstanceAsync(v)});
                         }
                         return JSON.stringify(trimToDepth(v, 2));
@@ -376,7 +388,11 @@ export class InstancesModel extends HoistModel {
                         ? 'Services'
                         : inst.isStore
                           ? 'Stores'
-                          : 'Models';
+                          : inst.isCube
+                            ? 'Cubes'
+                            : inst.isView
+                              ? 'Views'
+                              : 'Models';
                     data.push({...inst, displayGroup});
                 });
 
@@ -464,7 +480,9 @@ export class InstancesModel extends HoistModel {
             isProxy = !!v?._xhIsProxy,
             isHoistModel = v?.isHoistModel,
             isHoistService = v?.isHoistService,
-            isStore = v?.isStore;
+            isStore = v?.isStore,
+            isCube = Cube.isCube(v),
+            isView = View.isView(v);
 
         const valueType =
             isGetter && !isLoadedGetter
@@ -482,7 +500,7 @@ export class InstancesModel extends HoistModel {
             displayProperty: fromWatchlistItem ? `${instanceDisplayName}.${property}` : property,
             displayGroup: fromWatchlistItem ? 'Watchlist' : instanceDisplayName,
             value:
-                isHoistModel || isHoistService || isStore
+                isHoistModel || isHoistService || isStore || isCube || isView
                     ? v.xhId
                     : isProxy
                       ? '[cannot render]'
@@ -493,6 +511,8 @@ export class InstancesModel extends HoistModel {
             isHoistModel,
             isHoistService,
             isStore,
+            isCube,
+            isView,
             isGetter,
             isLoadedGetter,
             isWatchlistItem: !!this.getWatchlistItem(xhId, property)

--- a/inspector/instances/InstancesModel.ts
+++ b/inspector/instances/InstancesModel.ts
@@ -212,6 +212,7 @@ export class InstancesModel extends HoistModel {
             },
             sortBy: ['created|desc'],
             groupBy: this.showInGroups ? 'displayGroup' : null,
+            groupSortFn: (a, b) => GROUP_SORT_ORDER.indexOf(a) - GROUP_SORT_ORDER.indexOf(b),
             selModel: {mode: 'multiple'},
             colChooserModel: true,
             columns: [
@@ -552,6 +553,8 @@ export class InstancesModel extends HoistModel {
         return find(this.propsWatchlist, {instanceXhId, property});
     }
 }
+
+const GROUP_SORT_ORDER = ['Models', 'Services', 'Cubes', 'Views', 'Stores'];
 
 const timestampRenderer = v => fmtDate(v, {fmt: 'HH:mm:ss.SSS'});
 

--- a/inspector/instances/InstancesModel.ts
+++ b/inspector/instances/InstancesModel.ts
@@ -6,7 +6,7 @@
  */
 import {boolCheckCol, ColumnSpec, GridModel} from '@xh/hoist/cmp/grid';
 import {a} from '@xh/hoist/cmp/layout';
-import {HoistBase, hoistCmp, HoistModel, persist, XH} from '@xh/hoist/core';
+import {HoistBase, hoistCmp, HoistModel, managed, persist, XH} from '@xh/hoist/core';
 import {Cube, StoreRecord, View} from '@xh/hoist/data';
 import {actionCol, calcActionColWidth} from '@xh/hoist/desktop/cmp/grid';
 import {PanelModel} from '@xh/hoist/desktop/cmp/panel';
@@ -17,6 +17,7 @@ import {wait} from '@xh/hoist/promise';
 import {trimToDepth} from '@xh/hoist/utils/js';
 import {compact, find, forIn, head, without} from 'lodash';
 import {StatsModel} from '../stats/StatsModel';
+import {DiagnosticsModel} from './DiagnosticsModel';
 
 /**
  * Displays a list of current HoistModel, HoistService, and Store instances, with the ability to
@@ -30,6 +31,7 @@ export class InstancesModel extends HoistModel {
     instancesGridModel: GridModel;
     propertiesGridModel: GridModel;
     instancesPanelModel: PanelModel;
+    @managed diagnosticsModel: DiagnosticsModel;
 
     get statsModel(): StatsModel {
         return XH.getModels(StatsModel)[0] as StatsModel;
@@ -75,6 +77,7 @@ export class InstancesModel extends HoistModel {
 
         this.instancesGridModel = this.createInstancesGridModel();
         this.propertiesGridModel = this.createPropertiesGridModel();
+        this.diagnosticsModel = new DiagnosticsModel(this);
         this.instancesPanelModel = new PanelModel({
             defaultSize: 575,
             side: 'left',

--- a/inspector/instances/InstancesPanel.ts
+++ b/inspector/instances/InstancesPanel.ts
@@ -60,7 +60,7 @@ export const instancesPanel = hoistCmp.factory({
         return panel({
             item: hframe(
                 panel({
-                    title: `Models · Services · Stores · Cubes · Views`,
+                    title: `Models · Services · Data`,
                     headerItems,
                     icon: Icon.cube(),
                     compactHeader: true,

--- a/inspector/instances/InstancesPanel.ts
+++ b/inspector/instances/InstancesPanel.ts
@@ -58,7 +58,7 @@ export const instancesPanel = hoistCmp.factory({
         return panel({
             item: hframe(
                 panel({
-                    title: `Models · Services · Stores`,
+                    title: `Models · Services · Stores · Cubes · Views`,
                     headerItems,
                     icon: Icon.cube(),
                     compactHeader: true,

--- a/inspector/instances/InstancesPanel.ts
+++ b/inspector/instances/InstancesPanel.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {grid, gridCountLabel} from '@xh/hoist/cmp/grid';
-import {a, div, filler, hframe, hspacer, p, span} from '@xh/hoist/cmp/layout';
+import {a, div, filler, hframe, hspacer, p, span, vframe} from '@xh/hoist/cmp/layout';
 import {storeFilterField} from '@xh/hoist/cmp/store';
 import {creates, hoistCmp, useContextModel} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
@@ -14,6 +14,7 @@ import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
 import {InspectorModel} from '@xh/hoist/inspector/InspectorModel';
+import {diagnosticsPanel} from '@xh/hoist/inspector/instances/DiagnosticsPanel';
 import {InstancesModel} from '@xh/hoist/inspector/instances/InstancesModel';
 import {popover} from '@xh/hoist/kit/blueprint';
 
@@ -72,13 +73,16 @@ export const instancesPanel = hoistCmp.factory({
                     bbar: instanceGridBar(),
                     model: instancesPanelModel
                 }),
-                panel({
-                    title: 'Properties',
-                    icon: Icon.fileText(),
-                    compactHeader: true,
-                    item: grid({model: model.propertiesGridModel, agOptions: {popupParent}}),
-                    bbar: propertiesGridBar()
-                })
+                vframe(
+                    panel({
+                        title: 'Properties',
+                        icon: Icon.fileText(),
+                        compactHeader: true,
+                        item: grid({model: model.propertiesGridModel, agOptions: {popupParent}}),
+                        bbar: propertiesGridBar()
+                    }),
+                    diagnosticsPanel({model: model.diagnosticsModel})
+                )
             )
         });
     }

--- a/inspector/instances/InstancesPanel.ts
+++ b/inspector/instances/InstancesPanel.ts
@@ -5,8 +5,9 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {grid, gridCountLabel} from '@xh/hoist/cmp/grid';
-import {a, div, filler, hframe, hspacer, p, span, vframe} from '@xh/hoist/cmp/layout';
+import {a, div, filler, hframe, hspacer, p, span} from '@xh/hoist/cmp/layout';
 import {storeFilterField} from '@xh/hoist/cmp/store';
+import {tabContainer} from '@xh/hoist/cmp/tab';
 import {creates, hoistCmp, useContextModel} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {buttonGroupInput} from '@xh/hoist/desktop/cmp/input';
@@ -73,18 +74,43 @@ export const instancesPanel = hoistCmp.factory({
                     bbar: instanceGridBar(),
                     model: instancesPanelModel
                 }),
-                vframe(
-                    panel({
-                        title: 'Properties',
-                        icon: Icon.fileText(),
-                        compactHeader: true,
-                        item: grid({model: model.propertiesGridModel, agOptions: {popupParent}}),
-                        bbar: propertiesGridBar()
-                    }),
-                    diagnosticsPanel({model: model.diagnosticsModel})
-                )
+                tabContainer({
+                    modelConfig: {
+                        persistWith: {...model.persistWith, path: 'detailTabs'},
+                        xhImpl: true,
+                        tabs: [
+                            {
+                                id: 'properties',
+                                icon: Icon.fileText(),
+                                content: propertiesView
+                            },
+                            {
+                                id: 'diagnostics',
+                                icon: Icon.gauge(),
+                                content: diagnosticsView
+                            }
+                        ]
+                    }
+                })
             )
         });
+    }
+});
+
+const propertiesView = hoistCmp.factory<InstancesModel>({
+    render({model}) {
+        // Re-parent grid popups (context/column menus) when Inspector is detached.
+        const popupParent = useContextModel(InspectorModel)?.windowContainer ?? undefined;
+        return panel({
+            item: grid({model: model.propertiesGridModel, agOptions: {popupParent}}),
+            bbar: propertiesGridBar()
+        });
+    }
+});
+
+const diagnosticsView = hoistCmp.factory<InstancesModel>({
+    render({model}) {
+        return diagnosticsPanel({model: model.diagnosticsModel});
     }
 });
 

--- a/inspector/stats/StatsModel.ts
+++ b/inspector/stats/StatsModel.ts
@@ -38,6 +38,8 @@ export class StatsModel extends HoistModel {
 
         this.gridModel = new GridModel({
             colChooserModel: true,
+            filterModel: true,
+            headerMenuDisplay: 'hover',
             persistWith: this.persistWith,
             autosizeOptions: {mode: 'managed'},
             store: {
@@ -52,7 +54,7 @@ export class StatsModel extends HoistModel {
                 ]
             },
             sortBy: ['timestamp|desc'],
-            colDefaults: {autosizeIncludeHeaderIcons: false},
+            colDefaults: {autosizeIncludeHeaderIcons: false, filterable: true},
             columns: [
                 {field: 'timestamp', renderer: timestampRenderer},
                 {field: 'modelCount', renderer: numberRenderer({precision: 0})},

--- a/svc/InspectorService.ts
+++ b/svc/InspectorService.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {HoistService, InitContext, managed, persist, XH} from '@xh/hoist/core';
-import {Store} from '@xh/hoist/data';
+import {Cube, Store, View} from '@xh/hoist/data';
 import {action, bindable, makeObservable, observable} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 import {Timer} from '@xh/hoist/utils/async';
@@ -174,7 +174,13 @@ export class InspectorService extends HoistService {
     private sync() {
         if (!this.active) return;
 
-        const instances = [...XH.getModels(), ...XH.getServices(), ...XH.getStores()];
+        const instances = [
+            ...XH.getModels(),
+            ...XH.getServices(),
+            ...XH.getStores(),
+            ...XH.getCubes(),
+            ...XH.getViews()
+        ];
 
         const {_idToSyncRun, _syncRun} = this,
             newSyncRun = _syncRun + 1;
@@ -198,6 +204,8 @@ export class InspectorService extends HoistService {
                     isHoistService: inst.isHoistService,
                     isHoistModel: inst.isHoistModel,
                     isStore: Store.isStore(inst),
+                    isCube: Cube.isCube(inst),
+                    isView: View.isView(inst),
                     isLinked: inst.isLinked,
                     isXhImpl: inst.xhImpl,
                     hasLoadSupport: inst.loadSupport != null,
@@ -234,6 +242,8 @@ interface InspectorInstanceData {
     isHoistModel: boolean;
     isHoistService: boolean;
     isStore: boolean;
+    isCube: boolean;
+    isView: boolean;
     isLinked: boolean;
     isXhImpl: boolean;
     hasLoadSupport: boolean;

--- a/svc/InspectorService.ts
+++ b/svc/InspectorService.ts
@@ -14,7 +14,8 @@ import {instanceManager} from '@xh/hoist/core/impl/InstanceManager';
 
 /**
  * Developer/Admin focused service to provide additional processing and stats related to the
- * running application, specifically its current HoistModel, HoistService, and Store instances.
+ * running application, specifically its current HoistModel, HoistService, Store, Cube, and cube
+ * View instances.
  *
  * Activating this service will cause it to maintain an observable array of summary data synced
  * (with a minimal throttle) on each change to the Hoist registry, as well as an array of model


### PR DESCRIPTION
Surfaces the new data-pipeline `diagnostics` (#4585) in the Hoist Inspector, and extends the Inspector's reach to Cubes and cube Views.

- `Cube` and `View` now register with `InstanceManager` (mirroring `Store`), with new `XH.getCubes()` / `XH.getViews()` accessors and a `Cube.isCube()` type guard. Both appear in the Inspector's instances grid under new groups, and property values referencing them render as navigation links.
- New **Diagnostics** tab (paired with Properties in a tab container) shows a live readout for any selected Stores, Cube Views, and GridModels - one row per op kind with the last op's type, work detail, timing, and cumulative count/avg. Rows are discovered from each diagnostics object's shape rather than per-class schemas, insulating the UI from that deliberately unstable internal API. A selected `Cube` reports via its internal `Store`, where its data ops actually land.
- **Log operations to console** switch reflects and toggles the per-instance `diagnostics.logLevel` - sticky per instance, so logging continues as the selection moves and any number of instances can stream at once. `BaseDiagnostics.logLevel` is now observable to support this.
- All four Inspector grids gain structured column filters (`filterModel` + filterable columns, hover-only header affordances), and the instances grid gets a fixed group order (Models, Services, Cubes, Views, Stores) plus headerTooltips explaining the Sync columns.

Verified live against Toolbox (full local stack), primarily via the admin Cube Data test panel - selecting the cube store / view / grid pipeline together shows each stage's ops ticking during loads and updates, in both docked and popped-out Inspector modes.

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. (Additive only - new registry tracking, XH accessors, and xhImpl Inspector UI.)
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required. (Inspector is desktop-only; grid filterModel is a no-op on mobile.)
- [x] Created Toolbox branch / PR, or determined not required. (No Toolbox changes needed - verified against unmodified Toolbox.)
