### PR TITLE
Upgrade react-dropzone 15 -> 20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@
 
 ## 88.0.0-SNAPSHOT - unreleased
 
+### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW - one behavior change to `FileChooser`)
+
+* `FileChooser` now accepts as many dropped files as its `maxFiles` limit allows, rejecting only
+  the surplus. Previously a drop that would exceed the limit was discarded in full. Apps relying on
+  the all-or-nothing behavior should check `onFileAccepted` - it now reports only the files actually
+  added.
+
+### ⚙️ Technical
+
+* Upgraded `react-dropzone` to v20, which drops its UMD build and ships as an ESM + CJS package with
+  an `exports` map. Requires Node >= 22 to install.
+
+### 📚 Libraries
+
+* react-dropzone `15.0 → 20.1`
+
 ## 87.0.0 - 2026-08-25
 
 ### 💥 Breaking Changes (upgrade difficulty: 🟠 MEDIUM - React 19, data layer, column chooser)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,10 @@
 
 ## 88.0.0-SNAPSHOT - unreleased
 
-### 💥 Breaking Changes (upgrade difficulty: 🟢 LOW - one behavior change to `FileChooser`)
+### 🎁 New Features
 
-* `FileChooser` now accepts as many dropped files as its `maxFiles` limit allows, rejecting only
-  the surplus. Previously a drop that would exceed the limit was discarded in full. Apps relying on
-  the all-or-nothing behavior should check `onFileAccepted` - it now reports only the files actually
-  added.
+* `FileChooser` now takes as many dropped files as its `maxFiles` limit allows, warning about only
+  the surplus rather than discarding the entire drop.
 
 ### ⚙️ Technical
 

--- a/desktop/cmp/filechooser/FileChooserModel.ts
+++ b/desktop/cmp/filechooser/FileChooserModel.ts
@@ -11,7 +11,18 @@ import {ErrorCode, FileRejection} from '@xh/hoist/kit/react-dropzone';
 import {action, makeObservable, observable} from '@xh/hoist/mobx';
 import {pluralize, withDefault} from '@xh/hoist/utils/js';
 import {createObservableRef} from '@xh/hoist/utils/react';
-import {castArray, concat, filter, isEmpty, keys, fromPairs, map, sortBy, uniqBy} from 'lodash';
+import {
+    castArray,
+    differenceBy,
+    filter,
+    isEmpty,
+    keys,
+    fromPairs,
+    map,
+    sortBy,
+    take,
+    uniqBy
+} from 'lodash';
 import {ReactElement, ReactNode} from 'react';
 import {DropzoneRef} from 'react-dropzone';
 
@@ -120,10 +131,10 @@ export class FileChooserModel extends HoistModel {
     }
 
     /**
-     * Add files to the selection.
+     * Add files to the selection, taking as many as the `maxFiles` limit allows.
      *
-     * Respects the `maxFiles` limit but does NOT enforce the `accept` / file-size constraints
-     * (those are applied only on drop/browse) - use with care.
+     * Does NOT enforce the `accept` / file-size constraints (those are applied only on
+     * drop/browse) - use with care.
      */
     addFiles(files: Some<File>) {
         this.addFilesInternal(files);
@@ -158,33 +169,36 @@ export class FileChooserModel extends HoistModel {
             // In single-file mode, replace the current selection with the incoming file.
             if (maxFiles === 1 && accepted.length === 1) this.clear();
 
-            if (this.addFilesInternal(accepted)) {
-                this.onFileAccepted?.(accepted);
-            }
+            const added = this.addFilesInternal(accepted);
+            if (!isEmpty(added)) this.onFileAccepted?.(added);
         }
     }
 
     //------------------------
     // Implementation
     //------------------------
-    // De-dupe by name, then enforce `maxFiles` on the result. Warns and no-ops if exceeded;
-    // returns true if the selection was updated.
+    // Add incoming files, replacing any same-named file already selected and taking the rest up to
+    // the `maxFiles` limit. Warns on any surplus. Returns the files actually added.
     @action
