### PR TITLE
Add HoistBase.xhName - developer-facing instance name for logs, telemetry, and Inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
   log output, trace spans (new `xh.name` tag), and a new Inspector column. Accepted as a config by
   Hoist's config-driven models (`Store`, `GridModel`, `FormModel`, `TabContainerModel`,
   `PanelModel`, etc.), which also name the child models they create. Services are named with
-  their `XH` key (e.g. `fetchService`) and `XH.appModel` as `appModel`, so they now log under
-  those labels.
+  their `XH` key (e.g. `fetchService`), `XH.appModel` as `appModel`, and the app container's
+  models as `appContainerModel.*`, so they now log under those labels.
 * Added new `MessageSpec.suppress` config for `XH.message()` and its `alert`, `confirm`, and
   `prompt` variants. Set to `true` (or a config object) to offer users a "Don't show this message
   again" checkbox. Confirmed responses are saved to browser local or session storage - optionally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 
 ### 🎁 New Features
 
+* Added `HoistBase.xhName`, an optional developer-facing name that labels an instance in log
+  output, trace spans (new `xh.name` tag), and the Inspector's new `xhName` column. Accepted as a
+  config by `Store`, `Cube`, `View`, `GridModel`, and `FormModel` - a named `GridModel` or `Cube`
+  names the store it creates `{xhName}.store`, and a named `FormModel` names its fields
+  `{xhName}.{fieldName}`.
 * Added new `MessageSpec.suppress` config for `XH.message()` and its `alert`, `confirm`, and
   `prompt` variants. Set to `true` (or a config object) to offer users a "Don't show this message
   again" checkbox. Confirmed responses are saved to browser local or session storage - optionally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@
 * Added `HoistBase.xhName`, an optional developer-facing name shown in place of the class name in
   log output, trace spans (new `xh.name` tag), and a new Inspector column. Accepted as a config by
   Hoist's config-driven models (`Store`, `GridModel`, `FormModel`, `TabContainerModel`,
-  `PanelModel`, etc.), which also name the child models they create.
+  `PanelModel`, etc.), which also name the child models they create. Services are named with
+  their `XH` key (e.g. `fetchService`) and `XH.appModel` as `appModel`, so they now log under
+  those labels.
 * Added new `MessageSpec.suppress` config for `XH.message()` and its `alert`, `confirm`, and
   `prompt` variants. Set to `true` (or a config object) to offer users a "Don't show this message
   again" checkbox. Confirmed responses are saved to browser local or session storage - optionally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
   log output, trace spans (new `xh.name` tag), and a new Inspector column. Accepted as a config by
   Hoist's config-driven models (`Store`, `GridModel`, `FormModel`, `TabContainerModel`,
   `PanelModel`, etc.), which also name the child models they create. Services are named with
-  their `XH` key (e.g. `fetchService`), `XH.appModel` as `appModel`, and the app container's
-  models as `appContainerModel.*`, so they now log under those labels.
+  their `XH` key (e.g. `fetchService`), and `XH.appModel` and the app container's models by their
+  property (`appModel`, `routerModel`, `pageStateModel`, ...), so they now log under those labels.
 * Added new `MessageSpec.suppress` config for `XH.message()` and its `alert`, `confirm`, and
   `prompt` variants. Set to `true` (or a config object) to offer users a "Don't show this message
   again" checkbox. Confirmed responses are saved to browser local or session storage - optionally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,10 @@
 
 ### 🎁 New Features
 
-* Added `HoistBase.xhName`, an optional developer-facing name that labels an instance in log
-  output, trace spans (new `xh.name` tag), and the Inspector's new `xhName` column. Accepted as a
-  config by `Store`, `Cube`, `View`, `GridModel`, and `FormModel` - a named `GridModel` or `Cube`
-  names the store it creates `{xhName}.store`, and a named `FormModel` names its fields
-  `{xhName}.{fieldName}`.
+* Added `HoistBase.xhName`, an optional developer-facing name shown in place of the class name in
+  log output, trace spans (new `xh.name` tag), and a new Inspector column. Accepted as a config by
+  Hoist's config-driven models (`Store`, `GridModel`, `FormModel`, `TabContainerModel`,
+  `PanelModel`, etc.), which also name the child models they create.
 * Added new `MessageSpec.suppress` config for `XH.message()` and its `alert`, `confirm`, and
   `prompt` variants. Set to `true` (or a config object) to offer users a "Don't show this message
   again" checkbox. Confirmed responses are saved to browser local or session storage - optionally

