### PR TITLE
Align ViewManager manage dialog DnD lists with the desktop column chooser

### DIFF
--- a/desktop/cmp/viewmanager/ViewManager.scss
+++ b/desktop/cmp/viewmanager/ViewManager.scss
@@ -21,6 +21,12 @@
       background-color: var(--xh-intent-primary-trans2) !important;
     }
 
+    // Grip glyph swapped in via the grid's `icons` option - see ManageDialog.ts. Muted tone to
+    // match the ColChooser's handle, over ag-Grid's own drag-handle color.
+    &__drag-handle__grip {
+      color: var(--xh-text-color-muted);
+    }
+
     // Gray out the drag handles and block drag initiation for an undraggable selection.
     &__grid--drag-disabled .ag-drag-handle {
       color: var(--xh-text-color-muted);

--- a/desktop/cmp/viewmanager/dialog/ManageDialog.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialog.ts
@@ -117,6 +117,15 @@ export const viewsGrid = hoistCmp.factory<GridModel>({
                                     groupContracted: Icon.folder({
                                         asHtml: true,
                                         className: 'ag-group-contracted'
+                                    }),
+                                    // Replaces ag-Grid's own grip glyph, matching the ColChooser.
+                                    // Must be set here - the row-drag comp reads only grid-level
+                                    // icons, never the column's own.
+                                    rowDrag: Icon.grip({
+                                        asHtml: true,
+                                        prefix: 'fas',
+                                        className:
+                                            'xh-view-manager__manage-dialog__drag-handle__grip'
                                     })
                                 },
                                 ...dialogModel?.getRowDragAgOptions(model)

--- a/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
+++ b/desktop/cmp/viewmanager/dialog/ManageDialogModel.ts
@@ -961,7 +961,9 @@ export class ManageDialogModel extends HoistModel {
             // Sort groups above loose views among siblings, then alpha by name.
             sortBy: ['isGroupRow|desc', 'name'],
             treeMode: true,
-            treeStyle: TreeStyle.HIGHLIGHTS_AND_BORDERS,
+            // Highlights only - the tree-border style adds a second, differently colored rule on
+            // top of each level-0 row, which doubles up with the row borders below.
+            treeStyle: TreeStyle.HIGHLIGHTS,
             rowBorders: true,
             selModel: 'multiple',
             contextMenu,
@@ -992,7 +994,9 @@ export class ManageDialogModel extends HoistModel {
                     headerName: null,
                     width: 28,
                     resizable: false,
-                    align: 'center',
+                    // Left-aligned, so the cell keeps its standard left padding and the grip lands
+                    // at the same inset as the ColChooser's. Centering zeroes that padding, which
+                    // pinned the grip against the grid's left border.
                     omit: !this.dragDropEnabled(type),
                     agOptions: {rowDrag: true}
                 },


### PR DESCRIPTION
Brings the drag-and-drop view lists in the `ViewManager` manage dialog in line with the desktop ColChooser's lists.

* **Grip icon** - swapped ag-Grid's own grip glyph for the FontAwesome `grip-horizontal` the ColChooser uses, via the grid-level `icons.rowDrag` option. Has to be set at the grid level: `RowDragComp` calls `_createIconNoSpan('rowDrag', beans, null)` with a null column, so a `colDef.icons` entry is never read.

* **Left pad** - dropped `align: 'center'` from the `dragHandle` column. That pulled in `.xh-align-center`, which zeroes the cell's left/right padding and left the grip 1px from the grid's left border, against the ColChooser's 12px. Left-aligned, the cell keeps its standard padding and both grips now sit at the same inset (measured at 12px in each).

* **Doubled borders** - changed `treeStyle` from `HIGHLIGHTS_AND_BORDERS` to `HIGHLIGHTS`. The tree-border style draws a `border-top` on every non-first level-0 row in `--xh-grid-tree-group-border-color`, stacking against the `rowBorders` `border-bottom` in `--xh-grid-border-color`. Consecutive top-level rows therefore drew two adjacent 1px rules in two different colors. Group-row highlights are unaffected.

No changelog entry by request.