### PR TITLE
Add useComposedRefs hook with React 19 cleanup forwarding; migrate internal call sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,9 @@ columns.
   and stream ops to the devtools console.
 * Added `XH.getCubes()` and `XH.getViews()` to enumerate all active `Cube` and `View` instances,
   now registered with Hoist's instance registry.
+* Added `useComposedRefs` - a hook variant of `composeRefs` that manages identity via `useCallback`
+  and forwards React 19 ref-callback cleanups. Prefer it when composing refs within a component
+  render function.
 
 ### 🐞 Bug Fixes
 

--- a/cmp/chart/Chart.ts
+++ b/cmp/chart/Chart.ts
@@ -22,7 +22,7 @@ import {Highcharts} from '@xh/hoist/kit/highcharts';
 import {runInAction} from '@xh/hoist/mobx';
 import {logError, mergeDeep} from '@xh/hoist/utils/js';
 import {
-    composeRefs,
+    useComposedRefs,
     createObservableRef,
     getLayoutProps,
     useOnResize,
@@ -70,7 +70,7 @@ export const [Chart, chart] = hoistCmp.withFactory<ChartProps>({
         }
 
         const impl = useLocalModel(ChartLocalModel);
-        ref = composeRefs(
+        ref = useComposedRefs(
             ref,
             useOnResize(impl.onResize),
             useOnVisibleChange(impl.onVisibleChange)

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -47,7 +47,7 @@ import type {
 import {computed, observer} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
 import {consumeEvent, isDisplayed} from '@xh/hoist/utils/js';
-import {composeRefs, createObservableRef, getLayoutProps} from '@xh/hoist/utils/react';
+import {useComposedRefs, createObservableRef, getLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {compact, debounce, isBoolean, isEmpty, isEqual, isNil, max, maxBy, merge} from 'lodash';
 import {type MouseEvent} from 'react';
@@ -140,7 +140,7 @@ export const [Grid, grid] = hoistCmp.withFactory<GridProps>({
             testId,
             onKeyDown: impl.onKeyDown,
             onMouseDown: impl.onViewMouseDown,
-            ref: composeRefs(impl.viewRef, model.viewRef, ref)
+            ref: useComposedRefs(impl.viewRef, model.viewRef, ref)
         });
 
         // Safe to use the desktop component unconditionally - GridModel never creates this model

--- a/cmp/layout/TileFrame.ts
+++ b/cmp/layout/TileFrame.ts
@@ -6,7 +6,7 @@
  */
 import {hoistCmp, useLocalModel, HoistModel, BoxProps, HoistProps} from '@xh/hoist/core';
 import {frame, box} from '@xh/hoist/cmp/layout';
-import {composeRefs, useOnResize} from '@xh/hoist/utils/react';
+import {useComposedRefs, useOnResize} from '@xh/hoist/utils/react';
 import {useState, useLayoutEffect} from 'react';
 import {minBy, isEqual} from 'lodash';
 import {Children} from 'react';
@@ -96,7 +96,7 @@ export const [TileFrame, tileFrame] = hoistCmp.withFactory({
             [onLayoutChange, localModel.layout]
         );
 
-        ref = composeRefs(
+        ref = useComposedRefs(
             ref,
             useOnResize(
                 ({width, height}) => {

--- a/cmp/treemap/TreeMap.ts
+++ b/cmp/treemap/TreeMap.ts
@@ -22,7 +22,7 @@ import {Highcharts} from '@xh/hoist/kit/highcharts';
 import {wait} from '@xh/hoist/promise';
 import {logError, logWithDebug} from '@xh/hoist/utils/js';
 import {
-    composeRefs,
+    useComposedRefs,
     createObservableRef,
     getLayoutProps,
     useOnResize,
@@ -63,7 +63,7 @@ export const [TreeMap, treeMap] = hoistCmp.withFactory<TreeMapProps>({
         }
 
         const impl = useLocalModel(TreeMapLocalModel);
-        ref = composeRefs(
+        ref = useComposedRefs(
             ref,
             useOnResize(impl.startResize),
             useOnResize(impl.onResizeAsync, {debounce: 100}),

--- a/desktop/cmp/dash/canvas/DashCanvas.ts
+++ b/desktop/cmp/dash/canvas/DashCanvas.ts
@@ -11,7 +11,7 @@ import ReactGridLayout, {
     getCompactor
 } from 'react-grid-layout';
 import {GridBackground, type GridBackgroundProps, wrapCompactor} from 'react-grid-layout/extras';
-import {composeRefs} from '@xh/hoist/utils/react';
+import {useComposedRefs} from '@xh/hoist/utils/react';
 import {div, vbox, vspacer} from '@xh/hoist/cmp/layout';
 import {
     elementFactory,
@@ -83,7 +83,7 @@ export const [DashCanvas, dashCanvas] = hoistCmp.withFactory<DashCanvasProps>({
                     isDraggable ? `${className}--draggable` : null,
                     isResizable ? `${className}--resizable` : null
                 ),
-                ref: composeRefs(ref, model.ref, containerRef),
+                ref: useComposedRefs(ref, model.ref, containerRef),
                 onContextMenu: e => onContextMenu(e, model),
                 items: [
                     gridBackgroundCells({

--- a/desktop/cmp/dash/container/DashContainer.ts
+++ b/desktop/cmp/dash/container/DashContainer.ts
@@ -9,7 +9,7 @@ import {hoistCmp, HoistProps, refreshContextView, TestSupportProps, uses} from '
 import {mask} from '@xh/hoist/cmp/mask';
 import {dashContainerView} from '@xh/hoist/desktop/cmp/dash/container/impl/DashContainerView';
 import {Classes, overlay} from '@xh/hoist/kit/blueprint';
-import {composeRefs, useOnResize} from '@xh/hoist/utils/react';
+import {useComposedRefs, useOnResize} from '@xh/hoist/utils/react';
 import './DashContainer.scss';
 import {createPortal} from 'react-dom';
 import {DashContainerModel} from './DashContainerModel';
@@ -26,7 +26,7 @@ export const [DashContainer, dashContainer] = hoistCmp.withFactory<DashContainer
     className: 'xh-dash-container',
 
     render({model, className, testId}, ref) {
-        ref = composeRefs(
+        ref = useComposedRefs(
             ref,
             model.containerRef,
             useOnResize(() => model.onResize(), {debounce: 100})

--- a/desktop/cmp/form/FormField.ts
+++ b/desktop/cmp/form/FormField.ts
@@ -27,9 +27,9 @@ import {tooltip} from '@xh/hoist/kit/blueprint';
 import {isLocalDate} from '@xh/hoist/utils/datetime';
 import {errorIf, getTestId, logWarn, TEST_ID, throwIf, withDefault} from '@xh/hoist/utils/js';
 import {
-    composeRefs,
     getLayoutProps,
     getReactElementName,
+    useComposedRefs,
     useOnMount,
     useOnUnmount
 } from '@xh/hoist/utils/react';
@@ -346,7 +346,7 @@ const editableChild = hoistCmp.factory<FieldModel>({
             bind: 'value',
             id: childId,
             disabled: props.disabled || disabled,
-            ref: composeRefs(model?.boundInputRef, child.ref),
+            ref: useComposedRefs(model?.boundInputRef, child.ref),
             testId: props.testId ?? testId
         };
 

--- a/desktop/cmp/grid/editors/impl/InlineEditorModel.ts
+++ b/desktop/cmp/grid/editors/impl/InlineEditorModel.ts
@@ -11,7 +11,7 @@ import {ElementFactory, HoistModel, useLocalModel} from '@xh/hoist/core';
 import {EditorProps} from '@xh/hoist/desktop/cmp/grid/editors/EditorProps';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import {wait} from '@xh/hoist/promise';
-import {composeRefs, createObservableRef} from '@xh/hoist/utils/react';
+import {useComposedRefs, createObservableRef} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {ForwardedRef, ReactElement, useCallback} from 'react';
 
@@ -50,7 +50,7 @@ export function useInlineEditorModel(
         model: impl,
         bind: 'value',
         commitOnChange: true,
-        ref: composeRefs(impl.ref, ref),
+        ref: useComposedRefs(impl.ref, ref),
         ...inputProps,
         onCommit: (value: any, oldValue: any) => {
             agParams.onValueChange(value);

--- a/desktop/cmp/grid/find/GridFindField.ts
+++ b/desktop/cmp/grid/find/GridFindField.ts
@@ -13,7 +13,7 @@ import {textInput, TextInputProps} from '@xh/hoist/desktop/cmp/input';
 import '@xh/hoist/desktop/register';
 import {Icon} from '@xh/hoist/icon';
 import {consumeEvent} from '@xh/hoist/utils/js';
-import {composeRefs, splitLayoutProps} from '@xh/hoist/utils/react';
+import {useComposedRefs, splitLayoutProps} from '@xh/hoist/utils/react';
 import './GridFindField.scss';
 import {GridFindFieldImplModel} from './impl/GridFindFieldImplModel';
 
@@ -73,7 +73,7 @@ export const [GridFindField, gridFindField] = hoistCmp.withFactory<GridFindField
                 textInput({
                     model: impl,
                     bind: 'query',
-                    ref: composeRefs(impl.inputRef, ref),
+                    ref: useComposedRefs(impl.inputRef, ref),
                     commitOnChange: true,
                     leftIcon: Icon.search(),
                     enableClear: true,

--- a/desktop/cmp/input/NumberInput.ts
+++ b/desktop/cmp/input/NumberInput.ts
@@ -11,7 +11,7 @@ import {fmtNumber, NumericPrecision, parseNumber, Precision, ZeroPad} from '@xh/
 import {numericInput} from '@xh/hoist/kit/blueprint';
 import {wait} from '@xh/hoist/promise';
 import {TEST_ID, throwIf, withDefault} from '@xh/hoist/utils/js';
-import {composeRefs, getLayoutProps} from '@xh/hoist/utils/react';
+import {useComposedRefs, getLayoutProps} from '@xh/hoist/utils/react';
 import type {Property} from 'csstype';
 import {debounce, isNaN, isNil, isNumber, round} from 'lodash';
 import {KeyboardEventHandler, ReactElement, ReactNode, Ref, useLayoutEffect} from 'react';
@@ -256,7 +256,7 @@ const cmp = hoistCmp.factory<NumberInputModel>(({model, className, ...props}, re
         allowNumericCharactersOnly: !props.enableShorthandUnits && !props.displayWithCommas,
         buttonPosition: 'none',
         disabled: props.disabled,
-        inputRef: composeRefs(model.inputRef as Ref<HTMLInputElement>, props.inputRef),
+        inputRef: useComposedRefs(model.inputRef as Ref<HTMLInputElement>, props.inputRef),
         leftIcon: props.leftIcon,
         min: props.min,
         max: props.max,

--- a/desktop/cmp/input/TextArea.ts
+++ b/desktop/cmp/input/TextArea.ts
@@ -9,7 +9,7 @@ import {hoistCmp, HoistProps, LayoutProps, StyleProps} from '@xh/hoist/core';
 import '@xh/hoist/desktop/register';
 import {textArea as bpTextarea} from '@xh/hoist/kit/blueprint';
 import {TEST_ID, withDefault} from '@xh/hoist/utils/js';
-import {composeRefs, getLayoutProps} from '@xh/hoist/utils/react';
+import {useComposedRefs, getLayoutProps} from '@xh/hoist/utils/react';
 import {Ref} from 'react';
 import './TextArea.scss';
 
@@ -86,7 +86,7 @@ const cmp = hoistCmp.factory<TextAreaInputModel>(({model, className, ...props}, 
 
         autoFocus: props.autoFocus,
         disabled: props.disabled,
-        inputRef: composeRefs(model.inputRef as Ref<HTMLTextAreaElement>, props.inputRef),
+        inputRef: useComposedRefs(model.inputRef as Ref<HTMLTextAreaElement>, props.inputRef),
         placeholder: props.placeholder,
         spellCheck: withDefault(props.spellCheck, false),
         tabIndex: props.tabIndex,

--- a/desktop/cmp/input/TextInput.ts
+++ b/desktop/cmp/input/TextInput.ts
@@ -12,7 +12,7 @@ import '@xh/hoist/desktop/register';
 import {Icon} from '@xh/hoist/icon';
 import {inputGroup} from '@xh/hoist/kit/blueprint';
 import {getTestId, TEST_ID, withDefault} from '@xh/hoist/utils/js';
-import {composeRefs, getLayoutProps} from '@xh/hoist/utils/react';
+import {useComposedRefs, getLayoutProps} from '@xh/hoist/utils/react';
 import type {Property} from 'csstype';
 import {isEmpty} from 'lodash';
 import {FocusEvent, KeyboardEventHandler, ReactElement, ReactNode, Ref} from 'react';
@@ -136,7 +136,7 @@ const cmp = hoistCmp.factory<TextInputProps & {model: TextInputModel}>(
                 ),
                 autoFocus: props.autoFocus,
                 disabled: props.disabled,
-                inputRef: composeRefs(model.inputRef as Ref<HTMLInputElement>, props.inputRef),
+                inputRef: useComposedRefs(model.inputRef as Ref<HTMLInputElement>, props.inputRef),
                 leftElement: props.leftElement as ReactElement,
                 leftIcon: props.leftIcon,
                 placeholder: props.placeholder,

--- a/desktop/cmp/panel/impl/ResizeContainer.ts
+++ b/desktop/cmp/panel/impl/ResizeContainer.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {composeRefs} from '@xh/hoist/utils/react';
+import {useComposedRefs} from '@xh/hoist/utils/react';
 import {box, hbox, vbox} from '@xh/hoist/cmp/layout';
 import {hoistCmp, useContextModel} from '@xh/hoist/core';
 import {isString} from 'lodash';
@@ -43,9 +43,7 @@ export const resizeContainer = hoistCmp.factory({
             minDim = vertical ? 'minHeight' : 'minWidth',
             cmpSize = !collapsed && sizeIsPct ? size : undefined;
 
-        if (panelModel._resizeRef) {
-            ref = composeRefs(panelModel._resizeRef, ref);
-        }
+        ref = useComposedRefs(panelModel._resizeRef, ref);
 
         return cmp({
             ref,

--- a/desktop/cmp/tab/TabSwitcher.ts
+++ b/desktop/cmp/tab/TabSwitcher.ts
@@ -25,9 +25,9 @@ import {
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 import {consumeEvent, debounced, getTestId, isDisplayed, throwIf} from '@xh/hoist/utils/js';
 import {
-    composeRefs,
     createObservableRef,
     getLayoutProps,
+    useComposedRefs,
     useOnResize,
     useOnScroll,
     useOnVisibleChange
@@ -76,16 +76,19 @@ export const [TabSwitcher, tabSwitcher] = hoistCmp.withFactory<TabSwitcherProps>
             vertical = ['left', 'right'].includes(orientation),
             impl = useLocalModel(() => new TabSwitcherLocalModel(model, enableOverflow, vertical));
 
-        // Implement overflow
-        ref = impl.enableOverflow
-            ? composeRefs(
-                  ref,
-                  impl.switcherRef,
-                  useOnResize(() => impl.updateOverflowTabs()),
-                  useOnVisibleChange(() => impl.updateOverflowTabs()),
-                  useOnScroll(() => impl.updateOverflowTabs())
-              )
-            : composeRefs(ref, impl.switcherRef);
+        // Implement overflow. The tracking hooks run unconditionally to keep hook order stable -
+        // their refs are composed onto the switcher only when overflow is enabled.
+        const resizeRef = useOnResize(() => impl.updateOverflowTabs()),
+            visibleRef = useOnVisibleChange(() => impl.updateOverflowTabs()),
+            scrollRef = useOnScroll(() => impl.updateOverflowTabs());
+
+        ref = useComposedRefs(
+            ref,
+            impl.switcherRef,
+            impl.enableOverflow ? resizeRef : null,
+            impl.enableOverflow ? visibleRef : null,
+            impl.enableOverflow ? scrollRef : null
+        );
 
         // Create tabs
         const tabStyle: CSSProperties = {};

--- a/desktop/cmp/tab/dynamic/scroller/Scroller.ts
+++ b/desktop/cmp/tab/dynamic/scroller/Scroller.ts
@@ -3,7 +3,7 @@ import {BoxProps, creates, hoistCmp, HoistProps} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {ScrollerModel} from '@xh/hoist/desktop/cmp/tab/dynamic/scroller/ScrollerModel';
 import {Icon} from '@xh/hoist/icon';
-import {composeRefs, useOnResize} from '@xh/hoist/utils/react';
+import {useComposedRefs, useOnResize} from '@xh/hoist/utils/react';
 import React, {ReactElement, Ref} from 'react';
 
 /**
@@ -34,7 +34,7 @@ export const [Scroller, scroller] = hoistCmp.withFactory<ScrollerProps>({
                 scrollButton({direction: 'backward', model}),
                 content({
                     ...contentProps,
-                    ref: composeRefs(
+                    ref: useComposedRefs(
                         contentRef,
                         useOnResize(() => model.onViewportEvent())
                     )

--- a/mobile/cmp/form/FormField.ts
+++ b/mobile/cmp/form/FormField.ts
@@ -28,7 +28,7 @@ import {label as labelCmp} from '@xh/hoist/mobile/cmp/input';
 import '@xh/hoist/mobile/register';
 import {isLocalDate} from '@xh/hoist/utils/datetime';
 import {errorIf, getTestId, TEST_ID, throwIf, withDefault} from '@xh/hoist/utils/js';
-import {composeRefs, getLayoutProps, useOnMount, useOnUnmount} from '@xh/hoist/utils/react';
+import {getLayoutProps, useComposedRefs, useOnMount, useOnUnmount} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {first, isBoolean, isDate, isEmpty, isFinite, isUndefined} from 'lodash';
 import {Children, cloneElement, ReactNode, useContext, useEffect} from 'react';
@@ -227,7 +227,7 @@ const editableChild = hoistCmp.factory<FieldModel>({
             model,
             bind: 'value',
             disabled: props.disabled || disabled,
-            ref: composeRefs(model?.boundInputRef, child.ref),
+            ref: useComposedRefs(model?.boundInputRef, child.ref),
             testId
         };
 

--- a/utils/react/ComposeRefs.ts
+++ b/utils/react/ComposeRefs.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {MutableRefObject, Ref} from 'react';
+import {MutableRefObject, Ref, RefObject, useCallback} from 'react';
 
 type OptRef<T> = Ref<T> | undefined;
 
@@ -19,8 +19,8 @@ type OptRef<T> = Ref<T> | undefined;
  * Adapted from the (now unmaintained) `@seznam/compose-react-refs` package by Seznam.cz,
  * https://github.com/seznam/compose-react-refs - MIT licensed.
  *
- * TODO (React 19): forward ref-callback cleanup returns and add a `useComposedRefs` hook variant
- * (using `useCallback`) so callers no longer rely on this util's WeakMap caching for stability.
+ * Prefer the `useComposedRefs` hook variant within component render functions - it also forwards
+ * React 19 ref-callback cleanups, which this legacy form does not.
  */
 export function composeRefs<T>(...refs: [OptRef<T>, OptRef<T>, ...Array<OptRef<T>>]): Ref<T> {
     if (refs.length === 2) {
@@ -58,4 +58,45 @@ function assignRef<T>(ref: NonNullable<Ref<T>>, value: T | null): void {
     } else {
         (ref as MutableRefObject<T | null>).current = value;
     }
+}
+
+//---------------------
+// Hook variants
+//---------------------
+/**
+ * Compose two or more refs into a single callback ref, with identity managed by `useCallback` and
+ * keyed on the input refs. The preferred form within component render functions - see
+ * `composeRefs` for the non-hook variant, required where hooks are unavailable (conditional
+ * composition, cloned children, render props).
+ *
+ * Nullish inputs are skipped. React 19 ref-callback cleanups are forwarded: if any input callback
+ * returns a cleanup, the composed callback returns a combined cleanup, so React invokes cleanups
+ * on detach rather than calling back with `null`. Inputs without their own cleanup still get the
+ * legacy null-assignment.
+ */
+export function useComposedRefs<T>(...refs: [OptRef<T>, OptRef<T>, ...Array<OptRef<T>>]): Ref<T> {
+    return useCallback((value: T | null) => {
+        const cleanups = refs.map(ref => (ref ? attachRef(ref, value) : undefined));
+
+        if (cleanups.some(Boolean)) {
+            return () => {
+                refs.forEach((ref, idx) => {
+                    const cleanup = cleanups[idx];
+                    if (cleanup) cleanup();
+                    else if (ref) attachRef(ref, null);
+                });
+            };
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, refs);
+}
+
+/** Assign a value to a ref, returning any cleanup provided by a React 19 ref callback. */
+function attachRef<T>(ref: NonNullable<Ref<T>>, value: T | null): (() => void) | undefined {
+    if (typeof ref === 'function') {
+        const ret = ref(value);
+        return typeof ret === 'function' ? ret : undefined;
+    }
+    (ref as RefObject<T | null>).current = value;
+    return undefined;
 }

--- a/utils/react/ComposeRefs.ts
+++ b/utils/react/ComposeRefs.ts
@@ -6,8 +6,6 @@
  */
 import {MutableRefObject, Ref, RefObject, useCallback} from 'react';
 
-type OptRef<T> = Ref<T> | undefined;
-
 /**
  * Compose two or more refs into a single callback ref. Returns `null` if all inputs are nullish,
  * or the lone non-nullish ref when only one is provided.
@@ -22,16 +20,16 @@ type OptRef<T> = Ref<T> | undefined;
  * Prefer the `useComposedRefs` hook variant within component render functions - it also forwards
  * React 19 ref-callback cleanups, which this legacy form does not.
  */
-export function composeRefs<T>(...refs: [OptRef<T>, OptRef<T>, ...Array<OptRef<T>>]): Ref<T> {
+export function composeRefs<T>(...refs: [Ref<T>, Ref<T>, ...Array<Ref<T>>]): Ref<T> {
     if (refs.length === 2) {
         return composePair(refs[0], refs[1]) ?? null;
     }
-    return refs.slice(1).reduce<OptRef<T>>((acc, ref) => composePair(acc, ref), refs[0]) ?? null;
+    return refs.slice(1).reduce<Ref<T>>((acc, ref) => composePair(acc, ref), refs[0]) ?? null;
 }
 
 const cache = new WeakMap<object, WeakMap<object, Ref<unknown>>>();
 
-function composePair<T>(a: OptRef<T>, b: OptRef<T>): OptRef<T> {
+function composePair<T>(a: Ref<T>, b: Ref<T>): Ref<T> {
     if (!a) return b;
     if (!b) return a;
 
@@ -41,9 +39,9 @@ function composePair<T>(a: OptRef<T>, b: OptRef<T>): OptRef<T> {
     let inner = cache.get(keyA);
     if (!inner) cache.set(keyA, (inner = new WeakMap()));
 
-    let composed = inner.get(keyB) as Ref<T> | undefined;
+    let composed = inner.get(keyB) as Ref<T>;
     if (!composed) {
-        composed = (value: T | null) => {
+        composed = (value: T) => {
             assignRef(a, value);
             assignRef(b, value);
         };
@@ -52,11 +50,11 @@ function composePair<T>(a: OptRef<T>, b: OptRef<T>): OptRef<T> {
     return composed;
 }
 
-function assignRef<T>(ref: NonNullable<Ref<T>>, value: T | null): void {
+function assignRef<T>(ref: Ref<T>, value: T): void {
     if (typeof ref === 'function') {
         ref(value);
     } else {
-        (ref as MutableRefObject<T | null>).current = value;
+        (ref as MutableRefObject<T>).current = value;
     }
 }
 
@@ -74,16 +72,15 @@ function assignRef<T>(ref: NonNullable<Ref<T>>, value: T | null): void {
  * on detach rather than calling back with `null`. Inputs without their own cleanup still get the
  * legacy null-assignment.
  */
-export function useComposedRefs<T>(...refs: [OptRef<T>, OptRef<T>, ...Array<OptRef<T>>]): Ref<T> {
-    return useCallback((value: T | null) => {
-        const cleanups = refs.map(ref => (ref ? attachRef(ref, value) : undefined));
+export function useComposedRefs<T>(...refs: [Ref<T>, Ref<T>, ...Array<Ref<T>>]): Ref<T> {
+    return useCallback((value: T) => {
+        const cleanups = refs.map(ref => attachRef(ref, value));
 
         if (cleanups.some(Boolean)) {
             return () => {
                 refs.forEach((ref, idx) => {
                     const cleanup = cleanups[idx];
-                    if (cleanup) cleanup();
-                    else if (ref) attachRef(ref, null);
+                    cleanup ? cleanup() : attachRef(ref, null);
                 });
             };
         }
@@ -92,11 +89,12 @@ export function useComposedRefs<T>(...refs: [OptRef<T>, OptRef<T>, ...Array<OptR
 }
 
 /** Assign a value to a ref, returning any cleanup provided by a React 19 ref callback. */
-function attachRef<T>(ref: NonNullable<Ref<T>>, value: T | null): (() => void) | undefined {
+function attachRef<T>(ref: Ref<T>, value: T): () => void {
+    if (!ref) return undefined;
     if (typeof ref === 'function') {
         const ret = ref(value);
         return typeof ret === 'function' ? ret : undefined;
     }
-    (ref as RefObject<T | null>).current = value;
+    (ref as RefObject<T>).current = value;
     return undefined;
 }


### PR DESCRIPTION
Adds a `useComposedRefs` hook variant of `composeRefs` and migrates internal call sites, completing the React 19 TODO in `ComposeRefs.ts`. Companion to #4596 (independent - no shared files, merges in either order).

**New hook:**
- Identity managed by `useCallback` keyed on the input refs, replacing reliance on the module-level WeakMap cache for stability.
- Forwards React 19 ref-callback cleanups: when any input callback returns a cleanup, the composed callback returns a combined cleanup so React invokes it on detach rather than calling back with `null`.
- Always returns a wrapped callback ref (no lone-ref passthrough) - uniform output type, so a `.current`-reading receiver fails fast rather than only when a second ref appears.

**Legacy `composeRefs` is untouched.** It remains exported for contexts where hooks are unavailable - after this PR its sole internal caller is `DynamicTabSwitcher`, whose two usages sit inside react-beautiful-dnd render-prop callbacks.

**Migration:** all 16 hook-safe call sites swapped, including both platform `FormField`s. Two needed small restructures:
- `ResizeContainer`: conditional composition replaced by an unconditional hook call (nullish inputs are skipped).
- `TabSwitcher`: `useOnResize`/`useOnVisibleChange`/`useOnScroll` were called inside a ternary branch - a latent rules-of-hooks violation that held only because `enableOverflow` is fixed per instance. The hooks now run unconditionally, with their refs composed in conditionally.

Includes a changelog entry under v87 New Features.

Verified in Toolbox desktop: Grid (render/selection/filter typing through the migrated `TextInput` inputRef), TabSwitcher, panels - no console errors.
