### PR TITLE
Cleaned up select to no longer maintain a copy of its entire query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,9 +249,8 @@ columns.
 * Fixed `CodeInput` with `autoFormat` committing reformatted text back to its bound value, leaving
   forms dirty after a reset.
 * Fixed an `O(n²)` option merge in async `Select` (v86.3.0 regression) that could block the main
-  thread for seconds on large `queryFn` results. `Select` now retains only the queried options plus
-  any selected options not among them, instead of accumulating and de-duping the full query history,
-  and skips retaining results superseded by later input.
+  thread for seconds on large `queryFn` results. `Select` no longer accumulates and de-dupes the
+  full query history.
 
 ### ⚙️ Technical
 

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -199,13 +199,18 @@ export interface SelectProps extends HoistProps, HoistInputProps, LayoutProps {
     valueField?: string;
 
     /**
-     * Function to generate a `SelectOption` for a (non-null) selected value not present in the
-     * current options list. Return null to fall back to the default value-as-label behavior.
+     * Fallback function to look up the `SelectOption` for a (non-null) selected value that is not
+     * present in the current options. Return null to accept the default value-as-label behavior.
      *
-     * Useful with queryFn-based selects, readonly forms, or any case where options may not be
-     * loaded when a value is set, ensuring the value renders with its proper label.
+     * Intended for values that already exist but whose option is simply out of view - e.g. an
+     * initial value on a `queryFn`-based select, where the control is bound to the value alone and
+     * no query has yet run to supply its label. Useful where value-as-label would never be
+     * meaningful to the user, such as an object select that should always render the object's name
+     * rather than its id value.
+     *
+     * Note this is not intended as the hook for "generating" new values created via `enableCreate`.
      */
-    generateOptionFn?: (value: any) => SelectOption;
+    generateOptionFn?: (value: any) => SelectOption | null;
 }
 
 /**
@@ -301,7 +306,7 @@ class SelectInputModel extends HoistInputModel {
 
     override onLinked() {
         const queryBuffer = withDefault(this.componentProps.queryBuffer, 300);
-        if (queryBuffer) this.queryAsync = debouncePromise(this.queryAsync, queryBuffer);
+        if (queryBuffer) this.doQueryAsync = debouncePromise(this.doQueryAsync, queryBuffer);
 
         this.addReaction({
             track: () => this.componentProps.options,
@@ -450,10 +455,7 @@ class SelectInputModel extends HoistInputModel {
         return regex.test(opt.label);
     };
 
-    // Convert external value into option object(s). Options created if missing - this takes the
-    // external value from the model, and we will respect that even if we don't know about it.
-    // (Exception for a null value, which is never synthesized - accepted only if provided via
-    // options.)
+    // Convert external value (which may be a primitive string or number) into option object(s).
     override toInternal(external) {
         if (this.multiMode) {
             if (external == null || isEqual(external, this.emptyValue)) external = []; // avoid [null]
@@ -475,8 +477,14 @@ class SelectInputModel extends HoistInputModel {
 
         if (!createIfNotFound) return null;
 
-        // Value not among options - let the app generate an option for it, else synthesize one.
-        return this.componentProps.generateOptionFn?.(value) ?? this.valueToOption(value);
+        return (
+            // Attempts to find the option in internalValue.
+            this.selectedOptions.find(it => isEqual(it.value, value)) ??
+            // Attempts to call the generateOptionFn function to get the option for this value.
+            this.componentProps.generateOptionFn?.(value) ??
+            // All else failing, converts the value into an option.
+            this.valueToOption(value)
+        );
     }
 
     override toExternal(internal) {
@@ -534,32 +542,9 @@ class SelectInputModel extends HoistInputModel {
     //------------------------
     // Async
     //------------------------
-    // Bumped for each query issued by react-select, to identify superseded results below.
-    private queryGeneration = 0;
-
-    doQueryAsync = query => {
-        this.queryGeneration++;
-        return this.queryAsync(query);
-    };
-
-    // Debounced within onLinked(), per the queryBuffer prop.
-    private queryAsync = async query => {
-        const generation = this.queryGeneration,
-            rawOpts = await this.componentProps.queryFn(query),
-            matchOpts = this.normalizeOptions(rawOpts);
-
-        // Retain the queried options, plus any selected options not among them, to allow our value
-        // converters to continue to resolve all selected values in multiMode. Skipped if superseded
-        // by later input, as react-select discards such results.
-        if (generation === this.queryGeneration) {
-            const extraOpts = this.selectedOptions.filter(
-                it => !this.findOption(it.value, false, matchOpts)
-            );
-            this.internalOptions = [...matchOpts, ...extraOpts];
-        }
-
-        // But only return the matching options back to the combo.
-        return matchOpts;
+    doQueryAsync = async query => {
+        const rawOpts = await this.componentProps.queryFn(query);
+        return this.normalizeOptions(rawOpts);
     };
 
     // Option(s) backing the current selection, as produced by toInternal() above.

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -208,7 +208,7 @@ export interface SelectProps extends HoistProps, HoistInputProps, LayoutProps {
      * meaningful to the user, such as an object select that should always render the object's name
      * rather than its id value.
      *
-     * Note this is not intended as the hook for "generating" new values created via `enableCreate`.
+     * Note this is not capable of "creating" new values via `enableCreate`.
      */
     generateOptionFn?: (value: any) => SelectOption | null;
 }

