### PR TITLE
Hot-loop performance: per-record allocations in Store and RecordValidator

### DIFF
--- a/cmp/ag-grid/AgGridModel.ts
+++ b/cmp/ag-grid/AgGridModel.ts
@@ -482,8 +482,7 @@ export class AgGridModel extends HoistModel {
 
     /**
      * Sets the selected row node ids. Any rows currently selected which are not in the list will be
-     * deselected. Applies the delta against the current selection in (at most) two bulk calls,
-     * leaving already-selected rows untouched.
+     * deselected.
      *
      * @param ids - row node ids to mark as selected
      */

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -391,8 +391,6 @@ export class GridLocalModel extends HoistModel {
     }
 
     selectionReaction() {
-        // Track ids, not records - ag-Grid selection is by id, and tracking selectedRecords
-        // would pay a structural compare over record contents on every transaction.
         const {model} = this;
         return {
             track: () => [model.isReady, model.selModel.selectedIds],

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -555,7 +555,7 @@ export class Store
             : null;
 
         const {_committed, _current} = this,
-            records = this.createRecords(rawData, null, new Map(), this.summaryRecordIds),
+            records = this.createRecords(rawData, null, new Map()),
             updated = _committed.withNewRecords(records);
 
         this.diagnostics.noteLoad(updated, _committed, start);
@@ -676,9 +676,7 @@ export class Store
         const {update, add, remove, rawSummaryData, changedFields, ...other} = rawTransaction;
         throwIf(!isEmpty(other), 'Unknown argument(s) passed to updateData().');
 
-        // 1) Pre-process updates and adds into Records. Summary ids hoisted - referenced per
-        // updated/added record below.
-        const {summaryRecordIds} = this;
+        // 1) Pre-process updates and adds into Records
         let updateRecs: StoreRecord[], addRecs: Map<StoreRecordId, StoreRecord>;
         if (update) {
             updateRecs = [];
@@ -689,7 +687,7 @@ export class Store
                         'In order to update grid data, records must have stable ids. Note: XH.genId() will not provide such ids.'
                     ),
                     parent = rec.parent,
-                    isSummary = summaryRecordIds.has(recId),
+                    isSummary = this.summaryRecordIds.has(recId),
                     newRec = this.createRecord(it, parent, isSummary);
 
                 // Reused records signal an unchanged digest - drop such updates as no-ops.
@@ -702,9 +700,9 @@ export class Store
                 if (isChildRawDataObject(it)) {
                     const {rawData, parentId} = it,
                         parent = !isNil(parentId) ? this.getOrThrow(parentId) : null;
-                    this.createRecordDeep(rawData, parent, addRecs, summaryRecordIds);
+                    this.createRecordDeep(rawData, parent, addRecs);
                 } else {
-                    this.createRecordDeep(it, null, addRecs, summaryRecordIds);
+                    this.createRecordDeep(it, null, addRecs);
                 }
             });
         }
@@ -713,7 +711,7 @@ export class Store
         const {summaryRecords} = this;
         let summaryUpdateRecs: StoreRecord[];
         if (!isEmpty(summaryRecords)) {
-            summaryUpdateRecs = lodashRemove(updateRecs, ({id}) => summaryRecordIds.has(id));
+            summaryUpdateRecs = lodashRemove(updateRecs, ({id}) => this.summaryRecordIds.has(id));
         }
 
         if (isEmpty(summaryUpdateRecs) && rawSummaryData) {
@@ -929,8 +927,7 @@ export class Store
         const {summaryRecords} = this;
         let summaryUpdateRecs: StoreRecord[];
         if (!isEmpty(summaryRecords)) {
-            const {summaryRecordIds} = this;
-            summaryUpdateRecs = lodashRemove(updateRecs, ({id}) => summaryRecordIds.has(id));
+            summaryUpdateRecs = lodashRemove(updateRecs, ({id}) => this.summaryRecordIds.has(id));
         }
 
         if (!isEmpty(summaryUpdateRecs)) {
@@ -1469,7 +1466,7 @@ export class Store
         rawData: PlainObject[],
         parent: StoreRecord,
         recordMap: Map<StoreRecordId, StoreRecord>,
-        summaryRecordIds: Set<StoreRecordId>
+        summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
     ) {
         rawData.forEach(raw => this.createRecordDeep(raw, parent, recordMap, summaryRecordIds));
         return recordMap;
@@ -1480,7 +1477,7 @@ export class Store
         raw: PlainObject,
         parent: StoreRecord,
         recordMap: Map<StoreRecordId, StoreRecord>,
-        summaryRecordIds: Set<StoreRecordId>
+        summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
     ) {
         const rec = this.createRecord(raw, parent),
             {id} = rec;
@@ -1498,6 +1495,9 @@ export class Store
         }
     }
 
