### PR TITLE
Complete sideEffects declaration and break persist import cycle for tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,14 @@
 
 * Upgraded `react-dropzone` to v20, which drops its UMD build and ships as an ESM + CJS package with
   an `exports` map. Requires Node >= 22 to install.
-
 * Added an opt-in `enforceValueInOptions` prop to the desktop and mobile `Select`, constraining the
   value to the current `options` and dropping any selection no longer found there. Enforced once
   `options` is non-null, so pass null while options load.
+* Extended the package `sideEffects` declaration to cover the vendored golden-layout implementation
+  and the barrels with registration or configuration side effects on import - icon, mobx, blueprint
+  kit, golden-layout kit, and persist. Required by the tree-shaking in hoist-dev-utils v15.
+* Restructured `PersistenceProvider` provider registration to remove a base/subclass import cycle
+  that breaks under tree-shaking bundlers' re-export optimization. No API change.
 
 ### ⚙️ Typescript API Adjustments
 

--- a/core/persist/PersistOptions.ts
+++ b/core/persist/PersistOptions.ts
@@ -15,12 +15,7 @@ import type {ViewManagerModel} from '@xh/hoist/cmp/viewmanager'; // Import type 
  * Built-in Hoist PersistenceProviders.
  */
 export type PersistenceProviderType =
