### PR TITLE
DashCanvas: fix update-depth loop on widget drop

### DIFF
--- a/desktop/cmp/dash/canvas/DashCanvasModel.ts
+++ b/desktop/cmp/dash/canvas/DashCanvasModel.ts
@@ -27,6 +27,7 @@ import {
     pick,
     isEqual,
     startCase,
+    map,
     partition,
     keyBy,
     compact
@@ -636,10 +637,9 @@ export class DashCanvasModel
         rglLayout = rglLayout.map(it => pick(it, ['i', 'x', 'y', 'w', 'h']));
 
         // Accept only layouts whose ids correspond 1:1 with our current viewModels - RGL's copy
-        // lags ours by a render after a drop, and adopting it would strand the new view in an
-        // update loop.
-        const layoutIds = sortBy(rglLayout.map(it => it.i)),
-            viewIds = sortBy(this.viewModels.map(it => it.id));
+        // lags ours by a render after a drop. Adopting it would trap the app in an update loop.
+        const layoutIds = sortBy(map(rglLayout, 'i')),
+            viewIds = sortBy(map(this.viewModels, 'id'));
         if (!isEqual(layoutIds, viewIds)) return;
 
         this.setLayout(rglLayout);

--- a/desktop/cmp/dash/canvas/DashCanvasModel.ts
+++ b/desktop/cmp/dash/canvas/DashCanvasModel.ts
@@ -426,6 +426,7 @@ export class DashCanvasModel
      * and places it at the drop location. Called by the DashCanvas component - not typically
      * called directly by application code.
      */
+    @action // collapse internal actions
     onDrop(rglLayout: LayoutItem[], layoutItem: LayoutItem, evt: Event) {
         throwIf(
             !this.draggedInView,
@@ -434,8 +435,7 @@ export class DashCanvasModel
              a DashCanvasWidgetChooser or similar component.`
         );
 
-        const droppingItem: any = rglLayout.find(it => it.i === RGL_DROPPING_ITEM_ID);
-        if (!droppingItem) {
+        if (!rglLayout.some(it => it.i === RGL_DROPPING_ITEM_ID)) {
             // if `onDropDragOver` returned false, we won't have a dropping item
             // and we cancel the drop
             this.setDraggedInView(null);
@@ -450,14 +450,21 @@ export class DashCanvasModel
                 layout
             });
 
-        // Change ID of dropping item to the new view's id
-        // so that the new view goes where the dropping item is.
-        droppingItem.i = newViewModel.id;
+        // Adopt RGL's mid-drag layout - views already shifted aside - and give the placeholder's
+        // slot to the new view. Appending to our own pre-drag layout would leave it overlapping,
+        // and RGL settles such collisions by pushing the new view clear of where it was dropped.
+        this.setLayout(
+            rglLayout.map(({i, x, y, w, h}) => ({
+                i: i === RGL_DROPPING_ITEM_ID ? newViewModel.id : i,
+                x,
+                y,
+                w,
+                h
+            }))
+        );
 
-        // must wait a tick for RGL to settle
         wait().then(() => {
             this.setDraggedInView(null);
-            this.onRglLayoutChange(rglLayout);
             this.onDropDone?.(newViewModel);
         });
     }
@@ -628,10 +635,12 @@ export class DashCanvasModel
     onRglLayoutChange(rglLayout: LayoutItem[]) {
         rglLayout = rglLayout.map(it => pick(it, ['i', 'x', 'y', 'w', 'h']));
 
-        // Early out if RGL is changing layout as user is dragging droppable
-        // item around the canvas.  This will be called again once dragging
-        // has stopped and user has dropped the item onto the canvas.
-        if (rglLayout.some(it => it.i === RGL_DROPPING_ITEM_ID)) return;
+        // Accept only layouts whose ids correspond 1:1 with our current viewModels - RGL's copy
+        // lags ours by a render after a drop, and adopting it would strand the new view in an
+        // update loop.
+        const layoutIds = sortBy(rglLayout.map(it => it.i)),
+            viewIds = sortBy(this.viewModels.map(it => it.id));
+        if (!isEqual(layoutIds, viewIds)) return;
 
         this.setLayout(rglLayout);
     }
@@ -738,7 +747,8 @@ export class DashCanvasModel
 
 /**
  * Sentinel layout item ID hardcoded by react-grid-layout for the temporary placeholder element
- * shown while an external item is being dragged over the canvas. Used internally to detect
- * and filter RGL's in-flight drop placeholder from layout change events.
+ * shown while an external item is being dragged over the canvas. Its presence in the layout
+ * handed to {@link DashCanvasModel.onDrop} is what distinguishes a real drop from one vetoed by
+ * `onDropDragOver`.
  */
 const RGL_DROPPING_ITEM_ID = '__dropping-elem__';


### PR DESCRIPTION
Dragging a widget from a `DashCanvasWidgetChooser` onto a `DashCanvas` throws a `Maximum update depth exceeded`.

`onRglLayoutChange` guarded against react-grid-layout's in-flight drop placeholder by testing for `__dropping-elem__` in the published layout. RGL 2.x strips that entry before publishing (`publicLayout` in its layout-change effect), so the guard never fired on the layout RGL emits after clearing its placeholder but before syncing to the view added in `onDrop`. Accepting that interim layout discarded the new view's layout entry while its view model remained; RGL then synthesized a replacement entry, and the two sides compacted to conflicting results and re-triggered each other until React gave up.

### Changes

* `onRglLayoutChange` accepts only layouts whose ids correspond 1:1 with the current `viewModels`. This subsumes the old placeholder check - the placeholder has no view model - and also rejects the post-drop interim layout.
* `onDrop` adopts RGL's mid-drag layout, with existing views already shifted aside, and assigns the placeholder's slot to the new view. This replaces mutating `i` on RGL's internal layout item and replaying that array through `onRglLayoutChange` a tick later, so the new view lands where it was dropped without reaching into RGL's state.
* `onDrop` is now an `@action`, since it writes observable state twice.

### Testing

Verified against Toolbox's DashCanvas example with instrumented drags, reading `DashCanvasModel.layout` directly: widgets land at the placeholder's column, neighbors shift as expected, and every view retains a layout entry. Repeated drops settle in one or two renders rather than looping.

Two notes for reviewers:

* I could not pin down when this broke. An isolated harness reproduced the same loop on react-grid-layout 2.2.2 and 2.2.4 alike, so this is treated as a latent bug in our integration rather than an upgrade regression - hence no changelog entry.
* Chrome DevTools Protocol cannot initiate native HTML5 drag, so the drags above were synthetic `DragEvent` sequences. Worth a manual drag or two on top of this.