### PR TITLE
Hot-loop performance: cube generation and tick-path micro-costs

### DIFF
--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -25,7 +25,7 @@ import {ViewRowData} from '@xh/hoist/data/cube/ViewRowData';
 import {ViewDiagnostics} from './impl/ViewDiagnostics';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {throwIf} from '@xh/hoist/utils/js';
-import {castArray, find, forEach, groupBy, isEmpty, isNil, map, uniq} from 'lodash';
+import {castArray, forEach, groupBy, isEmpty, isNil, map} from 'lodash';
 import {AggregationContext} from './aggregate/AggregationContext';
 import {RowCache} from './impl/RowCache';
 import {RowDataGenerator} from './impl/RowDataGenerator';
@@ -148,6 +148,8 @@ export class View
     private _leafMap: Map<StoreRecordId, LeafRow> = null;
     _records: RecordSet = null; // cube records passing this view's filter
     private _bucketDependentFields = new Set<string>();
+
+    private _fieldsByName: Map<string, CubeField> = null;
     private _rowDataGenerator: RowDataGenerator = null;
     // Monotonic source for cubeRowDigest stamps - safe-integer headroom spans centuries of use.
     _rowDigest = 0;
@@ -173,7 +175,7 @@ export class View
         this.stores = this.parseStores(stores);
         this._rowCache = new RowCache(this);
         this._rowDataGenerator = new RowDataGenerator(this);
-        this.buildAggFields();
+        this.buildIndices();
         this.fullUpdate('query', start);
 
         if (connect) {
@@ -237,7 +239,7 @@ export class View
 
         this.query = newQuery;
         this._rowDataGenerator.onQueryChange();
-        this.buildAggFields();
+        this.buildIndices();
 
         // If the cube is changing potentially disconnect from the old cube and connect to the new
         const {cube: oldCube} = oldQuery,
@@ -274,7 +276,7 @@ export class View
 
     /** Get a specific Field by name.*/
     getField(name: string): CubeField {
-        return find(this.fields, {name});
+        return this._fieldsByName.get(name);
     }
 
     /** Set stores to be loaded/reloaded with data from this view. */
@@ -353,7 +355,9 @@ export class View
         data.cubeRowDigest = ++this._rowDigest;
     }
 