-    | 'pref'
-    | 'localStorage'
-    | 'sessionStorage'
-    | 'dashView'
-    | 'viewManager'
-    | 'custom';
+    'pref' | 'localStorage' | 'sessionStorage' | 'dashView' | 'viewManager' | 'custom';
 
 export interface PersistOptions {
     /** Dot delimited path to store state. */

--- a/core/persist/PersistenceProvider.ts
+++ b/core/persist/PersistenceProvider.ts
@@ -23,22 +23,25 @@ import {
 import {IReactionDisposer, reaction} from 'mobx';
 import {Class} from 'type-fest';
 import {DebounceSpec, HoistBase, Persistable, PersistableState} from '../';
-import {
-    CustomProvider,
-    DashViewProvider,
-    LocalStorageProvider,
-    PersistOptions,
-    persistOptions,
-    PrefProvider,
-    SessionStorageProvider,
-    ViewManagerProvider
-} from './';
+import {PersistenceProviderType, PersistOptions, persistOptions} from './PersistOptions';
 
 export type PersistenceProviderConfig<S = any> = {
     persistOptions: PersistOptions;
     target: Persistable<S>;
     owner?: HoistBase;
 };
+
+/**
+ * Provider registration metadata - see {@link PersistenceProvider.registerProviders}.
+ * @internal
+ */
+interface ProviderRegistration {
+    /** `PersistOptions.type` value that selects this provider. */
+    type: PersistenceProviderType;
+    /** `PersistOptions` keys whose presence selects this provider in shortcut (typeless) form. */
+    shortcutKeys: string[];
+    cls: Class<PersistenceProvider, [PersistenceProviderConfig]>;
+}
 
 /**
  * Abstract superclass for adaptor objects used by models and components to (re)store state to and
@@ -69,6 +72,19 @@ export abstract class PersistenceProvider<S = any> {
     private disposer: IReactionDisposer;
     private lastReadState: PersistableState<S>;
     private lastReadTime: number;
+
+    private static registrations: ProviderRegistration[] = [];
+
+    /**
+     * Register concrete provider implementations for lookup by `create`. Called by this
+     * package's index.ts for the built-in providers, which must not be statically imported by
+     * this base module: they extend this class, so it must be fully initialized before any of
+     * them can be defined - importing them here would create an initialization-order cycle.
+     * @internal
+     */
+    static registerProviders(regs: ProviderRegistration[]) {
+        PersistenceProvider.registrations.push(...regs);
+    }
 
     /**
      * Construct an instance of this class.
@@ -227,28 +243,17 @@ export abstract class PersistenceProvider<S = any> {
     static parseProviderClass<S>(
         opts: PersistOptions
     ): Class<PersistenceProvider<S>, [PersistenceProviderConfig<S>]> {
-        // 1) Recognize shortcut form
-        const {type, ...rest} = opts;
+        const {registrations} = PersistenceProvider,
+            {type, ...rest} = opts;
+
+        // 1) Recognize shortcut form - the presence of a provider-specific option key.
         if (!type) {
-            if (rest.prefKey) return PrefProvider;
-            if (rest.localStorageKey) return LocalStorageProvider;
-            if (rest.sessionStorageKey) return SessionStorageProvider;
-            if (rest.dashViewModel) return DashViewProvider;
-            if (rest.viewManagerModel) return ViewManagerProvider;
-            if (rest.getData || rest.setData) return CustomProvider;
+            const reg = registrations.find(it => it.shortcutKeys.some(key => rest[key]));
+            if (reg) return reg.cls;
         }
 
-        // 2) Map any string to known Provider Class, or return raw class
-        const ret = isString(type)
-            ? {
-                  pref: PrefProvider,
-                  localStorage: LocalStorageProvider,
-                  sessionStorage: SessionStorageProvider,
-                  dashView: DashViewProvider,
-                  viewManager: ViewManagerProvider,
-                  custom: CustomProvider
-              }[type]
-            : type;
+        // 2) Map any string to a registered Provider Class, or return raw class
+        const ret = isString(type) ? registrations.find(it => it.type === type)?.cls : type;
 
         throwIf(!ret, `Unknown Persistence Provider: ${type}`);
 

--- a/core/persist/index.ts
+++ b/core/persist/index.ts
@@ -7,3 +7,26 @@ export * from './provider/DashViewProvider';
 export * from './provider/PrefProvider';
 export * from './provider/CustomProvider';
 export * from './provider/ViewManagerProvider';
+
+import {PersistenceProvider} from './PersistenceProvider';
+import {CustomProvider} from './provider/CustomProvider';
+import {DashViewProvider} from './provider/DashViewProvider';
+import {LocalStorageProvider} from './provider/LocalStorageProvider';
+import {PrefProvider} from './provider/PrefProvider';
+import {SessionStorageProvider} from './provider/SessionStorageProvider';
+import {ViewManagerProvider} from './provider/ViewManagerProvider';
+
+// Register the built-in providers for lookup by `PersistenceProvider.create`. Registration
+// lives here - in a module declared side-effectful via the package `sideEffects` entry and
+// reached whenever anything imports from this package - rather than in the base class (which
+// must not import its own subclasses - see note on `registerProviders`) or in the provider
+// modules themselves (whose registrations would be pruned by a tree-shaking bundler, as
+// nothing consumes their exports directly).
+PersistenceProvider.registerProviders([
+    {type: 'pref', shortcutKeys: ['prefKey'], cls: PrefProvider},
+    {type: 'localStorage', shortcutKeys: ['localStorageKey'], cls: LocalStorageProvider},
+    {type: 'sessionStorage', shortcutKeys: ['sessionStorageKey'], cls: SessionStorageProvider},
+    {type: 'dashView', shortcutKeys: ['dashViewModel'], cls: DashViewProvider},
+    {type: 'viewManager', shortcutKeys: ['viewManagerModel'], cls: ViewManagerProvider},
+    {type: 'custom', shortcutKeys: ['getData', 'setData'], cls: CustomProvider}
+]);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,12 @@
     "./static/polyfills.js",
     "./desktop/register.ts",
     "./mobile/register.ts",
+    "./icon/index.ts",
+    "./mobx/index.ts",
+    "./kit/blueprint/index.ts",
+    "./kit/golden-layout/index.js",
+    "./kit/golden-layout/impl/js/**",
+    "./core/persist/index.ts",
     "**/*.scss",
     "**/*.css"
   ],


### PR DESCRIPTION
Enables the declaration-based tree-shaking that hoist-dev-utils v15 re-activates (xh/hoist-dev-utils#75) - planned to pair as this library's v87.1 release. **Requires no dev-utils upgrade to take**: verified under current dev-utils v14, where build output is equivalent (the only diff is this package.json's own text riding in the bundle) and persistence flows run identically - the expanded declarations are only read once an app builds with dev-utils v15. Two changes, both found by running the dev-utils trial live against Toolbox:

## Complete the `sideEffects` declaration

v87 shipped coverage for SCSS/CSS imports and the platform `register` modules. A sweep of all barrels for top-level side effects found five more modules a pruning bundler elides, each with real consequences:

- `icon/index.ts` - `library.add` of every by-name FontAwesome icon. Elided, the registry is empty and `Icon` lookups throw.
- `mobx/index.ts` - `configure({enforceActions})`. Elided, MobX enforcement silently changes.
- `kit/blueprint/index.ts` - `FocusStyleManager.onlyShowFocusOnTabs()`. Elided, focus-outline behavior silently changes.
- `kit/golden-layout/index.js` + vendored `impl/js/**` - namespace-assembly modules with no consumed exports. The JS survived elision but the styles silently dropped, reproducing the historical "random" style loss that first forced tree-shaking off years ago.

## Break the `PersistenceProvider` base/subclass import cycle

The base class imported its own subclasses (via the package barrel) for its `create()` factory, while every subclass `extends` it. Re-export elision wires consumers directly to the base module, flipping evaluation order into a boot-time `ReferenceError`. Providers now self-describe via `PersistenceProvider.registerProviders()`, called from the package barrel - which must carry the registrations itself, since nothing consumes the provider modules' exports directly and a pure-flagged re-export path to them is fully skippable. No API change: `create()` and all provider classes are exported exactly as before.

## Verification

- With pruning on (dev-utils v15 branch): all three Toolbox apps boot and render against a live backend - both dash flavors, golden-layout styling, persistence flows - zero console errors; Jobsite prod build clean and its Playwright suite identical to baseline.
- With pruning off (all current dev-utils releases): output equivalent, registrations run identically via the same barrel - this change is inert until apps take dev-utils v15.

dev-utils v15 enforces the pairing with a fail-fast floor of hoist-react >= 87.1.