--- a/appcontainer/AboutDialogModel.ts
+++ b/appcontainer/AboutDialogModel.ts
@@ -17,6 +17,7 @@ import {Icon} from '../icon';
  */
 export class AboutDialogModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'aboutDialogModel';
 
     @observable
     isOpen: boolean = false;

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -128,7 +128,7 @@ export class AppContainerModel extends HoistModel {
     constructor() {
         super();
         makeObservable(this);
-        this.nameManagedChildren();
+        this.nameManagedChildren(null);
     }
 
     /**

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -128,7 +128,6 @@ export class AppContainerModel extends HoistModel {
     constructor() {
         super();
         makeObservable(this);
-        this.nameManagedChildren(null);
     }
 
     /**

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -71,6 +71,8 @@ import {installServicesAsync} from '../core/impl/InstallServices';
  * Root object for Framework GUI State.
  */
 export class AppContainerModel extends HoistModel {
+    override xhName = 'appContainerModel';
+
     override telemetryPrefix = 'xh.client';
 
     private initCalled = false;
@@ -126,6 +128,7 @@ export class AppContainerModel extends HoistModel {
     constructor() {
         super();
         makeObservable(this);
+        this.nameManagedChildren();
     }
 
     /**

--- a/appcontainer/AppContainerModel.ts
+++ b/appcontainer/AppContainerModel.ts
@@ -338,6 +338,7 @@ export class AppContainerModel extends HoistModel {
         // App init phase
         this.setAppState('INITIALIZING_APP');
         this.appModel = createSingleton(this.appSpec.modelClass);
+        this.appModel.xhName ??= 'appModel';
         await this.runner(ctx)
             .span('appInit')
             .run(ctx => this.appModel.initAsync(ctx as InitContext));

--- a/appcontainer/AppStateModel.ts
+++ b/appcontainer/AppStateModel.ts
@@ -16,6 +16,7 @@ import {camelCase, isBoolean, isString, mapKeys, pick} from 'lodash';
  */
 export class AppStateModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'appStateModel';
 
     @observable state: AppState = 'PRE_AUTH';
 

--- a/appcontainer/BannerSourceModel.ts
+++ b/appcontainer/BannerSourceModel.ts
@@ -17,6 +17,7 @@ import {BannerModel} from './BannerModel';
  */
 export class BannerSourceModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'bannerSourceModel';
 
     @managed
     @observable.ref

--- a/appcontainer/ChangelogDialogModel.ts
+++ b/appcontainer/ChangelogDialogModel.ts
@@ -10,6 +10,7 @@ import {throwIf} from '@xh/hoist/utils/js';
 
 export class ChangelogDialogModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'changelogDialogModel';
 
     @observable isOpen: boolean = false;
 

--- a/appcontainer/ColChooserOptionsModel.ts
+++ b/appcontainer/ColChooserOptionsModel.ts
@@ -15,6 +15,7 @@ import {bindable, makeObservable} from '@xh/hoist/mobx';
  */
 export class ColChooserOptionsModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'colChooserOptionsModel';
     override persistWith = {localStorageKey: 'xhColChooser'};
 
     @bindable showGroups: boolean = true;

--- a/appcontainer/ExceptionDialogModel.ts
+++ b/appcontainer/ExceptionDialogModel.ts
@@ -18,6 +18,7 @@ import {action, observable, makeObservable, bindable} from '@xh/hoist/mobx';
  */
 export class ExceptionDialogModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'exceptionDialogModel';
 
     @observable.ref
     displayData: {exception: HoistException; options: ExceptionHandlerOptions};

--- a/appcontainer/FeedbackDialogModel.ts
+++ b/appcontainer/FeedbackDialogModel.ts
@@ -14,6 +14,7 @@ import {stripTags} from '@xh/hoist/utils/js';
  */
 export class FeedbackDialogModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'feedbackDialogModel';
 
     @observable isOpen: boolean = false;
     @observable message: string = null;

--- a/appcontainer/ImpersonationBarModel.ts
+++ b/appcontainer/ImpersonationBarModel.ts
@@ -17,6 +17,7 @@ export class ImpersonationBarModel extends HoistModel {
     override telemetryPrefix = 'xh.client.identity';
 
     override xhImpl = true;
+    override xhName = 'impersonationBarModel';
 
     @observable showRequested: boolean = false;
     @observable.ref targets: string[] = [];

--- a/appcontainer/MessageSourceModel.ts
+++ b/appcontainer/MessageSourceModel.ts
@@ -17,6 +17,7 @@ import {MessageModel} from './MessageModel';
  */
 export class MessageSourceModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'messageSourceModel';
 
     @managed
     @observable.ref

--- a/appcontainer/OptionsDialogModel.ts
+++ b/appcontainer/OptionsDialogModel.ts
@@ -18,6 +18,7 @@ import {AppOption} from './AppOption';
  */
 export class OptionsDialogModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'optionsDialogModel';
 
     @observable isOpen: boolean = false;
     @observable.ref options: AppOption[] = [];

--- a/appcontainer/PageStateModel.ts
+++ b/appcontainer/PageStateModel.ts
@@ -16,6 +16,7 @@ import {action, makeObservable, observable} from '@xh/hoist/mobx';
  */
 export class PageStateModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'pageStateModel';
 
     @observable state: PageState = null;
 

--- a/appcontainer/RouterModel.ts
+++ b/appcontainer/RouterModel.ts
@@ -20,6 +20,8 @@ import 'router5-plugin-browser';
  * underlying routes, presenting them to the application as a set of MobX observables.
  */
 export class RouterModel extends HoistModel {
+    override xhName = 'routerModel';
+
     /** Router5 state object representing the current state. */
     @observable.ref
     currentState: State;

--- a/appcontainer/SizingModeModel.ts
+++ b/appcontainer/SizingModeModel.ts
@@ -14,6 +14,7 @@ import {values, isPlainObject} from 'lodash';
  */
 export class SizingModeModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'sizingModeModel';
 
     @observable
     sizingMode: SizingMode = null;

--- a/appcontainer/ThemeModel.ts
+++ b/appcontainer/ThemeModel.ts
@@ -12,6 +12,7 @@ import {action, observable, makeObservable} from '@xh/hoist/mobx';
  */
 export class ThemeModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'themeModel';
 
     @observable
     darkTheme: boolean;

--- a/appcontainer/ToastSourceModel.ts
+++ b/appcontainer/ToastSourceModel.ts
@@ -15,6 +15,7 @@ import {ToastModel} from './ToastModel';
  */
 export class ToastSourceModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'toastSourceModel';
 
     @managed
     @observable.ref

--- a/appcontainer/UserAgentModel.ts
+++ b/appcontainer/UserAgentModel.ts
@@ -13,6 +13,7 @@ import {UAParser} from 'ua-parser-js';
  */
 export class UserAgentModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'userAgentModel';
 
     private _uaParser: any = null;
 

--- a/appcontainer/ViewportSizeModel.ts
+++ b/appcontainer/ViewportSizeModel.ts
@@ -16,6 +16,7 @@ import {isFinite, isString} from 'lodash';
  */
 export class ViewportSizeModel extends HoistModel {
     override xhImpl = true;
+    override xhName = 'viewportSizeModel';
 
     @observable.ref
     size: {width: number; height: number};

--- a/cmp/ag-grid/AgGridModel.ts
+++ b/cmp/ag-grid/AgGridModel.ts
@@ -58,6 +58,9 @@ export interface AgGridModelConfig {
 
     /** @internal */
     xhImpl?: boolean;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -125,11 +128,13 @@ export class AgGridModel extends HoistModel {
         stripeRows = true,
         showCellFocus = false,
         hideHeaders = false,
+        xhName = null,
         xhImpl = false
     }: AgGridModelConfig = {}) {
         super();
         makeObservable(this);
         this.xhImpl = xhImpl;
+        this.xhName = xhName;
 
         this.sizingMode = sizingMode;
         this.showHover = showHover;

--- a/cmp/chart/ChartModel.ts
+++ b/cmp/chart/ChartModel.ts
@@ -26,6 +26,9 @@ interface ChartConfig {
 
     /** @internal */
     xhImpl?: boolean;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 export interface ChartModelDefaults {
@@ -86,9 +89,16 @@ export class ChartModel extends HoistModel {
         super();
         makeObservable(this);
 
-        const {highchartsConfig, series = [], contextMenu, xhImpl = false} = config ?? {};
+        const {
+            highchartsConfig,
+            series = [],
+            contextMenu,
+            xhName = null,
+            xhImpl = false
+        } = config ?? {};
 
         this.xhImpl = xhImpl;
+        this.xhName = xhName;
         this.highchartsConfig = highchartsConfig;
         this.series = castArray(series);
         this.contextMenu = this.parseContextMenu(contextMenu);

--- a/cmp/dataview/DataViewModel.ts
+++ b/cmp/dataview/DataViewModel.ts
@@ -125,6 +125,9 @@ export interface DataViewConfig {
      * with its usages of GridModel.
      */
     gridOptions?: Omit<GridConfig, keyof DataViewConfig>;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 export type ItemHeightFn = (params: {
@@ -177,8 +180,10 @@ export class DataViewModel extends HoistModel {
             rowClassRules,
             onRowClicked,
             onRowDoubleClicked,
-            gridOptions
+            gridOptions,
+            xhName = null
         } = config;
+        this.xhName = xhName;
 
         throwIf(
             !isFunction(itemHeight) && !isNumber(itemHeight),
@@ -203,6 +208,7 @@ export class DataViewModel extends HoistModel {
         });
 
         this.gridModel = new GridModel({
+            xhName: this.childXhName('gridModel'),
             store,
             sortBy,
             selModel,

--- a/cmp/filter/FilterChooserModel.ts
+++ b/cmp/filter/FilterChooserModel.ts
@@ -136,6 +136,9 @@ export interface FilterChooserConfig {
 
     /** Options governing persistence. */
     persistWith?: FilterChooserPersistOptions;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -198,10 +201,12 @@ export class FilterChooserModel extends HoistModel {
         maxTags = 100,
         maxResults = 50,
         persistWith,
-        introHelpText
+        introHelpText,
+        xhName = null
     }: FilterChooserConfig = {}) {
         super();
         makeObservable(this);
+        this.xhName = xhName;
 
         this.bind = bind;
 
@@ -656,6 +661,4 @@ export type FilterChooserFilterSpec = CompoundFilterSpec | FieldFilterSpec;
 
 /** A variant of {@link FilterLike} that excludes FunctionFilters and FilterTestFn. */
 export type FilterChooserFilterLike =
-    | FilterChooserFilter
-    | FilterChooserFilterSpec
-    | FilterChooserFilterLike[];
+    FilterChooserFilter | FilterChooserFilterSpec | FilterChooserFilterLike[];

--- a/cmp/form/FormModel.ts
+++ b/cmp/form/FormModel.ts
@@ -59,6 +59,12 @@ export interface FormConfig {
     disabled?: boolean;
     readonly?: boolean;
 
+    /**
+     * See {@link HoistBase.xhName}. Fields without their own `xhName` are named
+     * `{xhName}.{fieldName}`, or just `{fieldName}` when the form is unnamed.
+     */
+    xhName?: string;
+
     /** @internal */
     xhImpl?: boolean;
 }
@@ -140,11 +146,13 @@ export class FormModel extends HoistModel {
         disabled = false,
         persistWith = null,
         readonly = false,
+        xhName = null,
         xhImpl = false
     }: FormConfig = {}) {
         super();
         makeObservable(this);
         this.xhImpl = xhImpl;
+        this.xhName = xhName;
 
         this.disabled = disabled;
         this.readonly = readonly;
@@ -171,6 +179,7 @@ export class FormModel extends HoistModel {
         forOwn(this.fields, f => {
             f.formModel = this;
             f.xhImpl = xhImpl;
+            f.xhName ??= xhName ? `${xhName}.${f.name}` : f.name;
         });
     }
 

--- a/cmp/form/FormModel.ts
+++ b/cmp/form/FormModel.ts
@@ -59,10 +59,7 @@ export interface FormConfig {
     disabled?: boolean;
     readonly?: boolean;
 
-    /**
-     * See {@link HoistBase.xhName}. Fields without their own `xhName` are named
-     * `{xhName}.{fieldName}`, or just `{fieldName}` when the form is unnamed.
-     */
+    /** See {@link HoistBase.xhName}. */
     xhName?: string;
 
     /** @internal */
@@ -179,7 +176,7 @@ export class FormModel extends HoistModel {
         forOwn(this.fields, f => {
             f.formModel = this;
             f.xhImpl = xhImpl;
-            f.xhName ??= xhName ? `${xhName}.${f.name}` : f.name;
+            f.xhName ??= this.childXhName(f.name) ?? f.name;
         });
     }
 

--- a/cmp/form/README.md
+++ b/cmp/form/README.md
@@ -108,7 +108,7 @@ const formModel = new FormModel({
 | `disabled` | `boolean` | Disable all fields |
 | `readonly` | `boolean` | Make all fields read-only |
 | `persistWith` | `FormPersistOptions` | Options for persisting form state |
-| `xhName` | `string` | Developer-facing name for logs and Inspector; fields are named `{xhName}.{fieldName}` |
+| `xhName` | `string` | Developer-facing name for logs, telemetry, and Inspector |
 
 ### Working with Data
 

--- a/cmp/form/README.md
+++ b/cmp/form/README.md
@@ -108,6 +108,7 @@ const formModel = new FormModel({
 | `disabled` | `boolean` | Disable all fields |
 | `readonly` | `boolean` | Make all fields read-only |
 | `persistWith` | `FormPersistOptions` | Options for persisting form state |
+| `xhName` | `string` | Developer-facing name for logs and Inspector; fields are named `{xhName}.{fieldName}` |
 
 ### Working with Data
 

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -392,10 +392,7 @@ export interface GridConfig {
     /** Extra app-specific data for the GridModel. */
     appData?: PlainObject;
 
-    /**
-     * See {@link HoistBase.xhName}. Also names a store created from a `store` config
-     * `{xhName}.store` unless that config sets its own `xhName`.
-     */
+    /** See {@link HoistBase.xhName}. */
     xhName?: string;
 
     /** @internal */
@@ -784,6 +781,7 @@ export class GridModel extends HoistModel {
         sizingMode = this.parseSizingMode(sizingMode);
 
         this.agGridModel = new AgGridModel({
+            xhName: this.childXhName('agGridModel'),
             sizingMode,
             showHover,
             rowBorders,
@@ -1903,7 +1901,7 @@ export class GridModel extends HoistModel {
         } else {
             storeOrConfig = this.enhanceStoreConfigFromColumns(storeOrConfig);
             store = new Store({
-                xhName: this.xhName ? `${this.xhName}.store` : null,
+                xhName: this.childXhName('store'),
                 loadTreeData: this.treeMode,
                 ...storeOrConfig
             });
@@ -2118,7 +2116,12 @@ export class GridModel extends HoistModel {
         }
 
         return this.markManaged(
-            new StoreSelectionModel({...selModel, store: this.store, xhImpl: true})
+            new StoreSelectionModel({
+                xhName: this.childXhName('selModel'),
+                ...selModel,
+                store: this.store,
+                xhImpl: true
+            })
         );
     }
 
@@ -2126,7 +2129,10 @@ export class GridModel extends HoistModel {
         if (XH.isMobileApp || !filterModel) return null;
 
         filterModel = filterModel === true ? {} : filterModel;
-        return new GridFilterModel({bind: this.store, ...filterModel}, this);
+        return new GridFilterModel(
+            {xhName: this.childXhName('filterModel'), bind: this.store, ...filterModel},
+            this
+        );
     }
 
     private parseExperimental(experimental: GridExperimentalFlags) {

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -2164,7 +2164,9 @@ export class GridModel extends HoistModel {
               ? DesktopDockedColChooserModel
               : DesktopModalColChooserModel;
 
-        return this.markManaged(new modelClass({...config, gridModel: this}));
+        const ret = this.markManaged(new modelClass({...config, gridModel: this}));
+        ret.xhName = this.childXhName('colChooserModel');
+        return ret;
     }
 
     private isGroupSpec(col: ColumnOrGroupSpec): col is ColumnGroupSpec {

--- a/cmp/grid/GridModel.ts
+++ b/cmp/grid/GridModel.ts
@@ -392,6 +392,12 @@ export interface GridConfig {
     /** Extra app-specific data for the GridModel. */
     appData?: PlainObject;
 
+    /**
+     * See {@link HoistBase.xhName}. Also names a store created from a `store` config
+     * `{xhName}.store` unless that config sets its own `xhName`.
+     */
+    xhName?: string;
+
     /** @internal */
     xhImpl?: boolean;
 }
@@ -707,11 +713,13 @@ export class GridModel extends HoistModel {
             enableFullWidthScroll = GridModel.defaults.enableFullWidthScroll,
             experimental,
             appData,
+            xhName = null,
             xhImpl,
             ...rest
         }: GridConfig = config;
 
         this.xhImpl = xhImpl;
+        this.xhName = xhName;
 
         this._defaultState = {columns, sortBy, groupBy, expandLevel};
 
@@ -1894,7 +1902,11 @@ export class GridModel extends HoistModel {
             store = storeOrConfig;
         } else {
             storeOrConfig = this.enhanceStoreConfigFromColumns(storeOrConfig);
-            store = new Store({loadTreeData: this.treeMode, ...storeOrConfig});
+            store = new Store({
+                xhName: this.xhName ? `${this.xhName}.store` : null,
+                loadTreeData: this.treeMode,
+                ...storeOrConfig
+            });
             store.xhImpl = this.xhImpl;
             this.markManaged(store);
         }

--- a/cmp/grid/Types.ts
+++ b/cmp/grid/Types.ts
@@ -161,6 +161,9 @@ export interface GridFilterModelConfig {
      * Defaults to `Icon.filter()` (the standard funnel icon in regular/outline style).
      */
     activeFilterIcon?: ReactElement;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**

--- a/cmp/grid/filter/GridFilterModel.ts
+++ b/cmp/grid/filter/GridFilterModel.ts
@@ -65,12 +65,14 @@ export class GridFilterModel extends HoistModel {
             commitOnChange = false,
             fieldSpecs,
             fieldSpecDefaults,
-            activeFilterIcon
+            activeFilterIcon,
+            xhName = null
         }: GridFilterModelConfig,
         gridModel: GridModel
     ) {
         super();
         makeObservable(this);
+        this.xhName = xhName;
         this.gridModel = gridModel;
         this.bind = bind;
         this.commitOnChange = commitOnChange;

--- a/cmp/grouping/GroupingChooserModel.ts
+++ b/cmp/grouping/GroupingChooserModel.ts
@@ -76,6 +76,9 @@ export interface GroupingChooserConfig {
      * provided in the `dimensions` config.
      */
     sortDimensions?: boolean;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 export interface GroupingChooserModelDefaults {
@@ -159,10 +162,12 @@ export class GroupingChooserModel extends HoistModel {
         initialValue = [],
         maxDepth = null,
         persistWith = null,
-        sortDimensions = true
+        sortDimensions = true,
+        xhName = null
     }: GroupingChooserConfig) {
         super();
         makeObservable(this);
+        this.xhName = xhName;
 
         this.allowEmpty = allowEmpty;
         this.bind = bind;

--- a/cmp/tab/TabContainerModel.ts
+++ b/cmp/tab/TabContainerModel.ts
@@ -93,6 +93,9 @@ export interface TabContainerConfig {
 
     /** @internal */
     xhImpl?: boolean;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -149,6 +152,7 @@ export class TabContainerModel extends HoistModel {
             refreshMode = 'onShowLazy',
             persistWith,
             emptyText = 'No tabs to display.',
+            xhName = null,
             xhImpl = false,
             switcher = {mode: 'static'}
         }: TabContainerConfig,
@@ -157,6 +161,7 @@ export class TabContainerModel extends HoistModel {
         super();
         makeObservable(this);
         this.xhImpl = xhImpl;
+        this.xhName = xhName;
 
         this.depth = depth;
         this.renderMode = renderMode;

--- a/cmp/tab/TabContainerModel.ts
+++ b/cmp/tab/TabContainerModel.ts
@@ -173,6 +173,7 @@ export class TabContainerModel extends HoistModel {
         this.setTabs(tabs);
         this.refreshContextModel = new RefreshContextModel();
         this.refreshContextModel.xhImpl = xhImpl;
+        this.refreshContextModel.xhName = this.childXhName('refreshContextModel');
         this.switcherConfig = switcher;
         this.dynamicTabSwitcherModel = this.parseSwitcher(switcher);
 
@@ -424,7 +425,9 @@ export class TabContainerModel extends HoistModel {
         if (!switcher || switcher.mode === 'static') return null;
         throwIf(XH.isMobileApp, 'DynamicTabSwitcherModel not supported for mobile TabContainer.');
 
-        return this.markManaged(new DynamicTabSwitcherModel(switcher, this));
+        const ret = this.markManaged(new DynamicTabSwitcherModel(switcher, this));
+        ret.xhName = this.childXhName('dynamicTabSwitcherModel');
+        return ret;
     }
 
     private initPersist({

--- a/cmp/tab/TabModel.ts
+++ b/cmp/tab/TabModel.ts
@@ -75,6 +75,9 @@ export interface TabConfig {
 
     /** @internal */
     xhImpl?: boolean;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -119,6 +122,7 @@ export class TabModel extends HoistModel {
             content,
             refreshMode,
             renderMode,
+            xhName = null,
             xhImpl = false
         }: TabConfig,
         containerModel: TabContainerModel
@@ -133,6 +137,7 @@ export class TabModel extends HoistModel {
         );
 
         this.id = id.toString();
+        this.xhName = xhName ?? containerModel.childXhName(this.id) ?? this.id;
         this.title = title;
         this.icon = icon;
         this.tooltip = tooltip;

--- a/cmp/treemap/SplitTreeMapModel.ts
+++ b/cmp/treemap/SplitTreeMapModel.ts
@@ -64,8 +64,10 @@ export class SplitTreeMapModel extends HoistModel {
             mapTitleFn,
             showSplitter = false,
             orientation = 'vertical',
+            xhName = null,
             ...rest
         } = config ?? {};
+        this.xhName = xhName;
 
         this.mapFilter = withDefault(mapFilter, this.defaultMapFilter);
         this.mapTitleFn = mapTitleFn;
@@ -77,8 +79,16 @@ export class SplitTreeMapModel extends HoistModel {
         );
         this.orientation = orientation;
 
-        this.primaryMapModel = new TreeMapModel({...rest, filter: r => this.mapFilter(r)});
-        this.secondaryMapModel = new TreeMapModel({...rest, filter: r => !this.mapFilter(r)});
+        this.primaryMapModel = new TreeMapModel({
+            xhName: this.childXhName('primaryMapModel'),
+            ...rest,
+            filter: r => this.mapFilter(r)
+        });
+        this.secondaryMapModel = new TreeMapModel({
+            xhName: this.childXhName('secondaryMapModel'),
+            ...rest,
+            filter: r => !this.mapFilter(r)
+        });
     }
 
     // Getters derived from both underlying TreeMapModels.

--- a/cmp/treemap/TreeMapModel.ts
+++ b/cmp/treemap/TreeMapModel.ts
@@ -90,6 +90,9 @@ export interface TreeMapConfig {
 
     /** Data filter to apply to records. */
     filter?: FilterLike;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 export interface TreeMapModelDefaults {
@@ -178,8 +181,10 @@ export class TreeMapModel extends HoistModel {
             onDoubleClick,
             tooltip = true,
             emptyText,
-            filter
+            filter,
+            xhName = null
         }: TreeMapConfig = config ?? {};
+        this.xhName = xhName;
 
         this.gridModel = gridModel;
         this.store = store ? store : gridModel ? gridModel.store : null;

--- a/cmp/viewmanager/ViewManagerModel.ts
+++ b/cmp/viewmanager/ViewManagerModel.ts
@@ -154,6 +154,9 @@ export interface ViewManagerConfig {
      * ViewManager menu.
      */
     viewMenuItemFn?: (view: ViewInfo, model: ViewManagerModel) => ReactNode;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -328,10 +331,12 @@ export class ViewManagerModel<T = PlainObject> extends HoistModel {
         enableGlobal = true,
         enableSharing = true,
         preserveUnsavedChanges = true,
-        initialViewSpec = null
+        initialViewSpec = null,
+        xhName = null
     }: ViewManagerConfig) {
         super();
         makeObservable(this);
+        this.xhName = xhName ?? type;
 
         throwIf(
             !enableDefault && !initialViewSpec,

--- a/cmp/zoneGrid/ZoneGridModel.ts
+++ b/cmp/zoneGrid/ZoneGridModel.ts
@@ -301,6 +301,9 @@ export interface ZoneGridConfig {
 
     /** @internal */
     xhImpl?: boolean;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -364,8 +367,10 @@ export class ZoneGridModel extends HoistModel {
             restoreDefaultsFn,
             restoreDefaultsWarning,
             persistWith,
+            xhName = null,
             ...rest
         } = config;
+        this.xhName = xhName;
 
         this.availableColumns = columns
             .filter(it => !executeIfFunction(it.omit))
@@ -569,6 +574,7 @@ export class ZoneGridModel extends HoistModel {
     //-----------------------
     private createGridModel(config: GridConfig): GridModel {
         return new GridModel({
+            xhName: this.childXhName('gridModel'),
             ...config,
             xhImpl: true,
             contextMenu: withDefault(config.contextMenu, this.getDefaultContextMenu),

--- a/cmp/zoneGrid/ZoneGridModel.ts
+++ b/cmp/zoneGrid/ZoneGridModel.ts
@@ -397,6 +397,7 @@ export class ZoneGridModel extends HoistModel {
         this.setGroupBy(groupBy);
 
         this.mapperModel = this.parseMapperModel(zoneMapperModel);
+        if (this.mapperModel) this.mapperModel.xhName = this.childXhName('mapperModel');
         if (persistWith) initPersist(this, persistWith);
 
         this.addReaction({

--- a/core/HoistBase.ts
+++ b/core/HoistBase.ts
@@ -283,6 +283,14 @@ export abstract class HoistBase {
         return this.xhName ? `${this.xhName}.${key}` : null;
     }
 
+    /** Name each unnamed `@managed` HoistBase child of this object `{xhName}.{property}`. */
+    protected nameManagedChildren() {
+        this['_xhManagedProperties']?.forEach(p => {
+            const child = this[p];
+            if (child?.isHoistBase) child.xhName ??= this.childXhName(p);
+        });
+    }
+
     /**
      * Mark an object as managed by this object.
      *

--- a/core/HoistBase.ts
+++ b/core/HoistBase.ts
@@ -283,11 +283,11 @@ export abstract class HoistBase {
         return this.xhName ? `${this.xhName}.${key}` : null;
     }
 
-    /** Name each unnamed `@managed` HoistBase child of this object `{xhName}.{property}`. */
-    protected nameManagedChildren() {
+    /** Name unnamed `@managed` HoistBase children `{prefix}.{property}`, or `{property}` if null. */
+    protected nameManagedChildren(prefix: string = this.xhName) {
         this['_xhManagedProperties']?.forEach(p => {
             const child = this[p];
-            if (child?.isHoistBase) child.xhName ??= this.childXhName(p);
+            if (child?.isHoistBase) child.xhName ??= prefix ? `${prefix}.${p}` : p;
         });
     }
 

--- a/core/HoistBase.ts
+++ b/core/HoistBase.ts
@@ -93,9 +93,8 @@ export abstract class HoistBase {
     xhImpl: boolean = undefined;
 
     /**
-     * Optional developer-facing name for this instance, distinguishing it from other instances of
-     * the same class in log output, telemetry, and the Hoist Inspector. Falls back to the class
-     * name when null. Uniqueness is not enforced - apps choose their own naming scheme.
+     * Optional developer-facing name for this instance, shown in place of its class name in log
+     * output, telemetry, and the Inspector. Uniqueness is not enforced.
      */
     xhName: string = null;
 
@@ -277,6 +276,11 @@ export abstract class HoistBase {
     /** @returns a unique id for this object within the lifetime of this document. */
     get xhId(): string {
         return getOrCreate(this, '_xhId', XH.genId);
+    }
+
+    /** Name for a child of this object - `{xhName}.{key}`, or null if this object is unnamed. */
+    childXhName(key: string): string {
+        return this.xhName ? `${this.xhName}.${key}` : null;
     }
 
     /**

--- a/core/HoistBase.ts
+++ b/core/HoistBase.ts
@@ -283,14 +283,6 @@ export abstract class HoistBase {
         return this.xhName ? `${this.xhName}.${key}` : null;
     }
 
-    /** Name unnamed `@managed` HoistBase children `{prefix}.{property}`, or `{property}` if null. */
-    protected nameManagedChildren(prefix: string = this.xhName) {
-        this['_xhManagedProperties']?.forEach(p => {
-            const child = this[p];
-            if (child?.isHoistBase) child.xhName ??= prefix ? `${prefix}.${p}` : p;
-        });
-    }
-
     /**
      * Mark an object as managed by this object.
      *

--- a/core/HoistBase.ts
+++ b/core/HoistBase.ts
@@ -92,6 +92,13 @@ export abstract class HoistBase {
      */
     xhImpl: boolean = undefined;
 
+    /**
+     * Optional developer-facing name for this instance, distinguishing it from other instances of
+     * the same class in log output, telemetry, and the Hoist Inspector. Falls back to the class
+     * name when null. Uniqueness is not enforced - apps choose their own naming scheme.
+     */
+    xhName: string = null;
+
     // Internal State
     private managedInstances = [];
     private disposers = [];

--- a/core/README.md
+++ b/core/README.md
@@ -143,6 +143,7 @@ export class PositionsModel extends HoistModel {
 | `xhId` | Unique identifier for this instance |
 | `xhName` | Optional developer-facing name for logs, telemetry, and Inspector |
 | `childXhName(key)` | `{xhName}.{key}`, for naming child objects |
+| `nameManagedChildren()` | Name unnamed `@managed` children `{xhName}.{property}` |
 
 ## HoistModel
 

--- a/core/README.md
+++ b/core/README.md
@@ -143,7 +143,6 @@ export class PositionsModel extends HoistModel {
 | `xhId` | Unique identifier for this instance |
 | `xhName` | Optional developer-facing name for logs, telemetry, and Inspector |
 | `childXhName(key)` | `{xhName}.{key}`, for naming child objects |
-| `nameManagedChildren(prefix?)` | Name unnamed `@managed` children `{prefix}.{property}` |
 
 ## HoistModel
 

--- a/core/README.md
+++ b/core/README.md
@@ -117,6 +117,25 @@ class MyModel extends HoistModel {
 }
 ```
 
+**Instance Naming**
+
+Log output, trace spans, and the Inspector label objects by class name, so several `Store`s all
+log as `[Store]`. Set `xhName` to tell them apart - it is accepted as a config by `Store`,
+`Cube`, `View`, `GridModel`, and `FormModel`, and can be set directly on any `HoistBase`:
+
+```typescript
+const gridModel = new GridModel({xhName: 'positionsGrid', store: {...}});
+// gridModel logs as [positionsGrid]; its store is named 'positionsGrid.store'
+
+export class PositionsModel extends HoistModel {
+    override xhName = 'positions';
+}
+```
+
+Owners name the children they create as `{owner}.{child}` - a `Cube`'s internal store, a
+`GridModel`'s store, a `FormModel`'s fields (`positionsForm.firstName`). Uniqueness is not
+enforced.
+
 ### Core API
 
 | Method | Purpose |
@@ -128,6 +147,7 @@ class MyModel extends HoistModel {
 | `setBindable(prop, val)` | Set value via conventional setter |
 | `destroy()` | Clean up all managed resources |
 | `xhId` | Unique identifier for this instance |
+| `xhName` | Optional developer-facing name, labelling this instance in logs, telemetry, and Inspector |
 
 ## HoistModel
 

--- a/core/README.md
+++ b/core/README.md
@@ -143,7 +143,7 @@ export class PositionsModel extends HoistModel {
 | `xhId` | Unique identifier for this instance |
 | `xhName` | Optional developer-facing name for logs, telemetry, and Inspector |
 | `childXhName(key)` | `{xhName}.{key}`, for naming child objects |
-| `nameManagedChildren()` | Name unnamed `@managed` children `{xhName}.{property}` |
+| `nameManagedChildren(prefix?)` | Name unnamed `@managed` children `{prefix}.{property}` |
 
 ## HoistModel
 

--- a/core/README.md
+++ b/core/README.md
@@ -119,22 +119,16 @@ class MyModel extends HoistModel {
 
 **Instance Naming**
 
-Log output, trace spans, and the Inspector label objects by class name, so several `Store`s all
-log as `[Store]`. Set `xhName` to tell them apart - it is accepted as a config by `Store`,
-`Cube`, `View`, `GridModel`, and `FormModel`, and can be set directly on any `HoistBase`:
+Set `xhName` to distinguish instances of the same class in logs, telemetry, and the Inspector.
+Config-driven models accept it as a config; any `HoistBase` can set it directly.
 
 ```typescript
-const gridModel = new GridModel({xhName: 'positionsGrid', store: {...}});
-// gridModel logs as [positionsGrid]; its store is named 'positionsGrid.store'
+new GridModel({xhName: 'positionsGrid', store: {...}});
 
 export class PositionsModel extends HoistModel {
     override xhName = 'positions';
 }
 ```
-
-Owners name the children they create as `{owner}.{child}` - a `Cube`'s internal store, a
-`GridModel`'s store, a `FormModel`'s fields (`positionsForm.firstName`). Uniqueness is not
-enforced.
 
 ### Core API
 
@@ -147,7 +141,8 @@ enforced.
 | `setBindable(prop, val)` | Set value via conventional setter |
 | `destroy()` | Clean up all managed resources |
 | `xhId` | Unique identifier for this instance |
-| `xhName` | Optional developer-facing name, labelling this instance in logs, telemetry, and Inspector |
+| `xhName` | Optional developer-facing name for logs, telemetry, and Inspector |
+| `childXhName(key)` | `{xhName}.{key}`, for naming child objects |
 
 ## HoistModel
 

--- a/core/impl/InstallServices.ts
+++ b/core/impl/InstallServices.ts
@@ -34,7 +34,11 @@ export async function installServicesAsync(
     const notSvc = serviceClasses.find((it: any) => !it.isHoistService);
     throwIf(notSvc, `Cannot initialize ${notSvc?.name} - does not extend HoistService`);
 
-    const svcs = serviceClasses.map(c => createSingleton(c));
+    const svcs = serviceClasses.map(c => {
+        const svc = createSingleton(c);
+        svc.xhName ??= camelCase(c.name);
+        return svc;
+    });
     await initServicesInternalAsync(svcs, ctx);
 
     svcs.forEach(svc => {

--- a/core/model/RootRefreshContextModel.ts
+++ b/core/model/RootRefreshContextModel.ts
@@ -18,6 +18,8 @@ import {RefreshContextModel} from './';
  * The `XH.refreshAppAsync()` convenience method is the recommended entry-point for apps to call.
  */
 export class RootRefreshContextModel extends RefreshContextModel {
+    override xhName = 'refreshContextModel';
+
     override async doLoadAsync(loadSpec: LoadSpec) {
         const {appModel} = XH;
         if (appModel.loadSupport) {

--- a/core/types/Telemetry.ts
+++ b/core/types/Telemetry.ts
@@ -88,10 +88,7 @@ export interface FullSpanConfig extends SpanConfig {
      */
     startTime?: number;
 
-    /**
-     * Usually the calling object/function. Its type-level name (class or component name) becomes
-     * the `code.namespace` tag; a HoistBase `xhName`, when set, becomes `xh.name`.
-     */
+    /** Usually the calling object/function - source of the `code.namespace` and `xh.name` tags. */
     caller?: NameSource;
 }
 

--- a/core/types/Telemetry.ts
+++ b/core/types/Telemetry.ts
@@ -88,7 +88,10 @@ export interface FullSpanConfig extends SpanConfig {
      */
     startTime?: number;
 
-    /** Source for the `code.namespace` tag - usually the calling object/function. */
+    /**
+     * Usually the calling object/function. Its type-level name (class or component name) becomes
+     * the `code.namespace` tag; a HoistBase `xhName`, when set, becomes `xh.name`.
+     */
     caller?: NameSource;
 }
 

--- a/data/README.md
+++ b/data/README.md
@@ -113,7 +113,7 @@ const store = new Store({
 | `idEncodesTreePath` | `boolean` | `false` | IDs imply a fixed tree position (performance). Not supported on View-connected stores |
 | `validationIsComplex` | `boolean` | `false` | Validate all uncommitted records on every change |
 | `experimental` | `PlainObject` | `{}` | Flags for experimental features - see [Performance and Memory](#performance-and-memory) |
-| `xhName` | `string` | `null` | Developer-facing name labelling this store in logs and Inspector - see [Instance Naming](../core/README.md#hoistbase) |
+| `xhName` | `string` | `null` | Developer-facing name for logs, telemetry, and Inspector |
 
 `Store.defaults` exposes `freezeData` for an app-wide override. See `StoreDefaults` for details.
 

--- a/data/README.md
+++ b/data/README.md
@@ -113,6 +113,7 @@ const store = new Store({
 | `idEncodesTreePath` | `boolean` | `false` | IDs imply a fixed tree position (performance). Not supported on View-connected stores |
 | `validationIsComplex` | `boolean` | `false` | Validate all uncommitted records on every change |
 | `experimental` | `PlainObject` | `{}` | Flags for experimental features - see [Performance and Memory](#performance-and-memory) |
+| `xhName` | `string` | `null` | Developer-facing name labelling this store in logs and Inspector - see [Instance Naming](../core/README.md#hoistbase) |
 
 `Store.defaults` exposes `freezeData` for an app-wide override. See `StoreDefaults` for details.
 
@@ -1066,7 +1067,8 @@ store.diagnostics.reset();
 ```
 
 Diagnostics log at `debug` level by default. Set `diagnostics.logLevel = 'info'` on one instance to
-follow that object alone at any `XH.logLevel`.
+follow that object alone at any `XH.logLevel`. Give the owning objects an `xhName` to tell
+their output apart - several stores logging at once are otherwise all labelled `[Store]`.
 
 ```typescript
 gridModel.store.diagnostics.logLevel = 'info';

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -237,6 +237,9 @@ export interface StoreConfig {
      *     it may also be changed on an existing Store at any time.
      */
     experimental?: PlainObject;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -447,10 +450,12 @@ export class Store
         projectionOnly = null,
         validationIsComplex = false,
         experimental,
+        xhName = null,
         data
     }: StoreConfig) {
         super();
         makeObservable(this);
+        this.xhName = xhName;
         throwIf(
             projectionOnly && processRawData,
             'Store.projectionOnly cannot be used with processRawData - a projection adopts data already parsed by its provider.'

--- a/data/Store.ts
+++ b/data/Store.ts
@@ -455,12 +455,12 @@ export class Store
     }: StoreConfig) {
         super();
         makeObservable(this);
-        this.xhName = xhName;
         throwIf(
             projectionOnly && processRawData,
             'Store.projectionOnly cannot be used with processRawData - a projection adopts data already parsed by its provider.'
         );
 
+        this.xhName = xhName;
         this.experimental = this.parseExperimental(experimental);
         this.fields = this.parseFields(fields, fieldDefaults);
         this.idSpec = this.parseIdSpec(idSpec);

--- a/data/StoreSelectionModel.ts
+++ b/data/StoreSelectionModel.ts
@@ -22,6 +22,9 @@ export interface StoreSelectionConfig {
     mode?: 'single' | 'multiple' | 'disabled';
     /** @internal */
     xhImpl?: boolean;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -50,11 +53,12 @@ export class StoreSelectionModel extends HoistModel {
         return this.mode !== 'disabled';
     }
 
-    constructor({store, mode = 'single', xhImpl = false}: StoreSelectionConfig) {
+    constructor({store, mode = 'single', xhName = null, xhImpl = false}: StoreSelectionConfig) {
         super();
         makeObservable(this);
 
         this.xhImpl = xhImpl;
+        this.xhName = xhName;
         this.store = store;
         this.mode = mode;
         this.addReaction(this.cullSelectionReaction());

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -76,6 +76,12 @@ export interface CubeConfig {
      * Return true to omit the row.
      */
     omitFn?: OmitFn;
+
+    /**
+     * See {@link HoistBase.xhName}. Also names the internal store `{xhName}.store`
+     * unless `store.xhName` is set explicitly.
+     */
+    xhName?: string;
 }
 
 /**
@@ -187,11 +193,14 @@ export class Cube extends HoistBase {
         info = {},
         lockFn,
         bucketSpecFn,
-        omitFn
+        omitFn,
+        xhName = null
     }: CubeConfig) {
         super();
         makeObservable(this);
+        this.xhName = xhName;
         this.store = new Store({
+            xhName: xhName ? `${xhName}.store` : null,
             ...store,
             fields: this.parseFields(fields, fieldDefaults),
             idSpec,

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -286,20 +286,24 @@ export class Cube extends HoistBase {
      * @param query - query to be used to construct this view.
      * @param stores - Stores to be automatically loaded/reloaded with View results.
      * @param connect - true to update View automatically when data in the underlying Cube changes.
+     * @param xhName - see {@link HoistBase.xhName}.
      */
     createView({
         query,
         stores,
-        connect = false
+        connect = false,
+        xhName = null
     }: {
         query: QueryConfig;
         stores?: Store[] | Store;
         connect?: boolean;
+        xhName?: string;
     }): View {
         return new View({
             query: new Query({...query, cube: this}),
             stores,
-            connect
+            connect,
+            xhName
         });
     }
 

--- a/data/cube/Cube.ts
+++ b/data/cube/Cube.ts
@@ -77,10 +77,7 @@ export interface CubeConfig {
      */
     omitFn?: OmitFn;
 
-    /**
-     * See {@link HoistBase.xhName}. Also names the internal store `{xhName}.store`
-     * unless `store.xhName` is set explicitly.
-     */
+    /** See {@link HoistBase.xhName}. */
     xhName?: string;
 }
 
@@ -200,7 +197,7 @@ export class Cube extends HoistBase {
         makeObservable(this);
         this.xhName = xhName;
         this.store = new Store({
-            xhName: xhName ? `${xhName}.store` : null,
+            xhName: this.childXhName('store'),
             ...store,
             fields: this.parseFields(fields, fieldDefaults),
             idSpec,
@@ -286,7 +283,6 @@ export class Cube extends HoistBase {
      * @param query - query to be used to construct this view.
      * @param stores - Stores to be automatically loaded/reloaded with View results.
      * @param connect - true to update View automatically when data in the underlying Cube changes.
-     * @param xhName - see {@link HoistBase.xhName}.
      */
     createView({
         query,

--- a/data/cube/View.ts
+++ b/data/cube/View.ts
@@ -63,6 +63,9 @@ export interface ViewConfig {
      * capture a snapshot without further (automatic) updates.
      */
     connect?: boolean;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 export interface ViewResult {
@@ -169,8 +172,9 @@ export class View
         makeObservable(this);
 
         const start = performance.now(),
-            {query, stores = [], connect = false} = config;
+            {query, stores = [], connect = false, xhName = null} = config;
 
+        this.xhName = xhName;
         this.query = query;
         this.stores = this.parseStores(stores);
         this._rowCache = new RowCache(this);

--- a/desktop/cmp/dash/DashConfig.ts
+++ b/desktop/cmp/dash/DashConfig.ts
@@ -50,4 +50,7 @@ export interface DashConfig<VSPEC extends DashViewSpec, VSTATE extends DashViewS
      * including when the dash container is empty.
      */
     extraMenuItems?: MenuItemLike[];
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }

--- a/desktop/cmp/dash/DashViewModel.ts
+++ b/desktop/cmp/dash/DashViewModel.ts
@@ -115,6 +115,7 @@ export abstract class DashViewModel<T extends DashViewSpec = DashViewSpec> exten
         this.xhName = xhName ?? containerModel?.childXhName(id) ?? id;
 
         this.refreshContextModel = new ManagedRefreshContextModel(this);
+        this.refreshContextModel.xhName = this.childXhName('refreshContextModel');
     }
 
     /**

--- a/desktop/cmp/dash/DashViewModel.ts
+++ b/desktop/cmp/dash/DashViewModel.ts
@@ -92,7 +92,15 @@ export abstract class DashViewModel<T extends DashViewSpec = DashViewSpec> exten
         return this.viewSpec.refreshMode ?? this.containerModel.refreshMode;
     }
 
-    constructor({id, viewSpec, icon, title, viewState = null, containerModel}: DashViewConfig<T>) {
+    constructor({
+        id,
+        viewSpec,
+        icon,
+        title,
+        viewState = null,
+        containerModel,
+        xhName = null
+    }: DashViewConfig<T>) {
         super();
         makeObservable(this);
         throwIf(!id, 'DashViewModel requires an id');
@@ -104,6 +112,7 @@ export abstract class DashViewModel<T extends DashViewSpec = DashViewSpec> exten
         this.title = title ?? viewSpec.title;
         this.viewState = viewState;
         this.containerModel = containerModel;
+        this.xhName = xhName ?? containerModel?.childXhName(id) ?? id;
 
         this.refreshContextModel = new ManagedRefreshContextModel(this);
     }
@@ -154,4 +163,7 @@ export interface DashViewConfig<T extends DashViewSpec = DashViewSpec> {
     title?: string;
     viewState?: DashViewState;
     containerModel?: any;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }

--- a/desktop/cmp/dash/canvas/DashCanvasModel.ts
+++ b/desktop/cmp/dash/canvas/DashCanvasModel.ts
@@ -229,10 +229,12 @@ export class DashCanvasModel
         showAddViewButtonWhenEmpty = true,
         allowsDrop = false,
         onDropDone,
-        onDropDragOver
+        onDropDragOver,
+        xhName = null
     }: DashCanvasConfig) {
         super();
         makeObservable(this);
+        this.xhName = xhName;
         viewSpecs = viewSpecs.filter(it => !isOmitted(it));
         ensureUniqueBy(viewSpecs, 'id');
         this.viewSpecs = viewSpecs.map(cfg => {

--- a/desktop/cmp/dash/container/DashContainerModel.ts
+++ b/desktop/cmp/dash/container/DashContainerModel.ts
@@ -207,10 +207,12 @@ export class DashContainerModel
         persistWith = null,
         emptyText = 'No views have been added to the container.',
         addViewButtonText = 'Add View',
-        extraMenuItems
+        extraMenuItems,
+        xhName = null
     }: DashContainerConfig) {
         super();
         makeObservable(this);
+        this.xhName = xhName;
         viewSpecs = viewSpecs.filter(it => !isOmitted(it));
         ensureUniqueBy(viewSpecs, 'id');
         this.viewSpecs = viewSpecs.map(cfg => {

--- a/desktop/cmp/dock/DockContainerModel.ts
+++ b/desktop/cmp/dock/DockContainerModel.ts
@@ -20,6 +20,9 @@ interface DockContainerConfig {
     renderMode?: RenderMode;
     /** Strategy for refreshing DockViews. Can also be set per-view via `DockViewModelConfig.refreshMode` */
     refreshMode?: RefreshMode;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -38,10 +41,12 @@ export class DockContainerModel extends HoistModel {
         views = [],
         direction = 'rtl',
         renderMode = 'lazy',
-        refreshMode = 'onShowLazy'
+        refreshMode = 'onShowLazy',
+        xhName = null
     }: DockContainerConfig = {}) {
         super();
         makeObservable(this);
+        this.xhName = xhName;
         views = views.filter(v => !isOmitted(v));
 
         ensureUniqueBy(views as [], 'id', 'Multiple DockContainerModel views have the same id.');

--- a/desktop/cmp/dock/DockViewModel.ts
+++ b/desktop/cmp/dock/DockViewModel.ts
@@ -66,6 +66,9 @@ export interface DockViewConfig {
     allowDialog?: boolean;
     /** Awaitable callback invoked on close. Return false to prevent close. */
     onClose?: () => Awaitable<boolean | void>;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -128,7 +131,8 @@ export class DockViewModel extends HoistModel {
         collapsed = false,
         allowClose = true,
         allowDialog = true,
-        onClose
+        onClose,
+        xhName = null
     }: DockViewConfig) {
         super();
         makeObservable(this);
@@ -136,6 +140,7 @@ export class DockViewModel extends HoistModel {
 
         this.id = id;
         this.containerModel = containerModel;
+        this.xhName = xhName ?? containerModel?.childXhName(id) ?? id;
         this.title = title;
         this.icon = icon;
         this.content = content;

--- a/desktop/cmp/leftrightchooser/LeftRightChooserModel.ts
+++ b/desktop/cmp/leftrightchooser/LeftRightChooserModel.ts
@@ -49,6 +49,9 @@ export interface LeftRightChooserConfig {
 
     /** @internal */
     xhImpl?: boolean;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /** Data record object for a LeftRightChooser value item. */
@@ -146,11 +149,13 @@ export class LeftRightChooserModel extends HoistModel {
         rightGroupingExpanded = true,
         rightEmptyText = null,
         showCounts = true,
+        xhName = null,
         xhImpl = false
     }: LeftRightChooserConfig) {
         super();
         makeObservable(this);
         this.xhImpl = xhImpl;
+        this.xhName = xhName;
 
         this.onChange = onChange;
         this._ungroupedName = ungroupedName;

--- a/desktop/cmp/panel/PanelModel.ts
+++ b/desktop/cmp/panel/PanelModel.ts
@@ -111,6 +111,9 @@ export interface PanelConfig {
 
     /** @internal */
     xhImpl?;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 export interface PanelPersistState {
@@ -215,11 +218,13 @@ export class PanelModel extends HoistModel implements Persistable<PanelPersistSt
         showSplitterCollapseButton = showSplitter && collapsible,
         showHeaderCollapseButton = true,
         showModalToggleButton = true,
+        xhName = null,
         xhImpl = false
     }: PanelConfig) {
         super();
         makeObservable(this);
         this.xhImpl = xhImpl;
+        this.xhName = xhName;
 
         defaultSize =
             isString(defaultSize) && defaultSize.endsWith('px')

--- a/desktop/cmp/panel/PanelModel.ts
+++ b/desktop/cmp/panel/PanelModel.ts
@@ -272,6 +272,7 @@ export class PanelModel extends HoistModel implements Persistable<PanelPersistSt
                 modalSupport === true
                     ? new ModalSupportModel()
                     : new ModalSupportModel(modalSupport);
+            this.modalSupportModel.xhName = this.childXhName('modalSupportModel');
         }
 
         if (errorBoundary) {
@@ -279,10 +280,12 @@ export class PanelModel extends HoistModel implements Persistable<PanelPersistSt
                 errorBoundary === true
                     ? new ErrorBoundaryModel()
                     : new ErrorBoundaryModel(errorBoundary);
+            this.errorBoundaryModel.xhName = this.childXhName('errorBoundaryModel');
         }
 
         if (collapsible) {
             this.refreshContextModel = new ManagedRefreshContextModel(this);
+            this.refreshContextModel.xhName = this.childXhName('refreshContextModel');
         }
 
         if (collapsible || resizable) {

--- a/desktop/cmp/rest/RestGridModel.ts
+++ b/desktop/cmp/rest/RestGridModel.ts
@@ -162,9 +162,11 @@ export class RestGridModel extends HoistModel {
         onRowDoubleClicked,
         store,
         appData,
+        xhName = null,
         ...rest
     }: RestGridConfig) {
         super();
+        this.xhName = xhName;
         this.readonly = readonly;
         this.editors = editors;
         this.toolbarActions = toolbarActions;
@@ -186,6 +188,7 @@ export class RestGridModel extends HoistModel {
         });
 
         this.gridModel = new GridModel({
+            xhName: this.childXhName('gridModel'),
             contextMenu: [...this.menuActions, '-', ...GridModel.defaults.contextMenu],
             exportOptions: {filename: pluralize(unit)},
             store: this.parseStore(store),
@@ -197,6 +200,7 @@ export class RestGridModel extends HoistModel {
         });
 
         this.formModel = new RestFormModel(this);
+        this.formModel.xhName = this.childXhName('formModel');
     }
 
     /** Load the underlying store. */

--- a/inspector/README.md
+++ b/inspector/README.md
@@ -122,7 +122,8 @@ navigation or load action created them.
 The Instances panel is a split layout with:
 
 - **Instances grid** (left, resizable) — Lists all live `HoistModel`, `HoistService`, `Store`,
-  `Cube`, and `View` instances with their class name, creation time, linked status, and sync run
+  `Cube`, and `View` instances with their `xhName` (when set), class name, creation time,
+  linked status, and sync run
 - **Properties grid** (right) — Shows properties of the selected instance(s), including observable
   values with live updates
 - **Diagnostics panel** (tabbed with properties) — Live readout of the data-pipeline

--- a/inspector/impl/InspectorUtils.ts
+++ b/inspector/impl/InspectorUtils.ts
@@ -1,0 +1,12 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import type {HoistBase} from '@xh/hoist/core';
+
+/** Label for an instance within Inspector - its `xhName` or class name, plus `xhId`. */
+export function instanceLabel(inst: HoistBase): string {
+    return `${inst.xhName ?? inst.constructor.name} [${inst.xhId}]`;
+}

--- a/inspector/instances/DiagnosticsModel.ts
+++ b/inspector/instances/DiagnosticsModel.ts
@@ -11,6 +11,7 @@ import {fmtDate, numberRenderer} from '@xh/hoist/format';
 import {action, makeObservable} from '@xh/hoist/mobx';
 import {Cube} from '@xh/hoist/data';
 import {forIn, isEmpty, isFinite} from 'lodash';
+import {instanceLabel} from '../impl/InspectorUtils';
 import type {InstancesModel} from './InstancesModel';
 
 /**
@@ -55,7 +56,7 @@ export class DiagnosticsModel extends HoistModel {
     private get diagnosticSources(): DiagnosticSource[] {
         const ret: DiagnosticSource[] = [];
         this.parent.selectedInstances.forEach(inst => {
-            const label = `${inst.constructor.name} [${inst.xhId}]`,
+            const label = instanceLabel(inst),
                 diag = (inst as any).diagnostics;
             if (diag instanceof BaseDiagnostics) {
                 ret.push({xhId: inst.xhId, diag, label});
@@ -63,7 +64,7 @@ export class DiagnosticsModel extends HoistModel {
                 ret.push({
                     xhId: inst.xhId,
                     diag: inst.store.diagnostics,
-                    label: `${label} › Store [${inst.store.xhId}]`
+                    label: `${label} › ${instanceLabel(inst.store)}`
                 });
             }
         });

--- a/inspector/instances/InstancesModel.ts
+++ b/inspector/instances/InstancesModel.ts
@@ -16,6 +16,7 @@ import {action, bindable, isObservableProp, makeObservable, runInAction} from '@
 import {wait} from '@xh/hoist/promise';
 import {trimToDepth} from '@xh/hoist/utils/js';
 import {compact, find, forIn, head, without} from 'lodash';
+import {instanceLabel} from '../impl/InspectorUtils';
 import {StatsModel} from '../stats/StatsModel';
 import {DiagnosticsModel} from './DiagnosticsModel';
 
@@ -195,6 +196,7 @@ export class InstancesModel extends HoistModel {
             store: {
                 fields: [
                     {name: 'className', type: 'string'},
+                    {name: 'xhName', type: 'string'},
                     {name: 'displayGroup', type: 'string'},
                     {name: 'created', type: 'date'},
                     {name: 'syncRun', type: 'number'},
@@ -252,6 +254,7 @@ export class InstancesModel extends HoistModel {
                     renderer: v => (v ? Icon.link() : null)
                 },
                 {field: 'displayGroup', hidden: true},
+                {field: 'xhName', flex: 1, minWidth: 150},
                 {field: 'className', flex: 1, minWidth: 150},
                 {
                     field: 'lastLoadCompleted',
@@ -482,8 +485,7 @@ export class InstancesModel extends HoistModel {
             return null;
 
         const {xhId} = instance,
-            ctorName = instance.constructor.name,
-            instanceDisplayName = `${ctorName} [${xhId}]`,
+            instanceDisplayName = instanceLabel(instance),
             isLoadedGetter = isGetter && this.shouldLoadGetter(xhId, property),
             v = !isGetter || isLoadedGetter ? instance[property] : null,
             // Detect FormModel.values Proxy object - throws otherwise on attempt to render in grid.

--- a/mobile/cmp/navigator/NavigatorModel.ts
+++ b/mobile/cmp/navigator/NavigatorModel.ts
@@ -52,6 +52,9 @@ export interface NavigatorConfig {
      * See enum for description of supported modes.
      */
     refreshMode?: RefreshMode;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -101,10 +104,12 @@ export class NavigatorModel extends HoistModel {
         pullDownToRefresh = true,
         transitionMs = 500,
         renderMode = 'lazy',
-        refreshMode = 'onShowLazy'
+        refreshMode = 'onShowLazy',
+        xhName = null
     }: NavigatorConfig) {
         super();
         makeObservable(this);
+        this.xhName = xhName;
 
         ensureNotEmpty(pages, 'NavigatorModel needs at least one page.');
         ensureUniqueBy(pages, 'id', 'Multiple NavigatorModel PageModels have the same id.');

--- a/mobile/cmp/navigator/PageModel.ts
+++ b/mobile/cmp/navigator/PageModel.ts
@@ -62,6 +62,9 @@ export interface PageConfig {
      * no need to specify manually.
      */
     navigatorModel?: NavigatorModel;
+
+    /** See {@link HoistBase.xhName}. */
+    xhName?: string;
 }
 
 /**
@@ -116,7 +119,8 @@ export class PageModel extends HoistModel {
         renderMode,
         refreshMode,
         disableDirectLink,
-        disableAppRefreshButton
+        disableAppRefreshButton,
+        xhName = null
     }: PageConfig) {
         super();
         makeObservable(this);
@@ -127,6 +131,7 @@ export class PageModel extends HoistModel {
 
         this.id = id;
         this.navigatorModel = navigatorModel;
+        this.xhName = xhName ?? navigatorModel?.childXhName(id) ?? id;
         this.content = content;
         this.props = withDefault(props, {});
         this.disableDirectLink = withDefault(disableDirectLink, false);

--- a/svc/InspectorService.ts
+++ b/svc/InspectorService.ts
@@ -201,6 +201,7 @@ export class InspectorService extends HoistService {
                 return {
                     id: xhId,
                     className: inst.constructor.name,
+                    xhName: inst.xhName,
                     created: inst._created,
                     isHoistService: inst.isHoistService,
                     isHoistModel: inst.isHoistModel,
@@ -239,6 +240,7 @@ export class InspectorService extends HoistService {
 
 interface InspectorInstanceData {
     className: string;
+    xhName: string;
     created: number;
     isHoistModel: boolean;
     isHoistService: boolean;

--- a/svc/TraceService.ts
+++ b/svc/TraceService.ts
@@ -6,7 +6,7 @@
  */
 import {HoistService, PlainObject, XH, Span, FullSpanConfig} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
-import {debounced, parseNameSource} from '@xh/hoist/utils/js';
+import {debounced, parseTypeName} from '@xh/hoist/utils/js';
 import {every, forEach, groupBy, isEmpty, isString, omitBy, takeRight} from 'lodash';
 import {terminationSafePostJson} from './impl/Fetch';
 
@@ -119,12 +119,15 @@ export class TraceService extends HoistService {
 
         // Apply default tags - safe to call even before identity is resolved (getUsername is null).
         // Remove nulls they are used in this API to just prevent defaults
+        const {caller} = ret,
+            xhName = caller?.['xhName'];
         ret.tags = {
             'xh.clientApp': XH.clientAppCode,
             'xh.loadId': XH.loadId,
             'xh.tabId': XH.tabId,
             'xh.source': ret.name.startsWith('xh.') ? 'hoist' : 'app',
-            ...(ret.caller ? {'code.namespace': parseNameSource(ret.caller)} : {}),
+            ...(caller ? {'code.namespace': parseTypeName(caller)} : {}),
+            ...(xhName ? {'xh.name': xhName} : {}),
             ...this.identityTags(),
             ...ret.tags
         };

--- a/utils/js/LangUtils.ts
+++ b/utils/js/LangUtils.ts
@@ -282,13 +282,28 @@ export function mergeDeep(target: PlainObject, ...sources: PlainObject[]): Plain
 }
 
 /**
- * A string, or an object from which a name can be derived - via `displayName` (e.g. React
- * components) or `constructor.name` (e.g. class instances). Used for logging and tracing.
+ * A string, or an object from which a name can be derived - via `xhName` (named HoistBase
+ * instances), `displayName` (e.g. React components), or `constructor.name` (class instances).
+ * Used for logging and tracing.
  */
-export type NameSource = string | {displayName: string} | {constructor: {name: string}};
+export type NameSource =
+    string | {xhName: string} | {displayName: string} | {constructor: {name: string}};
 
-/** Resolve a {@link NameSource} to a string, or null if unresolvable. */
+/**
+ * Resolve a {@link NameSource} to a string, or null if unresolvable.
+ * Prefers an instance-level `xhName` when set - see {@link parseTypeName} to skip it.
+ */
 export function parseNameSource(source: NameSource): string {
+    if (!source) return null;
+    if (isString(source)) return source;
+    return source['xhName'] || parseTypeName(source);
+}
+
+/**
+ * Resolve a {@link NameSource} to its type-level name - `displayName` or `constructor.name` -
+ * ignoring any instance-level `xhName`. Returns null if unresolvable.
+ */
+export function parseTypeName(source: NameSource): string {
     if (!source) return null;
     if (isString(source)) return source;
     if (source['displayName']) return source['displayName'];

--- a/utils/js/LangUtils.ts
+++ b/utils/js/LangUtils.ts
@@ -301,6 +301,8 @@ export function parseNameSource(source: NameSource): string {
 /**
  * Resolve a {@link NameSource} to its type-level name - `displayName` or `constructor.name` -
  * ignoring any instance-level `xhName`. Returns null if unresolvable.
+ *
+ * @internal - use {@link parseNameSource}.
  */
 export function parseTypeName(source: NameSource): string {
     if (!source) return null;

--- a/utils/js/LangUtils.ts
+++ b/utils/js/LangUtils.ts
@@ -4,7 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import type {PlainObject, Thunkable} from '@xh/hoist/core';
+import type {HoistBase, PlainObject, Thunkable} from '@xh/hoist/core';
 import {Exception} from '@xh/hoist/exception';
 import {
     flatMap,
@@ -282,12 +282,11 @@ export function mergeDeep(target: PlainObject, ...sources: PlainObject[]): Plain
 }
 
 /**
- * A string, or an object from which a name can be derived - via `xhName` (named HoistBase
- * instances), `displayName` (e.g. React components), or `constructor.name` (class instances).
- * Used for logging and tracing.
+ * A string, or an object from which a name can be derived - via `xhName` (HoistBase instances),
+ * `displayName` (e.g. React components), or `constructor.name` (class instances). Used for
+ * logging and tracing.
  */
-export type NameSource =
-    string | {xhName: string} | {displayName: string} | {constructor: {name: string}};
+export type NameSource = string | HoistBase | {displayName: string} | {constructor: {name: string}};
 
 /**
  * Resolve a {@link NameSource} to a string, or null if unresolvable.


### PR DESCRIPTION
Resolves the first half of #4584 (naming); Inspector Favorites follow in #4630. Design and decisions are in the [issue comment](https://github.com/xh/hoist-react/issues/4584#issuecomment-5456074159).

- Added `HoistBase.xhName` - optional, non-unique, developer-facing name. `parseNameSource` prefers it over the class name, so all existing `logXxx` / `withDebug` / diagnostics output relabels with no call-site changes.
- `xhName` config on Hoist's config-driven models: `Store`, `Cube`, `View` (incl. `cube.createView`), `GridModel`, `FormModel`, `TabContainerModel`/`TabModel`, `DockContainerModel`/`DockViewModel`, `NavigatorModel`/`PageModel`, Dash containers/views, `DataViewModel`, `RestGridModel`, `ZoneGridModel`, `TreeMapModel`/`SplitTreeMapModel`, `PanelModel`, `ChartModel`, `FilterChooserModel`, `GroupingChooserModel`, `LeftRightChooserModel`, `ViewManagerModel`, `AgGridModel`, `StoreSelectionModel`, `GridFilterModel`.
- Owners name the children they create via new `HoistBase.childXhName(key)` (`positionsGrid.store`, `positionsForm.firstName`); `TabModel`/`DockViewModel`/`PageModel`/`DashViewModel` fall back to their `id`, `ViewManagerModel` to its `type`.
- Internal helpers owned by tab containers, panels, dash views, zone grids, and grids (`refreshContextModel`, `modalSupportModel`, `colChooserModel`, ...) are named from their owner.
- Services are named with their `XH` key (`fetchService`), `XH.appModel` as `appModel`, and the app container's models by property (`routerModel`, `pageStateModel`, ...) - log labels for these change accordingly.
- New `parseTypeName` keeps `TraceService`'s `code.namespace` tag at the type level; a named caller adds an `xh.name` tag.
- Inspector: new `xhName` column, and a shared `instanceLabel` helper for instance and diagnostics labels.

Sibling Toolbox PR naming the Portfolio example's models: xh/toolbox#894.