### PR TITLE
Hot-Loop performance improvements in data/grid

### DIFF
--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -26,6 +26,7 @@ import {
     XH
 } from '@xh/hoist/core';
 import type {StoreRecord} from '@xh/hoist/data';
+import type {RecordSet, RecordSetDelta} from '@xh/hoist/data/impl/RecordSet';
 import {GridTransactionManager} from '@xh/hoist/cmp/grid/impl/GridTransactionManager';
 import {
     colChooser as desktopColChooser,
@@ -732,7 +733,7 @@ export class GridLocalModel extends HoistModel {
             model.autosizeAsync({columns});
         }
 
-        if (model.treeMode || !isEmpty(model.groupBy)) {
+        if (this.transactionCouldChangeStructure(transaction, prevRs)) {
             model.noteAgExpandStateChange();
         }
 
@@ -750,8 +751,19 @@ export class GridLocalModel extends HoistModel {
         }
     }
 
-    transactionIsEmpty(t) {
+    transactionIsEmpty(t: RecordSetDelta): boolean {
         return isEmpty(t.update) && isEmpty(t.add) && isEmpty(t.remove);
+    }
+
+    transactionCouldChangeStructure(t: RecordSetDelta, prevRs: RecordSet): boolean {
+        const {model} = this;
+        if (!isEmpty(model.groupBy) || !prevRs || !isEmpty(t.add) || !isEmpty(t.remove)) {
+            return true;
+        }
+        return (
+            model.treeMode &&
+            t.update.some(rec => rec.parentId !== prevRs.getById(rec.id)?.parentId)
+        );
     }
 
     //------------------------

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -1444,6 +1444,17 @@ export class GridModel extends HoistModel {
         return this.leafColumnMap.get(colId) ?? null;
     }
 
+    /**
+     * @returns the current GridSorter for the given column, or null if it is not sorted.
+     * Optimized for hot loops, should be a search in a collection of 1-3.
+     */
+    getSorter(colId: string): GridSorter {
+        for (const it of this.sortBy) {
+            if (it.colId === colId) return it;
+        }
+        return null;
+    }
+
     getColumnGroup(groupId: string): ColumnGroup {
         return this.findColumnGroup(this.columns, groupId);
     }

--- a/cmp/grid/columns/Column.ts
+++ b/cmp/grid/columns/Column.ts
@@ -22,7 +22,6 @@ import classNames from 'classnames';
 import {
     castArray,
     clone,
-    find,
     get,
     groupBy,
     isArray,
@@ -803,16 +802,7 @@ export class Column {
                     });
                     return true;
                 },
-                valueGetter: (agParams: ValueGetterParams) => {
-                    const record = agParams.data;
-                    return this.getValueFn({
-                        record,
-                        field,
-                        store: record?.store,
-                        column: this,
-                        gridModel
-                    });
-                },
+                valueGetter: this.buildFastValueGetter(),
                 suppressKeyboardEvent: ({editing, event}) => {
                     if (!editing) return false;
 
@@ -995,7 +985,7 @@ export class Column {
             ret.width = this.width;
         }
 
-        const sortCfg = find(gridModel.sortBy, {colId: ret.colId});
+        const sortCfg = gridModel.getSorter(ret.colId);
         if (sortCfg) {
             ret.sort = sortCfg.sort;
             ret.sortIndex = gridModel.sortBy.indexOf(sortCfg);
@@ -1007,7 +997,7 @@ export class Column {
                 const {gridModel, colId} = this,
                     // Note: sortCfg and agNodes can be undefined if comparator called during show
                     // of agGrid column header set filter menu.
-                    sortCfg = find(gridModel.sortBy, {colId}),
+                    sortCfg = gridModel.getSorter(colId),
                     sortDir = sortCfg?.sort || 'asc',
                     recordA = agNodeA?.data,
                     recordB = agNodeB?.data;
@@ -1018,7 +1008,7 @@ export class Column {
                 const sortToBottom = this.sortToBottomComparator(valueA, valueB, sortDir);
                 if (sortToBottom !== 0) return sortToBottom;
 
-                return this.defaultComparator(valueA, valueB);
+                return this.defaultComparator(valueA, valueB, sortCfg);
             };
         } else {
             // ...or process custom comparator with the Hoist-defined comparatorFn API.
@@ -1026,7 +1016,7 @@ export class Column {
                 const {gridModel, colId} = this,
                     // Note: sortCfg and agNodes can be undefined if comparator called during show
                     // of agGrid column header set filter menu.
-                    sortCfg = find(gridModel.sortBy, {colId}),
+                    sortCfg = gridModel.getSorter(colId),
                     sortDir = sortCfg?.sort || 'asc',
                     abs = sortCfg?.abs || false,
                     recordA = agNodeA?.data as StoreRecord,
@@ -1093,8 +1083,9 @@ export class Column {
     // Implementation
     //--------------------
     // Default comparator sorting to absValue-aware GridSorters in GridModel.sortBy[].
-    private defaultComparator = (v1, v2) => {
-        const sortCfg = find(this.gridModel.sortBy, {colId: this.colId});
+    // Optimized for hot path - internal callers pass the resolved sortCfg to skip the lookup.
+    private defaultComparator = (v1, v2, sortCfg?: GridSorter) => {
+        sortCfg ??= this.gridModel.getSorter(this.colId);
         return sortCfg ? sortCfg.comparator(v1, v2) : GridSorter.defaultComparator(v1, v2);
     };
 
@@ -1128,6 +1119,27 @@ export class Column {
         if (isArray(fieldPath)) return get(record.data, fieldPath);
         return record.data[fieldPath];
     };
+
+    // ag-Grid valueGetter factory - heavily optimized for common default hot-path
+    private buildFastValueGetter(): (agParams: ValueGetterParams) => any {
+        const {getValueFn, field, gridModel, fieldPath} = this;
+        if (getValueFn !== this.defaultGetValueFn) {
+            return agParams => {
+                const record = agParams.data;
+                return getValueFn({record, field, store: record?.store, column: this, gridModel});
+            };
+        }
+        if (isNil(fieldPath)) return () => '';
+        return isArray(fieldPath)
+            ? agParams => {
+                  const record = agParams.data;
+                  return record ? get(record.data, fieldPath) : '';
+              }
+            : agParams => {
+                  const record = agParams.data;
+                  return record ? record.data[fieldPath] : '';
+              };
+    }
 
     private parseField(field) {
         if (isPlainObject(field)) {

--- a/data/filter/FieldFilter.ts
+++ b/data/filter/FieldFilter.ts
@@ -17,6 +17,7 @@ import {
     isEmpty,
     isEqual,
     isNil,
+    isObject,
     isString,
     isUndefined,
     uniq
@@ -181,20 +182,35 @@ export class FieldFilter extends Filter {
         // Treat null, empty string, and empty array (blank `tags`) alike as "blank".
         const isBlank = (v: any) => isNil(v) || v === '' || (isArray(v) && isEmpty(v));
 
-        let regExps, opFn: (v: any) => boolean;
+        // Generate optimized closures for hot-loops, using sets, hoisted conditionals
+        let regExps, lookup: Set<any>, opFn: (v: any) => boolean;
         switch (op) {
             case '=':
-                opFn = v => {
-                    if (isBlank(v)) v = null;
-                    // A blank filter (empty `value`) matches only blank record values.
-                    return (v == null && isEmpty(value)) || value.some(it => isEqual(v, it));
-                };
+                lookup = this.lookupSet(value);
+                opFn = lookup
+                    ? v => {
+                          if (isBlank(v)) v = null;
+                          // A blank filter (empty `value`) matches only blank record values.
+                          return (v == null && !lookup.size) || lookup.has(v);
+                      }
+                    : v => {
+                          if (isBlank(v)) v = null;
+                          return (v == null && isEmpty(value)) || value.some(it => isEqual(v, it));
+                      };
                 break;
             case '!=':
-                opFn = v => {
-                    if (isBlank(v)) v = null;
-                    return (v != null || !isEmpty(value)) && !value.some(it => isEqual(v, it));
-                };
+                lookup = this.lookupSet(value);
+                opFn = lookup
+                    ? v => {
+                          if (isBlank(v)) v = null;
+                          return (v != null || !!lookup.size) && !lookup.has(v);
+                      }
+                    : v => {
+                          if (isBlank(v)) v = null;
+                          return (
+                              (v != null || !isEmpty(value)) && !value.some(it => isEqual(v, it))
+                          );
+                      };
                 break;
             case '>':
                 opFn = v => !isNil(v) && v > value;
@@ -233,10 +249,12 @@ export class FieldFilter extends Filter {
                 opFn = v => regExps.every(re => !re.test(v));
                 break;
             case 'includes':
-                opFn = v => !isNil(v) && v.some(it => value.includes(it));
+                lookup = new Set(value);
+                opFn = v => !isNil(v) && v.some(it => lookup.has(it));
                 break;
             case 'excludes':
-                opFn = v => isNil(v) || !v.some(it => value.includes(it));
+                lookup = new Set(value);
+                opFn = v => isNil(v) || !v.some(it => lookup.has(it));
                 break;
             default:
                 throw XH.exception(`Unknown operator: ${op}`);
@@ -316,5 +334,11 @@ export class FieldFilter extends Filter {
         if (value instanceof Date) return 'date';
         if (value instanceof LocalDate) return 'localDate';
         return undefined;
+    }
+
+    // Set-based candidate lookup for primitives, where `Set.has` (SameValueZero) matches `isEqual`
+    // semantics - null when any candidate is an object (e.g. Date) and requires the isEqual path.
+    private lookupSet(values: any[]): Set<any> {
+        return values.some(isObject) ? null : new Set(values);
     }
 }


### PR DESCRIPTION
Targeted allocation and complexity fixes on per-comparison, per-cell, and per-record hot paths, found in a follow-up perf audit after the v87 wave.

* **Sort path**: Column comparators resolve their `GridSorter` via a new allocation-free `GridModel.getSorter()` instead of a lodash `{colId}` matcher per comparison (which allocated matcher internals on every call - ~15M objects for one 400k-row sort). The default path resolves once and passes it into `defaultComparator`; app comparators calling via params get the cheap lookup automatically.
* **Value reads**: new `Column.buildFastValueGetter()` - when a column uses the default `getValueFn`, the ag-Grid `valueGetter` reads `record.data` directly, skipping the per-call params object (paid per cell render and twice per sort comparison). Custom `getValueFn`s keep the fully-featured path.
* **Tree-grid transactions**: `Grid` now skips its post-transaction expand-state sync - an ag-Grid walk over *all* rows plus deep-equal/freeze of the state tree - for updates that change no `parentId`. Adds/removes and grouped-by-value grids sync exactly as before.
* **FieldFilter**: `=`/`!=`/`includes`/`excludes` test via a Set instead of a linear candidate scan per record, capping the O(records × candidates) worst case (e.g. header-filter value selections on high-cardinality columns). `=`/`!=` use the Set only when all candidates are primitives, preserving `isEqual` semantics for Dates; `includes`/`excludes` were already SameValueZero, so the Set is semantically exact.

Validated in Toolbox: header sorts incl. abs-value cycling, tree grid reload with expansion preserved, grouped rows, and column filtering (`=` and tags `includes`) all clean.

Stacked follow-up with a second batch (StoreValidator, GridFindField, selection sync): #4602.