+    // Cached index of summary ids - keepAlive as this is read from non-reactive code, where an
+    // unobserved computed would re-evaluate (and re-allocate) on every access.
+    @computed({keepAlive: true})
     private get summaryRecordIds(): Set<StoreRecordId> {
         return new Set(this.summaryRecords?.map(it => it.id) ?? []);
     }

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -555,7 +555,7 @@ export class Store
             : null;
 
         const {_committed, _current} = this,
-            records = this.createRecords(rawData, null, new Map()),
+            records = this.createRecords(rawData, null, this.summaryRecordIds),
             updated = _committed.withNewRecords(records);
 
         this.diagnostics.noteLoad(updated, _committed, start);
@@ -602,7 +602,7 @@ export class Store
             summaryIds = new Set<StoreRecordId>();
 
         for await (const raw of rawData) {
-            this.createRecordDeep(raw, null, recordMap, summaryIds);
+            this.createRecordDeep(raw, null, summaryIds, recordMap);
         }
 
         runInAction(() => {
@@ -700,9 +700,9 @@ export class Store
                 if (isChildRawDataObject(it)) {
                     const {rawData, parentId} = it,
                         parent = !isNil(parentId) ? this.getOrThrow(parentId) : null;
-                    this.createRecordDeep(rawData, parent, addRecs);
+                    this.createRecordDeep(rawData, parent, this.summaryRecordIds, addRecs);
                 } else {
-                    this.createRecordDeep(it, null, addRecs);
+                    this.createRecordDeep(it, null, this.summaryRecordIds, addRecs);
                 }
             });
         }
@@ -1465,10 +1465,10 @@ export class Store
     private createRecords(
         rawData: PlainObject[],
         parent: StoreRecord,
-        recordMap: Map<StoreRecordId, StoreRecord>,
-        summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
+        summaryRecordIds: Set<StoreRecordId>,
+        recordMap: Map<StoreRecordId, StoreRecord> = new Map()
     ) {
-        rawData.forEach(raw => this.createRecordDeep(raw, parent, recordMap, summaryRecordIds));
+        rawData.forEach(raw => this.createRecordDeep(raw, parent, summaryRecordIds, recordMap));
         return recordMap;
     }
 
@@ -1476,8 +1476,8 @@ export class Store
     private createRecordDeep(
         raw: PlainObject,
         parent: StoreRecord,
-        recordMap: Map<StoreRecordId, StoreRecord>,
-        summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
+        summaryRecordIds: Set<StoreRecordId>,
+        recordMap: Map<StoreRecordId, StoreRecord>
     ) {
         const rec = this.createRecord(raw, parent),
             {id} = rec;
@@ -1491,7 +1491,7 @@ export class Store
         recordMap.set(id, rec);
 
         if (this.loadTreeData && raw[this.loadTreeDataFrom]) {
-            this.createRecords(raw[this.loadTreeDataFrom], rec, recordMap, summaryRecordIds);
+            this.createRecords(raw[this.loadTreeDataFrom], rec, summaryRecordIds, recordMap);
         }
     }
 

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -41,7 +41,6 @@ import {
     isString,
     partition,
     remove as lodashRemove,
-    some,
     uniq,
     values
 } from 'lodash';
