### PR TITLE
Hot-loop performance: StoreValidator, GridFindField, and selection sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,7 +306,10 @@ columns.
     * Developers who build against a local hoist-react checkout (`inlineHoist`) now need pnpm to
       install this repo's dependencies (`corepack enable pnpm`, then `pnpm install`). The app itself
       can remain on yarn or npm. Update any `startWithHoist`-style app scripts accordingly.
-
+* `Store`s with no validation `Rules` on any `Field` now skip record validation entirely, no longer
+  creating a `RecordValidator` per uncommitted record. Note that `StoreRecord.validationState` now
+  reports `Valid` (rather than `Unknown`) for records in such a Store.
+*
 ### ⚙️ Typescript API Adjustments
 
 * Retyped `BaseRow.data` from `ViewRowData` to `PlainObject`. When reading row data, custom

--- a/cmp/ag-grid/AgGridModel.ts
+++ b/cmp/ag-grid/AgGridModel.ts
@@ -482,19 +482,25 @@ export class AgGridModel extends HoistModel {
 
     /**
      * Sets the selected row node ids. Any rows currently selected which are not in the list will be
-     * deselected.
+     * deselected. Applies the delta against the current selection in (at most) two bulk calls,
+     * leaving already-selected rows untouched.
      *
      * @param ids - row node ids to mark as selected
      */
     setSelectedRowNodeIds(ids: string[]) {
         this.throwIfNotReady();
 
-        const {agApi} = this;
-        agApi.deselectAll();
+        const {agApi} = this,
+            idSet = new Set(ids),
+            toDeselect = agApi.getSelectedNodes().filter(it => !idSet.has(it.id)),
+            toSelect: IRowNode[] = [];
         ids.forEach(id => {
             const node = agApi.getRowNode(id);
-            if (node) node.setSelected(true);
+            if (node && !node.isSelected()) toSelect.push(node);
         });
+
+        if (!isEmpty(toDeselect)) agApi.setNodesSelected({nodes: toDeselect, newValue: false});
+        if (!isEmpty(toSelect)) agApi.setNodesSelected({nodes: toSelect, newValue: true});
     }
 
     /**

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -391,9 +391,11 @@ export class GridLocalModel extends HoistModel {
     }
 
     selectionReaction() {
+        // Track ids, not records - ag-Grid selection is by id, and tracking selectedRecords
+        // would pay a structural compare over record contents on every transaction.
         const {model} = this;
         return {
-            track: () => [model.isReady, model.selectedRecords],
+            track: () => [model.isReady, model.selModel.selectedIds],
             run: () => {
                 if (model.isReady) this.syncSelection();
             }
@@ -773,9 +775,8 @@ export class GridLocalModel extends HoistModel {
         return record.treePath;
     };
 
-    // We debounce this handler because the implementation of `AgGridModel.setSelectedRowNodeIds()`
-    // selects nodes one-by-one, and ag-Grid will fire a selection changed event for each iteration.
-    // This avoids a storm of events looping through the reaction when selecting in bulk.
+    // Debounced to coalesce the (up to two) events fired by `AgGridModel.setSelectedRowNodeIds()`
+    // bulk delta application, plus rapid user-driven selection changes.
     onSelectionChanged = debounce(() => {
         this.model.noteAgSelectionStateChanged();
         this.syncSelection();

--- a/data/StoreRecord.ts
+++ b/data/StoreRecord.ts
@@ -173,7 +173,10 @@ export class StoreRecord {
 
     /** The current validation state of the record. */
     get validationState(): ValidationState {
-        return this.validator?.validationState ?? 'Unknown';
+        const {validator} = this;
+        if (validator) return validator.validationState;
+
+        return this.store.validator.hasRules ? 'Unknown' : 'Valid';
     }
 
     /** Map of field names to list of errors. */

--- a/data/StoreSelectionModel.ts
+++ b/data/StoreSelectionModel.ts
@@ -7,7 +7,7 @@
 
 import {HoistModel} from '@xh/hoist/core';
 import {action, computed, observable, makeObservable} from '@xh/hoist/mobx';
-import {castArray, compact, remove, isEqual, union, map} from 'lodash';
+import {castArray, compact, isEqual, union} from 'lodash';
 import {Store} from './Store';
 import {StoreRecord, StoreRecordId, StoreRecordOrId} from './StoreRecord';
 
@@ -67,7 +67,9 @@ export class StoreSelectionModel extends HoistModel {
 
     @computed.struct
     get selectedIds(): StoreRecordId[] {
-        return map(this.selectedRecords, 'id');
+        // Independent of `selectedRecords` - identity-only observers (e.g. Grid selection sync)
+        // should not pay that computed's structural compare over record contents.
+        return this._ids.filter(id => this.store.getById(id, true));
     }
 
     /**
@@ -150,11 +152,15 @@ export class StoreSelectionModel extends HoistModel {
     // Implementation
     //------------------------
     private cullSelectionReaction() {
-        // Remove recs from selection if they are no longer in store.
+        // Remove recs from selection if they are no longer in store. Reassign (never mutate in
+        // place) - `_ids` is observable.ref, so only a new reference notifies observers.
         const {store} = this;
         return {
             track: () => store._filtered,
-            run: () => remove(this._ids, id => !store.getById(id, true))
+            run: action(() => {
+                const ids = this._ids.filter(id => store.getById(id, true));
+                if (ids.length !== this._ids.length) this._ids = ids;
+            })
         };
     }
 }

--- a/data/StoreSelectionModel.ts
+++ b/data/StoreSelectionModel.ts
@@ -67,8 +67,6 @@ export class StoreSelectionModel extends HoistModel {
 
     @computed.struct
     get selectedIds(): StoreRecordId[] {
-        // Independent of `selectedRecords` - identity-only observers (e.g. Grid selection sync)
-        // should not pay that computed's structural compare over record contents.
         return this._ids.filter(id => this.store.getById(id, true));
     }
 
@@ -152,8 +150,7 @@ export class StoreSelectionModel extends HoistModel {
     // Implementation
     //------------------------
     private cullSelectionReaction() {
-        // Remove recs from selection if they are no longer in store. Reassign (never mutate in
-        // place) - `_ids` is observable.ref, so only a new reference notifies observers.
+        // Remove recs from selection if they are no longer in store.
         const {store} = this;
         return {
             track: () => store._filtered,

--- a/data/StoreSelectionModel.ts
+++ b/data/StoreSelectionModel.ts
@@ -7,7 +7,7 @@
 
 import {HoistModel} from '@xh/hoist/core';
 import {action, computed, observable, makeObservable} from '@xh/hoist/mobx';
-import {castArray, compact, isEqual, union} from 'lodash';
+import {castArray, compact, remove, isEqual, union, map} from 'lodash';
 import {Store} from './Store';
 import {StoreRecord, StoreRecordId, StoreRecordOrId} from './StoreRecord';
 
@@ -67,7 +67,7 @@ export class StoreSelectionModel extends HoistModel {
 
     @computed.struct
     get selectedIds(): StoreRecordId[] {
-        return this._ids.filter(id => this.store.getById(id, true));
+        return map(this.selectedRecords, 'id');
     }
 
     /**
@@ -154,10 +154,7 @@ export class StoreSelectionModel extends HoistModel {
         const {store} = this;
         return {
             track: () => store._filtered,
-            run: action(() => {
-                const ids = this._ids.filter(id => store.getById(id, true));
-                if (ids.length !== this._ids.length) this._ids = ids;
-            })
+            run: () => remove(this._ids, id => !store.getById(id, true))
         };
     }
 }

--- a/data/impl/StoreValidator.ts
+++ b/data/impl/StoreValidator.ts
@@ -16,7 +16,11 @@ import {sumBy, chunk} from 'lodash';
 import {findIn} from '@xh/hoist/utils/js';
 import {RecordValidator} from './RecordValidator';
 import {Store} from '../Store';
-import {StoreRecordId} from '../StoreRecord';
+import {StoreRecord, StoreRecordId} from '../StoreRecord';
+
+// Shared stable return for clean stores - reference equality keeps the sync reaction from
+// firing on every transaction of a clean store.
+const EMPTY: StoreRecord[] = Object.freeze([]) as StoreRecord[];
 
 /**
  * Computes validation state for a Store's uncommitted Records.
@@ -80,7 +84,7 @@ export class StoreValidator extends HoistBase {
 
         this.addReaction({
             track: () => this.uncommittedRecords,
-            run: () => this.syncValidatorsAsync(),
+            run: recs => this.syncValidatorsAsync(recs),
             fireImmediately: true
         });
     }
@@ -124,18 +128,18 @@ export class StoreValidator extends HoistBase {
     //---------------------------------------
     // Implementation
     //---------------------------------------
-    private get uncommittedRecords() {
+    private get uncommittedRecords(): StoreRecord[] {
         const {store} = this;
-        return store.isDirty ? store.allRecords.filter(it => !it.isCommitted) : [];
+        return store.isDirty ? store.allRecords.filter(it => !it.isCommitted) : EMPTY;
     }
 
-    private async syncValidatorsAsync() {
+    private async syncValidatorsAsync(records: StoreRecord[]) {
         const isComplex = this.store.validationIsComplex,
             currValidators = this._validators,
             newValidators = new Map(),
             toValidate = [];
 
-        this.uncommittedRecords.forEach(record => {
+        records.forEach(record => {
             const {id} = record;
 
             // Re-use existing validators to preserve validation state and avoid churn.

--- a/data/impl/StoreValidator.ts
+++ b/data/impl/StoreValidator.ts
@@ -11,16 +11,12 @@ import {
     StoreValidationResultsMap,
     ValidationState
 } from '@xh/hoist/data';
-import {computed, makeObservable, runInAction, observable} from '@xh/hoist/mobx';
-import {sumBy, chunk} from 'lodash';
+import {comparer, computed, makeObservable, runInAction, observable} from '@xh/hoist/mobx';
+import {sumBy, chunk, isEmpty} from 'lodash';
 import {findIn} from '@xh/hoist/utils/js';
 import {RecordValidator} from './RecordValidator';
 import {Store} from '../Store';
 import {StoreRecord, StoreRecordId} from '../StoreRecord';
-
-// Shared stable return for clean stores - reference equality keeps the sync reaction from
-// firing on every transaction of a clean store.
-const EMPTY: StoreRecord[] = Object.freeze([]) as StoreRecord[];
 
 /**
  * Computes validation state for a Store's uncommitted Records.
@@ -28,6 +24,9 @@ const EMPTY: StoreRecord[] = Object.freeze([]) as StoreRecord[];
  */
 export class StoreValidator extends HoistBase {
     store: Store;
+
+    /** True if any Field has Rules - when false, all validation is skipped. */
+    readonly hasRules: boolean;
 
     /** True if the store is confirmed to be Valid. */
     @computed
@@ -80,13 +79,18 @@ export class StoreValidator extends HoistBase {
     constructor(config: {store: Store}) {
         super();
         makeObservable(this);
-        this.store = config.store;
 
-        this.addReaction({
-            track: () => this.uncommittedRecords,
-            run: recs => this.syncValidatorsAsync(recs),
-            fireImmediately: true
-        });
+        const {store} = config;
+        this.store = store;
+        this.hasRules = store.fields.some(f => !isEmpty(f.rules));
+
+        if (this.hasRules) {
+            this.addReaction({
+                track: () => this.uncommittedRecords,
+                run: recs => this.syncValidatorsAsync(recs),
+                fireImmediately: true
+            });
+        }
     }
 
     /**
@@ -128,9 +132,10 @@ export class StoreValidator extends HoistBase {
     //---------------------------------------
     // Implementation
     //---------------------------------------
+    @computed({equals: comparer.shallow})
     private get uncommittedRecords(): StoreRecord[] {
         const {store} = this;
-        return store.isDirty ? store.allRecords.filter(it => !it.isCommitted) : EMPTY;
+        return store.isDirty ? store.allRecords.filter(it => !it.isCommitted) : [];
     }
 
     private async syncValidatorsAsync(records: StoreRecord[]) {

--- a/desktop/cmp/grid/find/impl/GridFindFieldImplModel.ts
+++ b/desktop/cmp/grid/find/impl/GridFindFieldImplModel.ts
@@ -13,7 +13,6 @@ import {action, bindable, comparer, computed, makeObservable, observable} from '
 import {stripTags, withDefault} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
 import {
-    compact,
     filter,
     flatMap,
     get,
@@ -194,50 +193,40 @@ export class GridFindFieldImplModel extends HoistModel {
         return this._records;
     }
 
-    // Sort records with GridModel's sortBy(s) using the Column's comparator. Sorters are
-    // resolved once up front, and values/nodes resolved once per record (decorate-sort-
-    // undecorate) rather than per comparison.
+    // Sort records with GridModel's sortBy(s) using the Column's comparator
     private sortRecordsRecursive(records: StoreRecord[]): StoreRecord[] {
         const {gridModel} = this,
             {sortBy, treeMode, agApi, store} = gridModel,
-            sorters = compact(
-                [...sortBy].reverse().map(it => {
-                    const column = gridModel.getColumn(it.colId);
-                    if (!column) return null;
-                    const {field, getValueFn} = column;
-                    return {
-                        getValueFn,
-                        compFn: (column.getAgSpec().comparator as Function).bind(column),
-                        direction: it.sort === 'desc' ? -1 : 1,
-                        ctx: {field, column, gridModel, store, agParams: null}
-                    };
-                })
-            );
+            ret: StoreRecord[] = [];
 
-        const sortRecs = (records: StoreRecord[]): StoreRecord[] => {
-            const ret: StoreRecord[] = [];
+        [...sortBy].reverse().forEach(it => {
+            const column = gridModel.getColumn(it.colId);
+            if (!column) return;
 
-            sorters.forEach(({getValueFn, compFn, direction, ctx}) => {
-                const decorated = records.map(record => ({
-                    record,
-                    value: getValueFn({record, ...ctx}),
-                    node: agApi?.getRowNode(record.agId)
-                }));
-                decorated.sort((a, b) => compFn(a.value, b.value, a.node, b.node) * direction);
-                records = decorated.map(it => it.record);
+            const {field, getValueFn} = column,
+                compFn = (column.getAgSpec().comparator as Function).bind(column),
+                direction = it.sort === 'desc' ? -1 : 1;
+
+            const ctx = {field, column, gridModel, store, agParams: null};
+            records.sort((a, b) => {
+                const valueA = getValueFn({record: a, ...ctx}),
+                    valueB = getValueFn({record: b, ...ctx}),
+                    nodeA = agApi?.getRowNode(a.agId),
+                    nodeB = agApi?.getRowNode(b.agId);
+
+                return compFn(valueA, valueB, nodeA, nodeB) * direction;
             });
+        });
 
-            records.forEach(rec => {
-                ret.push(rec);
-                if (treeMode && !isEmpty(rec.children)) {
-                    ret.push(...sortRecs(rec.children));
-                }
-            });
+        records.forEach(rec => {
+            ret.push(rec);
+            if (treeMode && !isEmpty(rec.children)) {
+                const children = this.sortRecordsRecursive(rec.children);
+                ret.push(...children);
+            }
+        });
 
-            return ret;
-        };
-
-        return sortRecs(records);
+        return ret;
     }
 
     // Sort records with GridModel's groupBy(s) using the GridModel's groupSortFn
@@ -250,17 +239,16 @@ export class GridFindFieldImplModel extends HoistModel {
             if (!column) return;
 
             const {field, getValueFn} = column,
-                ctx = {field, column, gridModel, store, agParams: null},
-                decorated = records.map(record => ({
-                    record,
-                    value: getValueFn({record, ...ctx}),
-                    node: agApi?.getRowNode(record.agId)
-                }));
+                ctx = {field, column, gridModel, store, agParams: null};
 
-            decorated.sort((a, b) =>
-                groupSortFn(a.value, b.value, field, {gridModel, nodeA: a.node, nodeB: b.node})
-            );
-            records = decorated.map(it => it.record);
+            records.sort((a, b) => {
+                const valueA = getValueFn({record: a, ...ctx}),
+                    valueB = getValueFn({record: b, ...ctx}),
+                    nodeA = agApi?.getRowNode(a.agId),
+                    nodeB = agApi?.getRowNode(b.agId);
+
+                return groupSortFn(valueA, valueB, field, {gridModel, nodeA, nodeB});
+            });
         });
 
         return records;

--- a/desktop/cmp/grid/find/impl/GridFindFieldImplModel.ts
+++ b/desktop/cmp/grid/find/impl/GridFindFieldImplModel.ts
@@ -13,6 +13,7 @@ import {action, bindable, comparer, computed, makeObservable, observable} from '
 import {stripTags, withDefault} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
 import {
+    compact,
     filter,
     flatMap,
     get,
@@ -120,7 +121,8 @@ export class GridFindFieldImplModel extends HoistModel {
                 run: () => {
                     this._records = null;
                     if (this.hasQuery) this.updateResults();
-                }
+                },
+                debounce: this.queryBuffer
             },
             {
                 track: () => [this.includeFields, this.excludeFields, this.matchMode],
@@ -192,40 +194,50 @@ export class GridFindFieldImplModel extends HoistModel {
         return this._records;
     }
 
-    // Sort records with GridModel's sortBy(s) using the Column's comparator
+    // Sort records with GridModel's sortBy(s) using the Column's comparator. Sorters are
+    // resolved once up front, and values/nodes resolved once per record (decorate-sort-
+    // undecorate) rather than per comparison.
     private sortRecordsRecursive(records: StoreRecord[]): StoreRecord[] {
         const {gridModel} = this,
             {sortBy, treeMode, agApi, store} = gridModel,
-            ret: StoreRecord[] = [];
+            sorters = compact(
+                [...sortBy].reverse().map(it => {
+                    const column = gridModel.getColumn(it.colId);
+                    if (!column) return null;
+                    const {field, getValueFn} = column;
+                    return {
+                        getValueFn,
+                        compFn: (column.getAgSpec().comparator as Function).bind(column),
+                        direction: it.sort === 'desc' ? -1 : 1,
+                        ctx: {field, column, gridModel, store, agParams: null}
+                    };
+                })
+            );
 
-        [...sortBy].reverse().forEach(it => {
-            const column = gridModel.getColumn(it.colId);
-            if (!column) return;
+        const sortRecs = (records: StoreRecord[]): StoreRecord[] => {
+            const ret: StoreRecord[] = [];
 
-            const {field, getValueFn} = column,
-                compFn = (column.getAgSpec().comparator as Function).bind(column),
-                direction = it.sort === 'desc' ? -1 : 1;
-
-            const ctx = {field, column, gridModel, store, agParams: null};
-            records.sort((a, b) => {
-                const valueA = getValueFn({record: a, ...ctx}),
-                    valueB = getValueFn({record: b, ...ctx}),
-                    nodeA = agApi?.getRowNode(a.agId),
-                    nodeB = agApi?.getRowNode(b.agId);
-
-                return compFn(valueA, valueB, nodeA, nodeB) * direction;
+            sorters.forEach(({getValueFn, compFn, direction, ctx}) => {
+                const decorated = records.map(record => ({
+                    record,
+                    value: getValueFn({record, ...ctx}),
+                    node: agApi?.getRowNode(record.agId)
+                }));
+                decorated.sort((a, b) => compFn(a.value, b.value, a.node, b.node) * direction);
+                records = decorated.map(it => it.record);
             });
-        });
 
-        records.forEach(rec => {
-            ret.push(rec);
-            if (treeMode && !isEmpty(rec.children)) {
-                const children = this.sortRecordsRecursive(rec.children);
-                ret.push(...children);
-            }
-        });
+            records.forEach(rec => {
+                ret.push(rec);
+                if (treeMode && !isEmpty(rec.children)) {
+                    ret.push(...sortRecs(rec.children));
+                }
+            });
 
-        return ret;
+            return ret;
+        };
+
+        return sortRecs(records);
     }
 
     // Sort records with GridModel's groupBy(s) using the GridModel's groupSortFn
@@ -238,16 +250,17 @@ export class GridFindFieldImplModel extends HoistModel {
             if (!column) return;
 
             const {field, getValueFn} = column,
-                ctx = {field, column, gridModel, store, agParams: null};
+                ctx = {field, column, gridModel, store, agParams: null},
+                decorated = records.map(record => ({
+                    record,
+                    value: getValueFn({record, ...ctx}),
+                    node: agApi?.getRowNode(record.agId)
+                }));
 
-            records.sort((a, b) => {
-                const valueA = getValueFn({record: a, ...ctx}),
-                    valueB = getValueFn({record: b, ...ctx}),
-                    nodeA = agApi?.getRowNode(a.agId),
-                    nodeB = agApi?.getRowNode(b.agId);
-
-                return groupSortFn(valueA, valueB, field, {gridModel, nodeA, nodeB});
-            });
+            decorated.sort((a, b) =>
+                groupSortFn(a.value, b.value, field, {gridModel, nodeA: a.node, nodeB: b.node})
+            );
+            records = decorated.map(it => it.record);
         });
 
         return records;


### PR DESCRIPTION
Stacked on #4600 - second batch of hot-path fixes, split out for reviewability. Will re-target to `develop` automatically when #4600 merges.

* **StoreValidator**: a Store with no validation `Rules` on any `Field` now skips validation entirely - `hasRules` is computed once at construction and no sync reaction is created when false, so no `RecordValidator` per uncommitted record and no chunked no-op validate pass. This is item 1 of #4486, where a client reported multi-second freezes editing 10^3-10^4 records. Also makes `uncommittedRecords` a `@computed({equals: comparer.shallow})`, so it holds a stable identity across transactions that leave the uncommitted set untouched. `StoreRecord.validationState` now reports `Valid` rather than a permanent `Unknown` for records in a Store with no rules.

* **GridFindField**: the data reaction is debounced with the existing `queryBuffer`, coalescing a burst of store transactions into a single results recompute. The sorting rework from this model is reviewed separately in #4608.

* **Selection sync**: `AgGridModel.setSelectedRowNodeIds()` applies the selection delta in at most two bulk `setNodesSelected()` calls - unchanged rows untouched, and select-all no longer fires an event per row. `Grid.selectionReaction` now tracks `selModel.selectedIds` rather than `selectedRecords`: everything below `syncSelection` is keyed by row node id, so a change confined to a selected record's data cannot affect the outcome, but under `.struct` on `selectedRecords` it fired the reaction anyway - burning n lazy `agId` materializations plus an `agApi.getSelectedNodes()` traversal per tick before the `isEqual` guard no-oped it.

Validated in Toolbox: GridFindField query/cycle/reload, select-random + scroll-to-selection, and inline-edit validation incl. the dirty->clean transition. Zero console errors. The `StoreValidator` gate is newer than that pass and has been verified by typecheck and review only - worth re-running the inline-edit cases against a Store that does have rules before merge.