-    private buildAggFields() {
+    private buildIndices() {
+        this._fieldsByName = new Map(this.fields.map(it => [it.name, it]));
+
         // Aggregation eligibility is a function of level alone - dimensions apply in order, and
         // bucket rows share the level of the aggregate row above them. Note depth 0 has no applied
         // dimensions, and so holds the unfiltered superset of each list. Queries need not specify
@@ -649,14 +653,19 @@ export class View
 
     private hasDimOrBucketUpdates(update: StoreRecord[]): boolean {
         const {dimensions} = this.query,
-            bucketDependentFields = Array.from(this._bucketDependentFields);
+            bucketFields = this._bucketDependentFields;
 
-        if (isEmpty(dimensions) && isEmpty(bucketDependentFields)) return false;
+        if (isEmpty(dimensions) && !bucketFields.size) return false;
 
-        const fieldNames = uniq([...dimensions.map(it => it.name), ...bucketDependentFields]);
         for (const rec of update) {
-            const curRec = this._records.getById(rec.id);
-            if (fieldNames.some(name => rec.data[name] !== curRec.data[name])) return true;
+            const curData = this._records.getById(rec.id).data,
+                {data} = rec;
+            for (const dim of dimensions) {
+                if (data[dim.name] !== curData[dim.name]) return true;
+            }
+            for (const name of bucketFields) {
+                if (data[name] !== curData[name]) return true;
+            }
         }
 
         return false;

--- a/data/cube/aggregate/UniqueAggregator.ts
+++ b/data/cube/aggregate/UniqueAggregator.ts
@@ -12,12 +12,18 @@ export class UniqueAggregator extends Aggregator {
     override aggregate(rows, fieldName) {
         if (isEmpty(rows)) return null;
         const val = rows[0].data[fieldName];
-        return rows.every(it => isEqual(it.data[fieldName], val)) ? val : null;
+        for (const row of rows) {
+            const v = row.data[fieldName];
+            if (v !== val && !isEqual(v, val)) return null;
+        }
+        return val;
     }
 
     override replace(rows, currAgg, update, context) {
         const {newValue, field} = update;
-        if (rows.length === 1 || isEqual(newValue, currAgg)) return newValue;
+        if (rows.length === 1 || newValue === currAgg || isEqual(newValue, currAgg)) {
+            return newValue;
+        }
         return this.aggregate(rows, field.name);
     }
 }

--- a/data/cube/aggregate/UniqueAggregator.ts
+++ b/data/cube/aggregate/UniqueAggregator.ts
@@ -12,18 +12,12 @@ export class UniqueAggregator extends Aggregator {
     override aggregate(rows, fieldName) {
         if (isEmpty(rows)) return null;
         const val = rows[0].data[fieldName];
-        for (const row of rows) {
-            const v = row.data[fieldName];
-            if (v !== val && !isEqual(v, val)) return null;
-        }
-        return val;
+        return rows.every(it => isEqual(it.data[fieldName], val)) ? val : null;
     }
 
     override replace(rows, currAgg, update, context) {
         const {newValue, field} = update;
-        if (rows.length === 1 || newValue === currAgg || isEqual(newValue, currAgg)) {
-            return newValue;
-        }
+        if (rows.length === 1 || isEqual(newValue, currAgg)) return newValue;
         return this.aggregate(rows, field.name);
     }
 }

--- a/data/cube/row/BaseRow.ts
+++ b/data/cube/row/BaseRow.ts
@@ -8,7 +8,7 @@
 import {PlainObject, Some} from '@xh/hoist/core';
 import {ViewRowData} from '@xh/hoist/data/cube/ViewRowData';
 import {shallowEqualObjects} from '@xh/hoist/utils/impl';
-import {compact, isEmpty} from 'lodash';
+import {isArray, isEmpty} from 'lodash';
 import {View} from '../View';
 import type {ParentRow} from './ParentRow';
 
@@ -120,9 +120,17 @@ export abstract class BaseRow {
             if (row.locked) return null;
         }
 
-        // Recurse
-        const ret = compact(children.flatMap(it => it.getVisibleDatas()));
-        return !isEmpty(ret) ? ret : null;
+        // Recurse - single pass, folding in null filtering and flattening.
+        const ret: ViewRowData[] = [];
+        for (const child of children) {
+            const datas = child.getVisibleDatas();
+            if (isArray(datas)) {
+                for (const data of datas) ret.push(data);
+            } else if (datas) {
+                ret.push(datas);
+            }
+        }
+        return ret.length ? ret : null;
     }
 
     // Bucket context applying to this row and its descendants - BucketRow extends with own entry.


### PR DESCRIPTION
Fourth batch in the stack (#4600 → #4602 → #4603 → this) - pure internal reorg in the cube package, no API or behavior changes.

Each change below was benchmarked in isolation (two runs, node 24, shapes sized to a realistic view):

* **View.getField** - **~12x faster** (3M lookups against 25 fields: 274-290ms → 22-24ms). Reads a `Map` built eagerly in `buildIndices()` (renamed from `buildAggFields` - it now builds all per-query field collections together) - was a lodash `{name}` matcher `find` per forced field per row per generation via `recomputeAggregatesForContextChange`. The gap scales with field count, and should widen further on the real path, where mixed row classes make the matcher's property access megamorphic.

* **BaseRow.getChildrenDatas** - **~17% faster** (200k parents x 50 children: 2.62s → 2.18s). Single pass folding null-filtering and flattening into one loop - was `flatMap` + `compact`, i.e. two full arrays and two passes per parent per generation. Material mainly for `includeLeaves`/`provideLeaves` views, where leaves flow through this path.

* **View.hasDimOrBucketUpdates** - **~8% faster** (20k ticks x 200 changed records: 191-200ms → 171-178ms). Iterates dimensions and bucket-dependent fields directly - drops the per-tick `Array.from` + spread + `uniq` array assembly and the per-changed-record closure allocation. The modest wall-clock gain means its real value is the per-tick garbage it stops producing. A field appearing in both lists is now compared twice per record: an accepted nanosecond redundancy (identical short-circuiting test) vs rebuilding a deduped list on every tick. Caching the merged list was rejected - `_bucketDependentFields` rebuilds each generation, so a cache would need its own invalidation story.

A fourth change to `UniqueAggregator` (a `===` short-circuit ahead of `isEqual`, and `for..of` in place of `Array.every`) was **reverted** - benchmarking showed no gain and a small loss. lodash's `baseIsEqual` already opens with `if (value === other) return true`, so the manual guard only saved a call whose body is that same reference test, and `for..of` costs slightly more than the `Array.every` V8 inlines outright. The same measurement rules out converting `MaxAggregator`/`MinAggregator` from `reduce` to `for..of`: V8's escape analysis erases the callback allocation entirely (zero heap delta over 3M calls), and the loop rewrite measured ~13% slower.

Validated in Toolbox: cube-backed tree grid loads with internally-consistent totals (region P&Ls sum exactly to the summary row), expand-all, and regroup to the 5-level Fund›Region›Trader›Sector›Symbol favorite incl. Minor Positions bucket rows. Zero console errors.
