### PR TITLE
Fix mobile inputs broken by callback ref handed to react-onsenui

### DIFF
--- a/kit/onsen/index.ts
+++ b/kit/onsen/index.ts
@@ -8,10 +8,18 @@ import {ElementFactory, elementFactory, HoistModel} from '@xh/hoist/core';
 import onsen from 'onsenui';
 import 'onsenui/css/onsen-css-components.css';
 import 'onsenui/css/onsenui.css';
-import {composeRefs} from '@xh/hoist/utils/react';
-import {createElement, forwardRef, FunctionComponent, useLayoutEffect, useRef} from 'react';
+import {
+    createElement,
+    ForwardedRef,
+    forwardRef,
+    FunctionComponent,
+    RefObject,
+    useLayoutEffect,
+    useMemo,
+    useRef
+} from 'react';
 import * as ons from 'react-onsenui';
-import {mapKeys, omitBy, pickBy} from 'lodash';
+import {isFunction, mapKeys, omitBy, pickBy} from 'lodash';
 import './styles.scss';
 import './theme.scss';
 
@@ -72,12 +80,37 @@ function wrappedCmp(rawCmp): [ElementFactory, FunctionComponent] {
             if (elemRef.current) Object.assign(elemRef.current, boolProps);
         });
 
-        // 2) Set remaining props on the underlying component, including our ref.
+        // 2) Set remaining props on the underlying component, including our ref. Note
+        // react-onsenui reads `.current` on the ref it receives within its own effects, so it
+        // must be handed an object ref - a callback ref from `composeRefs` would break it.
         const childProps = {
             ...omitBy(props, it => it instanceof HoistModel || typeof it === 'boolean'),
-            ref: composeRefs(elemRef, ref)
+            ref: useComposedObjectRef(elemRef, ref)
         };
         return createElement(rawCmp, childProps);
     });
     return [elementFactory(cmp), cmp];
+}
+
+/**
+ * Compose our internal element ref with any caller-provided ref into a single object ref,
+ * memoized per component instance. Assignments to `current` fan out to every input ref with
+ * standard React semantics - callback refs are called, object refs assigned - at React's normal
+ * ref-attach timing.
+ */
+function useComposedObjectRef<T>(...refs: Array<ForwardedRef<T>>): RefObject<T | null> {
+    return useMemo(() => {
+        const targets = refs.filter(Boolean);
+        let value: T | null = null;
+        return {
+            get current() {
+                return value;
+            },
+            set current(v: T | null) {
+                value = v;
+                targets.forEach(it => (isFunction(it) ? it(v) : (it.current = v)));
+            }
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, refs);
 }

--- a/kit/onsen/index.ts
+++ b/kit/onsen/index.ts
@@ -95,15 +95,15 @@ function wrappedCmp(rawCmp): [ElementFactory, FunctionComponent] {
  * Compose refs into a single object ref, memoized per component instance. Assignments to
  * `current` fan out to every input ref with standard React semantics.
  */
-function useComposedObjectRef<T>(...refs: Array<ForwardedRef<T>>): RefObject<T | null> {
+function useComposedObjectRef<T>(...refs: Array<ForwardedRef<T>>): RefObject<T> {
     return useMemo(() => {
         const targets = refs.filter(Boolean);
-        let value: T | null = null;
+        let value: T = null;
         return {
             get current() {
                 return value;
             },
-            set current(v: T | null) {
+            set current(v: T) {
                 value = v;
                 targets.forEach(it => (isFunction(it) ? it(v) : (it.current = v)));
             }

--- a/kit/onsen/index.ts
+++ b/kit/onsen/index.ts
@@ -80,9 +80,8 @@ function wrappedCmp(rawCmp): [ElementFactory, FunctionComponent] {
             if (elemRef.current) Object.assign(elemRef.current, boolProps);
         });
 
-        // 2) Set remaining props on the underlying component, including our ref. Note
-        // react-onsenui reads `.current` on the ref it receives within its own effects, so it
-        // must be handed an object ref - a callback ref from `composeRefs` would break it.
+        // 2) Set remaining props on the underlying component, including our ref. Must be an
+        // object ref - react-onsenui reads `.current` on it within its own effects.
         const childProps = {
             ...omitBy(props, it => it instanceof HoistModel || typeof it === 'boolean'),
             ref: useComposedObjectRef(elemRef, ref)
@@ -93,10 +92,8 @@ function wrappedCmp(rawCmp): [ElementFactory, FunctionComponent] {
 }
 
 /**
- * Compose our internal element ref with any caller-provided ref into a single object ref,
- * memoized per component instance. Assignments to `current` fan out to every input ref with
- * standard React semantics - callback refs are called, object refs assigned - at React's normal
- * ref-attach timing.
+ * Compose refs into a single object ref, memoized per component instance. Assignments to
+ * `current` fan out to every input ref with standard React semantics.
  */
 function useComposedObjectRef<T>(...refs: Array<ForwardedRef<T>>): RefObject<T | null> {
     return useMemo(() => {


### PR DESCRIPTION
Fixes mobile `NumberInput`, `Checkbox`, `SwitchInput`, and `SearchInput`, which throw `Cannot read properties of undefined (reading 'addEventListener')` / `(setting 'value')` on mount - error-bounding any page containing them (e.g. the Toolbox mobile Inputs and Form pages).

**Cause:** react-onsenui reads `.current` on the ref it receives within its own effects, so it must be handed a plain object ref. The React 19 upgrade (#4428) passed it `composeRefs(elemRef, ref)`, which returns a composed *callback* ref whenever the caller also supplies a ref - exactly the case for the four inputs above, which ref the onsen widget directly.

**Fix:** `wrappedCmp` now composes via a private `useComposedObjectRef` hook - a per-instance memoized object ref whose `current` setter fans out to the internal element ref and any caller-provided ref with standard React semantics. Kept private to `kit/onsen` since react-onsenui is the only `.current`-reading ref consumer in the toolkit.

No changelog entry: the regression was introduced within the unreleased `87.0.0-SNAPSHOT`.

Verified against Toolbox mobile: all inputs render and commit correctly (shorthand number entry, switch toggling, clear buttons), no console errors.
