### PR TITLE
Adds a CSS override for coloring disabled select options (makes them more distinct in dark mode)

### DIFF
--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -174,6 +174,10 @@
         padding: var(--xh-pad-px);
       }
 
+      &--is-disabled {
+        color: var(--xh-input-disabled-text-color);
+      }
+
       &--is-selected {
         // Suppress default highlighting - checkmark indicate selection.
         color: var(--xh-text-color);

--- a/mobile/cmp/input/Select.scss
+++ b/mobile/cmp/input/Select.scss
@@ -83,6 +83,10 @@
         padding: var(--xh-pad-px);
       }
 
+      &--is-disabled {
+        color: var(--xh-input-disabled-text-color);
+      }
+
       &--is-selected {
         // Suppress default highlighting - checkmark indicate selection.
         color: var(--xh-text-color);


### PR DESCRIPTION
This came up in a client project, where I wanted a full list of possible options, but to disable any not available at the moment.

In light mode it looked ok, but in dark mode the disabled options were not distinct enough from enabled ones.

Original disabled look:
<img width="474" height="293" alt="Screenshot 2026-08-25 at 2 52 15 PM" src="https://github.com/user-attachments/assets/df3e5460-917b-4e53-b5eb-6fc5d95d76c8" />

Updated from this branch:
<img width="476" height="302" alt="Screenshot 2026-08-25 at 2 50 42 PM" src="https://github.com/user-attachments/assets/5626b026-ac1d-4192-bf05-3bb090e39087" />
<img width="444" height="271" alt="Screenshot 2026-08-25 at 2 50 47 PM" src="https://github.com/user-attachments/assets/d99e376c-54aa-428a-9d39-c790f078d93a" />

