### PR TITLE
Hot-loop performance: grid-layer micro-costs

### DIFF
--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -88,7 +88,6 @@ import {
     defaults,
     defaultsDeep,
     every,
-    find,
     first,
     forEach,
     isArray,
@@ -1573,7 +1572,7 @@ export class GridModel extends HoistModel {
      * current value of any state-tracked property is required.
      */
     getStateForColumn(colId: string): ColumnState {
-        return find(this.columnState, {colId});
+        return this.columnState.find(it => it.colId === colId) ?? null;
     }
 
     /**

--- a/cmp/grid/impl/GridHScrollbar.ts
+++ b/cmp/grid/impl/GridHScrollbar.ts
@@ -75,17 +75,11 @@ class GridHScrollbarModel extends HoistModel {
         );
     }
 
-    private get agViewport(): HTMLDivElement {
-        return this.viewRef.current.querySelector('.ag-center-cols-viewport');
-    }
-
-    private get agHeaderViewport(): HTMLDivElement {
-        return this.viewRef.current.querySelector('.ag-header-viewport');
-    }
-
-    private get agVerticalScrollContainer(): HTMLDivElement {
-        return this.viewRef.current.querySelector('.ag-body-vertical-scroll-container');
-    }
+    // ag-Grid viewport elements, resolved once on link - stable for the life of the grid
+    // instance, and read on the frame-critical scroll path.
+    private agViewport: HTMLDivElement;
+    private agHeaderViewport: HTMLDivElement;
+    private agVerticalScrollContainer: HTMLDivElement;
 
     private get gridModel(): GridModel {
         return this.componentProps.model as GridModel;
@@ -113,16 +107,22 @@ class GridHScrollbarModel extends HoistModel {
         this.addReaction({
             when: () => this.viewRef.current && this.gridModel.isReady,
             run: () => {
-                const {agViewport, viewRef} = this;
-                this.viewWidth = viewRef.current.clientWidth;
-                agViewport.addEventListener('scroll', e => {
+                const {viewRef} = this,
+                    view = viewRef.current;
+                this.agViewport = view.querySelector('.ag-center-cols-viewport');
+                this.agHeaderViewport = view.querySelector('.ag-header-viewport');
+                this.agVerticalScrollContainer = view.querySelector(
+                    '.ag-body-vertical-scroll-container'
+                );
+                this.viewWidth = view.clientWidth;
+                this.agViewport.addEventListener('scroll', e => {
                     const left = (e.target as HTMLDivElement).scrollLeft;
                     this.scrollScroller(left);
                     this.agHeaderViewport.scrollLeft = left;
                 });
                 this.agViewportResizeObserver = observeResize(
                     () => this.onAgViewportResized(),
-                    agViewport,
+                    this.agViewport,
                     {debounce: 100}
                 );
                 this.viewResizeObserver = observeResize(

--- a/cmp/grid/impl/Utils.ts
+++ b/cmp/grid/impl/Utils.ts
@@ -15,9 +15,9 @@ export function managedRenderer<T extends ColumnRenderer | GroupRowRenderer>(
     identifier: string
 ): T {
     if (!isFunction(fn)) return fn;
-    return function () {
+    return function (v, ctx) {
         try {
-            return fn.apply(null, arguments);
+            return (fn as any)(v, ctx);
         } catch (e) {
             logWarn([`Renderer for '${identifier}' has thrown an error`, e]);
             return '#ERROR';

--- a/data/StoreRecord.ts
+++ b/data/StoreRecord.ts
@@ -71,6 +71,7 @@ export class StoreRecord {
     readonly digest: RecordDigest;
 
     private _treePath: StoreRecordId[];
+    private _agId: string;
 
     /**
      * Unique ID for representing record within ag-Grid node API.
@@ -78,7 +79,9 @@ export class StoreRecord {
      * A string variant of the main record ID.  It should be used when trying to identify or
      * locate the record using the ag-Grid callbacks and API.
      */
-    readonly agId: string;
+    get agId(): string {
+        return (this._agId ??= 'ag_' + this.id.toString());
+    }
 
     /**
      * Path to this record within any tree hierarchy, as an array of string record IDs ending
@@ -267,16 +270,14 @@ export class StoreRecord {
             "Record needs an ID. Use 'Store.idSpec' to specify a unique ID for each record."
         );
 
-        const idStr = id.toString();
         this.id = id;
-        this.agId = 'ag_' + idStr;
         this.store = store;
         this.data = data;
         this.raw = raw;
         this.committedData = committedData;
         this.parentId = parent?.id;
         // Root record paths are built lazily by the getter - we may never need for flat data.
-        this._treePath = parent ? [...parent.treePath, idStr] : null;
+        this._treePath = parent ? [...parent.treePath, id.toString()] : null;
         this.digest = digest;
         this.isSummary = isSummary;
 


### PR DESCRIPTION
Fifth batch in the stack (#4600 → #4602 → #4603 → #4604 → this) - pure internal reorg, no API or behavior changes. Deliberately trimmed to three items with real multipliers (a cellClass static-array precompute and a ZoneGridRenderer cleanup were built, then rejected as cheap-regime churn - rationale in the working notes).

* **GridModel.getStateForColumn**: native `find` with a plain predicate - was a lodash `{colId}` matcher allocation per call, called per visible column per transaction via `Grid.syncData` (and from autosize / h-scrollbar paths).
* **GridHScrollbar**: the three ag-Grid viewport elements resolve once on link - was one to two `querySelector` DOM traversals per scroll event, on the frame-critical path.
* **managedRenderer**: fixed two-arg forward - was an `arguments` object + `Function.apply` per render call of every wrapped renderer, including per record × column during autosize sampling. Wrapped renderer types (`ColumnRenderer`, `GroupRowRenderer`) cap at two params, and the fixed signature is easier to reason about than the reflective forward.

Validated in Toolbox: standard grid render/sort, column chooser hide/show round-trip, zone grid rendering. Zero console errors.

Note: the `columnStateReaction` in-place-mutation bug found during this work shipped separately as #4605 against `develop`.