@@ -677,7 +676,9 @@ export class Store
         const {update, add, remove, rawSummaryData, changedFields, ...other} = rawTransaction;
         throwIf(!isEmpty(other), 'Unknown argument(s) passed to updateData().');
 
-        // 1) Pre-process updates and adds into Records
+        // 1) Pre-process updates and adds into Records. Summary ids hoisted - referenced per
+        // updated/added record below.
+        const {summaryRecordIds} = this;
         let updateRecs: StoreRecord[], addRecs: Map<StoreRecordId, StoreRecord>;
         if (update) {
             updateRecs = [];
@@ -688,7 +689,7 @@ export class Store
                         'In order to update grid data, records must have stable ids. Note: XH.genId() will not provide such ids.'
                     ),
                     parent = rec.parent,
-                    isSummary = some(this.summaryRecords, {id: recId}),
+                    isSummary = summaryRecordIds.has(recId),
                     newRec = this.createRecord(it, parent, isSummary);
 
                 // Reused records signal an unchanged digest - drop such updates as no-ops.
@@ -701,9 +702,9 @@ export class Store
                 if (isChildRawDataObject(it)) {
                     const {rawData, parentId} = it,
                         parent = !isNil(parentId) ? this.getOrThrow(parentId) : null;
-                    this.createRecordDeep(rawData, parent, addRecs);
+                    this.createRecordDeep(rawData, parent, addRecs, summaryRecordIds);
                 } else {
-                    this.createRecordDeep(it, null, addRecs);
+                    this.createRecordDeep(it, null, addRecs, summaryRecordIds);
                 }
             });
         }
