### PR TITLE
Fix Select not reliably scrolling selected option into view (#4645)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
 
 * Fixed `SegmentedControl.fill: false` leaving an empty run of tray to the right of its options -
   the control now sizes to its options.
+* Fixed desktop `Select` not reliably scrolling the selected option into view when opening its
+  menu - a regression from the v86 react-select upgrade. Selects with `enableFilter: false` never
+  scrolled; others did so intermittently.
 
 ### ⚙️ Technical
 

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -822,16 +822,12 @@ const cmp = hoistCmp.factory<SelectInputModel>(({model, className, ...props}, re
         rsProps.controlShouldRenderValue = !model.hasFocus;
     }
 
-    // Scroll the selected option into view on menu open. Required for all single-selects, as
-    // react-select's built-in equivalent does not fire for portalled menus (which we always use).
-    // Poll for the option element - the portalled menu mounts over multiple render passes.
-    if (!model.multiMode) {
+    // Scroll selected option into view on open - react-select's own does not fire for portalled menus.
+    if (!model.multiMode && model.renderValue) {
         rsProps.onMenuOpen = () => {
-            const getSelectedEl = () =>
+            const getSel = () =>
                 document.getElementsByClassName('xh-select__option--is-selected')[0];
-            waitFor(() => !!getSelectedEl())
-                .then(() => getSelectedEl()?.scrollIntoView({block: 'end'}))
-                .catch(() => {}); // Timeout expected when no option selected - nothing to scroll to.
+            waitFor(() => !!getSel()).then(() => getSel().scrollIntoView({block: 'end'}));
         };
     }
 

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -27,7 +27,7 @@ import {
     reactWindowedSelect
 } from '@xh/hoist/kit/react-select';
 import {action, bindable, makeObservable, observable, override} from '@xh/hoist/mobx';
-import {debouncePromise, wait} from '@xh/hoist/promise';
+import {debouncePromise, wait, waitFor} from '@xh/hoist/promise';
 import {elemWithin, getTestId, mergeDeep, TEST_ID, throwIf, withDefault} from '@xh/hoist/utils/js';
 import {createObservableRef, getLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
@@ -820,13 +820,18 @@ const cmp = hoistCmp.factory<SelectInputModel>(({model, className, ...props}, re
         rsProps.inputValue = model.inputValue || '';
         rsProps.onInputChange = model.onInputChange;
         rsProps.controlShouldRenderValue = !model.hasFocus;
+    }
+
+    // Scroll the selected option into view on menu open. Required for all single-selects, as
+    // react-select's built-in equivalent does not fire for portalled menus (which we always use).
+    // Poll for the option element - the portalled menu mounts over multiple render passes.
+    if (!model.multiMode) {
         rsProps.onMenuOpen = () => {
-            wait().then(() => {
-                const selectedEl = document.getElementsByClassName(
-                    'xh-select__option--is-selected'
-                )[0];
-                selectedEl?.scrollIntoView({block: 'end'});
-            });
+            const getSelectedEl = () =>
+                document.getElementsByClassName('xh-select__option--is-selected')[0];
+            waitFor(() => !!getSelectedEl())
+                .then(() => getSelectedEl()?.scrollIntoView({block: 'end'}))
+                .catch(() => {}); // Timeout expected when no option selected - nothing to scroll to.
         };
     }
 


### PR DESCRIPTION
Regression from the v86 react-select 4→5 upgrade. react-select 5.5.0 rewrote `MenuPortal` onto hooks + `@floating-ui/dom`, turning a one-pass portal mount into a two-pass one - the first render returns null until a layout effect sets the computed position. Hoist always portals its menu, so react-select's own scroll-into-view now runs in a commit where the portal rendered nothing, finds null refs, and never gets a second chance.

That broke two layers that both assumed a synchronous menu mount:

* Non-filterable single selects had no Hoist assist at all - it was gated on `manageInputValue` (`filterMode && !multiMode`). That gap was harmless while native scroll covered them, but nothing scrolls them now. Gate is now `!multiMode`.
* Filterable selects had the assist, but its single `wait()` macrotask no longer reliably lands after the options mount, failing silently behind an optional chain. Now polls for the option element via `waitFor()`.

Hoist P/R Checklist
-------------------

**Pull request authors:** Review and check off the below. Items that do not apply can also be
checked off to indicate they have been considered. If unclear if a step is relevant, please leave
unchecked and note in comments.

- [X] Caught up with `develop` branch as of last change.
- [X] Added CHANGELOG entry, or determined not required.
- [X] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [X] Updated doc comments / prop-types, or determined not required.
- [X] Reviewed and tested on Mobile, or determined not required.
- [X] Created Toolbox branch / PR, or determined not required.

**If your change is still a WIP**, please use the "Create draft pull request" option in the split
button below to indicate it is not ready yet for a final review.

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