--- a/mobile/cmp/input/Select.ts
+++ b/mobile/cmp/input/Select.ts
@@ -159,13 +159,18 @@ export interface SelectProps extends HoistProps, HoistInputProps, LayoutProps {
     valueField?: string;
 
     /**
-     * Function to generate a `SelectOption` for a (non-null) selected value not present in the
-     * current options list. Return null to fall back to the default value-as-label behavior.
+     * Fallback function to look up the `SelectOption` for a (non-null) selected value that is not
+     * present in the current options. Return null to accept the default value-as-label behavior.
      *
-     * Useful with queryFn-based selects, readonly forms, or any case where options may not be
-     * loaded when a value is set, ensuring the value renders with its proper label.
+     * Intended for values that already exist but whose option is simply out of view - e.g. an
+     * initial value on a `queryFn`-based select, where the control is bound to the value alone and
+     * no query has yet run to supply its label. Useful where value-as-label would never be
+     * meaningful to the user, such as an object select that should always render the object's name
+     * rather than its id value.
+     *
+     * Note this is not intended as the hook for "generating" new values created via `enableCreate`.
      */
-    generateOptionFn?: (value: any) => SelectOption;
+    generateOptionFn?: (value: any) => SelectOption | null;
 }
 
 /**
@@ -240,7 +245,7 @@ class SelectInputModel extends HoistInputModel {
 
     override onLinked() {
         const queryBuffer = withDefault(this.componentProps.queryBuffer, 300);
-        if (queryBuffer) this.queryAsync = debouncePromise(this.queryAsync, queryBuffer);
+        if (queryBuffer) this.doQueryAsync = debouncePromise(this.doQueryAsync, queryBuffer);
 
         this.addReaction({
             track: () => this.componentProps.options,
@@ -384,10 +389,7 @@ class SelectInputModel extends HoistInputModel {
         return regex.test(opt.label);
     };
 
-    // Convert external value into option object(s). Options created if missing - this takes the
-    // external value from the model, and we will respect that even if we don't know about it.
-    // (Exception for a null value, which is never synthesized - accepted only if provided via
-    // options.)
+    // Convert external value (which may be a primitive string or number) into option object(s).
     override toInternal(external) {
         return this.findOption(external, !isNil(external));
     }
@@ -405,8 +407,14 @@ class SelectInputModel extends HoistInputModel {
 
         if (!createIfNotFound) return null;
 
-        // Value not among options - let the app generate an option for it, else synthesize one.
-        return this.componentProps.generateOptionFn?.(value) ?? this.valueToOption(value);
+        return (
+            // Attempts to find the option in internalValue.
+            this.selectedOptions.find(it => isEqual(it.value, value)) ??
+            // Attempts to call the generateOptionFn function to get the option for this value.
+            this.componentProps.generateOptionFn?.(value) ??
+            // All else failing, converts the value into an option.
+            this.valueToOption(value)
+        );
     }
 
     override toExternal(internal) {
@@ -457,36 +465,10 @@ class SelectInputModel extends HoistInputModel {
     //------------------------
     // Async
     //------------------------
-    // Bumped for each query issued by react-select, to identify superseded results below.
-    private queryGeneration = 0;
-
     doQueryAsync = query => {
-        this.queryGeneration++;
-        return this.queryAsync(query);
-    };
-
-    // Debounced within onLinked(), per the queryBuffer prop.
-    private queryAsync = query => {
-        const generation = this.queryGeneration;
         return this.componentProps
             .queryFn(query)
-            .then(rawOpts => {
-                // Normalize query return.
-                const matchOpts = this.normalizeOptions(rawOpts);
-
-                // Retain the queried options, plus the selected option if not among them, to allow
-                // our value converters to continue to resolve it. Skipped if superseded by later
-                // input, as react-select discards such results.
-                if (generation === this.queryGeneration) {
-                    const extraOpts = this.selectedOptions.filter(
-                        it => !this.findOption(it.value, false, matchOpts)
-                    );
-                    this.internalOptions = [...matchOpts, ...extraOpts];
-                }
-
-                // But only return the matching options back to the combo.
-                return matchOpts;
-            })
+            .then(rawOpts => this.normalizeOptions(rawOpts))
             .catch(e => {
                 this.logError(e);
                 throw e;

--- a/mobile/cmp/input/Select.ts
+++ b/mobile/cmp/input/Select.ts
@@ -168,7 +168,7 @@ export interface SelectProps extends HoistProps, HoistInputProps, LayoutProps {
      * meaningful to the user, such as an object select that should always render the object's name
      * rather than its id value.
      *
-     * Note this is not intended as the hook for "generating" new values created via `enableCreate`.
+     * Note this is not capable of "creating" new values via `enableCreate`.
      */
     generateOptionFn?: (value: any) => SelectOption | null;
 }


### PR DESCRIPTION
Follow up on colin's bug to fix the issue at the source by no longer spending the effort to maintain unnecessary query cache using advanced Set and generation counters. The point of the original change was to make it convenient to hydrate non-value-as-label fields, it simply does not need to store every record it has ever encountered to achieve that.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [ ] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

