### PR TITLE
Fix columnStateReaction mutating GridModel.columnState in place

### DIFF
--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -533,12 +533,16 @@ export class GridLocalModel extends HoistModel {
             run: ([api, colState]) => {
                 if (!api) return;
 
-                const agColState = api.getColumnState();
+                const agColState = api.getColumnState(),
+                    agColStateMap = new Map(agColState.map(c => [c.colId, c]));
 
-                // Insert the auto group col state if it exists, since we won't have it in our column state list
-                const autoColState = agColState.find(c => c.colId === 'ag-Grid-AutoColumn');
+                // Insert the auto group col state if it exists, since we won't have it in our
+                // column state list. Work on a local copy - the tracked `colState` is the model's
+                // own observable array and must never be mutated in place.
+                const autoColState = agColStateMap.get('ag-Grid-AutoColumn');
                 if (autoColState) {
                     const {colId, width, hide, pinned} = autoColState;
+                    colState = [...colState];
                     colState.splice(agColState.indexOf(autoColState), 0, {
                         colId,
                         width,
@@ -556,9 +560,7 @@ export class GridLocalModel extends HoistModel {
                 // Build a list of column state changes
                 colState = compact(
                     colState.map(({colId, width, hidden, pinned}) => {
-                        const agCol: AgColumnState = agColState.find(c => c.colId === colId) || {
-                                colId
-                            },
+                        const agCol: AgColumnState = agColStateMap.get(colId) || {colId},
                             ret: any = {colId};
 
                         let hasChanges = applyOrder;


### PR DESCRIPTION
Grid's `columnStateReaction` spliced a synthetic `ag-Grid-AutoColumn` entry directly into the model's own `@observable.ref columnState` array on every run for tree/grouped grids - a silent, unnotified in-place mutation of observable state.

Consequences of the phantom entry:

* Threw off `updateColumnState`'s full-leaf-set check (`colStateChanges.length === leafColumnMap.size`), which gates sort-order synchronization.
* Had to be filtered back out by `cleanColumnState` before persistence.
* Shifted any index-based logic over `columnState`.

The reaction now works on a local copy of the array. Also indexes the ag column state into a `Map` up front rather than running a lodash `find` per column.

Standalone fix extracted from the hot-loop perf work (#4600 stack) so it can be reviewed and shipped on its own merits - no overlap with those diffs.