@@ -712,7 +713,7 @@ export class Store
         const {summaryRecords} = this;
         let summaryUpdateRecs: StoreRecord[];
         if (!isEmpty(summaryRecords)) {
-            summaryUpdateRecs = lodashRemove(updateRecs, ({id}) => some(summaryRecords, {id}));
+            summaryUpdateRecs = lodashRemove(updateRecs, ({id}) => summaryRecordIds.has(id));
         }
 
         if (isEmpty(summaryUpdateRecs) && rawSummaryData) {
@@ -928,7 +929,8 @@ export class Store
         const {summaryRecords} = this;
         let summaryUpdateRecs: StoreRecord[];
         if (!isEmpty(summaryRecords)) {
-            summaryUpdateRecs = lodashRemove(updateRecs, ({id}) => some(summaryRecords, {id}));
+            const {summaryRecordIds} = this;
+            summaryUpdateRecs = lodashRemove(updateRecs, ({id}) => summaryRecordIds.has(id));
         }
 
         if (!isEmpty(summaryUpdateRecs)) {

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -555,7 +555,7 @@ export class Store
             : null;
 
         const {_committed, _current} = this,
-            records = this.createRecords(rawData, null),
+            records = this.createRecords(rawData, null, new Map(), this.summaryRecordIds),
             updated = _committed.withNewRecords(records);
 
         this.diagnostics.noteLoad(updated, _committed, start);
@@ -1468,8 +1468,8 @@ export class Store
     private createRecords(
         rawData: PlainObject[],
         parent: StoreRecord,
-        recordMap: Map<StoreRecordId, StoreRecord> = new Map(),
-        summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
+        recordMap: Map<StoreRecordId, StoreRecord>,
+        summaryRecordIds: Set<StoreRecordId>
     ) {
         rawData.forEach(raw => this.createRecordDeep(raw, parent, recordMap, summaryRecordIds));
         return recordMap;
@@ -1480,7 +1480,7 @@ export class Store
         raw: PlainObject,
         parent: StoreRecord,
         recordMap: Map<StoreRecordId, StoreRecord>,
-        summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
+        summaryRecordIds: Set<StoreRecordId>
     ) {
         const rec = this.createRecord(raw, parent),
             {id} = rec;

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -555,7 +555,7 @@ export class Store
             : null;
 
         const {_committed, _current} = this,
-            records = this.createRecords(rawData, null, this.summaryRecordIds),
+            records = this.createRecords(rawData, null),
             updated = _committed.withNewRecords(records);
 
         this.diagnostics.noteLoad(updated, _committed, start);
@@ -602,7 +602,7 @@ export class Store
             summaryIds = new Set<StoreRecordId>();
 
         for await (const raw of rawData) {
-            this.createRecordDeep(raw, null, summaryIds, recordMap);
+            this.createRecordDeep(raw, null, recordMap, summaryIds);
         }
 
         runInAction(() => {
@@ -700,9 +700,9 @@ export class Store
                 if (isChildRawDataObject(it)) {
                     const {rawData, parentId} = it,
                         parent = !isNil(parentId) ? this.getOrThrow(parentId) : null;
-                    this.createRecordDeep(rawData, parent, this.summaryRecordIds, addRecs);
+                    this.createRecordDeep(rawData, parent, addRecs);
                 } else {
-                    this.createRecordDeep(it, null, this.summaryRecordIds, addRecs);
+                    this.createRecordDeep(it, null, addRecs);
                 }
             });
         }
@@ -1465,10 +1465,10 @@ export class Store
     private createRecords(
         rawData: PlainObject[],
         parent: StoreRecord,
-        summaryRecordIds: Set<StoreRecordId>,
-        recordMap: Map<StoreRecordId, StoreRecord> = new Map()
+        recordMap: Map<StoreRecordId, StoreRecord> = new Map(),
+        summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
     ) {
-        rawData.forEach(raw => this.createRecordDeep(raw, parent, summaryRecordIds, recordMap));
+        rawData.forEach(raw => this.createRecordDeep(raw, parent, recordMap, summaryRecordIds));
         return recordMap;
     }
 
@@ -1476,8 +1476,8 @@ export class Store
     private createRecordDeep(
         raw: PlainObject,
         parent: StoreRecord,
-        summaryRecordIds: Set<StoreRecordId>,
-        recordMap: Map<StoreRecordId, StoreRecord>
+        recordMap: Map<StoreRecordId, StoreRecord>,
+        summaryRecordIds: Set<StoreRecordId> = this.summaryRecordIds
     ) {
         const rec = this.createRecord(raw, parent),
             {id} = rec;
@@ -1491,7 +1491,7 @@ export class Store
         recordMap.set(id, rec);
 
         if (this.loadTreeData && raw[this.loadTreeDataFrom]) {
-            this.createRecords(raw[this.loadTreeDataFrom], rec, summaryRecordIds, recordMap);
+            this.createRecords(raw[this.loadTreeDataFrom], rec, recordMap, summaryRecordIds);
         }
     }
 

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -1495,8 +1495,6 @@ export class Store
         }
     }
 