-    private addFilesInternal(files: Some<File>): boolean {
+    private addFilesInternal(files: Some<File>): File[] {
         const {maxFiles} = this,
-            deduped = uniqBy(concat(files, this.files), 'name');
+            incoming = uniqBy(castArray(files), 'name'),
+            // Existing files the incoming batch does not replace - always retained.
+            retained = differenceBy(this.files, incoming, 'name'),
+            capacity = maxFiles != null ? Math.max(maxFiles - retained.length, 0) : incoming.length,
+            added = take(incoming, capacity),
+            surplus = incoming.length - added.length;
 
-        if (maxFiles != null && deduped.length > maxFiles) {
+        if (surplus) {
             XH.warningToast(
                 maxFiles === 1
                     ? 'Only one file allowed for upload.'
-                    : `File limit of ${maxFiles} exceeded.`
+                    : `File limit of ${maxFiles} reached - ${surplus} ${pluralize('file', surplus)} not added.`
             );
-            return false;
         }
 
-        this.files = deduped;
-        return true;
+        if (!isEmpty(added)) this.files = [...added, ...retained];
+        return added;
     }
 
     private defaultRejectMessage = (rejections: FileRejection[]): ReactElement => {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "onsenui": "~2.12.9",
     "qs": "^6.15.3",
     "react-day-picker": "^9.14.0",
-    "react-dropzone": "~15.0.0",
+    "react-dropzone": "~20.1.1",
     "react-grid-layout": "~2.2.4",
     "react-markdown": "~10.1.0",
     "react-onsenui": "~1.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: ^9.14.0
         version: 9.14.0(react@19.2.8)
       react-dropzone:
-        specifier: ~15.0.0
-        version: 15.0.0(react@19.2.8)
+        specifier: ~20.1.1
+        version: 20.1.1(@types/react@19.2.18)(react@19.2.8)
       react-grid-layout:
         specifier: ~2.2.4
         version: 2.2.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -2175,9 +2175,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
-  attr-accept@2.2.5:
-    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
-    engines: {node: '>=4'}
+  attr-accept@4.0.0:
+    resolution: {integrity: sha512-hmCnJClmeKNKlsBHgbM8yLZRiQZ4/20UXbLJb6OUT16eWcM5/xNZerr80a/zCYob768KIGq++aLrQNTuwPsIOQ==}
+    engines: {node: '>= 22'}
 
   autoprefixer@10.5.4:
     resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
@@ -2931,9 +2931,9 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
-  file-selector@2.1.2:
-    resolution: {integrity: sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==}
-    engines: {node: '>= 12'}
+  file-selector@5.0.1:
+    resolution: {integrity: sha512-v0g/PTeuQgvKCBrVRsfVudvwXlRHSWHEQkVgKawgCGHkEpKA1clp3Om5jvEVhz8G9W/mOYjJH9FhkH4C888PgQ==}
+    engines: {node: '>= 22'}
 
   filesize@11.0.22:
     resolution: {integrity: sha512-RlCVs9CY+oSsRnNZn95J9vDXjNjOwddKyTFjOYtA4yxYVIxBnwiVVGJX+TFhsmu3uUf81JDGyijtYL9xgawlTw==}
@@ -4063,10 +4063,6 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.5:
-    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.7:
     resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
     engines: {node: '>=12'}
@@ -4243,11 +4239,15 @@ packages:
       react: '>= 16.3.0'
       react-dom: '>= 16.3.0'
 
-  react-dropzone@15.0.0:
-    resolution: {integrity: sha512-lGjYV/EoqEjEWPnmiSvH4v5IoIAwQM2W4Z1C0Q/Pw2xD0eVzKPS359BQTUMum+1fa0kH2nrKjuavmTPOGhpLPg==}
-    engines: {node: '>= 10.13'}
+  react-dropzone@20.1.1:
+    resolution: {integrity: sha512-2cilRFP8bsjDOHpV0sJ6XY8pzJhmz4/cQ6s9yeckOACWYDR+n4MGGtnJh3Rycq/9SLhDWugqDx1z5mtfmOOZhw==}
+    engines: {node: '>= 22'}
     peerDependencies:
-      react: '>= 16.8 || 18.0.0'
+      '@types/react': '*'
+      react: '>= 18'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -7141,7 +7141,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.5
+      picomatch: 4.0.7
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.6.0
       '@parcel/watcher-darwin-arm64': 2.6.0
@@ -7835,7 +7835,7 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  attr-accept@2.2.5: {}
+  attr-accept@4.0.0: {}
 
   autoprefixer@10.5.4(postcss@8.5.26):
     dependencies:
@@ -8777,9 +8777,7 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-selector@2.1.2:
-    dependencies:
-      tslib: 2.8.1
+  file-selector@5.0.1: {}
 
   filesize@11.0.22: {}
 
@@ -10072,9 +10070,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.5:
-    optional: true
-
   picomatch@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
@@ -10234,12 +10229,13 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  react-dropzone@15.0.0(react@19.2.8):
+  react-dropzone@20.1.1(@types/react@19.2.18)(react@19.2.8):
     dependencies:
-      attr-accept: 2.2.5
-      file-selector: 2.1.2
-      prop-types: 15.8.1
+      attr-accept: 4.0.0
+      file-selector: 5.0.1
       react: 19.2.8
+    optionalDependencies:
+      '@types/react': 19.2.18
 
   react-fast-compare@3.2.2: {}
 


### PR DESCRIPTION
Replaces #4582, the Dependabot bump that went stale - its recreate failed on 8/18 and 20.1.1 has since shipped. Closed in favor of this.

Five majors, but our surface is two files (`kit/react-dropzone` and `desktop/cmp/filechooser`) and **no source changes were needed for the upgrade itself**. Everything we consume survives in v20: the default `Dropzone` component (still `forwardRef`), render-prop `children`, `DropzoneRef.open()`, `ErrorCode`, `Accept`, `FileRejection`, `FileWithPath`. `pnpm typecheck` and `pnpm lint` are clean.

I also confirmed the `_/_` dummy-MIME trick in `FileChooser.ts` still matches by extension under the new `attr-accept` v4 - v18 unbundled the extension-to-MIME table, but our accept lists are extension-only so it doesn't bite.

### The one behavior change worth reviewing

v19 made react-dropzone accept files **up to** `maxFiles` and reject only the surplus, instead of rejecting the whole batch. `FileChooserModel.addFilesInternal()` had its own all-or-nothing guard on top of that, so an overflowing drop would fire a rejection toast *and* a "File limit exceeded" warning and add nothing.

Rewrote it to match the new semantics: retain the current selection, replace any same-named file, take incoming files until full, and warn about the surplus. `onFileAccepted` now receives the files actually added rather than everything the dropzone handed us.

### Notes for the reviewer

- v20 declares `engines: {node: ">= 22"}` - worth a sanity check against any app pipeline still on 20.
- v16 dropped the UMD build and `dist/es/`; the package is now `"type": "module"` with an `exports` map. Bare imports are unaffected.
- Dependabot flagged a new `prepare` script - it's `prek install || exit 0`, which only runs for git/local installs, not registry tarballs.
- Free wins we could pick up separately: `getErrorMessage` (would replace the manual `FileInvalidType` message rewrite in `FileChooserModel`), async `validator`, `isProcessing`, paste-to-upload.
