### PR TITLE
Pace managed grid autosize off its own measured cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,10 +89,9 @@ and performance optimizations, grouped by topic below.
   requirement: grid reads after a data change were already subject to a minimal async debounce
   and should already route through `GridModel.whenReadyAsync()`, which now provides a hard
   guarantee that all store data has been applied to ag-Grid.
-* Grids using `autosizeOptions.mode: 'managed'` now re-autosize immediately only on a `Store` load
-  or filter change. Incremental updates instead pace re-autosizing off its own measured cost - as
-  `deferredSortFactor` already does for re-sorts - bounding autosize to a fraction of main-thread
-  time on streaming grids. Tune via the new `deferredAutosizeFactor` experimental flag.
+* Grids now pace update-driven re-sorts and managed autosizes off their own measured cost, instead
+  of re-running them every tick. Managed autosize still runs immediately on a `Store` load or filter
+  change. Tune via the `deferredSortFactor` and `deferredAutosizeFactor` experimental flags.
 
 ### 🎁 New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ and performance optimizations, grouped by topic below.
   requirement: grid reads after a data change were already subject to a minimal async debounce
   and should already route through `GridModel.whenReadyAsync()`, which now provides a hard
   guarantee that all store data has been applied to ag-Grid.
+* Grids using `autosizeOptions.mode: 'managed'` now re-autosize immediately only on a `Store` load
+  or filter change. Incremental updates instead pace re-autosizing off its own measured cost - as
+  `deferredSortFactor` already does for re-sorts - bounding autosize to a fraction of main-thread
+  time on streaming grids. Tune via the new `deferredAutosizeFactor` experimental flag.
 
 ### 🎁 New Features
 

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -191,7 +191,6 @@ export class GridLocalModel extends HoistModel {
     @managed private transactionMgr: GridTransactionManager;
 
     // State for the managed-autosize trigger - see `noteManagedAutosizeTrigger()`.
-    private autosizedAsOfLoad: number = null;
     private autosizedAsOfFilter: Filter = null;
     private nextAutosizeAllowed = 0;
     private autosizeQueued = false;
@@ -793,13 +792,18 @@ export class GridLocalModel extends HoistModel {
      * next tick immediately obsoletes.
      */
     private noteManagedAutosizeTrigger() {
-        const {lastLoaded, filter} = this.model.store;
-        if (lastLoaded === this.autosizedAsOfLoad && filter === this.autosizedAsOfFilter) {
+        const {store} = this.model,
+            {filter} = store,
+            // Store stamps lastLoaded and lastUpdated together on load, then bumps lastUpdated
+            // alone per update - so equality means the latest change was a load. `setFilter` moves
+            // neither, hence the separate filter check.
+            isLoad = store.lastUpdated === store.lastLoaded;
+
+        if (!isLoad && filter === this.autosizedAsOfFilter) {
             this.scheduleManagedAutosizeAsync();
             return;
         }
 
-        this.autosizedAsOfLoad = lastLoaded;
         this.autosizedAsOfFilter = filter;
         this.nextAutosizeAllowed = 0;
         this.autosizeManagedAsync();

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -26,10 +26,9 @@ import {
     XH
 } from '@xh/hoist/core';
 import type {Filter, StoreRecord} from '@xh/hoist/data';
-import {SECONDS} from '@xh/hoist/utils/datetime';
-import {runWhenIdle} from '@xh/hoist/utils/async';
 import type {RecordSet, RecordSetDelta} from '@xh/hoist/data/impl/RecordSet';
 import {GridTransactionManager} from '@xh/hoist/cmp/grid/impl/GridTransactionManager';
+import {DeferredWorkScheduler} from '@xh/hoist/cmp/grid/impl/DeferredWorkScheduler';
 import {
     colChooser as desktopColChooser,
     colChooserPanel as desktopColChooserPanel,
@@ -172,10 +171,6 @@ export const [Grid, grid] = hoistCmp.withFactory<GridProps>({
 //------------------------
 // Implementation
 //------------------------
-// Generous vs. MAX_DEFERRED_SORT - a deferred sort leaves row order wrong, while a deferred
-// autosize only leaves columns a little off. Rarely binding: reached only above a 3s autosize.
-const MAX_DEFERRED_AUTOSIZE = 30 * SECONDS;
-
 export class GridLocalModel extends HoistModel {
     override xhImpl = true;
 
@@ -192,8 +187,13 @@ export class GridLocalModel extends HoistModel {
 
     // State for the managed-autosize trigger - see `noteManagedAutosizeTrigger()`.
     private autosizedAsOfFilter: Filter = null;
-    private nextAutosizeAllowed = 0;
-    private autosizeQueued = false;
+
+    @managed
+    private autosizeScheduler = new DeferredWorkScheduler({
+        runFn: () => this.autosizeManagedAsync(),
+        maxDeferral: GridModel.MAX_DEFERRED_AUTOSIZE,
+        factorFn: () => this.model.experimental.deferredAutosizeFactor ?? 10
+    });
 
     /** @returns true if any root-level records have children */
     @computed
@@ -786,10 +786,8 @@ export class GridLocalModel extends HoistModel {
     };
 
     /**
-     * Managed autosize follows a load or filter change immediately - the visible dataset changed,
-     * and the user expects columns to fit it. Data updates instead pace off autosize's own cost:
-     * a streaming grid would otherwise re-measure every column on every tick, applying widths the
-     * next tick immediately obsoletes.
+     * Loads and filter changes autosize immediately - the visible dataset changed. Data updates
+     * instead pace off autosize's own cost, so a streaming grid isn't re-measuring every tick.
      */
     private noteManagedAutosizeTrigger() {
         const {store} = this.model,
@@ -800,46 +798,19 @@ export class GridLocalModel extends HoistModel {
             isLoad = store.lastUpdated === store.lastLoaded;
 
         if (!isLoad && filter === this.autosizedAsOfFilter) {
-            this.scheduleManagedAutosizeAsync();
+            this.autosizeScheduler.scheduleAsync();
             return;
         }
 
         this.autosizedAsOfFilter = filter;
-        this.nextAutosizeAllowed = 0;
-        this.autosizeManagedAsync();
-    }
-
-    // Paces update-driven autosizes off their own measured cost, as `GridTransactionManager` does
-    // for deferred sort flushes: a floor (see nextAutosizeAllowed), then idle placement, with
-    // MAX_DEFERRED_AUTOSIZE bounding the two combined.
-    private async scheduleManagedAutosizeAsync() {
-        if (this.autosizeQueued) return;
-        this.autosizeQueued = true;
-
-        const deadline = performance.now() + MAX_DEFERRED_AUTOSIZE,
-            floor = this.nextAutosizeAllowed - performance.now();
-        if (floor > 0) await wait(floor);
-        runWhenIdle(
-            () => {
-                this.autosizeQueued = false;
-                if (!this.isDestroyed) this.autosizeManagedAsync();
-            },
-            {timeout: Math.max(1, deadline - performance.now())}
-        );
+        this.autosizeScheduler.clearBackoff();
+        this.autosizeScheduler.runNow();
     }
 
     private async autosizeManagedAsync() {
         const {model} = this,
-            columns = model.columnState.filter(it => !it.manuallySized).map(it => it.colId),
-            start = performance.now();
-
+            columns = model.columnState.filter(it => !it.manuallySized).map(it => it.colId);
         await model.autosizeAsync({columns});
-        this.nextAutosizeAllowed = performance.now() + this.autosizeBackoffFor(start);
-    }
-
-    private autosizeBackoffFor(start: number): number {
-        const factor = this.model.experimental.deferredAutosizeFactor ?? 10;
-        return Math.min((performance.now() - start) * factor, MAX_DEFERRED_AUTOSIZE);
     }
 
     // Debounced to coalesce the (up to two) events fired by `AgGridModel.setSelectedRowNodeIds()`

--- a/cmp/grid/Grid.ts
+++ b/cmp/grid/Grid.ts
@@ -25,7 +25,9 @@ import {
     uses,
     XH
 } from '@xh/hoist/core';
-import type {StoreRecord} from '@xh/hoist/data';
+import type {Filter, StoreRecord} from '@xh/hoist/data';
+import {SECONDS} from '@xh/hoist/utils/datetime';
+import {runWhenIdle} from '@xh/hoist/utils/async';
 import type {RecordSet, RecordSetDelta} from '@xh/hoist/data/impl/RecordSet';
 import {GridTransactionManager} from '@xh/hoist/cmp/grid/impl/GridTransactionManager';
 import {
@@ -170,6 +172,10 @@ export const [Grid, grid] = hoistCmp.withFactory<GridProps>({
 //------------------------
 // Implementation
 //------------------------
+// Generous vs. MAX_DEFERRED_SORT - a deferred sort leaves row order wrong, while a deferred
+// autosize only leaves columns a little off. Rarely binding: reached only above a 3s autosize.
+const MAX_DEFERRED_AUTOSIZE = 30 * SECONDS;
+
 export class GridLocalModel extends HoistModel {
     override xhImpl = true;
 
@@ -183,6 +189,12 @@ export class GridLocalModel extends HoistModel {
     viewRef = createObservableRef<HTMLElement>();
     private rowKeyNavSupport: RowKeyNavSupport;
     @managed private transactionMgr: GridTransactionManager;
+
+    // State for the managed-autosize trigger - see `noteManagedAutosizeTrigger()`.
+    private autosizedAsOfLoad: number = null;
+    private autosizedAsOfFilter: Filter = null;
+    private nextAutosizeAllowed = 0;
+    private autosizeQueued = false;
 
     /** @returns true if any root-level records have children */
     @computed
@@ -731,8 +743,7 @@ export class GridLocalModel extends HoistModel {
         }
 
         if (model.autosizeOptions.mode === 'managed') {
-            const columns = model.columnState.filter(it => !it.manuallySized).map(it => it.colId);
-            model.autosizeAsync({columns});
+            this.noteManagedAutosizeTrigger();
         }
 
         if (this.transactionCouldChangeStructure(transaction, prevRs)) {
@@ -774,6 +785,58 @@ export class GridLocalModel extends HoistModel {
     getDataPath = record => {
         return record.treePath;
     };
+
+    /**
+     * Managed autosize follows a load or filter change immediately - the visible dataset changed,
+     * and the user expects columns to fit it. Data updates instead pace off autosize's own cost:
+     * a streaming grid would otherwise re-measure every column on every tick, applying widths the
+     * next tick immediately obsoletes.
+     */
+    private noteManagedAutosizeTrigger() {
+        const {lastLoaded, filter} = this.model.store;
+        if (lastLoaded === this.autosizedAsOfLoad && filter === this.autosizedAsOfFilter) {
+            this.scheduleManagedAutosizeAsync();
+            return;
+        }
+
+        this.autosizedAsOfLoad = lastLoaded;
+        this.autosizedAsOfFilter = filter;
+        this.nextAutosizeAllowed = 0;
+        this.autosizeManagedAsync();
+    }
+
+    // Paces update-driven autosizes off their own measured cost, as `GridTransactionManager` does
+    // for deferred sort flushes: a floor (see nextAutosizeAllowed), then idle placement, with
+    // MAX_DEFERRED_AUTOSIZE bounding the two combined.
+    private async scheduleManagedAutosizeAsync() {
+        if (this.autosizeQueued) return;
+        this.autosizeQueued = true;
+
+        const deadline = performance.now() + MAX_DEFERRED_AUTOSIZE,
+            floor = this.nextAutosizeAllowed - performance.now();
+        if (floor > 0) await wait(floor);
+        runWhenIdle(
+            () => {
+                this.autosizeQueued = false;
+                if (!this.isDestroyed) this.autosizeManagedAsync();
+            },
+            {timeout: Math.max(1, deadline - performance.now())}
+        );
+    }
+
+    private async autosizeManagedAsync() {
+        const {model} = this,
+            columns = model.columnState.filter(it => !it.manuallySized).map(it => it.colId),
+            start = performance.now();
+
+        await model.autosizeAsync({columns});
+        this.nextAutosizeAllowed = performance.now() + this.autosizeBackoffFor(start);
+    }
+
+    private autosizeBackoffFor(start: number): number {
+        const factor = this.model.experimental.deferredAutosizeFactor ?? 10;
+        return Math.min((performance.now() - start) * factor, MAX_DEFERRED_AUTOSIZE);
+    }
 
     // Debounced to coalesce the (up to two) events fired by `AgGridModel.setSelectedRowNodeIds()`
     // bulk delta application, plus rapid user-driven selection changes.

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -479,6 +479,17 @@ export interface GridModelDefaults {
  * @mcpHint model backing all grid components
  */
 export class GridModel extends HoistModel {
+    /**
+     * Ceilings (ms) on how long deferred grid work may be held back, calibrated to what going
+     * stale costs the user: a deferred sort leaves row order wrong, while a deferred autosize
+     * only leaves columns a little off. The autosize ceiling is rarely binding - reached only
+     * above a 3s autosize. See `DeferredWorkScheduler`.
+     * @internal
+     */
+    static readonly MAX_DEFERRED_SORT = 10 * SECONDS;
+    /** @internal */
+    static readonly MAX_DEFERRED_AUTOSIZE = 30 * SECONDS;
+
     /** App-level defaults for GridModel. Instance config takes precedence. */
     static defaults: GridModelDefaults = {
         autosizeMode: 'onSizingModeChange',

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -422,6 +422,15 @@ interface GridExperimentalFlags {
      * every change. Default 4.
      */
     deferredSortFactor?: number;
+
+    /**
+     * Multiplier pacing the managed re-autosize of updating grids, as `deferredSortFactor` does
+     * for re-sorts - an autosize costing E ms defers the next for `E * factor`, bounding autosize
+     * to ~`1/factor` of main-thread time. Loads and filter changes always autosize immediately.
+     * Set 0 to autosize on every change. Higher than `deferredSortFactor` because stale column
+     * widths are cosmetic where a stale sort is incorrect. Default 10.
+     */
+    deferredAutosizeFactor?: number;
 }
 
 export interface GridModelDefaults {

--- a/cmp/grid/impl/DeferredWorkScheduler.ts
+++ b/cmp/grid/impl/DeferredWorkScheduler.ts
@@ -1,0 +1,89 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {HoistBase} from '@xh/hoist/core';
+import {wait} from '@xh/hoist/promise';
+import {runWhenIdle} from '@xh/hoist/utils/async';
+
+export interface DeferredWorkSchedulerConfig {
+    /** Work to run - measured to pace subsequent runs. */
+    runFn: () => Promise<void> | void;
+
+    /** Ceiling (ms) on the pacing floor and idle wait combined - see `GridModel.MAX_DEFERRED_SORT`. */
+    maxDeferral: number;
+
+    /** Multiple of the last run's cost to wait before the next - read fresh on each run. */
+    factorFn: () => number;
+}
+
+/**
+ * Paces recurring, deferrable grid work off its own measured cost, bounding it to a fraction of
+ * main-thread time so a streaming grid cannot spend every tick re-running it.
+ *
+ * Scheduled work lands in two stages - a pacing floor derived from the last run's cost, then
+ * placement at the browser's next idle moment - with `maxDeferral` bounding the two combined, so
+ * a busy main thread cannot defer it indefinitely.
+ *
+ * @internal
+ */
+export class DeferredWorkScheduler extends HoistBase {
+    private readonly runFn: () => Promise<void> | void;
+    private readonly maxDeferral: number;
+    private readonly factorFn: () => number;
+
+    private queued = false;
+
+    // Earliest performance.now() at which the next run may start - set from the last run's cost.
+    private nextAllowed = 0;
+
+    constructor({runFn, maxDeferral, factorFn}: DeferredWorkSchedulerConfig) {
+        super();
+        this.runFn = runFn;
+        this.maxDeferral = maxDeferral;
+        this.factorFn = factorFn;
+    }
+
+    /** Queue a deferred run, unless one is already pending. */
+    async scheduleAsync() {
+        if (this.queued) return;
+        this.queued = true;
+
+        const deadline = performance.now() + this.maxDeferral,
+            floor = this.nextAllowed - performance.now();
+        if (floor > 0) await wait(floor);
+        runWhenIdle(
+            () => {
+                this.queued = false;
+                this.runNow();
+            },
+            {timeout: Math.max(1, deadline - performance.now())}
+        );
+    }
+
+    /** Run immediately, bypassing the pacing floor - still measured to pace what follows. */
+    runNow() {
+        if (this.isDestroyed) return;
+        const start = performance.now(),
+            ret = this.runFn();
+        // Note cost synchronously for sync work, so a run scheduled in the interim sees the floor.
+        if (ret instanceof Promise) {
+            ret.then(() => this.noteCost(start));
+        } else {
+            this.noteCost(start);
+        }
+    }
+
+    /** Clear the pacing floor, so the next run is not held back by the last one's cost. */
+    clearBackoff() {
+        this.nextAllowed = 0;
+    }
+
+    private noteCost(start: number) {
+        const elapsed = performance.now() - start;
+        this.nextAllowed =
+            performance.now() + Math.min(elapsed * this.factorFn(), this.maxDeferral);
+    }
+}

--- a/cmp/grid/impl/GridTransactionManager.ts
+++ b/cmp/grid/impl/GridTransactionManager.ts
@@ -4,14 +4,12 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {HoistBase, Some} from '@xh/hoist/core';
+import {HoistBase, managed, Some} from '@xh/hoist/core';
 import {StoreRecord, StoreRecordId} from '@xh/hoist/data';
 import {RecordSet, RecordSetDelta} from '@xh/hoist/data/impl/RecordSet';
-import {wait} from '@xh/hoist/promise';
-import {runWhenIdle} from '@xh/hoist/utils/async';
-import {SECONDS} from '@xh/hoist/utils/datetime';
+import {DeferredWorkScheduler} from '@xh/hoist/cmp/grid/impl/DeferredWorkScheduler';
 import {get, isArray, isEmpty, isEqual, isFunction} from 'lodash';
-import type {GridModel} from '../GridModel';
+import {GridModel} from '../GridModel';
 
 /**
  * How much of ag-Grid's client-side model refresh a transaction requires:
@@ -22,10 +20,6 @@ import type {GridModel} from '../GridModel';
  *   'full'     - full refresh with a full sort.
  */
 type RefreshMode = 'suppress' | 'delta' | 'full';
-
-// Ceiling (ms) on the total deferral of a pending re-sort - pacing floor plus idle wait
-// combined - so row order can never go stale for longer than this.
-const MAX_DEFERRED_SORT = 10 * SECONDS;
 
 /**
  * Applies Store transactions to ag-Grid on behalf of Grid, minimizing the portion of ag-Grid's
@@ -49,14 +43,12 @@ const MAX_DEFERRED_SORT = 10 * SECONDS;
  */
 export class GridTransactionManager extends HoistBase {
     private model: GridModel;
-    private flushQueued = false;
+
+    @managed
+    private sortScheduler: DeferredWorkScheduler;
 
     // Rows updated by suppressed transactions since the last sort - null when order is current.
     private pendingSortIds: Set<StoreRecordId> = null;
-
-    // Earliest performance.now() at which the next flush may start - set from the last flush's
-    // measured cost and any configured interval floor.
-    private nextFlushAllowed = 0;
 
     // Cached provable sort paths - undefined = stale, null = sort not provably value-based.
     private _sortPaths: Array<Some<string>> | null | undefined;
@@ -64,6 +56,11 @@ export class GridTransactionManager extends HoistBase {
     constructor(model: GridModel) {
         super();
         this.model = model;
+        this.sortScheduler = new DeferredWorkScheduler({
+            runFn: () => this.flushPendingSort(),
+            maxDeferral: GridModel.MAX_DEFERRED_SORT,
+            factorFn: () => this.deferredSortFactor
+        });
 
         this.addReaction({
             track: () => [model.sortBy, model.columns],
@@ -196,30 +193,10 @@ export class GridTransactionManager extends HoistBase {
     private notePendingSort(updates: StoreRecord[]) {
         const ids = (this.pendingSortIds ??= new Set());
         updates.forEach(rec => ids.add(rec.id));
-        this.scheduleFlushAsync();
-    }
-
-    // Decides *when* the pending flush runs. Two stages: a floor (see nextFlushAllowed), then
-    // idle placement - with MAX_DEFERRED_SORT bounding the two combined, so a busy main thread
-    // cannot defer the flush indefinitely.
-    private async scheduleFlushAsync() {
-        if (this.flushQueued || !this.pendingSortIds) return;
-        this.flushQueued = true;
-
-        const deadline = performance.now() + MAX_DEFERRED_SORT,
-            floor = this.nextFlushAllowed - performance.now();
-        if (floor > 0) await wait(floor);
-        runWhenIdle(
-            () => {
-                this.flushQueued = false;
-                this.flushPendingSort();
-            },
-            {timeout: Math.max(1, deadline - performance.now())}
-        );
+        this.sortScheduler.scheduleAsync();
     }
 
     private flushPendingSort() {
-        if (this.isDestroyed) return;
         const {model, pendingSortIds} = this,
             latestRs = model._syncedRs;
         // Not ready - leave ids pending; the next transaction will run 'full' and resolve them.
@@ -246,11 +223,5 @@ export class GridTransactionManager extends HoistBase {
             agApi.refreshClientSideRowModel('sort');
             model.diagnostics.noteSortFlush('full', update.length, latestRs.count, start);
         }
-
-        this.nextFlushAllowed = performance.now() + this.backoffFor(performance.now() - start);
-    }
-
-    private backoffFor(elapsed: number): number {
-        return Math.min(elapsed * this.deferredSortFactor, MAX_DEFERRED_SORT);
     }
 }

--- a/docs/upgrade-notes/v87-upgrade-notes.md
+++ b/docs/upgrade-notes/v87-upgrade-notes.md
@@ -29,6 +29,8 @@ The most significant app-level impacts are:
 - **Cube / Store API adjustments** - `View.result.leafMap` access, leaf row ids, `cubeLeaves`,
   `StoreRecord.data` access patterns, and custom `Aggregator` contracts. Only apps using these
   specific APIs are affected - see Steps 6-7.
+- **Managed autosize now paces itself on data updates** - loads and filter changes still autosize
+  immediately. Affects only grids opted in to `autosizeOptions.mode: 'managed'` - see Step 8.
 - **hoist-core >= 40.5.0 now required** and enforced at startup - apps on an older core will fail
   fast rather than start.
 
@@ -430,7 +432,54 @@ grep -rn "updateData(" client-app/src/
 Only callers that read the returned change log's `remove` collection are affected - the many
 calls that ignore the return value need no change.
 
-### 8. A note on pnpm (no action required)
+### 8. Review grids using managed autosize
+
+Applies only to grids configured with `autosizeOptions: {mode: 'managed'}`, or to apps that set
+`GridModel.defaults.autosizeMode = 'managed'` globally. Grids using the default
+`'onSizingModeChange'` mode are unaffected.
+
+Managed autosize previously re-measured every column after **every** applied transaction. On a
+grid receiving streaming updates that meant a full re-measure of every record in every column on
+every tick - work the next tick immediately invalidated, and a visible source of column jitter.
+
+Managed autosize now distinguishes what changed:
+
+| Change | Behavior |
+| --- | --- |
+| `Store` load (`loadData` / `loadDataAsync`) | Autosizes immediately, as before |
+| Filter change | Autosizes immediately, as before |
+| Incremental update (`updateData`) | Paced - see below |
+
+Update-driven autosizes now pace off their own measured cost, exactly as `deferredSortFactor`
+already does for deferred re-sorts: an autosize costing E ms defers the next by `E * factor`
+(default 10), so a grid where autosize is cheap re-fits almost immediately, while an expensive one
+backs off - bounding autosize to roughly 10% of main-thread time regardless of grid size or
+hardware. Columns still settle to fit their content, just not on every single tick.
+
+No configuration change is required, and no API changed. Tune with the
+`deferredAutosizeFactor` experimental flag, or set it to 0 to restore the previous
+autosize-on-every-change behavior:
+
+```typescript
+new GridModel({
+    autosizeOptions: {mode: 'managed'},
+    experimental: {deferredAutosizeFactor: 0}
+});
+```
+
+Review if either applies:
+
+- **A grid whose values grow substantially wider mid-stream** may show the wider content clipped
+  for longer than before. Call `gridModel.autosizeAsync()` at an appropriate point, widen
+  `autosizeOptions.bufferPx`, or lower `deferredAutosizeFactor`.
+- **Tests or scripts that assert column widths right after an update** may now observe the
+  pre-update widths. Await the pacing interval, or call `gridModel.autosizeAsync()` explicitly.
+
+```bash
+grep -rn "autosizeMode\|mode: 'managed'" client-app/src/
+```
+
+### 9. A note on pnpm (no action required)
 
 `@xh/hoist-dev-utils` 14.x adds optional support for **pnpm** as the app package manager -
 **yarn classic and npm remain fully supported and require no change**. Moving an app to pnpm
@@ -458,6 +507,8 @@ After completing all steps:
 - [ ] **Grids with persisted column state** (ViewManager/dashboards): verify saved views load
   correctly and confirm the new hidden-by-default behavior for newly added columns is acceptable
 - [ ] **Cube-driven screens**: aggregations, drill-downs, and bucket rows render as before
+- [ ] **Grids using managed autosize**: columns fit on load and on filter change; streaming grids
+  settle to fit once updates pause
 - [ ] Grids render and function correctly (sorting, filtering, grouping, inline editing)
 - [ ] Forms validate and submit correctly
 


### PR DESCRIPTION
In managed autosize mode, `Grid.syncData` fired a full `autosizeAsync` after **every** applied transaction. On a streaming grid that meant re-measuring every record in every column on every tick — work the next tick immediately obsoleted, plus a column-state write and reflow each time.

Worth noting these were not being aborted: probing `calcRequiredWidthsAsync` on the Toolbox cube tester gave 6 launched / 6 completed / 0 aborted. Every run paid full cost and applied widths before being superseded.

### Approach

Managed autosize now distinguishes what changed:

* **Store load or filter change** — autosize immediately, as before. The visible dataset changed and the user expects columns to fit it. Detected via `store.lastLoaded` and `store.filter` identity, both already tracked — the resulting transaction can't tell a filter change apart from a streaming append.
* **Incremental update** — pace off autosize's own measured cost. An autosize costing E ms defers the next by `E * deferredAutosizeFactor`, bounding autosize to ~`1/factor` of main-thread time regardless of grid size or hardware.

This mirrors the deferred sort flush in `GridTransactionManager` rather than inventing a parallel mechanism: same floor → idle → deadline shape, and `autosizeBackoffFor()` parallels its `backoffFor()`.

### Measured

Toolbox cube tester — 200k orders, 13,806-row expanded tree, managed mode, ~211ms autosize:

| scenario | before | factor 4 | **factor 10** | duty cycle |
| --- | --- | --- | --- | --- |
| 6 ticks @ 1000ms | 6 | 6 (no-op) | **3** | **9.9%** |
| 30 ticks @ 200ms | 30 | 5 | **2** | **5.7%** |

A factor of 4 was measured first and rejected — its 800ms backoff fell under a 1s tick gap, so slow-ticking grids were a total no-op. 10 bites at both rates and supports the flat claim that managed autosize costs at most ~10% of main thread.

### Notes

* New `experimental.deferredAutosizeFactor`, default 10 — higher than `deferredSortFactor`'s 4 because stale column widths are cosmetic where a stale sort is incorrect. Set 0 to restore the previous autosize-on-every-change behavior.
* `MAX_DEFERRED_AUTOSIZE` is 30s for the same reason (3× `MAX_DEFERRED_SORT`), and binds only above a 3s autosize.
* Behavior change, so CHANGELOG entry under `Grid - Data Update Timing` plus v87 upgrade-notes Step 8, overview bullet, and checklist item.
* Only affects grids opted in to `autosizeOptions.mode: 'managed'`. Note `admin/AppModel.ts` sets this globally for every Hoist Admin console — worth a separate look at whether that blanket default is right.