-    // Cached index of summary ids - keepAlive as this is read from non-reactive code, where an
-    // unobserved computed would re-evaluate (and re-allocate) on every access.
     @computed({keepAlive: true})
     private get summaryRecordIds(): Set<StoreRecordId> {
         return new Set(this.summaryRecords?.map(it => it.id) ?? []);

--- a/data/impl/RecordValidator.ts
+++ b/data/impl/RecordValidator.ts
@@ -16,7 +16,7 @@ import {
 } from '@xh/hoist/data';
 import {computed, observable, makeObservable, runInAction} from '@xh/hoist/mobx';
 import {compact, flatten, isEmpty, isString, mapValues, values} from 'lodash';
-import {TaskObserver} from '../../core';
+import {PlainObject, TaskObserver} from '../../core';
 
 /**
  * Computes validation state for a StoreRecord.
@@ -93,10 +93,11 @@ export class RecordValidator {
             {record} = this,
             fieldsToValidate = record.store.fields.filter(it => !isEmpty(it.rules));
 
+        const values = record.getValues();
         const promises = fieldsToValidate.flatMap(field => {
             fieldValidations[field.name] = [];
             return field.rules.map(async rule => {
-                const result = await this.evaluateRuleAsync(record, field, rule);
+                const result = await this.evaluateRuleAsync(record, field, rule, values);
                 fieldValidations[field.name].push(result);
             });
         });
@@ -120,13 +121,13 @@ export class RecordValidator {
     async evaluateRuleAsync(
         record: StoreRecord,
         field: Field,
-        rule: Rule
+        rule: Rule,
+        values: PlainObject = record.getValues()
     ): Promise<ValidationResult[]> {
-        const values = record.getValues(),
-            {name, displayName} = field,
+        const {name, displayName} = field,
             value = record.get(name);
 
-        if (this.ruleIsActive(record, field, rule)) {
+        if (this.ruleIsActive(field, rule, values)) {
             const promises = rule.check.map(async constraint => {
                 const fieldState = {value, name, displayName, record};
                 return constraint(fieldState, values);
@@ -139,8 +140,8 @@ export class RecordValidator {
         }
     }
 
-    ruleIsActive(record: StoreRecord, field: Field, rule: Rule) {
+    ruleIsActive(field: Field, rule: Rule, values: PlainObject) {
         const {when} = rule;
-        return !when || when(field, record.getValues());
+        return !when || when(field, values);
     }
 }

--- a/data/impl/RecordValidator.ts
+++ b/data/impl/RecordValidator.ts
@@ -118,11 +118,11 @@ export class RecordValidator {
         return 'Valid';
     }
 
-    async evaluateRuleAsync(
+    private async evaluateRuleAsync(
         record: StoreRecord,
         field: Field,
         rule: Rule,
-        values: PlainObject = record.getValues()
+        values: PlainObject
     ): Promise<ValidationResult[]> {
         const {name, displayName} = field,
             value = record.get(name);
@@ -140,7 +140,7 @@ export class RecordValidator {
         }
     }
 
-    ruleIsActive(field: Field, rule: Rule, values: PlainObject) {
+    private ruleIsActive(field: Field, rule: Rule, values: PlainObject) {
         const {when} = rule;
         return !when || when(field, values);
     }


### PR DESCRIPTION
Third batch in the stack (#4600 → #4602 → this) - pure internal reorg, no API or behavior changes.

* **Store.summaryRecordIds** is now a `@computed({keepAlive: true})` rather than a getter allocating a fresh `Set` per access. `summaryRecords` is already `@observable.ref`, so the index is just a cached derivation, invalidated when that ref is reassigned. `keepAlive` is load-bearing: an unobserved computed re-evaluates on every read, and this is read from non-reactive code, so a plain `@computed` would re-allocate exactly as the bare getter did. Same pattern as `GridModel.leafColumnMap`. With the read now cheap, the existing parameter defaults on `createRecords`/`createRecordDeep` are no longer a per-record allocation - `updateData`'s add loop was building one Set per *added* record, 10k for a 10k-row add.

* **Store summary-membership tests** are direct Set lookups instead of `some(summaryRecords, {id})`, which built a lodash matcher iteratee (a keys array, a match-data pair, and a closure) per call - unconditionally, so a Store with no summary records paid it per updated record to scan nothing.

* **RecordValidator**: `record.getValues()` (an object allocation over every Field) is built once per `validateAsync` run and threaded through `evaluateRuleAsync`/`ruleIsActive` - previously rebuilt twice per rule per field. Note that all rules for a record now share one `values` object where each previously got a fresh snapshot; records are immutable so the contents are identical, but a constraint that *mutates* what it is handed would no longer be isolated from later rules. `evaluateRuleAsync` and `ruleIsActive` are now `private` with adjusted signatures - `RecordValidator` is `@internal`, though instances are reachable via `store.validator.findRecordValidator()`.

No signature or call-site changes: the helpers and their callers are as they are on develop, including `loadDataAsync` passing its own empty Set (it clears `summaryRecords` only in its closing transaction, so consulting the observable during record creation would check against the *previous* load's summary records).

Validated in Toolbox: tree grid load/reload with summary row, inline-edit commit via `modifyRecords` + validation + revert. Zero console errors. The `summaryRecordIds` rework postdates that pass - typecheck and review only.
