### PR TITLE
Fix getSortedRecords() throwing when grouped by non-string field (87.1.1 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   3. Plain ASCII punctuation only. Use " - " for in-sentence breaks, never an em dash.
 -->
 
+## 87.1.1 - 2026-09-02
+
+### 🐞 Bug Fixes
+
+* Fixed `GridModel.getSortedRecords()` throwing e.g. grid exports when grouped by a non-string
+  field. Group values are now coerced to string keys before sorting.
+
 ## 87.1.0 - 2026-08-28
 
 ### 🎁 New Features

--- a/cmp/grid/impl/RecordSortUtils.ts
+++ b/cmp/grid/impl/RecordSortUtils.ts
@@ -105,13 +105,21 @@ function getGroupSorters(gridModel: GridModel): RecordSorter[] {
             const column = gridModel.getColumn(colId);
             if (!column) return null;
 
-            const {field} = column;
+            const {field} = column,
+                {getValueFn, ctx} = sorterFor(gridModel, column);
             return {
-                ...sorterFor(gridModel, column),
+                ctx,
+                // groupSortFn expects ag-Grid group keys - always string or null, never raw values.
+                getValueFn: params => toGroupKey(getValueFn(params)),
                 compare: (a, b, nodeA, nodeB) => groupSortFn(a, b, field, {gridModel, nodeA, nodeB})
             };
         })
     );
+}
+
+/** Mirror ag-Grid's ValueService.getKeyForNode - string/null pass through, else String(). */
+function toGroupKey(value: any): string {
+    return value == null || typeof value === 'string' ? value : String(value);
 }
 
 /** Value-resolution half of a sorter - the caller supplies the comparator. */


### PR DESCRIPTION
Hotfix for release as **87.1.1**.

`GridModel.getSortedRecords()` passed raw column values to `groupSortFn`, whose default implementation calls `localeCompare` and throws when a grid is grouped by a number, date, or other non-string field. This surfaced in grid exports on grouped grids.

**Changes**

* Group sorters in `RecordSortUtils` now coerce values to string keys once per record during the decorate phase, before `groupSortFn` sees them.
* New `toGroupKey` helper mirrors ag-Grid's `ValueService.getKeyForNode` (string/null pass through, all else via `String()`) so ordering matches the rendered grid.
* Changelog entry for 87.1.1.

Validated crash before / fixed after in Toolbox locally.

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change. (Hotfix targets `master` - to be merged forward to `develop` after release.)
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required.
- [x] Created Toolbox branch / PR, or determined not required.
