### PR TITLE
DateRangePicker: live anchorDay, lossless stepping via offset, businessDayMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
 
 * Fixed `SegmentedControl.fill: false` leaving an empty run of tray to the right of its options -
   the control now sizes to its options.
+* Fixed desktop `Select` not reliably scrolling the selected option into view when opening its
+  menu - a regression from the v86 react-select upgrade. Selects with `enableFilter: false` never
+  scrolled; others did so intermittently.
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   3. Plain ASCII punctuation only. Use " - " for in-sentence breaks, never an em dash.
 -->
 
+## 87.1.1 - 2026-09-02
+
+### 🐞 Bug Fixes
+
+* Fixed `GridModel.getSortedRecords()` throwing e.g. grid exports when grouped by a non-string
+  field. Group values are now coerced to string keys before sorting.
+
 ## 87.1.0 - 2026-08-28
 
 ### 🎁 New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,10 @@
 ### 🎁 New Features
 
 * Added `DateRangePicker` (`desktop/cmp/daterange`), a compact control for selecting a period as a
-  preset (MTD, Prev 30 Days, ...), a relative lookback, a calendar month or year, or a custom date
-  range. Its `DateRangePickerModel` persists the selection as plain JSON and resolves it to concrete
-  date ranges and `FieldFilterSpec`s for querying. The model keeps its `anchorDay` on the current
-  day as midnight passes, steps presets and lookbacks back and forth without losing their kind, and
-  offers a `businessDayMode` for desks that walk single days by business day.
+  preset (Today, MTD, Prev 30 Days, ...), a relative lookback, a calendar month or year, or a custom
+  date range. Its `DateRangePickerModel` persists the selection as plain JSON, resolves it to date
+  ranges and `FieldFilterSpec`s, keeps a live `anchorDay` current across midnight, steps periods
+  back and forth without changing their kind, and offers a `businessDayMode` for single-day walks.
 * The Admin Console's Activity Tracking tab now selects its query period with a `DateRangePicker`.
   Periods saved in existing views reset to Today on first load.
 * Added `Icon.calendarDays` and `Icon.calendarRange`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@
 ### 🎁 New Features
 
 * Added `DateRangePicker` (`desktop/cmp/daterange`), a compact control for selecting a period as a
-  preset (MTD, Last 30 Days, ...), a relative lookback, a calendar month or year, or a custom date
+  preset (MTD, Prev 30 Days, ...), a relative lookback, a calendar month or year, or a custom date
   range. Its `DateRangePickerModel` persists the selection as plain JSON and resolves it to concrete
-  date ranges and `FieldFilterSpec`s for querying.
+  date ranges and `FieldFilterSpec`s for querying. The model keeps its `anchorDay` on the current
+  day as midnight passes, steps presets and lookbacks back and forth without losing their kind, and
+  offers a `businessDayMode` for desks that walk single days by business day.
 * The Admin Console's Activity Tracking tab now selects its query period with a `DateRangePicker`.
   Periods saved in existing views reset to Today on first load.
 * Added `Icon.calendarDays` and `Icon.calendarRange`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@
 * Added `SegmentedControl.equalSegmentWidths` to the desktop control, matching the existing mobile
   prop. Defaults to `true`, so a filled control now divides its width into equal segments rather
   than sizing each option to its own label.
+* Added read-only detail panels to the Admin Console's Config, User Preferences, and JSON Blobs
+  tabs, docked to the right of each grid and tracking its selection. The Config panel shows every
+  view of a config's value - resolved, instance override, database, and typedClass defaults -
+  opening on the most-derived view, and renders config notes as Markdown. Each panel offers an
+  `Edit` button to open the grid's editor, which is now dedicated to editing: the Config editor
+  opens JSON values on the `Database` tab, and double-click no longer opens a view-only dialog for
+  read-only admins.
 
 ### 🐞 Bug Fixes
 

--- a/admin/AdminUtils.ts
+++ b/admin/AdminUtils.ts
@@ -5,8 +5,14 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {AppModel} from '@xh/hoist/admin/AppModel';
+import {div, span} from '@xh/hoist/cmp/layout';
+import {markdown} from '@xh/hoist/cmp/markdown';
 import {XH} from '@xh/hoist/core';
+import {defaultReadonlyRenderer} from '@xh/hoist/desktop/cmp/form';
+import {jsonInput} from '@xh/hoist/desktop/cmp/input';
 import {LocalDate} from '@xh/hoist/utils/datetime';
+import {isString} from 'lodash';
+import {ReactElement, ReactNode} from 'react';
 
 /**
  * Generate a standardized filename for an Admin module grid export, without datestamp.
@@ -25,4 +31,62 @@ export function exportFilenameWithDate(moduleName: string): () => string {
 
 export function getAppModel<T extends AppModel>() {
     return XH.appModel as T;
+}
+
+/** Muted "N/A" placeholder for empty values in read-only detail forms. */
+export function naSpan(): ReactNode {
+    return span({item: 'N/A', className: 'xh-text-color-muted'});
+}
+
+/**
+ * Default readonly renderer for detail forms - FormField's standard formatting (dates, numbers,
+ * booleans, JSON, text), or {@link naSpan} when null.
+ */
+export function valOrNa(v: any): ReactNode {
+    return v != null ? defaultReadonlyRenderer(v) : naSpan();
+}
+
+/**
+ * Read-only JsonInput for detail displays - fixed to `height` if given, otherwise filling its
+ * container. Pair fill mode with the `xh-admin-readonly-form__fill` class on the enclosing
+ * `formFieldSet` to have it take the remaining panel height.
+ */
+export function readonlyJsonInput(value: any, height: number = null): ReactElement {
+    return jsonInput({
+        value: isString(value) ? value : JSON.stringify(value),
+        readonly: true,
+        autoFormat: true,
+        enableSearch: true,
+        width: '100%',
+        ...(height != null ? {height} : {flex: 1, height: '100%'})
+    });
+}
+
+/**
+ * Readonly renderer for stored scalar values (config / preference values) - the value as literal
+ * text, with no number or date formatting, or {@link naSpan} when null.
+ */
+export function rawValueRenderer(v: any): ReactNode {
+    return v == null ? naSpan() : v.toString();
+}
+
+/** Readonly renderer for JSON fields in detail forms - {@link readonlyJsonInput} in fill mode. */
+export function jsonRenderer(v: any): ReactNode {
+    return v == null ? naSpan() : readonlyJsonInput(v);
+}
+
+/** Readonly renderer for boolean fields in detail forms - "Yes" / "No", or {@link naSpan} when null. */
+export function yesNoRenderer(v: boolean): ReactNode {
+    return v == null ? naSpan() : v ? 'Yes' : 'No';
+}
+
+/**
+ * Readonly renderer for free-text fields in detail forms that may contain Markdown (notes,
+ * descriptions). Renders via {@link markdown} within a wrapper styled for compact display, or
+ * {@link naSpan} when null.
+ */
+export function markdownRenderer(v: string): ReactNode {
+    return v == null
+        ? naSpan()
+        : div({className: 'xh-admin-readonly-form__markdown', item: markdown({content: v})});
 }

--- a/admin/App.scss
+++ b/admin/App.scss
@@ -23,6 +23,94 @@
     background-color: var(--xh-intent-primary-darker);
     font-family: var(--xh-font-family-mono);
   }
+
+  // Value type badges - shown in grid cells and detail forms, so drop Badge's inline-text offset.
+  // Fixed width keeps a column of mixed types from looking ragged.
+  .xh-value-type-badge {
+    --xh-badge-font-size: 0.85em;
+    --xh-badge-font-weight: normal;
+    margin-left: 0;
+    width: 64px;
+  }
+}
+
+// Read-only detail forms within the Admin Console - stacked fields with small, muted, uppercase
+// labels sitting directly above their values. Apply to the container of a read-only `form`.
+// Styled entirely via the framework's form-field CSS vars - see `styles/vars.scss`.
+.xh-admin-readonly-form {
+  --xh-form-field-margin: 0 0 var(--xh-pad-half-px) 0;
+  --xh-form-field-label-color: var(--xh-text-color-muted);
+  --xh-form-field-label-font-size: var(--xh-font-size-small-px);
+  --xh-form-field-label-font-weight: 600;
+  --xh-form-field-label-text-transform: uppercase;
+  --xh-form-field-readonly-label-margin: 0;
+
+  // A field set (or other child) that stretches to fill the remaining height, passing the flex
+  // down to a read-only code editor within. `.xh-card` renders as a <fieldset>, so make it an
+  // explicit flex column.
+  &__fill {
+    display: flex;
+    // Floor via flex-basis, not min-height - a min-height-clamped <fieldset> collapses its content.
+    flex: 1 0 250px;
+    flex-direction: column;
+
+    > .xh-card__content,
+    .xh-form-field,
+    .xh-form-field__inner,
+    .xh-form-field__readonly-display {
+      flex: 1;
+      min-height: 0;
+    }
+
+    // FormField's read-only wrapper is a block - make it (and the display within) flex columns
+    // so a percentage-height editor has a definite height to fill.
+    .xh-form-field__inner,
+    .xh-form-field__readonly-display {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .xh-form-field__readonly-display {
+      padding: 0;
+    }
+  }
+
+  // Markdown-rendered text fields - undo the readonly display's pre-wrap (which turns
+  // react-markdown's inter-element newlines into blank lines) and tighten block spacing.
+  &__markdown {
+    white-space: normal;
+
+    p,
+    ul,
+    ol {
+      margin: 0 0 var(--xh-pad-half-px) 0;
+    }
+
+    ul,
+    ol {
+      padding-left: 1.5em;
+    }
+
+    li > p {
+      margin: 0;
+    }
+
+    > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  // Frame read-only editors - they otherwise float borderless within a field set.
+  .xh-code-input {
+    border: var(--xh-border-solid);
+    border-radius: var(--xh-border-radius-px);
+  }
+}
+
+// RestDetailPanel form body.
+.xh-admin-rest-detail__form {
+  padding: var(--xh-pad-px);
+  gap: var(--xh-pad-px);
 }
 
 .xh-units-label {

--- a/admin/columns/UserData.ts
+++ b/admin/columns/UserData.ts
@@ -4,9 +4,13 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
+import {badge} from '@xh/hoist/cmp/badge';
 import * as Col from '@xh/hoist/cmp/grid/columns';
-import {truncate} from 'lodash';
 import {ColumnSpec} from '@xh/hoist/cmp/grid/columns';
+import {Intent} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
+import {truncate} from 'lodash';
+import {ReactElement} from 'react';
 
 export const value: ColumnSpec = {
     field: {name: 'value', type: 'auto'},
@@ -35,8 +39,31 @@ export const valueType: ColumnSpec = {
         type: 'string',
         displayName: 'Type'
     },
-    width: 80,
-    align: 'center'
+    width: 90,
+    align: 'center',
+    renderer: v => valueTypeRenderer(v)
+};
+
+/** Renders a config value type (json, string, int, bool, pwd...) as an icon + colored badge. */
+export function valueTypeRenderer(valueType: string): ReactElement {
+    if (!valueType) return null;
+    const {icon, intent} = VALUE_TYPE_BADGES[valueType] ?? {};
+    return badge({
+        item: valueType,
+        icon: icon?.(),
+        intent,
+        className: 'xh-value-type-badge'
+    });
+}
+
+const VALUE_TYPE_BADGES: Record<string, {icon: () => ReactElement; intent?: Intent}> = {
+    json: {icon: Icon.json, intent: 'primary'},
+    bool: {icon: Icon.checkSquare, intent: 'success'},
+    int: {icon: Icon.calculator, intent: 'warning'},
+    long: {icon: Icon.calculator, intent: 'warning'},
+    double: {icon: Icon.calculator, intent: 'warning'},
+    pwd: {icon: Icon.lock, intent: 'danger'},
+    string: {icon: Icon.list}
 };
 
 export const groupName: ColumnSpec = {

--- a/admin/detail/RestDetailModel.ts
+++ b/admin/detail/RestDetailModel.ts
@@ -1,0 +1,64 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {FormModel} from '@xh/hoist/cmp/form';
+import {HoistModel, lookup, managed} from '@xh/hoist/core';
+import {StoreRecord} from '@xh/hoist/data';
+import {RestGridModel} from '@xh/hoist/desktop/cmp/rest';
+import {computed, makeObservable} from '@xh/hoist/mobx';
+
+/**
+ * Backs a {@link restDetailPanel}. Resolves the host RestGridModel via `@lookup` - the model of an
+ * enclosing component must expose it as a public property - then tracks its single selection and
+ * mirrors the selected record into a read-only FormModel with a field for every store field.
+ */
+export class RestDetailModel extends HoistModel {
+    override xhImpl = true;
+
+    @lookup(RestGridModel) gridModel: RestGridModel;
+
+    @managed formModel: FormModel;
+
+    get record(): StoreRecord {
+        return this.gridModel.selectedRecord;
+    }
+
+    @computed
+    get hasSelection(): boolean {
+        return !!this.record;
+    }
+
+    get readonly(): boolean {
+        return this.gridModel.readonly;
+    }
+
+    constructor() {
+        super();
+        makeObservable(this);
+    }
+
+    override onLinked() {
+        this.formModel = new FormModel({
+            readonly: true,
+            fields: this.gridModel.store.fields.map(f => ({
+                name: f.name,
+                displayName: f.displayName
+            }))
+        });
+
+        // Record identity changes on selection and on store reload (e.g. after a save), so the
+        // form tracks both a new selection and fresh data for the current one.
+        this.addReaction({
+            track: () => this.record,
+            run: rec => this.formModel.init(rec?.data ?? {}),
+            fireImmediately: true
+        });
+    }
+
+    edit() {
+        this.gridModel.editRecord(this.record);
+    }
+}

--- a/admin/detail/RestDetailPanel.ts
+++ b/admin/detail/RestDetailPanel.ts
@@ -1,0 +1,106 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {valOrNa} from '@xh/hoist/admin/AdminUtils';
+import {form, FormModel} from '@xh/hoist/cmp/form';
+import {filler, placeholder, vframe} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp, HoistProps, PersistOptions} from '@xh/hoist/core';
+import {StoreRecord} from '@xh/hoist/data';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {panel} from '@xh/hoist/desktop/cmp/panel';
+import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
+import {Icon} from '@xh/hoist/icon';
+import {startCase} from 'lodash';
+import {ReactElement, ReactNode} from 'react';
+import {RestDetailModel} from './RestDetailModel';
+
+export interface RestDetailPanelProps extends HoistProps<RestDetailModel> {
+    /** Icon for the panel header and empty-state placeholder. */
+    icon: ReactElement;
+    /** Placeholder text when no single record is selected. */
+    emptyText?: string;
+    /** Default width in pixels. */
+    defaultSize?: number;
+    /** Minimum width in pixels. */
+    minSize?: number;
+    /** Options for persisting panel size and collapsed state. */
+    persistWith?: PersistOptions;
+    /** Panel title for the selected record - defaults to its `name`. */
+    titleFn?: (record: StoreRecord) => ReactNode;
+    /**
+     * Renders the form body for the selected record - typically one or more `formFieldSet`s of
+     * `formField`s bound to the store's field names. Rendered within a read-only `form` bound to
+     * the model's FormModel, styled with the `xh-admin-readonly-form` class.
+     */
+    renderForm: (record: StoreRecord, formModel: FormModel) => ReactNode;
+}
+
+/**
+ * Read-only detail view of the record selected in a RestGrid, docked to its right. Tracks the
+ * grid's selection, refreshes when the grid reloads, and offers an Edit button to open the grid's
+ * editor dialog for the selected record.
+ *
+ * Render as a sibling of `restGrid()` within an `hframe`. The host RestGridModel is resolved via
+ * `@lookup`, so the model of an enclosing component must expose it as a public property.
+ */
+export const restDetailPanel = hoistCmp.factory<RestDetailPanelProps>({
+    displayName: 'RestDetailPanel',
+    className: 'xh-admin-rest-detail',
+    model: creates(RestDetailModel),
+
+    render({model, className, icon, titleFn, renderForm, ...props}) {
+        const {
+                emptyText = 'Select a record to view its details.',
+                defaultSize = 550,
+                minSize = 400,
+                persistWith
+            } = props,
+            {hasSelection, readonly, record, formModel, gridModel} = model;
+
+        return panel({
+            className,
+            title: hasSelection
+                ? (titleFn?.(record) ?? record.data.name)
+                : `${startCase(gridModel.unit)} Detail`,
+            icon,
+            compactHeader: true,
+            modelConfig: {
+                side: 'right',
+                defaultSize,
+                minSize,
+                persistWith,
+                // Skip per-selection form work while collapsed.
+                renderMode: 'unmountOnHide'
+            },
+            item: hasSelection
+                ? form({
+                      model: formModel,
+                      fieldDefaults: {readonlyRenderer: valOrNa},
+                      item: vframe({
+                          className: 'xh-admin-rest-detail__form xh-admin-readonly-form',
+                          // Scroll when content outgrows the panel - inline to beat the frame's
+                          // own overflow: hidden.
+                          overflowY: 'auto',
+                          items: renderForm(record, formModel)
+                      })
+                  })
+                : placeholder(icon, emptyText),
+            bbar: toolbar({
+                omit: !hasSelection || readonly,
+                items: [
+                    filler(),
+                    button({
+                        text: 'Edit',
+                        icon: Icon.edit(),
+                        intent: 'primary',
+                        outlined: true,
+                        onClick: () => model.edit()
+                    })
+                ]
+            })
+        });
+    }
+});

--- a/admin/tabs/activity/tracking/ActivityTrackingModel.ts
+++ b/admin/tabs/activity/tracking/ActivityTrackingModel.ts
@@ -20,8 +20,7 @@ import {HoistModel, LoadSpec, managed, PlainObject, XH} from '@xh/hoist/core';
 import {Cube, CubeFieldSpec, FieldSpec, getCubeLeaves, ViewRowData} from '@xh/hoist/data';
 import {dateRenderer, dateTimeSecRenderer, numberRenderer} from '@xh/hoist/format';
 import {action, computed, makeObservable, observable} from '@xh/hoist/mobx';
-import {Timer} from '@xh/hoist/utils/async';
-import {LocalDate, ONE_MINUTE} from '@xh/hoist/utils/datetime';
+import {LocalDate} from '@xh/hoist/utils/datetime';
 import {compact, get, isEmpty, isEqual, round} from 'lodash';
 import moment from 'moment';
 import {ActivityDetailProvider} from './detail/ActivityDetailModel';
@@ -107,7 +106,6 @@ export class ActivityTrackingModel extends HoistModel implements ActivityDetailP
     @observable.ref trackLogs: PlainObject[] = [];
 
     private _monthFormat = 'MMM YYYY';
-    @managed private anchorTimer: Timer;
 
     constructor() {
         super();
@@ -201,30 +199,22 @@ export class ActivityTrackingModel extends HoistModel implements ActivityDetailP
     }
 
     private createDateRangePickerModel(): DateRangePickerModel {
-        const ret = new DateRangePickerModel({
+        return new DateRangePickerModel({
             persistWith: this.persistWith,
             presets: [
-                'today',
-                'yesterday',
-                'last7Days',
-                'last30Days',
-                'last90Days',
+                'anchorDay',
+                'prevDay',
+                'prev7Days',
+                'prev30Days',
+                'prev90Days',
                 'mtd',
-                'lastMonth',
+                'prevMonth',
                 'ytd'
             ],
-            initialValue: 'today',
-            anchorDate: LocalDate.currentAppDay()
+            initialValue: 'anchorDay',
+            // Track logs are stamped in the app time zone - follow its day, across midnight too.
+            anchorDay: 'appDay'
         });
-
-        // Admin sessions can stay open across midnight - keep the anchor on the current app day so
-        // relative periods (and the latest selectable date) follow it.
-        this.anchorTimer = Timer.create({
-            runFn: () => ret.setAnchorDate(LocalDate.currentAppDay()),
-            interval: ONE_MINUTE
-        });
-
-        return ret;
     }
 
     private async loadGridAsync() {

--- a/admin/tabs/activity/tracking/detail/ActivityDetailView.ts
+++ b/admin/tabs/activity/tracking/detail/ActivityDetailView.ts
@@ -4,6 +4,7 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
+import {naSpan, valOrNa} from '@xh/hoist/admin/AdminUtils';
 import {badgeRenderer} from '@xh/hoist/admin/columns';
 import {form} from '@xh/hoist/cmp/form';
 import {grid, gridCountLabel} from '@xh/hoist/cmp/grid';
@@ -205,6 +206,4 @@ const additionalDataPanel = hoistCmp.factory<ActivityDetailModel>(({model}) => {
     });
 });
 
-const valOrNa = v => (v != null ? v : naSpan());
-const naSpan = () => span({item: 'N/A', className: 'xh-text-color-muted'});
 const hyperlinkVal = v => (v ? a({href: v, item: v, target: '_blank'}) : '-');

--- a/admin/tabs/general/config/ConfigDetailPanel.ts
+++ b/admin/tabs/general/config/ConfigDetailPanel.ts
@@ -1,0 +1,72 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {markdownRenderer, yesNoRenderer} from '@xh/hoist/admin/AdminUtils';
+import {valueTypeRenderer} from '@xh/hoist/admin/columns';
+import {restDetailPanel} from '@xh/hoist/admin/detail/RestDetailPanel';
+import {formFieldSet} from '@xh/hoist/cmp/form';
+import {hbox} from '@xh/hoist/cmp/layout';
+import {hoistCmp, uses} from '@xh/hoist/core';
+import {formField} from '@xh/hoist/desktop/cmp/form';
+import {Icon} from '@xh/hoist/icon';
+import {ConfigPanelModel} from './ConfigPanelModel';
+import {configValue} from './ConfigValue';
+
+/**
+ * Read-only detail view of the config selected in the grid. Shows the config's metadata and every
+ * available view of its value - resolved, instance override, database, and typedClass defaults -
+ * opening on the most-derived view.
+ */
+export const configDetailPanel = hoistCmp.factory<ConfigPanelModel>({
+    displayName: 'ConfigDetailPanel',
+    model: uses(ConfigPanelModel),
+
+    render({model}) {
+        return restDetailPanel({
+            icon: Icon.settings(),
+            emptyText: 'Select a config to view its details.',
+            persistWith: {...model.persistWith, path: 'detailPanel'},
+            renderForm: (record, formModel) => {
+                const {note, valueType} = formModel.values;
+                return [
+                    formFieldSet({
+                        title: 'Config',
+                        items: [
+                            hbox(
+                                formField({field: 'groupName', flex: 1}),
+                                formField({
+                                    field: 'valueType',
+                                    readonlyRenderer: valueTypeRenderer,
+                                    flex: 1
+                                }),
+                                formField({
+                                    field: 'clientVisible',
+                                    readonlyRenderer: yesNoRenderer,
+                                    flex: 1
+                                })
+                            ),
+                            formField({
+                                field: 'note',
+                                readonlyRenderer: markdownRenderer,
+                                omit: !note
+                            }),
+                            hbox(
+                                formField({field: 'lastUpdatedBy', label: 'Updated By', flex: 1}),
+                                formField({field: 'lastUpdated', label: 'Updated', flex: 2})
+                            )
+                        ]
+                    }),
+                    formFieldSet({
+                        title: 'Value',
+                        // JSON values stretch to fill the remaining height - scalars sit compactly.
+                        className: valueType === 'json' ? 'xh-admin-readonly-form__fill' : null,
+                        item: configValue({formModel})
+                    })
+                ];
+            }
+        });
+    }
+});

--- a/admin/tabs/general/config/ConfigPanel.ts
+++ b/admin/tabs/general/config/ConfigPanel.ts
@@ -7,8 +7,8 @@
 import * as AdminCol from '@xh/hoist/admin/columns';
 import * as Col from '@xh/hoist/admin/columns/Rest';
 import {jsonSearchButton} from '@xh/hoist/admin/jsonsearch/JsonSearch';
-import {filler, fragment} from '@xh/hoist/cmp/layout';
-import {creates, hoistCmp, XH} from '@xh/hoist/core';
+import {filler, fragment, hframe} from '@xh/hoist/cmp/layout';
+import {creates, hoistCmp} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {recordActionBar} from '@xh/hoist/desktop/cmp/record';
 import {restGrid} from '@xh/hoist/desktop/cmp/rest';
@@ -17,6 +17,7 @@ import {toolbar, toolbarSep} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
 import {differ} from '../../../differ/Differ';
 import {regroupDialog} from '../../../regroup/RegroupDialog';
+import {configDetailPanel} from './ConfigDetailPanel';
 import {ConfigPanelModel} from './ConfigPanelModel';
 
 export const configPanel = hoistCmp.factory({
@@ -24,46 +25,49 @@ export const configPanel = hoistCmp.factory({
 
     render({model}) {
         return fragment(
-            restGrid({
-                testId: 'config',
-                formBbar: configFormBbar(),
-                extraToolbarItems: () => [
-                    button({
-                        icon: Icon.diff(),
-                        text: 'Compare w/ Remote',
-                        onClick: () => model.openDiffer()
-                    }),
-                    toolbarSep(),
-                    jsonSearchButton({
-                        subjectName: 'Config',
-                        docSearchUrl: 'jsonSearch/searchConfigs',
-                        gridModelConfig: {
-                            sortBy: ['groupName', 'name'],
-                            columns: [
-                                {...AdminCol.groupName},
-                                {...AdminCol.name},
-                                {
-                                    field: {name: 'json', type: 'string'},
-                                    hidden: true
-                                },
-                                {...Col.lastUpdated}
-                            ]
-                        },
-                        groupByOptions: ['groupName']
-                    })
-                ]
-            }),
+            hframe(
+                restGrid({
+                    testId: 'config',
+                    formBbar: configFormBbar(),
+                    extraToolbarItems: () => [
+                        button({
+                            icon: Icon.diff(),
+                            text: 'Compare w/ Remote',
+                            onClick: () => model.openDiffer()
+                        }),
+                        toolbarSep(),
+                        jsonSearchButton({
+                            subjectName: 'Config',
+                            docSearchUrl: 'jsonSearch/searchConfigs',
+                            gridModelConfig: {
+                                sortBy: ['groupName', 'name'],
+                                columns: [
+                                    {...AdminCol.groupName},
+                                    {...AdminCol.name},
+                                    {
+                                        field: {name: 'json', type: 'string'},
+                                        hidden: true
+                                    },
+                                    {...Col.lastUpdated}
+                                ]
+                            },
+                            groupByOptions: ['groupName']
+                        })
+                    ]
+                }),
+                configDetailPanel()
+            ),
             differ({omit: !model.differModel}),
             regroupDialog()
         );
     }
 });
 
-// Custom toolbar supports reverting the form, and leaving it open after change
+// Custom toolbar adds a Revert button to the standard record actions and Cancel/Save. The dialog
+// is edit-only - viewing is handled by the docked detail panel.
 const configFormBbar = hoistCmp.factory<RestFormModel>(({model}) => {
     const {formModel, actions, currentRecord, gridModel} = model,
-        {isDirty, isValid, readonly} = formModel,
-        containsResolved = formModel.values.resolvedValue != null;
+        {isDirty, isValid} = formModel;
     return toolbar(
         recordActionBar({
             actions,
@@ -74,11 +78,11 @@ const configFormBbar = hoistCmp.factory<RestFormModel>(({model}) => {
             text: 'Revert',
             icon: Icon.reset(),
             onClick: () => formModel.reset(),
-            omit: readonly || !isDirty
+            omit: !isDirty
         }),
         filler(),
         button({
-            text: readonly || (containsResolved && !isDirty) ? 'Close' : 'Cancel',
+            text: 'Cancel',
             onClick: () => model.close()
         }),
         button({
@@ -87,23 +91,7 @@ const configFormBbar = hoistCmp.factory<RestFormModel>(({model}) => {
             intent: 'success',
             outlined: true,
             disabled: (!model.isAdd && !isDirty) || !isValid,
-            onClick: async () => {
-                const {isAdd} = model,
-                    {id} = model.currentRecord,
-                    reopen = !isAdd && containsResolved && formModel.getField('value')?.isDirty;
-
-                await model.validateAndSaveAsync();
-                if (reopen && !model.isOpen) {
-                    const record = model.store.getById(id);
-                    if (record) {
-                        model.parent.editRecord(record);
-                        XH.successToast(
-                            'The edit has been saved and the resolved value has been updated.'
-                        );
-                    }
-                }
-            },
-            omit: readonly
+            onClick: () => model.validateAndSaveAsync()
         })
     );
 });

--- a/admin/tabs/general/config/ConfigPanelModel.ts
+++ b/admin/tabs/general/config/ConfigPanelModel.ts
@@ -62,6 +62,9 @@ export class ConfigPanelModel extends HoistModel {
             selModel: 'multiple',
             sortBy: 'name',
             unit: 'config',
+            onRowDoubleClicked: ({data}) => {
+                if (data && !this.gridModel.readonly) this.gridModel.editRecord(data);
+            },
             // Store + fields
             store: {
                 url: 'rest/configAdmin',

--- a/admin/tabs/general/config/ConfigValue.scss
+++ b/admin/tabs/general/config/ConfigValue.scss
@@ -77,3 +77,17 @@
     padding: 0;
   }
 }
+
+// Fill mode (no fixed `height`) - the tab set / single field stretches to its container, with
+// the nested layers passing the flex down to the JSON editor.
+.xh-config-value--fill {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+
+  .xh-form-field__inner {
+    flex: 1;
+    min-height: 0;
+  }
+}

--- a/admin/tabs/general/config/ConfigValue.ts
+++ b/admin/tabs/general/config/ConfigValue.ts
@@ -7,7 +7,8 @@
 import {FormModel} from '@xh/hoist/cmp/form';
 import {placeholder, span} from '@xh/hoist/cmp/layout';
 import {tabContainer, TabContainerModel, TabConfig} from '@xh/hoist/cmp/tab';
-import {creates, hoistCmp, HoistModel, managed} from '@xh/hoist/core';
+import {readonlyJsonInput} from '@xh/hoist/admin/AdminUtils';
+import {creates, hoistCmp, HoistModel, managed, PlainObject, XH} from '@xh/hoist/core';
 import {formField} from '@xh/hoist/desktop/cmp/form';
 import {
     CodeInputLineStyles,
@@ -17,7 +18,7 @@ import {
     textInput
 } from '@xh/hoist/desktop/cmp/input';
 import {Icon} from '@xh/hoist/icon';
-import {makeObservable} from '@xh/hoist/mobx';
+import {makeObservable, observable} from '@xh/hoist/mobx';
 import classNames from 'classnames';
 import {isPlainObject, last, union} from 'lodash';
 import {ReactElement} from 'react';
@@ -25,9 +26,13 @@ import {buildResolvedJson, changedKeysFromStored} from './ConfigUtils';
 import './ConfigValue.scss';
 
 /**
- * Presentation of a config's value within the config editor, bound to the enclosing RestForm's
- * `value` field. Plain configs render a single editor by type; configs with a typedClass and/or
- * an active instance-config override render a tab set over the applicable views of the value.
+ * Presentation of a config's value, bound to the `value` field of an enclosing Form. Plain configs
+ * render a single editor by type; configs with a typedClass and/or an active instance-config
+ * override render a tab set over the applicable views of the value.
+ *
+ * Used within the RestGrid editor dialog (editable, opening on the Database tab) and the docked
+ * detail panel (read-only, opening on the most-derived view). Pass `height` for a fixed-height
+ * display, or omit it to fill the available space.
  */
 export const configValue = hoistCmp.factory<ConfigValueModel>({
     displayName: 'ConfigValue',
@@ -35,22 +40,28 @@ export const configValue = hoistCmp.factory<ConfigValueModel>({
     model: creates(() => new ConfigValueModel()),
 
     render({model, className}) {
+        const {height} = model;
+        className = classNames(className, height == null ? 'xh-config-value--fill' : null);
         return model.usesTabs
             ? tabContainer({model: model.tabContainerModel, className})
-            : valueFormField(model.valueType, model.height, className);
+            : valueFormField(model.valueType, height, className);
     }
 });
 
 class ConfigValueModel extends HoistModel {
     override xhImpl = true;
 
-    @managed tabContainerModel: TabContainerModel;
+    @managed @observable.ref tabContainerModel: TabContainerModel;
 
     get formModel(): FormModel {
         return this.componentProps.formModel;
     }
-    get height(): number {
-        return this.componentProps.height ?? 250;
+    /** Fixed height for the value display, or null to fill available space. */
+    get height(): number | null {
+        return this.componentProps.height ?? null;
+    }
+    get readonly(): boolean {
+        return this.formModel?.readonly ?? false;
     }
     get valueField() {
         return this.formModel?.fields?.value;
@@ -85,15 +96,76 @@ class ConfigValueModel extends HoistModel {
     }
 
     override onLinked() {
-        if (this.usesTabs) this.buildTabs();
+        // Rebuild the tab set whenever the bound data changes - a new record selected into a
+        // shared FormModel (detail panel) or the same one re-saved. Tracks the value field's
+        // initialValue, not its live value, so typing in the editor does not tear down the tabs.
+        this.addReaction({
+            track: () => [
+                this.resolvedValue,
+                this.defaultValue,
+                this.overrideValue,
+                this.valueType,
+                this.valueField?.initialValue
+            ],
+            run: () => this.buildTabs(),
+            fireImmediately: true
+        });
     }
 
     private buildTabs() {
-        const {resolvedValue, defaultValue, overrideValue, valueType, valueField, height} = this,
+        XH.safeDestroy(this.tabContainerModel);
+        this.tabContainerModel = null;
+        if (!this.usesTabs) return;
+
+        const {
+                resolvedValue,
+                defaultValue,
+                overrideValue,
+                valueType,
+                valueField,
+                height,
+                readonly
+            } = this,
             hasOverride = overrideValue != null,
             hasResolved = resolvedValue != null,
             hasDefaults = defaultValue != null,
             tabs: TabConfig[] = [];
+
+        // Tabs run least- to most-derived: Defaults, Database, Instance, Resolved.
+        if (hasDefaults) {
+            tabs.push({
+                id: 'defaults',
+                title: 'Defaults',
+                icon: Icon.code(),
+                content: () =>
+                    jsonInput({
+                        value: JSON.stringify(defaultValue),
+                        readonly: true,
+                        autoFormat: true,
+                        enableSearch: true,
+                        className: 'xh-config-value__defaults',
+                        ...sizeProps(height)
+                    })
+            });
+        }
+
+        tabs.push({
+            id: 'db',
+            title: hasOverride
+                ? span({className: 'xh-config-value__overridden', item: 'Database'})
+                : 'Database',
+            icon: Icon.edit(),
+            content: () => valueFormField(valueType, height)
+        });
+
+        if (hasOverride) {
+            tabs.push({
+                id: 'instance',
+                title: 'Instance',
+                icon: Icon.warning({intent: 'warning'}),
+                content: () => readonlyValue(valueType, overrideValue, height)
+            });
+        }
 
         // Resolved - effective value with typedClass defaults applied.
         if (hasResolved) {
@@ -111,50 +183,15 @@ class ConfigValueModel extends HoistModel {
                 id: 'resolved',
                 title: 'Resolved',
                 icon: Icon.bolt(),
-                content: () => resolvedTab({text, lineStyles, height})
+                content: () => resolvedTab({text, lineStyles, ...sizeProps(height)})
             });
         }
 
-        if (hasOverride) {
-            tabs.push({
-                id: 'instance',
-                title: 'Instance',
-                icon: Icon.warning({intent: 'warning'}),
-                content: () => readonlyValue(valueType, overrideValue, height)
-            });
-        }
-
-        tabs.push({
-            id: 'db',
-            title: hasOverride
-                ? span({className: 'xh-config-value__overridden', item: 'Database'})
-                : 'Database',
-            icon: Icon.edit(),
-            content: () => valueFormField(valueType, height)
+        // Open on Database if editable, else the most-derived view.
+        this.tabContainerModel = new TabContainerModel({
+            defaultTabId: readonly ? last(tabs).id : 'db',
+            tabs
         });
-
-        // Defaults - the typedClass defaults as declared in code.
-        if (hasDefaults) {
-            tabs.push({
-                id: 'defaults',
-                title: 'Defaults',
-                icon: Icon.code(),
-                content: () =>
-                    jsonInput({
-                        value: JSON.stringify(defaultValue),
-                        readonly: true,
-                        autoFormat: true,
-                        enableSearch: true,
-                        className: 'xh-config-value__defaults',
-                        height
-                    })
-            });
-        }
-
-        // Built most- to least-derived above, but displayed the other way round - opening on the
-        // last tab, i.e. the most derived view available.
-        tabs.reverse();
-        this.tabContainerModel = new TabContainerModel({defaultTabId: last(tabs).id, tabs});
     }
 }
 
@@ -182,7 +219,11 @@ const resolvedTab = hoistCmp.factory<ConfigValueModel>(({model, text, lineStyles
 
 // Label-less FormField for `value`, bound via the enclosing Form context for standard validation
 // display and read-only rendering. The plain branch passes `className` for the full-width rule.
-function valueFormField(valueType: string, height: number, className?: string): ReactElement {
+function valueFormField(
+    valueType: string,
+    height: number | null,
+    className?: string
+): ReactElement {
     return formField({
         field: 'value',
         label: null,
@@ -193,13 +234,13 @@ function valueFormField(valueType: string, height: number, className?: string): 
 }
 
 // Editable input for a config value, by type. Bound by the enclosing FormField.
-function valueInput(valueType: string, height: number): ReactElement {
+function valueInput(valueType: string, height: number | null): ReactElement {
     switch (valueType) {
         case 'json':
             return jsonInput({
                 autoFormat: true,
                 enableSearch: true,
-                height
+                ...sizeProps(height)
             });
         case 'bool':
             return select({options: [true, false], enableClear: false});
@@ -217,22 +258,20 @@ function valueInput(valueType: string, height: number): ReactElement {
 }
 
 // Read-only display of a raw stored value, by type. Masks pwd.
-function readonlyValue(valueType: string, value: any, height: number): ReactElement {
+function readonlyValue(valueType: string, value: any, height: number | null): ReactElement {
     switch (valueType) {
         case 'json':
-            return jsonInput({
-                value,
-                readonly: true,
-                autoFormat: true,
-                enableSearch: true,
-                width: null,
-                height
-            });
+            return readonlyJsonInput(value, height);
         case 'pwd':
-            return textInput({value: value == null ? '' : '*****', disabled: true});
+            return span(value == null ? '' : '*****');
         default:
-            return textInput({value: value?.toString() ?? '', disabled: true});
+            return span(value?.toString() ?? '');
     }
+}
+
+// Layout props for a JSON editor - fixed to `height` if given, otherwise filling its container.
+function sizeProps(height: number | null): PlainObject {
+    return height != null ? {height} : {flex: 1, height: '100%', width: '100%'};
 }
 
 // Muting styles for pre-rendered JSON `text` - every line NOT in `highlightLines`.

--- a/admin/tabs/userData/jsonblob/JsonBlobDetailPanel.ts
+++ b/admin/tabs/userData/jsonblob/JsonBlobDetailPanel.ts
@@ -1,0 +1,93 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {jsonRenderer, yesNoRenderer} from '@xh/hoist/admin/AdminUtils';
+import {badgeRenderer} from '@xh/hoist/admin/columns';
+import {restDetailPanel} from '@xh/hoist/admin/detail/RestDetailPanel';
+import {formFieldSet} from '@xh/hoist/cmp/form';
+import {hbox} from '@xh/hoist/cmp/layout';
+import {hoistCmp, uses} from '@xh/hoist/core';
+import {formField} from '@xh/hoist/desktop/cmp/form';
+import {Icon} from '@xh/hoist/icon';
+import {archivedDateRenderer} from './JsonBlobColumns';
+import {JsonBlobModel} from './JsonBlobModel';
+
+/** Read-only detail view of the JSON Blob selected in the grid. */
+export const jsonBlobDetailPanel = hoistCmp.factory<JsonBlobModel>({
+    displayName: 'JsonBlobDetailPanel',
+    model: uses(JsonBlobModel),
+
+    render({model}) {
+        return restDetailPanel({
+            icon: Icon.json(),
+            emptyText: 'Select a blob to view its details.',
+            persistWith: {...model.persistWith, path: 'detailPanel'},
+            renderForm: (record, formModel) => {
+                const {description, meta, archived} = formModel.values,
+                    // Meta is stored as JSON text - a serialized null is as empty as no value.
+                    hasMeta = meta != null && meta !== 'null';
+                return [
+                    formFieldSet({
+                        title: 'Blob',
+                        items: [
+                            hbox(
+                                formField({field: 'type', flex: 1}),
+                                formField({field: 'owner', flex: 1}),
+                                formField({field: 'acl', flex: 1})
+                            ),
+                            formField({field: 'description', omit: !description}),
+                            hbox(
+                                formField({
+                                    field: 'token',
+                                    readonlyRenderer: badgeRenderer,
+                                    flex: 1
+                                }),
+                                formField({
+                                    field: 'archived',
+                                    readonlyRenderer: yesNoRenderer,
+                                    flex: 1
+                                }),
+                                formField({
+                                    field: 'archivedDate',
+                                    readonlyRenderer: archivedDateRenderer,
+                                    omit: !archived,
+                                    flex: 1
+                                })
+                            ),
+                            hbox(
+                                formField({field: 'dateCreated', label: 'Created', flex: 1}),
+                                formField({field: 'lastUpdated', label: 'Updated', flex: 1}),
+                                formField({field: 'lastUpdatedBy', label: 'Updated By', flex: 1})
+                            )
+                        ]
+                    }),
+                    // Value and Meta share the remaining height 3:2, favoring the value.
+                    formFieldSet({
+                        title: 'Value',
+                        className: 'xh-admin-readonly-form__fill',
+                        flexGrow: 3,
+                        item: formField({
+                            field: 'value',
+                            label: null,
+                            readonlyRenderer: jsonRenderer
+                        })
+                    }),
+                    formFieldSet({
+                        title: 'Meta',
+                        className: 'xh-admin-readonly-form__fill',
+                        flexGrow: 2,
+                        omit: !hasMeta,
+                        item: formField({
+                            field: 'meta',
+                            label: null,
+                            readonlyRenderer: jsonRenderer
+                        })
+                    })
+                ];
+            }
+        });
+    }
+});

--- a/admin/tabs/userData/jsonblob/JsonBlobModel.ts
+++ b/admin/tabs/userData/jsonblob/JsonBlobModel.ts
@@ -68,6 +68,10 @@ export class JsonBlobModel extends HoistModel {
                     {...(Col.lastUpdatedBy.field as FieldSpec), editable: false}
                 ]
             },
+            onRowDoubleClicked: ({data}) => {
+                if (data && !this.gridModel.readonly) this.gridModel.editRecord(data);
+            },
+            toolbarActions: [addAction, editAction, cloneAction, deleteAction],
             menuActions: [addAction, editAction, cloneAction, deleteAction],
             prepareCloneFn: ({clone}) => (clone.name = `${clone.name}_CLONE`),
             sortBy: ['owner', 'name'],

--- a/admin/tabs/userData/jsonblob/JsonBlobPanel.ts
+++ b/admin/tabs/userData/jsonblob/JsonBlobPanel.ts
@@ -16,6 +16,7 @@ import {restGrid} from '@xh/hoist/desktop/cmp/rest';
 import {toolbarSep} from '@xh/hoist/desktop/cmp/toolbar';
 import {Icon} from '@xh/hoist/icon';
 import {differ} from '../../../differ/Differ';
+import {jsonBlobDetailPanel} from './JsonBlobDetailPanel';
 import {JsonBlobModel} from './JsonBlobModel';
 
 export const jsonBlobPanel = hoistCmp.factory({
@@ -64,6 +65,7 @@ export const jsonBlobPanel = hoistCmp.factory({
                     ]
                 })
             }),
+            jsonBlobDetailPanel(),
             differ({omit: !model.differModel})
         );
     }

--- a/admin/tabs/userData/prefs/UserPreferenceDetailPanel.ts
+++ b/admin/tabs/userData/prefs/UserPreferenceDetailPanel.ts
@@ -1,0 +1,62 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {jsonRenderer, rawValueRenderer} from '@xh/hoist/admin/AdminUtils';
+import {valueTypeRenderer} from '@xh/hoist/admin/columns';
+import {restDetailPanel} from '@xh/hoist/admin/detail/RestDetailPanel';
+import {formFieldSet} from '@xh/hoist/cmp/form';
+import {hbox} from '@xh/hoist/cmp/layout';
+import {hoistCmp, uses} from '@xh/hoist/core';
+import {formField} from '@xh/hoist/desktop/cmp/form';
+import {Icon} from '@xh/hoist/icon';
+import {UserPreferenceModel} from './UserPreferenceModel';
+
+/** Read-only detail view of the user preference value selected in the grid. */
+export const userPreferenceDetailPanel = hoistCmp.factory<UserPreferenceModel>({
+    displayName: 'UserPreferenceDetailPanel',
+    model: uses(UserPreferenceModel),
+
+    render({model}) {
+        return restDetailPanel({
+            icon: Icon.bookmark(),
+            emptyText: 'Select a user preference to view its details.',
+            persistWith: {...model.persistWith, path: 'detailPanel'},
+            renderForm: (record, formModel) => {
+                const {type} = formModel.values,
+                    isJson = type === 'json';
+                return [
+                    formFieldSet({
+                        title: 'Preference',
+                        items: [
+                            hbox(
+                                formField({field: 'username', flex: 1}),
+                                formField({field: 'groupName', flex: 1}),
+                                formField({
+                                    field: 'type',
+                                    readonlyRenderer: valueTypeRenderer,
+                                    flex: 1
+                                })
+                            ),
+                            hbox(
+                                formField({field: 'lastUpdatedBy', label: 'Updated By', flex: 1}),
+                                formField({field: 'lastUpdated', label: 'Updated', flex: 2})
+                            )
+                        ]
+                    }),
+                    formFieldSet({
+                        title: 'Value',
+                        className: isJson ? 'xh-admin-readonly-form__fill' : null,
+                        item: formField({
+                            field: 'userValue',
+                            label: null,
+                            readonlyRenderer: isJson ? jsonRenderer : rawValueRenderer
+                        })
+                    })
+                ];
+            }
+        });
+    }
+});

--- a/admin/tabs/userData/prefs/UserPreferenceModel.ts
+++ b/admin/tabs/userData/prefs/UserPreferenceModel.ts
@@ -9,10 +9,12 @@ import {AppModel} from '@xh/hoist/admin/AppModel';
 import * as Col from '@xh/hoist/admin/columns';
 import {HoistModel, LoadSpec, managed, XH} from '@xh/hoist/core';
 import {FieldSpec} from '@xh/hoist/data';
-import {RestGridModel} from '@xh/hoist/desktop/cmp/rest';
+import {addAction, deleteAction, editAction, RestGridModel} from '@xh/hoist/desktop/cmp/rest';
 import {bindable, makeObservable} from '@xh/hoist/mobx';
 
 export class UserPreferenceModel extends HoistModel {
+    override persistWith = {localStorageKey: 'xhAdminUserPreferenceState'};
+
     @managed gridModel: RestGridModel;
 
     @bindable showEditorDialog: boolean = false;
@@ -32,11 +34,16 @@ export class UserPreferenceModel extends HoistModel {
             exportOptions: {filename: exportFilenameWithDate('user-prefs')},
             filterFields: ['name', 'username'],
             groupBy: 'groupName',
-            persistWith: {localStorageKey: 'xhAdminUserPreferenceState'},
+            persistWith: this.persistWith,
             readonly: AppModel.readonly,
             selModel: 'multiple',
             sortBy: 'name',
             unit: 'user preference',
+            onRowDoubleClicked: ({data}) => {
+                if (data && !this.gridModel.readonly) this.gridModel.editRecord(data);
+            },
+            toolbarActions: [addAction, editAction, deleteAction],
+            menuActions: [addAction, editAction, deleteAction],
             // Store + fields
             store: {
                 url: 'rest/userPreferenceAdmin',
@@ -65,7 +72,7 @@ export class UserPreferenceModel extends HoistModel {
             // Cols + editors
             columns: [
                 {...Col.name},
-                {...Col.type},
+                {...Col.type, renderer: Col.valueTypeRenderer, align: 'center'},
                 {...Col.username},
                 {...Col.groupName, hidden},
                 {...Col.userValue},

--- a/admin/tabs/userData/prefs/UserPreferencePanel.ts
+++ b/admin/tabs/userData/prefs/UserPreferencePanel.ts
@@ -8,6 +8,7 @@
 import * as Col from '@xh/hoist/admin/columns/Rest';
 import * as AdminCol from '@xh/hoist/admin/columns';
 import {prefEditorDialog} from '@xh/hoist/admin/tabs/userData/prefs/editor/PrefEditorDialog';
+import {userPreferenceDetailPanel} from '@xh/hoist/admin/tabs/userData/prefs/UserPreferenceDetailPanel';
 import {UserPreferenceModel} from '@xh/hoist/admin/tabs/userData/prefs/UserPreferenceModel';
 import {hframe} from '@xh/hoist/cmp/layout';
 import {creates, hoistCmp} from '@xh/hoist/core';
@@ -59,7 +60,8 @@ export const userPreferencePanel = hoistCmp.factory({
                     prefEditorDialog()
                 ],
                 mask: 'onLoad'
-            })
+            }),
+            userPreferenceDetailPanel()
         );
     }
 });

--- a/admin/tabs/userData/roles/details/RoleDetails.scss
+++ b/admin/tabs/userData/roles/details/RoleDetails.scss
@@ -1,23 +1,6 @@
 .xh-admin-role-details {
   &__form {
-    overflow-y: auto;
-
-    .xh-form-field {
-      margin: 0;
-      padding: 2px var(--xh-pad-px);
-
-      &__label {
-        font-size: var(--xh-font-size-small-px);
-        padding: 0;
-      }
-
-      &__readonly-display {
-        padding: var(--xh-pad-half-px);
-      }
-
-      &:nth-child(odd) {
-        background-color: var(--xh-grid-bg-odd);
-      }
-    }
+    flex: none;
+    margin: var(--xh-pad-px);
   }
 }

--- a/admin/tabs/userData/roles/details/RoleDetails.ts
+++ b/admin/tabs/userData/roles/details/RoleDetails.ts
@@ -4,8 +4,9 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {form} from '@xh/hoist/cmp/form';
-import {div, frame, placeholder, span, vframe} from '@xh/hoist/cmp/layout';
+import {valOrNa} from '@xh/hoist/admin/AdminUtils';
+import {form, formFieldSet} from '@xh/hoist/cmp/form';
+import {frame, hbox, placeholder, vframe} from '@xh/hoist/cmp/layout';
 import {tabContainer} from '@xh/hoist/cmp/tab';
 import {creates, hoistCmp} from '@xh/hoist/core';
 import {formField} from '@xh/hoist/desktop/cmp/form';
@@ -31,21 +32,20 @@ export const roleDetails = hoistCmp.factory({
 
 const details = hoistCmp.factory(() =>
     form({
-        fieldDefaults: {inline: true},
-        item: div({
-            className: 'xh-admin-role-details__form',
+        fieldDefaults: {readonlyRenderer: valOrNa},
+        item: formFieldSet({
+            title: 'Role',
+            className: 'xh-admin-role-details__form xh-admin-readonly-form',
             items: [
-                formField({field: 'name'}),
-                formField({field: 'category'}),
+                hbox(formField({field: 'name', flex: 1}), formField({field: 'category', flex: 1})),
                 formField({
                     field: 'notes',
-                    readonlyRenderer: v => {
-                        return frame({
+                    readonlyRenderer: v =>
+                        frame({
                             style: {overflowY: 'auto'},
-                            height: 50,
-                            item: v ?? span({item: 'N/A', className: 'xh-text-color-muted'})
-                        });
-                    }
+                            maxHeight: 80,
+                            item: valOrNa(v)
+                        })
                 }),
                 formField({field: 'lastUpdated'})
             ]

--- a/cmp/daterange/DateRangePickerModel.ts
+++ b/cmp/daterange/DateRangePickerModel.ts
@@ -238,11 +238,9 @@ export class DateRangePickerModel extends HoistModel {
     }
 
     /**
-     * True if the anchor date is the reader's current day - when `anchorDay` reads as "Today".
-     * False whenever the anchor sits on any other day, whether pinned there by the app, snapped
-     * by `businessDayMode`, or drawn from an app time zone a day apart from the browser's - in
-     * each case the picker reads "As Of" and shows the date, so the reader is never told a day
-     * that is not theirs is "today".
+     * True if the anchor date is the reader's current day - when `anchorDay` reads "Today". False
+     * for any other day, however the anchor got there (pinned, business-day snapped, or an app
+     * time zone a day apart from the browser's) - the picker then reads "As Of" with the date.
      */
     get isAnchorToday(): boolean {
         return this.anchorDate === this.today;

--- a/cmp/daterange/DateRangePickerModel.ts
+++ b/cmp/daterange/DateRangePickerModel.ts
@@ -6,6 +6,7 @@
  */
 import {
     HoistModel,
+    managed,
     PersistableState,
     PersistenceProvider,
     type PersistOptions,
@@ -13,11 +14,13 @@ import {
 } from '@xh/hoist/core';
 import type {FieldFilterSpec} from '@xh/hoist/data';
 import {action, bindable, computed, makeObservable, observable} from '@xh/hoist/mobx';
-import {LocalDate} from '@xh/hoist/utils/datetime';
+import {Timer} from '@xh/hoist/utils/async';
+import {LocalDate, SECONDS} from '@xh/hoist/utils/datetime';
 import {throwIf} from '@xh/hoist/utils/js';
 import {isEmpty, isEqual, isFunction, isObject, isString, keyBy, uniq, uniqBy} from 'lodash';
 import {dateRangePresets, DEFAULT_DATE_RANGE_PRESETS} from './DateRangePresets';
 import {
+    businessDayOnOrBefore,
     DATE_RANGE_PICKER_TABS,
     fmtDateRange,
     getDateRangeLabel,
@@ -26,6 +29,7 @@ import {
     stepDateRangeSelection
 } from './DateRangeUtils';
 import type {
+    DateRangeAnchorDay,
     DateRangeContext,
     DateRangePickerTab,
     DateRangePreset,
@@ -41,11 +45,20 @@ import type {
  */
 export interface DateRangePickerConfig {
     /**
-     * Date that relative and to-date selections resolve against, and (unless `maxDate` is set)
-     * the latest selectable date. Supply a function to track a live, observable source - e.g.
-     * the as-of date of the data on display. Default: today, as of construction.
+     * The day that relative and to-date selections resolve against, and (unless `maxDate` is set)
+     * the latest selectable date. Default `'localDay'` - the current day in the browser's time
+     * zone, kept current as the day rolls. See {@link DateRangeAnchorDay} for the app-day, pinned,
+     * and computed alternatives.
      */
-    anchorDate?: LocalDate | (() => LocalDate);
+    anchorDay?: DateRangeAnchorDay;
+
+    /**
+     * True to treat single days by business day: a live `anchorDay` (`'localDay'` or `'appDay'`)
+     * snaps back to the most recent business day, and single-day selections step by business day
+     * rather than calendar day. Multi-day ranges are unaffected - seven days is still seven days.
+     * A pinned or computed `anchorDay` is honored verbatim, never snapped. Default false.
+     */
+    businessDayMode?: boolean;
 
     /**
      * False (default) waits for the user to apply a relative or custom draft before updating the
@@ -77,15 +90,15 @@ export interface DateRangePickerConfig {
     initialValue?: DateRangeSelection | DateRangePresetToken | string;
 
     /**
-     * Test for whether a date is a business day, consulted by presets such as `lastBusinessDay`
-     * and available to app-defined presets via {@link DateRangeContext}. Default: weekdays. Supply
-     * to honor a holiday calendar.
+     * Test for whether a date is a business day, consulted by `businessDayMode` and available to
+     * app-defined presets via {@link DateRangeContext}. Default: weekdays. Supply to honor a
+     * holiday calendar.
      */
     isBusinessDay?: (date: LocalDate) => boolean;
 
     /**
-     * Latest selectable date. Default: `anchorDate`, so nothing beyond the anchor can be
-     * selected. Set later than the anchor to allow selection of future dates.
+     * Latest selectable date. Default: the anchor date, so nothing beyond it can be selected. Set
+     * later than the anchor to allow selection of future dates.
      */
     maxDate?: LocalDate;
 
@@ -118,6 +131,9 @@ export interface DateRangePickerConfig {
 /** Default `isBusinessDay` - Monday through Friday. */
 const isWeekday = (date: LocalDate): boolean => date.isWeekday;
 
+/** How often a live `anchorDay` is re-evaluated. Cheap: a no-op until the day actually changes. */
+const ANCHOR_REFRESH_INTERVAL = 10 * SECONDS;
+
 export interface DateRangePickerPersistOptions extends PersistOptions {
     /** True (default) to persist the value, or provide value-specific PersistOptions. */
     persistValue?: boolean | PersistOptions;
@@ -127,13 +143,15 @@ export interface DateRangePickerPersistOptions extends PersistOptions {
  * App-wide overridable defaults for {@link DateRangePickerModel}. Instance config takes precedence.
  */
 export interface DateRangePickerModelDefaults {
+    anchorDay?: DateRangeAnchorDay;
+    businessDayMode?: boolean;
     commitOnChange?: boolean;
     dateFormat?: string;
 }
 
 /**
- * Model for a control that allows users to select a period of time - a preset (e.g. MTD, Last
- * 30 Days), a relative lookback (e.g. Last 6 Months), a calendar month or year, or a custom
+ * Model for a control that allows users to select a period of time - a preset (e.g. MTD, Prev
+ * 30 Days), a relative lookback (e.g. Prev 6 Months), a calendar month or year, or a custom
  * range of dates - and the API through which an app reads the applied period.
  *
  * The value is a single compound {@link DateRangeSelection}, which this model resolves to a
@@ -141,6 +159,9 @@ export interface DateRangePickerModelDefaults {
  * The value is plain JSON, so it persists via `persistWith` (including through saved views)
  * without custom serialization, and re-resolves as the anchor date moves forward - a persisted
  * `mtd` stays month-to-date.
+ *
+ * The anchor date is live by default: this model keeps it on the current day as midnight passes,
+ * so every derived range, label, and filter follows without app intervention. See `anchorDay`.
  *
  * Construct one within an app model and render a {@link DateRangePicker} bound to it to let users
  * view and change the value. The value and its derived ranges and filters stay live whether or
@@ -153,6 +174,8 @@ export interface DateRangePickerModelDefaults {
 export class DateRangePickerModel extends HoistModel {
     /** App-level defaults for DateRangePickerModel. Instance config takes precedence. */
     static defaults: DateRangePickerModelDefaults = {
+        anchorDay: 'localDay',
+        businessDayMode: false,
         commitOnChange: false,
         dateFormat: 'YYYY-MM-DD'
     };
@@ -166,15 +189,25 @@ export class DateRangePickerModel extends HoistModel {
     /** Presets offered on the Presets tab, in display order. Set via `setPresets()`. */
     @observable.ref presets: DateRangePreset[];
 
-    /** Date that relative and to-date selections resolve against. Set via `setAnchorDate()`. */
+    /** How the anchor date is determined - see {@link DateRangeAnchorDay}. Set via `setAnchorDay()`. */
+    @observable.ref anchorDay: DateRangeAnchorDay;
+
+    /**
+     * Date that relative and to-date selections resolve against - `anchorDay` resolved, and (in
+     * `businessDayMode`) snapped to a business day when live. Kept current by this model.
+     */
     @observable.ref anchorDate: LocalDate;
+
+    /** The current day, in the app time zone for `anchorDay: 'appDay'`, else the browser's. */
+    @observable.ref today: LocalDate;
 
     /** Earliest selectable date, or null if unbounded. Set via `setMinDate()`. */
     @observable.ref minDate: LocalDate | null;
 
-    /** Business-day test used by presets. Set via `setIsBusinessDay()`. */
+    /** Business-day test used by `businessDayMode` and presets. Set via `setIsBusinessDay()`. */
     @observable.ref isBusinessDay: (date: LocalDate) => boolean;
 
+    @bindable businessDayMode: boolean;
     @bindable commitOnChange: boolean;
     @bindable dateFormat: string;
     @bindable filterField: string;
@@ -183,10 +216,16 @@ export class DateRangePickerModel extends HoistModel {
     readonly defaultValue: DateRangeSelection;
 
     @observable.ref private explicitMaxDate: LocalDate | null;
+    @managed private anchorTimer: Timer;
 
     /** Latest selectable date - the explicit `maxDate` config if set, otherwise `anchorDate`. */
     get maxDate(): LocalDate {
         return this.explicitMaxDate ?? this.anchorDate;
+    }
+
+    /** True if the anchor date is the current day - when `anchorDay` reads as "Today". */
+    get isAnchorToday(): boolean {
+        return this.anchorDate === this.today;
     }
 
     /** Configured presets, keyed by token. */
@@ -198,8 +237,16 @@ export class DateRangePickerModel extends HoistModel {
     /** The live context that selections resolve against. */
     @computed
     get context(): DateRangeContext {
-        const {anchorDate, minDate, maxDate, isBusinessDay, presetMap: presets} = this;
-        return {anchorDate, minDate, maxDate, isBusinessDay, presets};
+        const {anchorDate, today, minDate, maxDate, isBusinessDay, businessDayMode} = this;
+        return {
+            anchorDate,
+            today,
+            minDate,
+            maxDate,
+            isBusinessDay,
+            businessDayMode,
+            presets: this.presetMap
+        };
     }
 
     /** Resolved date range for the applied value. */
@@ -217,7 +264,7 @@ export class DateRangePickerModel extends HoistModel {
         return this.resolvedValue.prior;
     }
 
-    /** Short label for the applied value - e.g. `MTD`, `Last 6 Months`, `Aug 2026`, `Custom`. */
+    /** Short label for the applied value - e.g. `MTD`, `Prev 6 Months`, `Aug 2026`, `Custom`. */
     get label(): string {
         return this.getLabel(this.value);
     }
@@ -232,14 +279,26 @@ export class DateRangePickerModel extends HoistModel {
 
     /**
      * Longer-form name for the applied value, suitable for panel titles - the period's name
-     * rather than its dates, with months spelled out (e.g. `August 2026`). A custom range is the
-     * one selection with no name, so it falls back to its dates.
+     * rather than its dates, with months spelled out (e.g. `August 2026`). A custom range, and the
+     * anchor day when it is not today, have no name beyond their dates, so they read as those.
      */
     get displayName(): string {
         const {value, currentRange} = this;
-        if (value.kind === 'custom') return this.rangeLabel;
+        if (value.kind === 'custom' || this.labelNeedsDates) return this.rangeLabel;
         if (value.kind === 'month') return currentRange.start.format('MMMM YYYY');
         return this.label;
+    }
+
+    /**
+     * True when `label` alone does not identify the period - a custom range, or the anchor day
+     * when it is not today and so reads only as `As Of`. The picker shows the dates instead.
+     */
+    get labelNeedsDates(): boolean {
+        const {value} = this;
+        return (
+            value.kind === 'custom' ||
+            (value.kind === 'preset' && value.token === 'anchorDay' && !this.isAnchorToday)
+        );
     }
 
     /** True if `stepRange(-1)` would move the applied range - bounded and not yet at `minDate`. */
@@ -266,7 +325,8 @@ export class DateRangePickerModel extends HoistModel {
         tabs,
         presets = DEFAULT_DATE_RANGE_PRESETS,
         initialValue,
-        anchorDate,
+        anchorDay = DateRangePickerModel.defaults.anchorDay,
+        businessDayMode = DateRangePickerModel.defaults.businessDayMode,
         commitOnChange = DateRangePickerModel.defaults.commitOnChange,
         minDate = null,
         maxDate = null,
@@ -280,19 +340,14 @@ export class DateRangePickerModel extends HoistModel {
         makeObservable(this);
         this.xhName = xhName;
 
+        this.businessDayMode = businessDayMode;
         this.commitOnChange = commitOnChange;
         this.dateFormat = dateFormat;
         this.filterField = filterField;
         this.minDate = minDate;
         this.explicitMaxDate = maxDate;
         this.isBusinessDay = isBusinessDay;
-
-        if (isFunction(anchorDate)) {
-            this.anchorDate = anchorDate();
-            this.addReaction({track: anchorDate, run: v => this.setAnchorDate(v)});
-        } else {
-            this.anchorDate = anchorDate ?? LocalDate.today();
-        }
+        this.setAnchorDay(anchorDay);
 
         this.setPresets(presets);
         this.setTabs(
@@ -307,6 +362,25 @@ export class DateRangePickerModel extends HoistModel {
         this.value = this.defaultValue;
 
         if (persistWith) this.initPersist(persistWith);
+
+        // Keep a live anchor on the current day. Idle for a pinned date - nothing to track.
+        this.anchorTimer = Timer.create({
+            runFn: () => this.refreshAnchorDate(),
+            interval: () => (this.isLiveAnchor ? ANCHOR_REFRESH_INTERVAL : 0)
+        });
+
+        this.addReaction(
+            {
+                // A computed anchor may read observables - follow those immediately, not on the
+                // next tick of the timer.
+                track: () => (isFunction(this.anchorDay) ? this.anchorDay() : null),
+                run: () => this.refreshAnchorDate()
+            },
+            {
+                track: () => [this.businessDayMode, this.isBusinessDay],
+                run: () => this.refreshAnchorDate()
+            }
+        );
     }
 
     /**
@@ -358,10 +432,16 @@ export class DateRangePickerModel extends HoistModel {
         if (this.value && !this.parseValue(this.value)) this.value = this.fallbackValue;
     }
 
+    /** Set how the anchor date is determined - see {@link DateRangeAnchorDay}. */
     @action
-    setAnchorDate(anchorDate: LocalDate) {
-        throwIf(!anchorDate, 'DateRangePickerModel requires an anchorDate.');
-        this.anchorDate = anchorDate;
+    setAnchorDay(anchorDay: DateRangeAnchorDay) {
+        throwIf(
+            !anchorDay ||
+                (isString(anchorDay) && anchorDay !== 'localDay' && anchorDay !== 'appDay'),
+            `Invalid DateRangePickerModel anchorDay: '${anchorDay}'.`
+        );
+        this.anchorDay = anchorDay;
+        this.refreshAnchorDate();
     }
 
     @action
@@ -381,10 +461,11 @@ export class DateRangePickerModel extends HoistModel {
     }
 
     /**
-     * Move the applied range by `steps` periods of its own length - e.g. `stepRange(-1)` for the
-     * previous period. Month and year selections keep their kind. All others become a `custom`
-     * selection of the shifted dates. Clamped to `minDate` and `maxDate`, and a no-op when the
-     * range cannot move - see {@link stepDateRangeSelection}.
+     * Move the applied range by `steps` periods - e.g. `stepRange(-1)` for the previous period.
+     * No selection changes kind: presets and relative lookbacks step through their own prior-range
+     * logic via `offset`, months and years by calendar unit, and custom ranges by their length.
+     * Clamped to `minDate` and `maxDate`, and a no-op when the range cannot move - see
+     * {@link stepDateRangeSelection}.
      */
     @action
     stepRange(steps: number) {
@@ -442,6 +523,34 @@ export class DateRangePickerModel extends HoistModel {
     @computed.struct
     private get resolvedValue(): ResolvedDateRange {
         return this.resolve(this.value);
+    }
+
+    /** True unless `anchorDay` is a pinned LocalDate. */
+    private get isLiveAnchor(): boolean {
+        return !LocalDate.isLocalDate(this.anchorDay);
+    }
+
+    /**
+     * Re-evaluate `today` and `anchorDate` from `anchorDay`. Assignments are identity no-ops until
+     * the day actually changes, as LocalDate instances are memoized.
+     */
+    @action
+    private refreshAnchorDate() {
+        const {anchorDay, businessDayMode, isBusinessDay} = this,
+            today = anchorDay === 'appDay' ? LocalDate.currentAppDay() : LocalDate.today();
+
+        let anchorDate: LocalDate;
+        if (isString(anchorDay)) {
+            // Only a clock-derived anchor is snapped. A pinned or computed date is what the app
+            // asked for - e.g. a month-end that falls on a Sunday.
+            anchorDate = businessDayMode ? businessDayOnOrBefore(today, {isBusinessDay}) : today;
+        } else {
+            anchorDate = isFunction(anchorDay) ? anchorDay() : anchorDay;
+        }
+        throwIf(!anchorDate, 'DateRangePickerModel anchorDay function must return a LocalDate.');
+
+        if (this.today !== today) this.today = today;
+        if (this.anchorDate !== anchorDate) this.anchorDate = anchorDate;
     }
 
     private initPersist({

--- a/cmp/daterange/DateRangePickerModel.ts
+++ b/cmp/daterange/DateRangePickerModel.ts
@@ -198,7 +198,7 @@ export class DateRangePickerModel extends HoistModel {
      */
     @observable.ref anchorDate: LocalDate;
 
-    /** The current day, in the app time zone for `anchorDay: 'appDay'`, else the browser's. */
+    /** The current day in the browser's time zone - the reader's "today". Kept current. */
     @observable.ref today: LocalDate;
 
     /** Earliest selectable date, or null if unbounded. Set via `setMinDate()`. */
@@ -223,7 +223,13 @@ export class DateRangePickerModel extends HoistModel {
         return this.explicitMaxDate ?? this.anchorDate;
     }
 
-    /** True if the anchor date is the current day - when `anchorDay` reads as "Today". */
+    /**
+     * True if the anchor date is the reader's current day - when `anchorDay` reads as "Today".
+     * False whenever the anchor sits on any other day, whether pinned there by the app, snapped
+     * by `businessDayMode`, or drawn from an app time zone a day apart from the browser's - in
+     * each case the picker reads "As Of" and shows the date, so the reader is never told a day
+     * that is not theirs is "today".
+     */
     get isAnchorToday(): boolean {
         return this.anchorDate === this.today;
     }
@@ -537,13 +543,14 @@ export class DateRangePickerModel extends HoistModel {
     @action
     private refreshAnchorDate() {
         const {anchorDay, businessDayMode, isBusinessDay} = this,
-            today = anchorDay === 'appDay' ? LocalDate.currentAppDay() : LocalDate.today();
+            today = LocalDate.today();
 
         let anchorDate: LocalDate;
         if (isString(anchorDay)) {
             // Only a clock-derived anchor is snapped. A pinned or computed date is what the app
             // asked for - e.g. a month-end that falls on a Sunday.
-            anchorDate = businessDayMode ? businessDayOnOrBefore(today, {isBusinessDay}) : today;
+            const day = anchorDay === 'appDay' ? LocalDate.currentAppDay() : today;
+            anchorDate = businessDayMode ? businessDayOnOrBefore(day, {isBusinessDay}) : day;
         } else {
             anchorDate = isFunction(anchorDay) ? anchorDay() : anchorDay;
         }

--- a/cmp/daterange/DateRangePickerModel.ts
+++ b/cmp/daterange/DateRangePickerModel.ts
@@ -119,7 +119,7 @@ export interface DateRangePickerConfig {
     presets?: Array<DateRangePresetToken | DateRangePreset>;
 
     /**
-     * Tabs to offer within the picker popover, in rail order. Default: all tabs, less the
+     * Tabs to offer within the picker popover, in display order. Default: all tabs, less the
      * Presets tab when `presets` is empty. A single tab renders without a rail.
      */
     tabs?: DateRangePickerTab[];
@@ -183,7 +183,7 @@ export class DateRangePickerModel extends HoistModel {
     /** The applied selection, always in normalized form. Set via `setValue()`. */
     @observable.ref value: DateRangeSelection;
 
-    /** Tabs offered in the popover, in rail order. Set via `setTabs()` - the picker follows. */
+    /** Tabs offered in the popover, in display order. Set via `setTabs()` - the picker follows. */
     @observable.ref tabs: DateRangePickerTab[];
 
     /** Presets offered on the Presets tab, in display order. Set via `setPresets()`. */

--- a/cmp/daterange/DateRangePickerModel.ts
+++ b/cmp/daterange/DateRangePickerModel.ts
@@ -84,7 +84,7 @@ export interface DateRangePickerConfig {
      * where the weekday matters more than the year. A moment.js format string, or a function of
      * the date. Default `ddd MMM D`, overridable app-wide via `DateRangePickerModel.defaults`.
      */
-    dayFormat?: DateRangeFormat;
+    singleDayFormat?: DateRangeFormat;
 
     /**
      * Name of the field to filter in the {@link FieldFilterSpec}s produced by
@@ -158,7 +158,7 @@ export interface DateRangePickerModelDefaults {
     businessDayMode?: boolean;
     commitOnChange?: boolean;
     dateFormat?: DateRangeFormat;
-    dayFormat?: DateRangeFormat;
+    singleDayFormat?: DateRangeFormat;
 }
 
 /**
@@ -190,7 +190,7 @@ export class DateRangePickerModel extends HoistModel {
         businessDayMode: false,
         commitOnChange: false,
         dateFormat: 'YYYY-MM-DD',
-        dayFormat: 'ddd MMM D'
+        singleDayFormat: 'ddd MMM D'
     };
 
     /** The applied selection, always in normalized form. Set via `setValue()`. */
@@ -223,7 +223,7 @@ export class DateRangePickerModel extends HoistModel {
     @bindable businessDayMode: boolean;
     @bindable commitOnChange: boolean;
     @bindable.ref dateFormat: DateRangeFormat;
-    @bindable.ref dayFormat: DateRangeFormat;
+    @bindable.ref singleDayFormat: DateRangeFormat;
     @bindable filterField: string;
 
     /** The initial value, and the fallback for a missing or invalid persisted value. */
@@ -289,7 +289,7 @@ export class DateRangePickerModel extends HoistModel {
 
     /**
      * Resolved range as `start ▸ end` per `dateFormat`, with `…` for an unbounded edge. A single
-     * day reads as that one date, per `dayFormat`.
+     * day reads as that one date, per `singleDayFormat`.
      */
     get rangeLabel(): string {
         return this.fmtRange(this.currentRange);
@@ -351,7 +351,7 @@ export class DateRangePickerModel extends HoistModel {
         isBusinessDay = isWeekday,
         filterField = null,
         dateFormat = DateRangePickerModel.defaults.dateFormat,
-        dayFormat = DateRangePickerModel.defaults.dayFormat,
+        singleDayFormat = DateRangePickerModel.defaults.singleDayFormat,
         persistWith = null,
         xhName = null
     }: DateRangePickerConfig = {}) {
@@ -362,7 +362,7 @@ export class DateRangePickerModel extends HoistModel {
         this.businessDayMode = businessDayMode;
         this.commitOnChange = commitOnChange;
         this.dateFormat = dateFormat;
-        this.dayFormat = dayFormat;
+        this.singleDayFormat = singleDayFormat;
         this.filterField = filterField;
         this.minDate = minDate;
         this.explicitMaxDate = maxDate;
@@ -532,14 +532,14 @@ export class DateRangePickerModel extends HoistModel {
         return ret;
     }
 
-    /** Format a range as `start ▸ end` per this model's `dateFormat` - a single day per `dayFormat`. */
+    /** Format a range as `start ▸ end` per this model's `dateFormat` - a single day per `singleDayFormat`. */
     fmtRange(range: LocalDateRange): string {
-        return fmtDateRange(range, this.dateFormat, this.dayFormat);
+        return fmtDateRange(range, this.dateFormat, this.singleDayFormat);
     }
 
-    /** Format a single day per this model's `dayFormat`. */
-    fmtDay(date: LocalDate): string {
-        return fmtDate(date, this.dayFormat);
+    /** Format a single day per this model's `singleDayFormat`. */
+    fmtSingleDay(date: LocalDate): string {
+        return fmtDate(date, this.singleDayFormat);
     }
 
     //------------------------

--- a/cmp/daterange/DateRangePickerModel.ts
+++ b/cmp/daterange/DateRangePickerModel.ts
@@ -22,6 +22,7 @@ import {dateRangePresets, DEFAULT_DATE_RANGE_PRESETS} from './DateRangePresets';
 import {
     businessDayOnOrBefore,
     DATE_RANGE_PICKER_TABS,
+    fmtDate,
     fmtDateRange,
     getDateRangeLabel,
     parseDateRangeSelection,
@@ -31,6 +32,7 @@ import {
 import type {
     DateRangeAnchorDay,
     DateRangeContext,
+    DateRangeFormat,
     DateRangePickerTab,
     DateRangePreset,
     DateRangePresetToken,
@@ -70,10 +72,19 @@ export interface DateRangePickerConfig {
     commitOnChange?: boolean;
 
     /**
-     * Format for dates shown by the picker and in `rangeLabel`, as a moment.js format string.
-     * Default `YYYY-MM-DD`, overridable app-wide via `DateRangePickerModel.defaults`.
+     * Format for the dates of a range - the two ends shown on the trigger, beside presets, and in
+     * `rangeLabel`. A moment.js format string, or a function of the date. Default `YYYY-MM-DD`,
+     * overridable app-wide via `DateRangePickerModel.defaults`. The Custom tab's date inputs use
+     * it when it is a string, else `YYYY-MM-DD`.
      */
-    dateFormat?: string;
+    dateFormat?: DateRangeFormat;
+
+    /**
+     * Format for a single day - a one-day range, and the anchor date in the popover footer -
+     * where the weekday matters more than the year. A moment.js format string, or a function of
+     * the date. Default `ddd MMM D`, overridable app-wide via `DateRangePickerModel.defaults`.
+     */
+    dayFormat?: DateRangeFormat;
 
     /**
      * Name of the field to filter in the {@link FieldFilterSpec}s produced by
@@ -146,7 +157,8 @@ export interface DateRangePickerModelDefaults {
     anchorDay?: DateRangeAnchorDay;
     businessDayMode?: boolean;
     commitOnChange?: boolean;
-    dateFormat?: string;
+    dateFormat?: DateRangeFormat;
+    dayFormat?: DateRangeFormat;
 }
 
 /**
@@ -177,7 +189,8 @@ export class DateRangePickerModel extends HoistModel {
         anchorDay: 'localDay',
         businessDayMode: false,
         commitOnChange: false,
-        dateFormat: 'YYYY-MM-DD'
+        dateFormat: 'YYYY-MM-DD',
+        dayFormat: 'ddd MMM D'
     };
 
     /** The applied selection, always in normalized form. Set via `setValue()`. */
@@ -209,7 +222,8 @@ export class DateRangePickerModel extends HoistModel {
 
     @bindable businessDayMode: boolean;
     @bindable commitOnChange: boolean;
-    @bindable dateFormat: string;
+    @bindable.ref dateFormat: DateRangeFormat;
+    @bindable.ref dayFormat: DateRangeFormat;
     @bindable filterField: string;
 
     /** The initial value, and the fallback for a missing or invalid persisted value. */
@@ -277,7 +291,7 @@ export class DateRangePickerModel extends HoistModel {
 
     /**
      * Resolved range as `start ▸ end` per `dateFormat`, with `…` for an unbounded edge. A single
-     * day reads as that one date.
+     * day reads as that one date, per `dayFormat`.
      */
     get rangeLabel(): string {
         return this.fmtRange(this.currentRange);
@@ -339,6 +353,7 @@ export class DateRangePickerModel extends HoistModel {
         isBusinessDay = isWeekday,
         filterField = null,
         dateFormat = DateRangePickerModel.defaults.dateFormat,
+        dayFormat = DateRangePickerModel.defaults.dayFormat,
         persistWith = null,
         xhName = null
     }: DateRangePickerConfig = {}) {
@@ -349,6 +364,7 @@ export class DateRangePickerModel extends HoistModel {
         this.businessDayMode = businessDayMode;
         this.commitOnChange = commitOnChange;
         this.dateFormat = dateFormat;
+        this.dayFormat = dayFormat;
         this.filterField = filterField;
         this.minDate = minDate;
         this.explicitMaxDate = maxDate;
@@ -518,9 +534,14 @@ export class DateRangePickerModel extends HoistModel {
         return ret;
     }
 
-    /** Format a range as `start ▸ end`, per this model's `dateFormat`. */
+    /** Format a range as `start ▸ end` per this model's `dateFormat` - a single day per `dayFormat`. */
     fmtRange(range: LocalDateRange): string {
-        return fmtDateRange(range, this.dateFormat);
+        return fmtDateRange(range, this.dateFormat, this.dayFormat);
+    }
+
+    /** Format a single day per this model's `dayFormat`. */
+    fmtDay(date: LocalDate): string {
+        return fmtDate(date, this.dayFormat);
     }
 
     //------------------------

--- a/cmp/daterange/DateRangePickerModel.ts
+++ b/cmp/daterange/DateRangePickerModel.ts
@@ -462,9 +462,9 @@ export class DateRangePickerModel extends HoistModel {
 
     /**
      * Move the applied range by `steps` periods - e.g. `stepRange(-1)` for the previous period.
-     * No selection changes kind: presets and relative lookbacks step through their own prior-range
-     * logic via `offset`, months and years by calendar unit, and custom ranges by their length.
-     * Clamped to `minDate` and `maxDate`, and a no-op when the range cannot move - see
+     * No selection changes kind: presets and relative lookbacks step through their own prior- and
+     * next-range logic via `offset`, months and years by calendar unit, and custom ranges by their
+     * length. Stops at `minDate` and `maxDate`, and a no-op when the range cannot move - see
      * {@link stepDateRangeSelection}.
      */
     @action

--- a/cmp/daterange/DateRangePresets.ts
+++ b/cmp/daterange/DateRangePresets.ts
@@ -14,76 +14,6 @@ import type {
     LocalDateRange
 } from './Types';
 
-type Resolver = DateRangePreset['resolve'];
-type Shifter = DateRangePreset['resolvePrior'];
-type ShiftedLabel = DateRangePreset['shiftedLabel'];
-
-/** From the start of the unit containing the anchor date, through the anchor date. */
-const toDate =
-    (unit: DateRangeUnit): Resolver =>
-    ({anchorDate}) => ({start: anchorDate.startOf(unit), end: anchorDate});
-
-/** A rolling window of `n` days ending on the anchor date. */
-const prevDays =
-    (n: number): Resolver =>
-    ({anchorDate}) => ({start: anchorDate.subtract(n - 1, 'days'), end: anchorDate});
-
-/** A rolling window of `n` months ending on the anchor date. */
-const prevMonths =
-    (n: number): Resolver =>
-    ({anchorDate}) => ({start: anchorDate.subtract(n, 'months').nextDay(), end: anchorDate});
-
-/** The full calendar unit before the one containing the anchor date. */
-const previousUnit =
-    (unit: DateRangeUnit): Resolver =>
-    ctx => {
-        const start = previousUnitStart(ctx, unit);
-        return {start, end: start.endOf(unit)};
-    };
-
-const previousUnitStart = ({anchorDate}: DateRangeContext, unit: DateRangeUnit): LocalDate =>
-    anchorDate.startOf(unit).subtract(1, unit);
-
-/** The current range shifted by `n` units - negative back, positive forward - keeping its shape. */
-const shiftedBy =
-    (unit: DateRangeUnit, n: number): Shifter =>
-    ({start, end}) => ({start: start.add(n, unit), end: end.add(n, unit)});
-
-/** The full calendar unit `n` units from a current range that is itself a full unit. */
-const adjacentUnit =
-    (unit: DateRangeUnit, n: number): Shifter =>
-    ({start}) => {
-        const next = start.add(n, unit);
-        return {start: next, end: next.endOf(unit)};
-    };
-
-/** The day before or after a single-day range - by business day in `businessDayMode`. */
-const priorDay: Shifter = ({start}, ctx) => singleDay(previousDayInMode(start, ctx));
-const nextDay: Shifter = ({start}, ctx) => singleDay(nextDayInMode(start, ctx));
-
-/** Shifted label for a rolling window - its length alone, e.g. `7 Days`. */
-const lengthLabel =
-    (length: string): ShiftedLabel =>
-    () =>
-        length;
-
-/** Shifted label for a previous-unit preset - the period the range now covers. */
-const periodLabel =
-    (format: string): ShiftedLabel =>
-    ({start}: LocalDateRange) =>
-        start.format(format);
-
-const isAnchorToday = ({anchorDate, today}: DateRangeContext) => anchorDate === today;
-const anchorLabel = (ctx: DateRangeContext) => (isAnchorToday(ctx) ? 'Today' : 'As Of');
-
-/**
- * A single day `n` steps from the anchor day, in the T-1 idiom finance users speak - `Today −2`,
- * `As Of −1` - so a walk through single days reads the same however it began. Zero is the anchor
- * day itself.
- */
-const dayFromAnchor = (n: number, ctx: DateRangeContext): string =>
-    n ? `${anchorLabel(ctx)} ${fmtDateRangeOffset(n)}` : anchorLabel(ctx);
-
 /**
  * Presets shipped with Hoist, keyed by token. Offer any subset (in any order) via the `presets`
  * config of {@link DateRangePickerModel}, alongside any app-defined {@link DateRangePreset}s.
@@ -249,7 +179,6 @@ export const DATE_RANGE_PRESET_TOKENS = Object.keys(dateRangePresets) as DateRan
 /** Presets offered by {@link DateRangePickerModel} when none are configured. */
 export const DEFAULT_DATE_RANGE_PRESETS: DateRangePresetToken[] = [
     'anchorDay',
-    'prevDay',
     'mtd',
     'qtd',
     'ytd',
@@ -260,3 +189,86 @@ export const DEFAULT_DATE_RANGE_PRESETS: DateRangePresetToken[] = [
     'prevMonth',
     'prevYear'
 ];
+
+//------------------
+// Implementation
+//------------------
+type Resolver = DateRangePreset['resolve'];
+type Shifter = DateRangePreset['resolvePrior'];
+type ShiftedLabel = DateRangePreset['shiftedLabel'];
+
+/** From the start of the unit containing the anchor date, through the anchor date. */
+function toDate(unit: DateRangeUnit): Resolver {
+    return ({anchorDate}) => ({start: anchorDate.startOf(unit), end: anchorDate});
+}
+
+/** A rolling window of `n` days ending on the anchor date. */
+function prevDays(n: number): Resolver {
+    return ({anchorDate}) => ({start: anchorDate.subtract(n - 1, 'days'), end: anchorDate});
+}
+
+/** A rolling window of `n` months ending on the anchor date. */
+function prevMonths(n: number): Resolver {
+    return ({anchorDate}) => ({start: anchorDate.subtract(n, 'months').nextDay(), end: anchorDate});
+}
+
+/** The full calendar unit before the one containing the anchor date. */
+function previousUnit(unit: DateRangeUnit): Resolver {
+    return ctx => {
+        const start = previousUnitStart(ctx, unit);
+        return {start, end: start.endOf(unit)};
+    };
+}
+
+function previousUnitStart({anchorDate}: DateRangeContext, unit: DateRangeUnit): LocalDate {
+    return anchorDate.startOf(unit).subtract(1, unit);
+}
+
+/** The current range shifted by `n` units - negative back, positive forward - keeping its shape. */
+function shiftedBy(unit: DateRangeUnit, n: number): Shifter {
+    return ({start, end}) => ({start: start.add(n, unit), end: end.add(n, unit)});
+}
+
+/** The full calendar unit `n` units from a current range that is itself a full unit. */
+function adjacentUnit(unit: DateRangeUnit, n: number): Shifter {
+    return ({start}) => {
+        const next = start.add(n, unit);
+        return {start: next, end: next.endOf(unit)};
+    };
+}
+
+/** The day before or after a single-day range - by business day in `businessDayMode`. */
+function priorDay({start}: LocalDateRange, ctx: DateRangeContext): LocalDateRange {
+    return singleDay(previousDayInMode(start, ctx));
+}
+
+function nextDay({start}: LocalDateRange, ctx: DateRangeContext): LocalDateRange {
+    return singleDay(nextDayInMode(start, ctx));
+}
+
+/** Shifted label for a rolling window - its length alone, e.g. `7 Days`. */
+function lengthLabel(length: string): ShiftedLabel {
+    return () => length;
+}
+
+/** Shifted label for a previous-unit preset - the period the range now covers. */
+function periodLabel(format: string): ShiftedLabel {
+    return ({start}) => start.format(format);
+}
+
+function isAnchorToday({anchorDate, today}: DateRangeContext): boolean {
+    return anchorDate === today;
+}
+
+function anchorLabel(ctx: DateRangeContext): string {
+    return isAnchorToday(ctx) ? 'Today' : 'As Of';
+}
+
+/**
+ * A single day `n` steps from the anchor day, in the T-1 idiom finance users speak - `Today −2`,
+ * `As Of −1` - so a walk through single days reads the same however it began. Zero is the anchor
+ * day itself.
+ */
+function dayFromAnchor(n: number, ctx: DateRangeContext): string {
+    return n ? `${anchorLabel(ctx)} ${fmtDateRangeOffset(n)}` : anchorLabel(ctx);
+}

--- a/cmp/daterange/DateRangePresets.ts
+++ b/cmp/daterange/DateRangePresets.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import type {LocalDate} from '@xh/hoist/utils/datetime';
-import {previousDayInMode, singleDay} from './DateRangeUtils';
+import {nextDayInMode, previousDayInMode, singleDay} from './DateRangeUtils';
 import type {
     DateRangeContext,
     DateRangePreset,
@@ -15,7 +15,7 @@ import type {
 } from './Types';
 
 type Resolver = DateRangePreset['resolve'];
-type PriorResolver = DateRangePreset['resolvePrior'];
+type Shifter = DateRangePreset['resolvePrior'];
 type ShiftedLabel = DateRangePreset['shiftedLabel'];
 
 /** From the start of the unit containing the anchor date, through the anchor date. */
@@ -44,21 +44,22 @@ const previousUnit =
 const previousUnitStart = ({anchorDate}: DateRangeContext, unit: DateRangeUnit): LocalDate =>
     anchorDate.startOf(unit).subtract(1, unit);
 
-/** The current range shifted back `n` units - a prior of equal calendar shape. */
-const shiftedPrior =
-    (unit: DateRangeUnit, n: number = 1): PriorResolver =>
-    ({start, end}) => ({start: start.subtract(n, unit), end: end.subtract(n, unit)});
+/** The current range shifted by `n` units - negative back, positive forward - keeping its shape. */
+const shiftedBy =
+    (unit: DateRangeUnit, n: number): Shifter =>
+    ({start, end}) => ({start: start.add(n, unit), end: end.add(n, unit)});
 
-/** The full calendar unit before a current range that is itself a full unit. */
-const previousUnitPrior =
-    (unit: DateRangeUnit): PriorResolver =>
+/** The full calendar unit `n` units from a current range that is itself a full unit. */
+const adjacentUnit =
+    (unit: DateRangeUnit, n: number): Shifter =>
     ({start}) => {
-        const priorStart = start.subtract(1, unit);
-        return {start: priorStart, end: priorStart.endOf(unit)};
+        const next = start.add(n, unit);
+        return {start: next, end: next.endOf(unit)};
     };
 
-/** The day before a single-day range - by business day in `businessDayMode`. */
-const previousDayPrior: PriorResolver = ({start}, ctx) => singleDay(previousDayInMode(start, ctx));
+/** The day before or after a single-day range - by business day in `businessDayMode`. */
+const priorDay: Shifter = ({start}, ctx) => singleDay(previousDayInMode(start, ctx));
+const nextDay: Shifter = ({start}, ctx) => singleDay(nextDayInMode(start, ctx));
 
 /** Shifted label for a rolling window - its length alone, e.g. `7 Days`. */
 const lengthLabel =
@@ -87,7 +88,7 @@ const isAnchorToday = ({anchorDate, today}: DateRangeContext) => anchorDate === 
  * one unit earlier - e.g. MTD on the 12th compares against the 1st through 12th of the prior
  * month. Previous-unit presets (`prevWeek`, `prevMonth`, ...) compare against the unit before.
  * Rolling windows compare against the window of equal length immediately preceding them. The
- * same prior logic drives stepping, so `mtd` stepped back once is the prior MTD.
+ * same logic, mirrored by `resolveNext`, drives stepping: `mtd` stepped back once is the prior MTD.
  *
  * A preset that names a specific period reads the same as a pick of that period on the Months &
  * Years tab - `prevMonth` labels as e.g. `Aug 2026` and `prevYear` as `2025` - so the trigger
@@ -100,14 +101,16 @@ export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
         label: ctx => (isAnchorToday(ctx) ? 'Today' : 'As Of'),
         name: ctx => (isAnchorToday(ctx) ? 'Today' : 'As Of Date'),
         resolve: ({anchorDate}) => singleDay(anchorDate),
-        resolvePrior: previousDayPrior,
+        resolvePrior: priorDay,
+        resolveNext: nextDay,
         shiftedLabel: lengthLabel('1 Day')
     },
     prevDay: {
         token: 'prevDay',
         label: 'Prev Day',
         resolve: ctx => singleDay(previousDayInMode(ctx.anchorDate, ctx)),
-        resolvePrior: previousDayPrior,
+        resolvePrior: priorDay,
+        resolveNext: nextDay,
         shiftedLabel: lengthLabel('1 Day')
     },
     wtd: {
@@ -115,28 +118,32 @@ export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
         label: 'WTD',
         name: 'Week to Date',
         resolve: toDate('weeks'),
-        resolvePrior: shiftedPrior('weeks')
+        resolvePrior: shiftedBy('weeks', -1),
+        resolveNext: shiftedBy('weeks', 1)
     },
     mtd: {
         token: 'mtd',
         label: 'MTD',
         name: 'Month to Date',
         resolve: toDate('months'),
-        resolvePrior: shiftedPrior('months')
+        resolvePrior: shiftedBy('months', -1),
+        resolveNext: shiftedBy('months', 1)
     },
     qtd: {
         token: 'qtd',
         label: 'QTD',
         name: 'Quarter to Date',
         resolve: toDate('quarters'),
-        resolvePrior: shiftedPrior('quarters')
+        resolvePrior: shiftedBy('quarters', -1),
+        resolveNext: shiftedBy('quarters', 1)
     },
     ytd: {
         token: 'ytd',
         label: 'YTD',
         name: 'Year to Date',
         resolve: toDate('years'),
-        resolvePrior: shiftedPrior('years')
+        resolvePrior: shiftedBy('years', -1),
+        resolveNext: shiftedBy('years', 1)
     },
     prev7Days: {
         token: 'prev7Days',
@@ -160,28 +167,32 @@ export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
         token: 'prev3Months',
         label: 'Prev 3 Months',
         resolve: prevMonths(3),
-        resolvePrior: shiftedPrior('months', 3),
+        resolvePrior: shiftedBy('months', -3),
+        resolveNext: shiftedBy('months', 3),
         shiftedLabel: lengthLabel('3 Months')
     },
     prev6Months: {
         token: 'prev6Months',
         label: 'Prev 6 Months',
         resolve: prevMonths(6),
-        resolvePrior: shiftedPrior('months', 6),
+        resolvePrior: shiftedBy('months', -6),
+        resolveNext: shiftedBy('months', 6),
         shiftedLabel: lengthLabel('6 Months')
     },
     prev12Months: {
         token: 'prev12Months',
         label: 'Prev 12 Months',
         resolve: prevMonths(12),
-        resolvePrior: shiftedPrior('years'),
+        resolvePrior: shiftedBy('years', -1),
+        resolveNext: shiftedBy('years', 1),
         shiftedLabel: lengthLabel('12 Months')
     },
     prevWeek: {
         token: 'prevWeek',
         label: 'Prev Week',
         resolve: previousUnit('weeks'),
-        resolvePrior: previousUnitPrior('weeks'),
+        resolvePrior: adjacentUnit('weeks', -1),
+        resolveNext: adjacentUnit('weeks', 1),
         shiftedLabel: periodLabel('[Wk of] MMM D')
     },
     prevMonth: {
@@ -189,7 +200,8 @@ export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
         label: ctx => previousUnitStart(ctx, 'months').format('MMM YYYY'),
         name: ctx => `Prev Month (${previousUnitStart(ctx, 'months').format('MMM YYYY')})`,
         resolve: previousUnit('months'),
-        resolvePrior: previousUnitPrior('months'),
+        resolvePrior: adjacentUnit('months', -1),
+        resolveNext: adjacentUnit('months', 1),
         shiftedLabel: periodLabel('MMM YYYY')
     },
     prevQuarter: {
@@ -197,7 +209,8 @@ export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
         label: ctx => previousUnitStart(ctx, 'quarters').format('[Q]Q YYYY'),
         name: ctx => `Prev Quarter (${previousUnitStart(ctx, 'quarters').format('[Q]Q YYYY')})`,
         resolve: previousUnit('quarters'),
-        resolvePrior: previousUnitPrior('quarters'),
+        resolvePrior: adjacentUnit('quarters', -1),
+        resolveNext: adjacentUnit('quarters', 1),
         shiftedLabel: periodLabel('[Q]Q YYYY')
     },
     prevYear: {
@@ -205,7 +218,8 @@ export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
         label: ctx => previousUnitStart(ctx, 'years').format('YYYY'),
         name: ctx => `Prev Year (${previousUnitStart(ctx, 'years').format('YYYY')})`,
         resolve: previousUnit('years'),
-        resolvePrior: previousUnitPrior('years'),
+        resolvePrior: adjacentUnit('years', -1),
+        resolveNext: adjacentUnit('years', 1),
         shiftedLabel: periodLabel('YYYY')
     },
     all: {
@@ -214,7 +228,8 @@ export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
         name: 'All Dates',
         // Everything selectable - unbounded at the start unless the model sets a `minDate`.
         resolve: ({minDate, maxDate}) => ({start: minDate, end: maxDate}),
-        resolvePrior: () => null
+        resolvePrior: () => null,
+        resolveNext: () => null
     }
 };
 

--- a/cmp/daterange/DateRangePresets.ts
+++ b/cmp/daterange/DateRangePresets.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import type {LocalDate} from '@xh/hoist/utils/datetime';
-import {nextDayInMode, previousDayInMode, singleDay} from './DateRangeUtils';
+import {fmtDateRangeOffset, nextDayInMode, previousDayInMode, singleDay} from './DateRangeUtils';
 import type {
     DateRangeContext,
     DateRangePreset,
@@ -74,6 +74,15 @@ const periodLabel =
         start.format(format);
 
 const isAnchorToday = ({anchorDate, today}: DateRangeContext) => anchorDate === today;
+const anchorLabel = (ctx: DateRangeContext) => (isAnchorToday(ctx) ? 'Today' : 'As Of');
+
+/**
+ * A single day `n` steps from the anchor day, in the T-1 idiom finance users speak - `Today −2`,
+ * `As Of −1` - so a walk through single days reads the same however it began. Zero is the anchor
+ * day itself.
+ */
+const dayFromAnchor = (n: number, ctx: DateRangeContext): string =>
+    n ? `${anchorLabel(ctx)} ${fmtDateRangeOffset(n)}` : anchorLabel(ctx);
 
 /**
  * Presets shipped with Hoist, keyed by token. Offer any subset (in any order) via the `presets`
@@ -98,12 +107,12 @@ const isAnchorToday = ({anchorDate, today}: DateRangeContext) => anchorDate === 
 export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
     anchorDay: {
         token: 'anchorDay',
-        label: ctx => (isAnchorToday(ctx) ? 'Today' : 'As Of'),
+        label: anchorLabel,
         name: ctx => (isAnchorToday(ctx) ? 'Today' : 'As Of Date'),
         resolve: ({anchorDate}) => singleDay(anchorDate),
         resolvePrior: priorDay,
         resolveNext: nextDay,
-        shiftedLabel: lengthLabel('1 Day')
+        shiftedLabel: (range, offset, ctx) => dayFromAnchor(offset, ctx)
     },
     prevDay: {
         token: 'prevDay',
@@ -111,7 +120,8 @@ export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
         resolve: ctx => singleDay(previousDayInMode(ctx.anchorDate, ctx)),
         resolvePrior: priorDay,
         resolveNext: nextDay,
-        shiftedLabel: lengthLabel('1 Day')
+        // Already one step back - stepped, it reads from the anchor like `anchorDay` does.
+        shiftedLabel: (range, offset, ctx) => dayFromAnchor(offset - 1, ctx)
     },
     wtd: {
         token: 'wtd',
@@ -239,6 +249,7 @@ export const DATE_RANGE_PRESET_TOKENS = Object.keys(dateRangePresets) as DateRan
 /** Presets offered by {@link DateRangePickerModel} when none are configured. */
 export const DEFAULT_DATE_RANGE_PRESETS: DateRangePresetToken[] = [
     'anchorDay',
+    'prevDay',
     'mtd',
     'qtd',
     'ytd',

--- a/cmp/daterange/DateRangePresets.ts
+++ b/cmp/daterange/DateRangePresets.ts
@@ -5,110 +5,110 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import type {LocalDate} from '@xh/hoist/utils/datetime';
+import {previousDayInMode, singleDay} from './DateRangeUtils';
 import type {
     DateRangeContext,
     DateRangePreset,
     DateRangePresetToken,
-    DateRangeCalendarUnit
+    DateRangeUnit,
+    LocalDateRange
 } from './Types';
 
 type Resolver = DateRangePreset['resolve'];
 type PriorResolver = DateRangePreset['resolvePrior'];
+type ShiftedLabel = DateRangePreset['shiftedLabel'];
 
 /** From the start of the unit containing the anchor date, through the anchor date. */
 const toDate =
-    (unit: DateRangeCalendarUnit): Resolver =>
+    (unit: DateRangeUnit): Resolver =>
     ({anchorDate}) => ({start: anchorDate.startOf(unit), end: anchorDate});
 
 /** A rolling window of `n` days ending on the anchor date. */
-const lastDays =
+const prevDays =
     (n: number): Resolver =>
     ({anchorDate}) => ({start: anchorDate.subtract(n - 1, 'days'), end: anchorDate});
 
 /** A rolling window of `n` months ending on the anchor date. */
-const lastMonths =
+const prevMonths =
     (n: number): Resolver =>
     ({anchorDate}) => ({start: anchorDate.subtract(n, 'months').nextDay(), end: anchorDate});
 
-/**
- * The same elapsed span as period-to-date, one unit earlier - e.g. prior MTD on the 12th is the
- * 1st through 12th of last month.
- */
-const priorToDate =
-    (unit: DateRangeCalendarUnit): Resolver =>
-    ({anchorDate}) => ({
-        start: anchorDate.startOf(unit).subtract(1, unit),
-        end: anchorDate.subtract(1, unit)
-    });
-
-/** The nearest business day strictly before `date`, per the context's `isBusinessDay`. */
-const previousBusinessDay = (date: LocalDate, ctx: DateRangeContext): LocalDate => {
-    let ret = date.previousDay();
-    // Bounded walk - guards against an `isBusinessDay` that never returns true.
-    for (let i = 0; i < 366 && !ctx.isBusinessDay(ret); i++) ret = ret.previousDay();
-    return ret;
-};
-
 /** The full calendar unit before the one containing the anchor date. */
 const previousUnit =
-    (unit: DateRangeCalendarUnit): Resolver =>
+    (unit: DateRangeUnit): Resolver =>
     ctx => {
         const start = previousUnitStart(ctx, unit);
         return {start, end: start.endOf(unit)};
     };
 
-const previousUnitStart = (
-    {anchorDate}: DateRangeContext,
-    unit: DateRangeCalendarUnit
-): LocalDate => anchorDate.startOf(unit).subtract(1, unit);
+const previousUnitStart = ({anchorDate}: DateRangeContext, unit: DateRangeUnit): LocalDate =>
+    anchorDate.startOf(unit).subtract(1, unit);
 
 /** The current range shifted back `n` units - a prior of equal calendar shape. */
 const shiftedPrior =
-    (unit: DateRangeCalendarUnit, n: number = 1): PriorResolver =>
+    (unit: DateRangeUnit, n: number = 1): PriorResolver =>
     ({start, end}) => ({start: start.subtract(n, unit), end: end.subtract(n, unit)});
 
 /** The full calendar unit before a current range that is itself a full unit. */
 const previousUnitPrior =
-    (unit: DateRangeCalendarUnit): PriorResolver =>
+    (unit: DateRangeUnit): PriorResolver =>
     ({start}) => {
         const priorStart = start.subtract(1, unit);
         return {start: priorStart, end: priorStart.endOf(unit)};
     };
 
+/** The day before a single-day range - by business day in `businessDayMode`. */
+const previousDayPrior: PriorResolver = ({start}, ctx) => singleDay(previousDayInMode(start, ctx));
+
+/** Shifted label for a rolling window - its length alone, e.g. `7 Days`. */
+const lengthLabel =
+    (length: string): ShiftedLabel =>
+    () =>
+        length;
+
+/** Shifted label for a previous-unit preset - the period the range now covers. */
+const periodLabel =
+    (format: string): ShiftedLabel =>
+    ({start}: LocalDateRange) =>
+        start.format(format);
+
+const isAnchorToday = ({anchorDate, today}: DateRangeContext) => anchorDate === today;
+
 /**
  * Presets shipped with Hoist, keyed by token. Offer any subset (in any order) via the `presets`
  * config of {@link DateRangePickerModel}, alongside any app-defined {@link DateRangePreset}s.
  *
+ * Labels describe a range without claiming it ends today, since the anchor date need not be
+ * today: `Prev 7 Days` rather than `Last 7 Days`. The one exception is `anchorDay`, which reads
+ * `Today` when the anchor date is the current day and `As Of` otherwise - the trigger's dates
+ * supply the day itself.
+ *
  * Period-to-date presets (`wtd`, `mtd`, `qtd`, `ytd`) resolve their prior range as the same span
  * one unit earlier - e.g. MTD on the 12th compares against the 1st through 12th of the prior
- * month. Previous-unit presets (`lastWeek`, `lastMonth`, ...) compare against the unit before.
- * Rolling windows compare against the window of equal length immediately preceding them.
- *
- * Prior period-to-date presets (`priorMtd`, `priorQtd`, `priorYtd`) select the comparison period
- * itself - the same elapsed span one unit earlier, as also exposed by `priorRange` for the
- * current-period presets. `lastBusinessDay` walks back from the anchor date over non-business days
- * per the context's `isBusinessDay` - weekdays by default, or a model-supplied calendar.
+ * month. Previous-unit presets (`prevWeek`, `prevMonth`, ...) compare against the unit before.
+ * Rolling windows compare against the window of equal length immediately preceding them. The
+ * same prior logic drives stepping, so `mtd` stepped back once is the prior MTD.
  *
  * A preset that names a specific period reads the same as a pick of that period on the Months &
- * Years tab - `lastMonth` labels as e.g. `Aug 2026` and `lastYear` as `2025` - so the trigger
+ * Years tab - `prevMonth` labels as e.g. `Aug 2026` and `prevYear` as `2025` - so the trigger
  * describes the period, whichever way it was chosen. The underlying values stay distinct: a preset
  * re-resolves against the anchor date as time passes, where a pinned month or year does not.
  */
 export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
-    today: {
-        token: 'today',
-        label: 'Today',
-        resolve: ({anchorDate}) => ({start: anchorDate, end: anchorDate}),
-        resolvePrior: shiftedPrior('days')
+    anchorDay: {
+        token: 'anchorDay',
+        label: ctx => (isAnchorToday(ctx) ? 'Today' : 'As Of'),
+        name: ctx => (isAnchorToday(ctx) ? 'Today' : 'As Of Date'),
+        resolve: ({anchorDate}) => singleDay(anchorDate),
+        resolvePrior: previousDayPrior,
+        shiftedLabel: lengthLabel('1 Day')
     },
-    yesterday: {
-        token: 'yesterday',
-        label: 'Yesterday',
-        resolve: ({anchorDate}) => {
-            const day = anchorDate.previousDay();
-            return {start: day, end: day};
-        },
-        resolvePrior: shiftedPrior('days')
+    prevDay: {
+        token: 'prevDay',
+        label: 'Prev Day',
+        resolve: ctx => singleDay(previousDayInMode(ctx.anchorDate, ctx)),
+        resolvePrior: previousDayPrior,
+        shiftedLabel: lengthLabel('1 Day')
     },
     wtd: {
         token: 'wtd',
@@ -138,86 +138,75 @@ export const dateRangePresets: Record<DateRangePresetToken, DateRangePreset> = {
         resolve: toDate('years'),
         resolvePrior: shiftedPrior('years')
     },
-    last7Days: {token: 'last7Days', label: 'Last 7 Days', resolve: lastDays(7)},
-    last30Days: {token: 'last30Days', label: 'Last 30 Days', resolve: lastDays(30)},
-    last90Days: {token: 'last90Days', label: 'Last 90 Days', resolve: lastDays(90)},
-    last3Months: {
-        token: 'last3Months',
-        label: 'Last 3 Months',
-        resolve: lastMonths(3),
-        resolvePrior: shiftedPrior('months', 3)
+    prev7Days: {
+        token: 'prev7Days',
+        label: 'Prev 7 Days',
+        resolve: prevDays(7),
+        shiftedLabel: lengthLabel('7 Days')
     },
-    last6Months: {
-        token: 'last6Months',
-        label: 'Last 6 Months',
-        resolve: lastMonths(6),
-        resolvePrior: shiftedPrior('months', 6)
+    prev30Days: {
+        token: 'prev30Days',
+        label: 'Prev 30 Days',
+        resolve: prevDays(30),
+        shiftedLabel: lengthLabel('30 Days')
     },
-    last12Months: {
-        token: 'last12Months',
-        label: 'Last 12 Months',
-        resolve: lastMonths(12),
-        resolvePrior: shiftedPrior('years')
+    prev90Days: {
+        token: 'prev90Days',
+        label: 'Prev 90 Days',
+        resolve: prevDays(90),
+        shiftedLabel: lengthLabel('90 Days')
     },
-    lastWeek: {
-        token: 'lastWeek',
-        label: 'Last Week',
+    prev3Months: {
+        token: 'prev3Months',
+        label: 'Prev 3 Months',
+        resolve: prevMonths(3),
+        resolvePrior: shiftedPrior('months', 3),
+        shiftedLabel: lengthLabel('3 Months')
+    },
+    prev6Months: {
+        token: 'prev6Months',
+        label: 'Prev 6 Months',
+        resolve: prevMonths(6),
+        resolvePrior: shiftedPrior('months', 6),
+        shiftedLabel: lengthLabel('6 Months')
+    },
+    prev12Months: {
+        token: 'prev12Months',
+        label: 'Prev 12 Months',
+        resolve: prevMonths(12),
+        resolvePrior: shiftedPrior('years'),
+        shiftedLabel: lengthLabel('12 Months')
+    },
+    prevWeek: {
+        token: 'prevWeek',
+        label: 'Prev Week',
         resolve: previousUnit('weeks'),
-        resolvePrior: previousUnitPrior('weeks')
+        resolvePrior: previousUnitPrior('weeks'),
+        shiftedLabel: periodLabel('[Wk of] MMM D')
     },
-    lastMonth: {
-        token: 'lastMonth',
+    prevMonth: {
+        token: 'prevMonth',
         label: ctx => previousUnitStart(ctx, 'months').format('MMM YYYY'),
-        name: ctx => `Last Month (${previousUnitStart(ctx, 'months').format('MMM YYYY')})`,
+        name: ctx => `Prev Month (${previousUnitStart(ctx, 'months').format('MMM YYYY')})`,
         resolve: previousUnit('months'),
-        resolvePrior: previousUnitPrior('months')
+        resolvePrior: previousUnitPrior('months'),
+        shiftedLabel: periodLabel('MMM YYYY')
     },
-    lastQuarter: {
-        token: 'lastQuarter',
+    prevQuarter: {
+        token: 'prevQuarter',
         label: ctx => previousUnitStart(ctx, 'quarters').format('[Q]Q YYYY'),
-        name: ctx => `Last Quarter (${previousUnitStart(ctx, 'quarters').format('[Q]Q YYYY')})`,
+        name: ctx => `Prev Quarter (${previousUnitStart(ctx, 'quarters').format('[Q]Q YYYY')})`,
         resolve: previousUnit('quarters'),
-        resolvePrior: previousUnitPrior('quarters')
+        resolvePrior: previousUnitPrior('quarters'),
+        shiftedLabel: periodLabel('[Q]Q YYYY')
     },
-    lastYear: {
-        token: 'lastYear',
+    prevYear: {
+        token: 'prevYear',
         label: ctx => previousUnitStart(ctx, 'years').format('YYYY'),
-        name: ctx => `Last Year (${previousUnitStart(ctx, 'years').format('YYYY')})`,
+        name: ctx => `Prev Year (${previousUnitStart(ctx, 'years').format('YYYY')})`,
         resolve: previousUnit('years'),
-        resolvePrior: previousUnitPrior('years')
-    },
-    lastBusinessDay: {
-        token: 'lastBusinessDay',
-        label: 'Last Business Day',
-        resolve: ctx => {
-            const day = previousBusinessDay(ctx.anchorDate, ctx);
-            return {start: day, end: day};
-        },
-        resolvePrior: ({start}, ctx) => {
-            const day = previousBusinessDay(start, ctx);
-            return {start: day, end: day};
-        }
-    },
-    priorMtd: {
-        token: 'priorMtd',
-        label: 'Prior MTD',
-        name: 'Prior Month to Date',
-        resolve: priorToDate('months'),
-        resolvePrior: shiftedPrior('months')
-    },
-    priorQtd: {
-        token: 'priorQtd',
-        label: 'Prior QTD',
-        name: 'Prior Quarter to Date',
-        resolve: priorToDate('quarters'),
-        resolvePrior: shiftedPrior('quarters')
-    },
-    priorYtd: {
-        token: 'priorYtd',
-        label: 'Prior YTD',
-        name: 'Prior Year to Date',
-        resolve: priorToDate('years'),
-        resolvePrior: shiftedPrior('years')
+        resolvePrior: previousUnitPrior('years'),
+        shiftedLabel: periodLabel('YYYY')
     },
     all: {
         token: 'all',
@@ -234,14 +223,14 @@ export const DATE_RANGE_PRESET_TOKENS = Object.keys(dateRangePresets) as DateRan
 
 /** Presets offered by {@link DateRangePickerModel} when none are configured. */
 export const DEFAULT_DATE_RANGE_PRESETS: DateRangePresetToken[] = [
-    'today',
+    'anchorDay',
     'mtd',
     'qtd',
     'ytd',
-    'last7Days',
-    'last30Days',
-    'last90Days',
-    'last12Months',
-    'lastMonth',
-    'lastYear'
+    'prev7Days',
+    'prev30Days',
+    'prev90Days',
+    'prev12Months',
+    'prevMonth',
+    'prevYear'
 ];

--- a/cmp/daterange/DateRangeUtils.ts
+++ b/cmp/daterange/DateRangeUtils.ts
@@ -420,18 +420,18 @@ export function fmtDate(date: LocalDate, format: DateRangeFormat): string {
 
 /**
  * Format a range as `start ▸ end` per `dateFormat`, with `…` for an unbounded edge. A single-day
- * range formats as that one date per `dayFormat`, which defaults to `dateFormat`. Returns an empty
+ * range formats as that one date per `singleDayFormat`, which defaults to `dateFormat`. Returns an empty
  * string for a null range.
  */
 export function fmtDateRange(
     range: LocalDateRange,
     dateFormat: DateRangeFormat = 'YYYY-MM-DD',
-    dayFormat: DateRangeFormat = dateFormat
+    singleDayFormat: DateRangeFormat = dateFormat
 ): string {
     if (!range) return '';
     const {start, end} = range,
         fmt = (d: LocalDate) => (d ? fmtDate(d, dateFormat) : '…');
-    return start && start === end ? fmtDate(start, dayFormat) : `${fmt(start)} ▸ ${fmt(end)}`;
+    return start && start === end ? fmtDate(start, singleDayFormat) : `${fmt(start)} ▸ ${fmt(end)}`;
 }
 
 /** First day of the given month (1-12) of the given year. */

--- a/cmp/daterange/DateRangeUtils.ts
+++ b/cmp/daterange/DateRangeUtils.ts
@@ -24,7 +24,7 @@ import type {
 export const DATE_RANGE_PICKER_TABS: DateRangePickerTab[] = [
     'presets',
     'relative',
-    'monthYear',
+    'period',
     'custom'
 ];
 
@@ -36,6 +36,9 @@ export const MAX_RELATIVE_COUNT = 999;
 
 /** Furthest a preset or relative selection can be stepped from its natural range, either way. */
 export const MAX_STEP_OFFSET = 9999;
+
+/** The calendar unit each pinned-period selection kind steps by. */
+const CALENDAR_KIND_UNITS = {month: 'months', quarter: 'quarters', year: 'years'} as const;
 
 /** Year bounds for month and year selections - shared by validation and picker navigation. */
 export const MIN_SELECTION_YEAR = 1900;
@@ -85,6 +88,14 @@ export function resolveDateRange(
             return resolveCalendarUnit(
                 getMonthStart(sel.year, sel.month),
                 'months',
+                minDate,
+                maxDate
+            );
+
+        case 'quarter':
+            return resolveCalendarUnit(
+                getQuarterStart(sel.year, sel.quarter),
+                'quarters',
                 minDate,
                 maxDate
             );
@@ -163,13 +174,14 @@ function shiftRelative(
 
 /**
  * A full calendar month or year, clamped to `maxDate` (and `minDate`) when those dates fall
- * within it - so the current month reads as month-to-date, and the current year as year-to-date.
+ * within it - so the current month covers the 1st through the anchor, and the current year Jan 1
+ * through the anchor.
  * A period entirely beyond `maxDate` (e.g. a persisted pick from a user with a later anchor)
  * keeps its natural bounds rather than producing an inverted range.
  */
 function resolveCalendarUnit(
     naturalStart: LocalDate,
-    unit: 'months' | 'years',
+    unit: 'months' | 'quarters' | 'years',
     minDate: LocalDate,
     maxDate: LocalDate
 ): ResolvedDateRange {
@@ -291,6 +303,13 @@ export function parseDateRangeSelection(
                 : null;
         }
 
+        case 'quarter': {
+            const {year, quarter} = obj;
+            return isValidYear(year) && Number.isInteger(quarter) && quarter >= 1 && quarter <= 4
+                ? {kind: 'quarter', year, quarter}
+                : null;
+        }
+
         case 'year':
             return isValidYear(obj.year) ? {kind: 'year', year: obj.year} : null;
 
@@ -346,9 +365,11 @@ function parseIsoDate(s: unknown): LocalDate | null {
  * Short label for a selection, suitable for the picker trigger - e.g. `MTD`, `Prev 6 Months`,
  * `Aug 2026`, `2025`, or `Custom`.
  *
- * A period that can be selected two ways reads the same either way: the `ytd` preset and a
- * current-year pick on the Months & Years tab both read `YTD`, and `prevYear` and a prior-year
- * pick both read as that year.
+ * Month and year picks read as the period they name - `Sep 2026`, `2026` - even when clamped to
+ * the anchor date, with the trigger's dates showing the clamp. `MTD` and `YTD` are reserved for
+ * the presets, which are live and step to the same partial span a unit earlier, where a pinned
+ * month or year steps by whole units. The `prevMonth` and `prevYear` presets read as the period
+ * too, since they resolve to a full one.
  *
  * Once stepped to a non-zero offset, the trigger's dates locate the range and the label describes
  * only its shape: a rolling window reads as its length (`7 Days`, `3 Months`), a named period as
@@ -371,14 +392,10 @@ export function getDateRangeLabel(sel: DateRangeSelection, ctx: DateRangeContext
         }
         case 'month':
             return getMonthStart(sel.year, sel.month).format('MMM YYYY');
-        case 'year': {
-            // A year cut short at the anchor date is the same range as the `ytd` preset, so it
-            // takes the same name. A year clamped by an explicit `maxDate` is not "to date".
-            const {current} = resolveDateRange(sel, ctx);
-            return current.end === ctx.anchorDate && current.end < current.start.endOfYear()
-                ? 'YTD'
-                : String(sel.year);
-        }
+        case 'quarter':
+            return `Q${sel.quarter} ${sel.year}`;
+        case 'year':
+            return String(sel.year);
         case 'custom':
             return 'Custom';
     }
@@ -444,6 +461,11 @@ export function getMonthStart(year: number, month: number): LocalDate {
     return LocalDate.get(`${year}-${String(month).padStart(2, '0')}-01`);
 }
 
+/** First day of the given quarter (1-4) of the given year. */
+export function getQuarterStart(year: number, quarter: number): LocalDate {
+    return getMonthStart(year, quarter * 3 - 2);
+}
+
 /**
  * Move a selection by `steps` periods - negative to go back, positive to go forward. No selection
  * changes kind:
@@ -483,12 +505,10 @@ export function stepDateRangeSelection(
         return next;
     }
 
-    if (sel.kind === 'month' || sel.kind === 'year') {
-        const unit = sel.kind === 'month' ? 'months' : 'years',
-            start =
-                sel.kind === 'month'
-                    ? getMonthStart(sel.year, sel.month)
-                    : LocalDate.get(`${sel.year}-01-01`),
+    if (sel.kind === 'month' || sel.kind === 'quarter' || sel.kind === 'year') {
+        const unit = CALENDAR_KIND_UNITS[sel.kind],
+            start = resolveDateRange({...sel}, {...ctx, minDate: null, maxDate: null}).current
+                .start,
             // Never step beyond the period containing a bound, or below the supported years.
             maxStart = maxDate.startOf(unit),
             minStart = (minDate ?? LocalDate.get(`${MIN_SELECTION_YEAR}-01-01`)).startOf(unit);
@@ -501,9 +521,14 @@ export function stepDateRangeSelection(
         if (steps > 0 ? next <= start : next >= start) return null;
 
         const year = next.moment.year();
-        return sel.kind === 'month'
-            ? {kind: 'month', year, month: next.moment.month() + 1}
-            : {kind: 'year', year};
+        switch (sel.kind) {
+            case 'month':
+                return {kind: 'month', year, month: next.moment.month() + 1};
+            case 'quarter':
+                return {kind: 'quarter', year, quarter: next.moment.quarter()};
+            case 'year':
+                return {kind: 'year', year};
+        }
     }
 
     const {start, end} = resolveDateRange(sel, ctx).current;

--- a/cmp/daterange/DateRangeUtils.ts
+++ b/cmp/daterange/DateRangeUtils.ts
@@ -19,7 +19,7 @@ import type {
     ResolvedDateRange
 } from './Types';
 
-/** All picker tabs, in their default rail order. */
+/** All picker tabs, in their default display order. */
 export const DATE_RANGE_PICKER_TABS: DateRangePickerTab[] = [
     'presets',
     'relative',

--- a/cmp/daterange/DateRangeUtils.ts
+++ b/cmp/daterange/DateRangeUtils.ts
@@ -33,7 +33,7 @@ export const DATE_RANGE_UNITS: DateRangeUnit[] = ['days', 'weeks', 'months', 'qu
 /** Largest `count` accepted for a relative selection. */
 export const MAX_RELATIVE_COUNT = 999;
 
-/** Furthest back a preset or relative selection can be stepped. */
+/** Furthest a preset or relative selection can be stepped from its natural range, either way. */
 export const MAX_STEP_OFFSET = 9999;
 
 /** Year bounds for month and year selections - shared by validation and picker navigation. */
@@ -57,6 +57,7 @@ export function resolveDateRange(
             return applyOffset(
                 preset.resolve(ctx),
                 range => resolvePresetPrior(preset, range, ctx),
+                range => resolvePresetNext(preset, range, ctx),
                 sel.offset
             );
         }
@@ -73,7 +74,8 @@ export function resolveDateRange(
                       anchorDate.subtract(count, unit).nextDay();
             return applyOffset(
                 {start, end: anchorDate},
-                range => resolveRelativePrior(sel, range, ctx),
+                range => shiftRelative(sel, range, -1, ctx),
+                range => shiftRelative(sel, range, 1, ctx),
                 sel.offset
             );
         }
@@ -102,19 +104,21 @@ export function resolveDateRange(
 }
 
 /**
- * Step a natural range back `|offset|` periods via its prior-range logic, then compute the prior
- * of where it lands. Stops early if the range becomes unbounded - `stepDateRangeSelection` refuses
- * offsets the range cannot reach.
+ * Step a natural range `|offset|` periods - back via its prior-range logic, forward via its
+ * next-range logic - then compute the prior of where it lands. Stops early if the range becomes
+ * unbounded; `stepDateRangeSelection` refuses offsets the range cannot reach.
  */
 function applyOffset(
     current: LocalDateRange,
     priorFn: (range: LocalDateRange) => LocalDateRange | null,
+    nextFn: (range: LocalDateRange) => LocalDateRange | null,
     offset: number = 0
 ): ResolvedDateRange {
-    for (let i = 0; i < -offset; i++) {
-        const prior = priorFn(current);
-        if (!prior) break;
-        current = prior;
+    const stepFn = offset < 0 ? priorFn : nextFn;
+    for (let i = 0; i < Math.abs(offset); i++) {
+        const stepped = stepFn(current);
+        if (!stepped) break;
+        current = stepped;
     }
     return {current, prior: priorFn(current)};
 }
@@ -124,27 +128,36 @@ function resolvePresetPrior(
     range: LocalDateRange,
     ctx: DateRangeContext
 ): LocalDateRange | null {
-    return preset.resolvePrior ? preset.resolvePrior(range, ctx) : equalDurationPrior(range);
+    return preset.resolvePrior ? preset.resolvePrior(range, ctx) : shiftByDuration(range, -1);
+}
+
+function resolvePresetNext(
+    preset: DateRangePreset,
+    range: LocalDateRange,
+    ctx: DateRangeContext
+): LocalDateRange | null {
+    return preset.resolveNext ? preset.resolveNext(range, ctx) : shiftByDuration(range, 1);
 }
 
 /**
- * Compare like against like: a lookback in weeks or larger units steps its prior back by the same
- * units, matching the equivalent presets - so 3 months ending May 31 compares against 3 months
- * ending Feb 28, not 92 days. Days keep an equal number of days, with a single day walking by
- * business day when the model is in `businessDayMode`.
+ * Compare like against like: a lookback in weeks or larger units steps by the same units,
+ * matching the equivalent presets - so 3 months ending May 31 compares against 3 months ending
+ * Feb 28, not 92 days. Days keep an equal number of days, with a single day walking by business
+ * day when the model is in `businessDayMode`. `dir` is -1 for the prior range, 1 for the next.
  */
-function resolveRelativePrior(
+function shiftRelative(
     sel: RelativeDateRangeSelection,
     {start, end}: LocalDateRange,
+    dir: 1 | -1,
     ctx: DateRangeContext
 ): LocalDateRange {
     const {unit} = sel,
-        count = Math.max(1, sel.count);
-    if (unit !== 'days') {
-        return {start: start.subtract(count, unit), end: end.subtract(count, unit)};
+        count = Math.max(1, sel.count) * dir;
+    if (unit !== 'days') return {start: start.add(count, unit), end: end.add(count, unit)};
+    if (Math.abs(count) === 1 && ctx.businessDayMode) {
+        return singleDay(dir < 0 ? previousBusinessDay(start, ctx) : nextBusinessDay(start, ctx));
     }
-    if (count === 1 && ctx.businessDayMode) return singleDay(previousBusinessDay(start, ctx));
-    return equalDurationPrior({start, end});
+    return shiftByDuration({start, end}, dir);
 }
 
 /**
@@ -174,11 +187,19 @@ function resolveCalendarUnit(
     };
 }
 
-/** The immediately preceding range of equal duration in days, or null if `current` is unbounded. */
-function equalDurationPrior({start, end}: LocalDateRange): LocalDateRange | null {
+/**
+ * The adjacent range of equal duration in days - preceding for `dir` -1, following for 1 - or
+ * null if `current` is unbounded.
+ */
+function shiftByDuration({start, end}: LocalDateRange, dir: 1 | -1): LocalDateRange | null {
     if (!start || !end) return null;
-    const dayCount = end.diff(start, 'days') + 1;
-    return {start: start.subtract(dayCount, 'days'), end: end.subtract(dayCount, 'days')};
+    const days = (end.diff(start, 'days') + 1) * dir;
+    return {start: start.add(days, 'days'), end: end.add(days, 'days')};
+}
+
+/** The immediately preceding range of equal duration in days, or null if `current` is unbounded. */
+function equalDurationPrior(range: LocalDateRange): LocalDateRange | null {
+    return shiftByDuration(range, -1);
 }
 
 /** A range of the one given day. */
@@ -216,6 +237,11 @@ type BusinessDayContext = Pick<DateRangeContext, 'isBusinessDay'>;
  */
 export function previousDayInMode(date: LocalDate, ctx: DateRangeContext): LocalDate {
     return ctx.businessDayMode ? previousBusinessDay(date, ctx) : date.previousDay();
+}
+
+/** The day after `date` - the next business day in `businessDayMode`, else the next calendar day. */
+export function nextDayInMode(date: LocalDate, ctx: DateRangeContext): LocalDate {
+    return ctx.businessDayMode ? nextBusinessDay(date, ctx) : date.nextDay();
 }
 
 /**
@@ -281,10 +307,10 @@ export function parseDateRangeSelection(
     }
 }
 
-/** A missing offset is zero. Anything else must be an integer within [-MAX_STEP_OFFSET, 0]. */
+/** A missing offset is zero. Anything else must be an integer within ±MAX_STEP_OFFSET. */
 function parseOffset(raw: unknown): number | null {
     if (raw == null) return 0;
-    return Number.isInteger(raw) && (raw as number) <= 0 && (raw as number) >= -MAX_STEP_OFFSET
+    return Number.isInteger(raw) && Math.abs(raw as number) <= MAX_STEP_OFFSET
         ? (raw as number)
         : null;
 }
@@ -323,9 +349,10 @@ function parseIsoDate(s: unknown): LocalDate | null {
  * current-year pick on the Months & Years tab both read `YTD`, and `prevYear` and a prior-year
  * pick both read as that year.
  *
- * Once stepped back to a non-zero offset, the trigger's dates locate the range and the label
- * describes only its shape: a rolling window reads as its length (`7 Days`, `3 Months`), a named
- * period as the period (`Jul 2026`), and a to-date preset as its name with the offset (`MTD −1`).
+ * Once stepped to a non-zero offset, the trigger's dates locate the range and the label describes
+ * only its shape: a rolling window reads as its length (`7 Days`, `3 Months`), a named period as
+ * the period (`Jul 2026`), and a to-date preset as its name with the signed offset (`MTD −1`,
+ * `MTD +1`).
  */
 export function getDateRangeLabel(sel: DateRangeSelection, ctx: DateRangeContext): string {
     switch (sel.kind) {
@@ -365,9 +392,9 @@ function evalLabel(label: DateRangePreset['label'], ctx: DateRangeContext): stri
     return isFunction(label) ? label(ctx) : label;
 }
 
-/** A negative offset as `−n`, with a true minus sign. */
+/** A signed offset as `−n` or `+n`, with a true minus sign. */
 function fmtOffset(offset: number): string {
-    return `−${Math.abs(offset)}`;
+    return `${offset < 0 ? '−' : '+'}${Math.abs(offset)}`;
 }
 
 function getPreset(token: string, ctx: DateRangeContext): DateRangePreset {
@@ -410,16 +437,16 @@ export function getMonthStart(year: number, month: number): LocalDate {
  * Move a selection by `steps` periods - negative to go back, positive to go forward. No selection
  * changes kind:
  *
- * - Preset and relative selections adjust their `offset`, stepping through their own prior-range
- *   logic - so a lookback in months steps by months, and a single day steps by business day in
- *   `businessDayMode`. Their offset never exceeds zero, as the natural range already ends on the
- *   anchor date.
+ * - Preset and relative selections adjust their `offset`, stepping through their own prior- and
+ *   next-range logic - so a lookback in months steps by months, and a single day steps by
+ *   business day in `businessDayMode`. Their natural range ends on the anchor date, so a positive
+ *   offset is reachable only when `maxDate` allows dates beyond it.
  * - Month and year selections step by calendar unit.
  * - Custom selections step by their length in days - or by business day when a single day in
  *   `businessDayMode`.
  *
- * Steps are clamped to the context's `minDate` and `maxDate`. Returns null when the selection
- * cannot move that way: it is already at a bound, at offset zero, or unbounded.
+ * Steps stop at the context's `minDate` and `maxDate`. Returns null when the selection cannot
+ * move that way: it is already at a bound, or unbounded.
  */
 export function stepDateRangeSelection(
     sel: DateRangeSelection,
@@ -431,16 +458,17 @@ export function stepDateRangeSelection(
 
     if (sel.kind === 'preset' || sel.kind === 'relative') {
         const offset = sel.offset ?? 0,
-            nextOffset = Math.max(-MAX_STEP_OFFSET, Math.min(0, offset + steps));
+            nextOffset = Math.max(-MAX_STEP_OFFSET, Math.min(MAX_STEP_OFFSET, offset + steps));
         if (nextOffset === offset) return null;
 
         const next = withOffset(sel, nextOffset),
             {current} = resolveDateRange(next, ctx),
             {current: prev} = resolveDateRange(sel, ctx);
-        // Unbounded, or the prior logic could not reach the requested offset.
+        // Unbounded, or the prior/next logic could not reach the requested offset.
         if (!current.start || !current.end) return null;
         if (current.start === prev.start && current.end === prev.end) return null;
-        if (minDate && current.end < minDate) return null;
+        // A stepped range may not lie entirely outside the bounds.
+        if (current.end > maxDate || (minDate && current.start < minDate)) return null;
         return next;
     }
 

--- a/cmp/daterange/DateRangeUtils.ts
+++ b/cmp/daterange/DateRangeUtils.ts
@@ -362,7 +362,7 @@ export function getDateRangeLabel(sel: DateRangeSelection, ctx: DateRangeContext
             if (!offset) return evalLabel(preset.label, ctx);
             return preset.shiftedLabel
                 ? preset.shiftedLabel(resolveDateRange(sel, ctx).current, offset, ctx)
-                : `${evalLabel(preset.label, ctx)} ${fmtOffset(offset)}`;
+                : `${evalLabel(preset.label, ctx)} ${fmtDateRangeOffset(offset)}`;
         }
         case 'relative': {
             const length = `${sel.count} ${getDateRangeUnitLabel(sel.unit, sel.count)}`;
@@ -392,8 +392,8 @@ function evalLabel(label: DateRangePreset['label'], ctx: DateRangeContext): stri
     return isFunction(label) ? label(ctx) : label;
 }
 
-/** A signed offset as `−n` or `+n`, with a true minus sign. */
-function fmtOffset(offset: number): string {
+/** A signed offset as `−n` or `+n`, with a true minus sign - the default suffix for a stepped label. */
+export function fmtDateRangeOffset(offset: number): string {
     return `${offset < 0 ? '−' : '+'}${Math.abs(offset)}`;
 }
 

--- a/cmp/daterange/DateRangeUtils.ts
+++ b/cmp/daterange/DateRangeUtils.ts
@@ -9,6 +9,7 @@ import {throwIf} from '@xh/hoist/utils/js';
 import {isFinite, isFunction, isPlainObject, isString} from 'lodash';
 import type {
     DateRangeContext,
+    DateRangeFormat,
     DateRangePickerTab,
     DateRangePreset,
     DateRangeSelection,
@@ -417,15 +418,25 @@ export function getDateRangeUnitLabel(unit: DateRangeUnit, count: number = 2): s
     return count === 1 ? singular : `${singular}s`;
 }
 
+/** Format a date per a {@link DateRangeFormat} - a moment.js format string or a function. */
+export function fmtDate(date: LocalDate, format: DateRangeFormat): string {
+    return isFunction(format) ? format(date) : date.format(format);
+}
+
 /**
- * Format a range as `start ▸ end` using a moment.js format string, with `…` for an unbounded
- * edge. A single-day range formats as that one date. Returns an empty string for a null range.
+ * Format a range as `start ▸ end` per `dateFormat`, with `…` for an unbounded edge. A single-day
+ * range formats as that one date per `dayFormat`, which defaults to `dateFormat`. Returns an empty
+ * string for a null range.
  */
-export function fmtDateRange(range: LocalDateRange, dateFormat: string = 'YYYY-MM-DD'): string {
+export function fmtDateRange(
+    range: LocalDateRange,
+    dateFormat: DateRangeFormat = 'YYYY-MM-DD',
+    dayFormat: DateRangeFormat = dateFormat
+): string {
     if (!range) return '';
     const {start, end} = range,
-        fmt = (d: LocalDate) => (d ? d.format(dateFormat) : '…');
-    return start && start === end ? fmt(start) : `${fmt(start)} ▸ ${fmt(end)}`;
+        fmt = (d: LocalDate) => (d ? fmtDate(d, dateFormat) : '…');
+    return start && start === end ? fmtDate(start, dayFormat) : `${fmt(start)} ▸ ${fmt(end)}`;
 }
 
 /** First day of the given month (1-12) of the given year. */

--- a/cmp/daterange/DateRangeUtils.ts
+++ b/cmp/daterange/DateRangeUtils.ts
@@ -8,13 +8,14 @@ import {LocalDate} from '@xh/hoist/utils/datetime';
 import {throwIf} from '@xh/hoist/utils/js';
 import {isFinite, isFunction, isPlainObject, isString} from 'lodash';
 import type {
-    DateRangeCalendarUnit,
     DateRangeContext,
     DateRangePickerTab,
     DateRangePreset,
     DateRangeSelection,
     DateRangeUnit,
     LocalDateRange,
+    PresetDateRangeSelection,
+    RelativeDateRangeSelection,
     ResolvedDateRange
 } from './Types';
 
@@ -26,20 +27,14 @@ export const DATE_RANGE_PICKER_TABS: DateRangePickerTab[] = [
     'custom'
 ];
 
-/** Calendar units offered on the Relative tab's unit control, in display order. */
-export const DATE_RANGE_CALENDAR_UNITS: DateRangeCalendarUnit[] = [
-    'days',
-    'weeks',
-    'months',
-    'quarters',
-    'years'
-];
-
-/** All units valid for a relative selection. */
-export const DATE_RANGE_UNITS: DateRangeUnit[] = [...DATE_RANGE_CALENDAR_UNITS, 'businessDays'];
+/** Units offered on the Relative tab's unit control, in display order. */
+export const DATE_RANGE_UNITS: DateRangeUnit[] = ['days', 'weeks', 'months', 'quarters', 'years'];
 
 /** Largest `count` accepted for a relative selection. */
 export const MAX_RELATIVE_COUNT = 999;
+
+/** Furthest back a preset or relative selection can be stepped. */
+export const MAX_STEP_OFFSET = 9999;
 
 /** Year bounds for month and year selections - shared by validation and picker navigation. */
 export const MIN_SELECTION_YEAR = 1900;
@@ -58,51 +53,29 @@ export function resolveDateRange(
 
     switch (sel.kind) {
         case 'preset': {
-            const preset = ctx.presets[sel.token];
-            throwIf(!preset, `Unknown date range preset: '${sel.token}'.`);
-            const current = preset.resolve(ctx),
-                prior = preset.resolvePrior
-                    ? preset.resolvePrior(current, ctx)
-                    : equalDurationPrior(current);
-            return {current, prior};
+            const preset = getPreset(sel.token, ctx);
+            return applyOffset(
+                preset.resolve(ctx),
+                range => resolvePresetPrior(preset, range, ctx),
+                sel.offset
+            );
         }
 
         case 'relative': {
             const {unit} = sel,
-                count = Math.max(1, sel.count);
-
-            if (unit === 'businessDays') {
-                // The window ends on the anchor date, business day or not, and reaches back far
-                // enough to hold `count` business days. The prior window holds the `count`
-                // business days before it.
-                const start = businessDayWindowStart(anchorDate, count, ctx),
-                    priorEnd = start.previousDay();
-                return {
-                    current: {start, end: anchorDate},
-                    prior: {start: businessDayWindowStart(priorEnd, count, ctx), end: priorEnd}
-                };
-            }
-
-            // Days need no special case: a day is already a calendar boundary, so both
-            // expressions below reduce to `anchorDate - count + 1` for that unit.
-            const start = sel.snap
+                count = Math.max(1, sel.count),
+                // Days need no special case: a day is already a calendar boundary, so both
+                // expressions below reduce to `anchorDate - count + 1` for that unit.
+                start = sel.snap
                     ? // Calendar-aligned - the current (partial) unit counts as one.
                       anchorDate.startOf(unit).subtract(count - 1, unit)
                     : // Rolling window of exactly `count` units ending on the anchor date.
-                      anchorDate.subtract(count, unit).nextDay(),
-                current = {start, end: anchorDate},
-                // Compare like against like: a lookback in months, quarters, weeks, or years steps
-                // its prior back by the same units, matching the equivalent presets - so 3 months
-                // ending May 31 compares against 3 months ending Feb 28, not 92 days. Days keep
-                // an equal number of days.
-                prior =
-                    unit === 'days'
-                        ? equalDurationPrior(current)
-                        : {
-                              start: start.subtract(count, unit),
-                              end: anchorDate.subtract(count, unit)
-                          };
-            return {current, prior};
+                      anchorDate.subtract(count, unit).nextDay();
+            return applyOffset(
+                {start, end: anchorDate},
+                range => resolveRelativePrior(sel, range, ctx),
+                sel.offset
+            );
         }
 
         case 'month':
@@ -126,6 +99,52 @@ export function resolveDateRange(
             return {current, prior: equalDurationPrior(current)};
         }
     }
+}
+
+/**
+ * Step a natural range back `|offset|` periods via its prior-range logic, then compute the prior
+ * of where it lands. Stops early if the range becomes unbounded - `stepDateRangeSelection` refuses
+ * offsets the range cannot reach.
+ */
+function applyOffset(
+    current: LocalDateRange,
+    priorFn: (range: LocalDateRange) => LocalDateRange | null,
+    offset: number = 0
+): ResolvedDateRange {
+    for (let i = 0; i < -offset; i++) {
+        const prior = priorFn(current);
+        if (!prior) break;
+        current = prior;
+    }
+    return {current, prior: priorFn(current)};
+}
+
+function resolvePresetPrior(
+    preset: DateRangePreset,
+    range: LocalDateRange,
+    ctx: DateRangeContext
+): LocalDateRange | null {
+    return preset.resolvePrior ? preset.resolvePrior(range, ctx) : equalDurationPrior(range);
+}
+
+/**
+ * Compare like against like: a lookback in weeks or larger units steps its prior back by the same
+ * units, matching the equivalent presets - so 3 months ending May 31 compares against 3 months
+ * ending Feb 28, not 92 days. Days keep an equal number of days, with a single day walking by
+ * business day when the model is in `businessDayMode`.
+ */
+function resolveRelativePrior(
+    sel: RelativeDateRangeSelection,
+    {start, end}: LocalDateRange,
+    ctx: DateRangeContext
+): LocalDateRange {
+    const {unit} = sel,
+        count = Math.max(1, sel.count);
+    if (unit !== 'days') {
+        return {start: start.subtract(count, unit), end: end.subtract(count, unit)};
+    }
+    if (count === 1 && ctx.businessDayMode) return singleDay(previousBusinessDay(start, ctx));
+    return equalDurationPrior({start, end});
 }
 
 /**
@@ -155,25 +174,48 @@ function resolveCalendarUnit(
     };
 }
 
-/**
- * Start of the window ending on `end` (inclusive) that holds `count` business days per the
- * context. Bounded, to guard against an `isBusinessDay` that never returns true.
- */
-function businessDayWindowStart(end: LocalDate, count: number, ctx: DateRangeContext): LocalDate {
-    let day = end,
-        found = ctx.isBusinessDay(day) ? 1 : 0;
-    for (let i = 0, limit = count * 10 + 366; found < count && i < limit; i++) {
-        day = day.previousDay();
-        if (ctx.isBusinessDay(day)) found++;
-    }
-    return day;
-}
-
 /** The immediately preceding range of equal duration in days, or null if `current` is unbounded. */
 function equalDurationPrior({start, end}: LocalDateRange): LocalDateRange | null {
     if (!start || !end) return null;
     const dayCount = end.diff(start, 'days') + 1;
     return {start: start.subtract(dayCount, 'days'), end: end.subtract(dayCount, 'days')};
+}
+
+/** A range of the one given day. */
+export function singleDay(day: LocalDate): LocalDateRange {
+    return {start: day, end: day};
+}
+
+/**
+ * The nearest business day strictly before `date`, per the context's `isBusinessDay`. Bounded, to
+ * guard against a test that never returns true.
+ */
+export function previousBusinessDay(date: LocalDate, ctx: BusinessDayContext): LocalDate {
+    let ret = date.previousDay();
+    for (let i = 0; i < 366 && !ctx.isBusinessDay(ret); i++) ret = ret.previousDay();
+    return ret;
+}
+
+/** The nearest business day strictly after `date`, per the context's `isBusinessDay`. Bounded. */
+export function nextBusinessDay(date: LocalDate, ctx: BusinessDayContext): LocalDate {
+    let ret = date.nextDay();
+    for (let i = 0; i < 366 && !ctx.isBusinessDay(ret); i++) ret = ret.nextDay();
+    return ret;
+}
+
+/** `date` itself if it is a business day, else the nearest business day before it. */
+export function businessDayOnOrBefore(date: LocalDate, ctx: BusinessDayContext): LocalDate {
+    return ctx.isBusinessDay(date) ? date : previousBusinessDay(date, ctx);
+}
+
+type BusinessDayContext = Pick<DateRangeContext, 'isBusinessDay'>;
+
+/**
+ * The day before `date` - the previous business day in `businessDayMode`, else the previous
+ * calendar day. The step taken by single-day presets and their prior ranges.
+ */
+export function previousDayInMode(date: LocalDate, ctx: DateRangeContext): LocalDate {
+    return ctx.businessDayMode ? previousBusinessDay(date, ctx) : date.previousDay();
 }
 
 /**
@@ -191,21 +233,27 @@ export function parseDateRangeSelection(
 
     const obj = raw as any;
     switch (obj.kind) {
-        case 'preset':
-            return isString(obj.token) && presets[obj.token]
-                ? {kind: 'preset', token: obj.token}
+        case 'preset': {
+            const offset = parseOffset(obj.offset);
+            return isString(obj.token) && presets[obj.token] && offset != null
+                ? withOffset({kind: 'preset', token: obj.token}, offset)
                 : null;
+        }
 
         case 'relative': {
             const count = Math.round(obj.count),
-                {unit} = obj,
-                isDayUnit = unit === 'days' || unit === 'businessDays';
+                offset = parseOffset(obj.offset),
+                {unit} = obj;
             return isFinite(count) &&
                 count >= 1 &&
                 count <= MAX_RELATIVE_COUNT &&
-                DATE_RANGE_UNITS.includes(unit)
+                DATE_RANGE_UNITS.includes(unit) &&
+                offset != null
                 ? // Snap has no meaning at day grain - normalize it away so values compare equal.
-                  {kind: 'relative', count, unit, snap: !isDayUnit && obj.snap === true}
+                  withOffset(
+                      {kind: 'relative', count, unit, snap: unit !== 'days' && obj.snap === true},
+                      offset
+                  )
                 : null;
         }
 
@@ -233,6 +281,23 @@ export function parseDateRangeSelection(
     }
 }
 
+/** A missing offset is zero. Anything else must be an integer within [-MAX_STEP_OFFSET, 0]. */
+function parseOffset(raw: unknown): number | null {
+    if (raw == null) return 0;
+    return Number.isInteger(raw) && (raw as number) <= 0 && (raw as number) >= -MAX_STEP_OFFSET
+        ? (raw as number)
+        : null;
+}
+
+/** The selection at the given offset, in normalized form - `offset` present only when non-zero. */
+function withOffset<T extends PresetDateRangeSelection | RelativeDateRangeSelection>(
+    sel: T,
+    offset: number
+): T {
+    const {offset: _, ...rest} = sel;
+    return (offset ? {...rest, offset} : rest) as T;
+}
+
 function isValidYear(year: unknown): year is number {
     return (
         Number.isInteger(year) &&
@@ -251,22 +316,31 @@ function parseIsoDate(s: unknown): LocalDate | null {
 }
 
 /**
- * Short label for a selection, suitable for the picker trigger - e.g. `MTD`, `Last 6 Months`,
+ * Short label for a selection, suitable for the picker trigger - e.g. `MTD`, `Prev 6 Months`,
  * `Aug 2026`, `2025`, or `Custom`.
  *
  * A period that can be selected two ways reads the same either way: the `ytd` preset and a
- * current-year pick on the Months & Years tab both read `YTD`, and `lastYear` and a prior-year
+ * current-year pick on the Months & Years tab both read `YTD`, and `prevYear` and a prior-year
  * pick both read as that year.
+ *
+ * Once stepped back to a non-zero offset, the trigger's dates locate the range and the label
+ * describes only its shape: a rolling window reads as its length (`7 Days`, `3 Months`), a named
+ * period as the period (`Jul 2026`), and a to-date preset as its name with the offset (`MTD −1`).
  */
 export function getDateRangeLabel(sel: DateRangeSelection, ctx: DateRangeContext): string {
     switch (sel.kind) {
         case 'preset': {
-            const preset = ctx.presets[sel.token];
-            throwIf(!preset, `Unknown date range preset: '${sel.token}'.`);
-            return evalLabel(preset.label, ctx);
+            const preset = getPreset(sel.token, ctx),
+                {offset} = sel;
+            if (!offset) return evalLabel(preset.label, ctx);
+            return preset.shiftedLabel
+                ? preset.shiftedLabel(resolveDateRange(sel, ctx).current, offset, ctx)
+                : `${evalLabel(preset.label, ctx)} ${fmtOffset(offset)}`;
         }
-        case 'relative':
-            return `Last ${sel.count} ${getDateRangeUnitLabel(sel.unit, sel.count)}`;
+        case 'relative': {
+            const length = `${sel.count} ${getDateRangeUnitLabel(sel.unit, sel.count)}`;
+            return sel.offset ? length : `Prev ${length}`;
+        }
         case 'month':
             return getMonthStart(sel.year, sel.month).format('MMM YYYY');
         case 'year': {
@@ -291,16 +365,26 @@ function evalLabel(label: DateRangePreset['label'], ctx: DateRangeContext): stri
     return isFunction(label) ? label(ctx) : label;
 }
 
+/** A negative offset as `−n`, with a true minus sign. */
+function fmtOffset(offset: number): string {
+    return `−${Math.abs(offset)}`;
+}
+
+function getPreset(token: string, ctx: DateRangeContext): DateRangePreset {
+    const preset = ctx.presets[token];
+    throwIf(!preset, `Unknown date range preset: '${token}'.`);
+    return preset;
+}
+
 const UNIT_LABELS: Record<DateRangeUnit, string> = {
     days: 'Day',
     weeks: 'Week',
     months: 'Month',
     quarters: 'Quarter',
-    years: 'Year',
-    businessDays: 'Business Day'
+    years: 'Year'
 };
 
-/** Title-case unit label, singular when count is 1 - e.g. `Days`, `Month`, `Business Days`. */
+/** Title-case unit label, singular when count is 1 - e.g. `Days`, `Month`. */
 export function getDateRangeUnitLabel(unit: DateRangeUnit, count: number = 2): string {
     const singular = UNIT_LABELS[unit];
     return count === 1 ? singular : `${singular}s`;
@@ -323,14 +407,19 @@ export function getMonthStart(year: number, month: number): LocalDate {
 }
 
 /**
- * Move a selection by `steps` periods of its own length - negative to go back, positive to go
- * forward. Month and year selections step by calendar unit and keep their kind. All other
- * selections step by their resolved length in days and become `custom` selections, as their dates
- * are now fixed rather than relative.
+ * Move a selection by `steps` periods - negative to go back, positive to go forward. No selection
+ * changes kind:
  *
- * Steps are clamped to the context's `minDate` and `maxDate` - a range that would overshoot a bound
- * slides up against it instead. Returns null when the selection cannot move at all: it is already
- * at the bound, or is unbounded.
+ * - Preset and relative selections adjust their `offset`, stepping through their own prior-range
+ *   logic - so a lookback in months steps by months, and a single day steps by business day in
+ *   `businessDayMode`. Their offset never exceeds zero, as the natural range already ends on the
+ *   anchor date.
+ * - Month and year selections step by calendar unit.
+ * - Custom selections step by their length in days - or by business day when a single day in
+ *   `businessDayMode`.
+ *
+ * Steps are clamped to the context's `minDate` and `maxDate`. Returns null when the selection
+ * cannot move that way: it is already at a bound, at offset zero, or unbounded.
  */
 export function stepDateRangeSelection(
     sel: DateRangeSelection,
@@ -339,6 +428,21 @@ export function stepDateRangeSelection(
 ): DateRangeSelection | null {
     if (!steps) return null;
     const {minDate, maxDate} = ctx;
+
+    if (sel.kind === 'preset' || sel.kind === 'relative') {
+        const offset = sel.offset ?? 0,
+            nextOffset = Math.max(-MAX_STEP_OFFSET, Math.min(0, offset + steps));
+        if (nextOffset === offset) return null;
+
+        const next = withOffset(sel, nextOffset),
+            {current} = resolveDateRange(next, ctx),
+            {current: prev} = resolveDateRange(sel, ctx);
+        // Unbounded, or the prior logic could not reach the requested offset.
+        if (!current.start || !current.end) return null;
+        if (current.start === prev.start && current.end === prev.end) return null;
+        if (minDate && current.end < minDate) return null;
+        return next;
+    }
 
     if (sel.kind === 'month' || sel.kind === 'year') {
         const unit = sel.kind === 'month' ? 'months' : 'years',
@@ -365,6 +469,16 @@ export function stepDateRangeSelection(
 
     const {start, end} = resolveDateRange(sel, ctx).current;
     if (!start || !end) return null;
+
+    // A single day walks by business day in that mode - stopping at a bound rather than crossing it.
+    if (start === end && ctx.businessDayMode) {
+        let day = start;
+        for (let i = 0; i < Math.abs(steps); i++) {
+            day = steps > 0 ? nextBusinessDay(day, ctx) : previousBusinessDay(day, ctx);
+        }
+        if (day > maxDate || (minDate && day < minDate)) return null;
+        return {kind: 'custom', start: day.isoString, end: day.isoString};
+    }
 
     const dayCount = end.diff(start, 'days') + 1;
     let nextStart = start.add(dayCount * steps, 'days'),

--- a/cmp/daterange/DateRangeUtils.ts
+++ b/cmp/daterange/DateRangeUtils.ts
@@ -15,9 +15,12 @@ import type {
     DateRangeSelection,
     DateRangeUnit,
     LocalDateRange,
+    MonthDateRangeSelection,
     PresetDateRangeSelection,
+    QuarterDateRangeSelection,
     RelativeDateRangeSelection,
-    ResolvedDateRange
+    ResolvedDateRange,
+    YearDateRangeSelection
 } from './Types';
 
 /** All picker tabs, in their default display order. */
@@ -37,8 +40,8 @@ export const MAX_RELATIVE_COUNT = 999;
 /** Furthest a preset or relative selection can be stepped from its natural range, either way. */
 export const MAX_STEP_OFFSET = 9999;
 
-/** The calendar unit each pinned-period selection kind steps by. */
-const CALENDAR_KIND_UNITS = {month: 'months', quarter: 'quarters', year: 'years'} as const;
+/** The calendar unit of each pinned-period selection kind. */
+const PERIOD_UNITS = {month: 'months', quarter: 'quarters', year: 'years'} as const;
 
 /** Year bounds for month and year selections - shared by validation and picker navigation. */
 export const MIN_SELECTION_YEAR = 1900;
@@ -85,32 +88,13 @@ export function resolveDateRange(
         }
 
         case 'month':
-            return resolveCalendarUnit(
-                getMonthStart(sel.year, sel.month),
-                'months',
-                minDate,
-                maxDate
-            );
-
         case 'quarter':
-            return resolveCalendarUnit(
-                getQuarterStart(sel.year, sel.quarter),
-                'quarters',
-                minDate,
-                maxDate
-            );
-
         case 'year':
-            return resolveCalendarUnit(
-                LocalDate.get(`${sel.year}-01-01`),
-                'years',
-                minDate,
-                maxDate
-            );
+            return resolveCalendarUnit(periodStart(sel), PERIOD_UNITS[sel.kind], minDate, maxDate);
 
         case 'custom': {
             const current = {start: LocalDate.get(sel.start), end: LocalDate.get(sel.end)};
-            return {current, prior: equalDurationPrior(current)};
+            return {current, prior: shiftByDuration(current, -1)};
         }
     }
 }
@@ -173,15 +157,14 @@ function shiftRelative(
 }
 
 /**
- * A full calendar month or year, clamped to `maxDate` (and `minDate`) when those dates fall
- * within it - so the current month covers the 1st through the anchor, and the current year Jan 1
- * through the anchor.
- * A period entirely beyond `maxDate` (e.g. a persisted pick from a user with a later anchor)
- * keeps its natural bounds rather than producing an inverted range.
+ * A full calendar month, quarter or year, clamped to `maxDate` (and `minDate`) when those fall
+ * within it - so the current month covers the 1st through the anchor. A period entirely beyond
+ * `maxDate` (e.g. a persisted pick from a user with a later anchor) keeps its natural bounds
+ * rather than producing an inverted range.
  */
 function resolveCalendarUnit(
     naturalStart: LocalDate,
-    unit: 'months' | 'quarters' | 'years',
+    unit: PeriodUnit,
     minDate: LocalDate,
     maxDate: LocalDate
 ): ResolvedDateRange {
@@ -208,11 +191,6 @@ function shiftByDuration({start, end}: LocalDateRange, dir: 1 | -1): LocalDateRa
     if (!start || !end) return null;
     const days = (end.diff(start, 'days') + 1) * dir;
     return {start: start.add(days, 'days'), end: end.add(days, 'days')};
-}
-
-/** The immediately preceding range of equal duration in days, or null if `current` is unbounded. */
-function equalDurationPrior(range: LocalDateRange): LocalDateRange | null {
-    return shiftByDuration(range, -1);
 }
 
 /** A range of the one given day. */
@@ -466,6 +444,21 @@ export function getQuarterStart(year: number, quarter: number): LocalDate {
     return getMonthStart(year, quarter * 3 - 2);
 }
 
+type PeriodSelection = MonthDateRangeSelection | QuarterDateRangeSelection | YearDateRangeSelection;
+type PeriodUnit = (typeof PERIOD_UNITS)[PeriodSelection['kind']];
+
+/** Natural (unclamped) first day of a month, quarter or year selection. */
+function periodStart(sel: PeriodSelection): LocalDate {
+    switch (sel.kind) {
+        case 'month':
+            return getMonthStart(sel.year, sel.month);
+        case 'quarter':
+            return getQuarterStart(sel.year, sel.quarter);
+        case 'year':
+            return LocalDate.get(`${sel.year}-01-01`);
+    }
+}
+
 /**
  * Move a selection by `steps` periods - negative to go back, positive to go forward. No selection
  * changes kind:
@@ -474,7 +467,7 @@ export function getQuarterStart(year: number, quarter: number): LocalDate {
  *   next-range logic - so a lookback in months steps by months, and a single day steps by
  *   business day in `businessDayMode`. Their natural range ends on the anchor date, so a positive
  *   offset is reachable only when `maxDate` allows dates beyond it.
- * - Month and year selections step by calendar unit.
+ * - Month, quarter and year selections step by calendar unit.
  * - Custom selections step by their length in days - or by business day when a single day in
  *   `businessDayMode`.
  *
@@ -506,9 +499,8 @@ export function stepDateRangeSelection(
     }
 
     if (sel.kind === 'month' || sel.kind === 'quarter' || sel.kind === 'year') {
-        const unit = CALENDAR_KIND_UNITS[sel.kind],
-            start = resolveDateRange({...sel}, {...ctx, minDate: null, maxDate: null}).current
-                .start,
+        const unit = PERIOD_UNITS[sel.kind],
+            start = periodStart(sel),
             // Never step beyond the period containing a bound, or below the supported years.
             maxStart = maxDate.startOf(unit),
             minStart = (minDate ?? LocalDate.get(`${MIN_SELECTION_YEAR}-01-01`)).startOf(unit);

--- a/cmp/daterange/README.md
+++ b/cmp/daterange/README.md
@@ -9,7 +9,7 @@ period and its dates, opening a popover with a tab for each way of choosing a pe
 
 **Key features:**
 - One value that can express a preset (MTD, Prev 30 Days, ...), a relative lookback, a calendar
-  month or year, or a custom range of dates
+  month, quarter, or year, or a custom range of dates
 - Resolution against a live anchor day, so a persisted "month to date" stays month to date - and
   rolls over at midnight without app involvement
 - A comparable prior range for every selection, for period-over-period comparisons
@@ -50,6 +50,7 @@ DateRangeSelection (plain JSON, discriminated on `kind`)
 ├── {kind: 'preset', token, offset?}
 ├── {kind: 'relative', count, unit, snap, offset?}
 ├── {kind: 'month', year, month}
+├── {kind: 'quarter', year, quarter}
 ├── {kind: 'year', year}
 └── {kind: 'custom', start, end}       # 'YYYY-MM-DD' strings
 
@@ -133,14 +134,15 @@ validation: an unknown preset, an out-of-range count, year, or offset, or a malf
 | `preset` | `{kind: 'preset', token: 'mtd'}` | Whatever the preset's resolver returns for the current context |
 | `relative` | `{kind: 'relative', count: 6, unit: 'months', snap: false}` | A window of `count` units ending on the anchor date |
 | `month` | `{kind: 'month', year: 2026, month: 8}` | The calendar month, clamped to `maxDate` if it falls inside |
+| `quarter` | `{kind: 'quarter', year: 2026, quarter: 3}` | The calendar quarter, clamped likewise |
 | `year` | `{kind: 'year', year: 2026}` | The calendar year, clamped likewise |
 | `custom` | `{kind: 'custom', start: '2026-08-10', end: '2026-08-20'}` | Exactly those dates |
 
 Preset and relative selections re-resolve as the anchor date moves, and carry an optional
-`offset` when stepped back from their natural range - see Stepping. Month and year selections
-name a fixed period, though one containing `maxDate` is clamped to it. Custom selections name
-fixed dates. All are plain JSON, so the value round-trips through persistence without custom
-serialization.
+`offset` when stepped from their natural range - see Stepping. Month, quarter, and year
+selections name a fixed period, though one containing `maxDate` is clamped to it. Custom
+selections name fixed dates. All are plain JSON, so the value round-trips through persistence
+without custom serialization.
 
 ### Presets
 
@@ -209,7 +211,7 @@ comparison. It is `null` when the current range is unbounded.
 | Lookbacks in weeks, months, quarters, or years | The same span `count` units earlier, matching the equivalent presets |
 | Lookbacks in days, and `custom` | The preceding window of equal length in days |
 | Single days in `businessDayMode` | The previous business day |
-| `month`, `year` | The previous month or year, clamped the same way if the current one is |
+| `month`, `quarter`, `year` | The previous month, quarter, or year, clamped the same way if the current one is |
 
 The same logic drives stepping, so the prior period is always one step back. An app that wants
 the prior MTD as the *selected* value can set `{kind: 'preset', token: 'mtd', offset: -1}`.
@@ -233,7 +235,7 @@ query body. `getRangeFilter(range, field)` builds filters for any range and fiel
   ones are later, and reachable only when `maxDate` allows dates beyond the anchor, since the
   natural range already ends there. The offset is omitted from the value when zero. A stepped
   selection is still live: `mtd` at offset `-1` becomes the new prior MTD when the month turns.
-- **Month and year** selections step by calendar unit.
+- **Month, quarter, and year** selections step by calendar unit.
 - **Custom** selections step by their length in days, or by business day when a single day in
   `businessDayMode`.
 
@@ -289,9 +291,10 @@ day. Seven days is still seven days, and a month is still a month. A pinned or c
 `anchorDay` is honored verbatim - a month-end that falls on a Sunday stays the 31st.
 
 Nothing beyond `maxDate` is selectable: later months and days are disabled in the popover, and
-month and year selections spanning `maxDate` are clamped to it, which is how the current year
-reads as YTD. `maxDate` defaults to `anchorDate`. Set it later to allow future dates, or set
-`minDate` to bound the past.
+month and year selections spanning `maxDate` are clamped to it, so the current year covers Jan 1
+through the anchor. It still reads as its year, `2026` - `YTD` is the preset, which steps to the
+same partial span a year earlier, where a year pick steps by whole years. `maxDate` defaults to
+`anchorDate`. Set it later to allow future dates, or set `minDate` to bound the past.
 
 ### Persistence
 
@@ -388,7 +391,7 @@ both dates, or handle a `null` edge in the query.
 
 ```typescript
 new DateRangePickerModel({
-    tabs: ['monthYear'],
+    tabs: ['period'],
     initialValue: {kind: 'month', year: 2026, month: 1}
 });
 ```

--- a/cmp/daterange/README.md
+++ b/cmp/daterange/README.md
@@ -115,8 +115,12 @@ touch:
   or a rolling 30 days when there are none.
 - `persistWith` persists the value - see Persistence below.
 
-`businessDayMode`, `commitOnChange`, `dateFormat`, and `isBusinessDay` round out the config. All
-but the last can be defaulted app-wide via `DateRangePickerModel.defaults`, as can `anchorDay`.
+`businessDayMode`, `commitOnChange`, `dateFormat`, `dayFormat`, and `isBusinessDay` round out the
+config. All but the last can be defaulted app-wide via `DateRangePickerModel.defaults`, as can
+`anchorDay`. The two formats split along what they show: `dateFormat` (default `YYYY-MM-DD`) for
+the ends of a range, where the year earns its place, and `dayFormat` (default `ddd MMM D`) for a
+single day, where the weekday matters more. Either may be a function of the date - e.g. to add the
+year only when it is not the current one.
 
 ### The Selection Value
 
@@ -309,7 +313,7 @@ falls back to `defaultValue` rather than carrying a previous value over.
 | Property | Example | Use |
 |----------|---------|-----|
 | `label` | `MTD`, `Prev 6 Months`, `Aug 2026`, `Custom` | The trigger |
-| `rangeLabel` | `2026-08-01 ▸ 2026-09-02` | The trigger's dates, per `dateFormat`. A single day reads as one date. |
+| `rangeLabel` | `2026-08-01 ▸ 2026-09-02`, `Fri Sep 4` | The trigger's dates, per `dateFormat`. A single day reads as one date, per `dayFormat`. |
 | `displayName` | `MTD`, `August 2026`, the dates for a custom range or `As Of` | Panel titles - the label, with months spelled out and unnamed periods as their dates |
 
 ## DateRangePicker

--- a/cmp/daterange/README.md
+++ b/cmp/daterange/README.md
@@ -31,7 +31,8 @@ the Hoist symbol tools surface.
 DateRangePickerModel
 ├── value: DateRangeSelection          # The applied period, always normalized
 ├── anchorDay: DateRangeAnchorDay      # How the anchor date is determined - live by default
-├── anchorDate, today, minDate, maxDate  # The dates selections resolve against
+├── anchorDate, minDate, maxDate       # The dates selections resolve against
+├── today                              # The reader's current day - what "Today" means
 ├── businessDayMode, isBusinessDay     # Single-day handling
 ├── presets: DateRangePreset[]         # Offered on the Presets tab
 ├── tabs: DateRangePickerTab[]         # Offered in the popover
@@ -269,10 +270,11 @@ anchorDay: () => {
 }
 ```
 
-The `anchorDay` preset labels itself `Today` only when the anchor date is the current day (per
-`today`, in the app or browser zone to match the mode). Otherwise it reads `As Of`, and the trigger
-shows the date. So on the Friday evening above the picker reads `As Of | 2026-09-07` until Monday
-morning, when it reads `Today`.
+The `anchorDay` preset labels itself `Today` only when the anchor date is the reader's current day
+- the browser's, always, whatever zone the anchor is drawn from. Otherwise it reads `As Of`, and the
+trigger shows the date. So on the Friday evening above the picker reads `As Of | 2026-09-07` until
+Monday morning, when it reads `Today`. Likewise a user whose browser is a day ahead of an
+`'appDay'` anchor sees `As Of` with the app's date rather than a "Today" that is not theirs.
 
 **`businessDayMode`** is for users who think in calendar-length windows but stand on business
 days. It has two effects and no others: a live `anchorDay` (`'localDay'` or `'appDay'`) snaps back

--- a/cmp/daterange/README.md
+++ b/cmp/daterange/README.md
@@ -116,10 +116,10 @@ touch:
   or a rolling 30 days when there are none.
 - `persistWith` persists the value - see Persistence below.
 
-`businessDayMode`, `commitOnChange`, `dateFormat`, `dayFormat`, and `isBusinessDay` round out the
-config. All but the last can be defaulted app-wide via `DateRangePickerModel.defaults`, as can
-`anchorDay`. The two formats split along what they show: `dateFormat` (default `YYYY-MM-DD`) for
-the ends of a range, where the year earns its place, and `dayFormat` (default `ddd MMM D`) for a
+`businessDayMode`, `commitOnChange`, `dateFormat`, `singleDayFormat`, and `isBusinessDay` round out
+the config. All but the last can be defaulted app-wide via `DateRangePickerModel.defaults`, as can
+`anchorDay`. The two formats split along what they show: `dateFormat` (default `YYYY-MM-DD`) for the
+ends of a range, where the year earns its place, and `singleDayFormat` (default `ddd MMM D`) for a
 single day, where the weekday matters more. Either may be a function of the date - e.g. to add the
 year only when it is not the current one.
 
@@ -316,7 +316,7 @@ falls back to `defaultValue` rather than carrying a previous value over.
 | Property | Example | Use |
 |----------|---------|-----|
 | `label` | `MTD`, `Prev 6 Months`, `Aug 2026`, `Custom` | The trigger |
-| `rangeLabel` | `2026-08-01 ▸ 2026-09-02`, `Fri Sep 4` | The trigger's dates, per `dateFormat`. A single day reads as one date, per `dayFormat`. |
+| `rangeLabel` | `2026-08-01 ▸ 2026-09-02`, `Fri Sep 4` | The trigger's dates, per `dateFormat`. A single day reads as one date, per `singleDayFormat`. |
 | `displayName` | `MTD`, `August 2026`, the dates for a custom range or `As Of` | Panel titles - the label, with months spelled out and unnamed periods as their dates |
 
 ## DateRangePicker

--- a/cmp/daterange/README.md
+++ b/cmp/daterange/README.md
@@ -8,12 +8,14 @@ time and reading it back as concrete dates and filters. Its desktop UI, `DateRan
 period and its dates, opening a popover with a tab for each way of choosing a period.
 
 **Key features:**
-- One value that can express a preset (MTD, Last 30 Days, ...), a relative lookback, a calendar
+- One value that can express a preset (MTD, Prev 30 Days, ...), a relative lookback, a calendar
   month or year, or a custom range of dates
-- Resolution against an anchor date, so a persisted "month to date" stays month to date
+- Resolution against a live anchor day, so a persisted "month to date" stays month to date - and
+  rolls over at midnight without app involvement
 - A comparable prior range for every selection, for period-over-period comparisons
+- Stepping back and forth through periods without a selection losing what it is
 - Ready-made `FieldFilterSpec`s for filtering a Store, Cube View, or server query
-- Built-in presets, app-defined presets, and business-day-aware lookbacks
+- Built-in presets, app-defined presets, and a business-day mode for single-day navigation
 - Plain JSON value that persists through `persistWith`, including ViewManager views
 
 The model is cross-platform. Only the desktop component exists today.
@@ -28,7 +30,9 @@ the Hoist symbol tools surface.
 ```
 DateRangePickerModel
 ├── value: DateRangeSelection          # The applied period, always normalized
-├── anchorDate, minDate, maxDate       # The dates selections resolve against
+├── anchorDay: DateRangeAnchorDay      # How the anchor date is determined - live by default
+├── anchorDate, today, minDate, maxDate  # The dates selections resolve against
+├── businessDayMode, isBusinessDay     # Single-day handling
 ├── presets: DateRangePreset[]         # Offered on the Presets tab
 ├── tabs: DateRangePickerTab[]         # Offered in the popover
 ├── currentRange: LocalDateRange       # Resolved {start, end}
@@ -39,18 +43,18 @@ DateRangePickerModel
     ├── setValue()                     # Apply a selection or preset token
     ├── stepRange()                    # Previous / next period
     ├── resolve(), parseValue()        # Work with selections other than the applied one
-    └── setAnchorDate(), setMaxDate(), setPresets(), setTabs(), ...
+    └── setAnchorDay(), setMaxDate(), setPresets(), setTabs(), ...
 
 DateRangeSelection (plain JSON, discriminated on `kind`)
-├── {kind: 'preset', token}
-├── {kind: 'relative', count, unit, snap}
+├── {kind: 'preset', token, offset?}
+├── {kind: 'relative', count, unit, snap, offset?}
 ├── {kind: 'month', year, month}
 ├── {kind: 'year', year}
 └── {kind: 'custom', start, end}       # 'YYYY-MM-DD' strings
 
 DateRangeContext                       # What selections resolve against
-├── anchorDate, minDate, maxDate
-├── isBusinessDay(date)
+├── anchorDate, today, minDate, maxDate
+├── isBusinessDay(date), businessDayMode
 └── presets: Record<token, DateRangePreset>
 ```
 
@@ -102,22 +106,22 @@ touch:
 
 - `tabs` and `presets` select which of the four tabs appear and which presets the Presets tab
   lists, in order. Presets may be built-in tokens, app-defined `DateRangePreset` objects, or both.
-- `anchorDate`, `minDate`, and `maxDate` set the dates everything resolves against - see Anchor
-  Date and Bounds below.
+- `anchorDay`, `minDate`, and `maxDate` set the dates everything resolves against - see Anchor
+  Day and Bounds below.
 - `filterField` names the field for `currentRangeFilter` and `priorRangeFilter`.
 - `initialValue` is the starting selection, given as a selection object or a preset token, and
   the fallback for missing or invalid persisted state. It defaults to the first configured preset,
   or a rolling 30 days when there are none.
 - `persistWith` persists the value - see Persistence below.
 
-`commitOnChange`, `dateFormat`, and `isBusinessDay` round out the config; the first two can be
-defaulted app-wide via `DateRangePickerModel.defaults`.
+`businessDayMode`, `commitOnChange`, `dateFormat`, and `isBusinessDay` round out the config. All
+but the last can be defaulted app-wide via `DateRangePickerModel.defaults`, as can `anchorDay`.
 
 ### The Selection Value
 
 `value` is always a normalized `DateRangeSelection`. Set it with `setValue()`, which accepts a
 selection object or a bare preset token and ignores (with a logged warning) anything that fails
-validation: an unknown preset, an out-of-range count or year, or a malformed date.
+validation: an unknown preset, an out-of-range count, year, or offset, or a malformed date.
 
 | Kind | Shape | Resolves to |
 |------|-------|-------------|
@@ -127,7 +131,8 @@ validation: an unknown preset, an out-of-range count or year, or a malformed dat
 | `year` | `{kind: 'year', year: 2026}` | The calendar year, clamped likewise |
 | `custom` | `{kind: 'custom', start: '2026-08-10', end: '2026-08-20'}` | Exactly those dates |
 
-Preset and relative selections re-resolve as the anchor date moves. Month and year selections
+Preset and relative selections re-resolve as the anchor date moves, and carry an optional
+`offset` when stepped back from their natural range - see Stepping. Month and year selections
 name a fixed period, though one containing `maxDate` is clamped to it. Custom selections name
 fixed dates. All are plain JSON, so the value round-trips through persistence without custom
 serialization.
@@ -137,27 +142,28 @@ serialization.
 Built-in presets live in `dateRangePresets`, keyed by token. Offer any subset in any order via
 the `presets` config.
 
-| Token | Resolves to |
-|-------|-------------|
-| `today`, `yesterday` | That single day |
-| `wtd`, `mtd`, `qtd`, `ytd` | Start of the unit containing the anchor, through the anchor |
-| `last7Days`, `last30Days`, `last90Days` | Rolling window ending on the anchor |
-| `last3Months`, `last6Months`, `last12Months` | Rolling window ending on the anchor |
-| `lastWeek`, `lastMonth`, `lastQuarter`, `lastYear` | The full unit before the one containing the anchor |
-| `lastBusinessDay` | The nearest business day before the anchor |
-| `priorMtd`, `priorQtd`, `priorYtd` | The same elapsed span one unit earlier |
-| `all` | `minDate` (or unbounded) through `maxDate` |
+| Token | Resolves to | Label |
+|-------|-------------|-------|
+| `anchorDay` | The anchor date itself | `Today` when the anchor is the current day, else `As Of` |
+| `prevDay` | The day before the anchor - the previous business day in `businessDayMode` | `Prev Day` |
+| `wtd`, `mtd`, `qtd`, `ytd` | Start of the unit containing the anchor, through the anchor | `MTD`, ... |
+| `prev7Days`, `prev30Days`, `prev90Days` | Rolling window ending on the anchor | `Prev 7 Days`, ... |
+| `prev3Months`, `prev6Months`, `prev12Months` | Rolling window ending on the anchor | `Prev 3 Months`, ... |
+| `prevWeek`, `prevMonth`, `prevQuarter`, `prevYear` | The full unit before the one containing the anchor | The period: `Aug 2026`, `Q2 2026`, `2025` |
+| `all` | `minDate` (or unbounded) through `maxDate` | `All` |
 
-`DEFAULT_DATE_RANGE_PRESETS` is `today`, `mtd`, `qtd`, `ytd`, `last7Days`, `last30Days`,
-`last90Days`, `last12Months`, `lastMonth`, and `lastYear`.
+`DEFAULT_DATE_RANGE_PRESETS` is `anchorDay`, `mtd`, `qtd`, `ytd`, `prev7Days`, `prev30Days`,
+`prev90Days`, `prev12Months`, `prevMonth`, and `prevYear`.
 
-Presets that name a specific period label as that period - `lastMonth` reads `Aug 2026`,
-`lastYear` reads `2025` - so the trigger describes the same period the same way however it was
-chosen.
+Labels say "Prev" rather than "Last" because the anchor date need not be today: "Prev 7 Days" is
+true whatever the anchor is, where "Last 7 Days" quietly claims the window ends now. Only
+`anchorDay` reads differently by context, and when it reads `As Of` the picker shows its date
+wherever the label would otherwise stand alone.
 
 An app-defined preset is a `DateRangePreset`: a unique `token`, a `label` (string or function of
-the context), an optional longer `name` for its row in the picker, a `resolve` function, and an
-optional `resolvePrior`. The default prior is the preceding range of equal length in days.
+the context), an optional longer `name` for its row in the picker, a `resolve` function, an
+optional `resolvePrior`, and an optional `shiftedLabel` for the preset once stepped back (see
+Stepping). The default prior is the preceding range of equal length in days.
 
 ```typescript
 const FISCAL_YTD: DateRangePreset = {
@@ -171,21 +177,19 @@ const FISCAL_YTD: DateRangePreset = {
     })
 };
 
-new DateRangePickerModel({presets: [FISCAL_YTD, 'qtd', 'ytd', 'last90Days']});
+new DateRangePickerModel({presets: [FISCAL_YTD, 'qtd', 'ytd', 'prev90Days']});
 ```
 
 ### Relative Lookbacks
 
-A relative selection is `count` units ending on the anchor date. Units are `days`,
-`businessDays`, `weeks`, `months`, `quarters`, and `years`.
+A relative selection is `count` units ending on the anchor date. Units are `days`, `weeks`,
+`months`, `quarters`, and `years`.
 
 - **Rolling** (`snap: false`, the default) is exactly `count` units back from the anchor: 3 months
   ending Sep 2 starts Jun 3.
 - **Calendar** (`snap: true`) aligns to unit boundaries and counts the current partial unit as one:
-  3 calendar months ending Sep 2 starts Jul 1.
-- **Business days** count only days that pass `isBusinessDay`. The window still ends on the anchor
-  even when that is a weekend, so 2 business days ending on a Saturday spans Thursday through
-  Saturday. Snap does not apply to either day unit and is normalized to `false`.
+  3 calendar months ending Sep 2 starts Jul 1. Snap does not apply to days and is normalized to
+  `false` for that unit.
 
 ### Prior Ranges
 
@@ -195,14 +199,14 @@ comparison. It is `null` when the current range is unbounded.
 | Selection | Prior range |
 |-----------|-------------|
 | Period-to-date presets (`mtd`, `ytd`, ...) | The same span one unit earlier: MTD on the 12th compares against the 1st through 12th of last month |
-| Previous-unit presets (`lastMonth`, ...) | The unit before that |
+| Previous-unit presets (`prevMonth`, ...) | The unit before that |
 | Lookbacks in weeks, months, quarters, or years | The same span `count` units earlier, matching the equivalent presets |
 | Lookbacks in days, and `custom` | The preceding window of equal length in days |
-| `businessDays` lookbacks | The preceding window with the same number of business days |
+| Single days in `businessDayMode` | The previous business day |
 | `month`, `year` | The previous month or year, clamped the same way if the current one is |
 
-Apps that want the prior period as the *selected* value, rather than as a comparison, can offer
-the `priorMtd`, `priorQtd`, and `priorYtd` presets.
+The same logic drives stepping, so the prior period is always one step back. An app that wants
+the prior MTD as the *selected* value can set `{kind: 'preset', token: 'mtd', offset: -1}`.
 
 ### Filters
 
@@ -214,24 +218,65 @@ query body. `getRangeFilter(range, field)` builds filters for any range and fiel
 
 ### Stepping
 
-`stepRange(steps)` moves the applied range by its own length: `-1` for the previous period, `1`
-for the next. Month and year selections keep their kind and step by calendar unit. Every other
-selection becomes a `custom` selection of the shifted dates, since they are now fixed. Steps clamp
-to `minDate` and `maxDate`. `canStepBack` and `canStepForward` drive the component's step buttons.
+`stepRange(steps)` moves the applied range by one period per step: `-1` for the previous period,
+`1` for the next. No selection changes kind:
 
-### Anchor Date and Bounds
+- **Preset and relative** selections adjust their `offset`, stepping through their own prior-range
+  logic - a lookback in months steps by months, MTD steps to the prior MTD, a single day steps by
+  business day in `businessDayMode`. The offset is zero or negative, since the natural range
+  already ends on the anchor date, and is omitted from the value when zero. A stepped selection
+  is still live: `mtd` at offset `-1` becomes the new prior MTD when the month turns.
+- **Month and year** selections step by calendar unit.
+- **Custom** selections step by their length in days, or by business day when a single day in
+  `businessDayMode`.
 
-`anchorDate` defaults to today in the browser's time zone, as of construction. Pass a function to
-track an observable source, such as the as-of date of the data on display. For long-lived screens
-that must roll over at midnight, update it explicitly. This example anchors to the app time zone;
-pass `anchorDate: LocalDate.currentAppDay()` in the config to match from the start.
+Steps clamp to `minDate` and `maxDate`. `canStepBack` and `canStepForward` drive the component's
+step buttons, and the trigger's left and right arrow keys.
+
+Once stepped, the trigger's dates locate the range, so the label describes only its shape: a
+rolling window reads as its length (`7 Days`, `3 Months`), a previous-unit preset as the period it
+now covers (`Jul 2026`), and a to-date preset as its name with the offset (`MTD −1`) - its length
+is set by the calendar, not the selection, so a length alone would mislead. App-defined presets
+control this via `shiftedLabel`; the default appends the offset.
+
+### Anchor Day and Bounds
+
+`anchorDay` determines the date that relative and to-date selections resolve against, exposed as
+`anchorDate`. It is live by default: the model re-evaluates it every few seconds, and everything
+derived from it - ranges, labels, filters, step enablement - follows the day over as midnight
+passes, with no app code.
+
+| `anchorDay` | Anchor date |
+|-------------|-------------|
+| `'localDay'` (default) | The current day in the browser's time zone, kept current |
+| `'appDay'` | The current day in the app's time zone (`LocalDate.currentAppDay()`), kept current |
+| A `LocalDate` | That day, pinned. Never moves, never snapped |
+| `() => LocalDate` | Re-evaluated every few seconds and whenever observables it reads change. Must be pure and cheap |
+
+The function form covers as-of dates with their own rule. A desk whose day rolls to the next
+business day at an evening cutoff, for example:
 
 ```typescript
-Timer.create({
-    runFn: () => model.setAnchorDate(LocalDate.currentAppDay()),
-    interval: ONE_MINUTE
-});
+anchorDay: () => {
+    const now = moment(),
+        day = LocalDate.today(),
+        afterCutoff = now.hour() >= 18;
+    let ret = afterCutoff ? day.nextDay() : day;
+    while (!ret.isWeekday) ret = ret.nextDay();
+    return ret;
+}
 ```
+
+The `anchorDay` preset labels itself `Today` only when the anchor date is the current day (per
+`today`, in the app or browser zone to match the mode). Otherwise it reads `As Of`, and the trigger
+shows the date. So on the Friday evening above the picker reads `As Of | 2026-09-07` until Monday
+morning, when it reads `Today`.
+
+**`businessDayMode`** is for users who think in calendar-length windows but stand on business
+days. It has two effects and no others: a live `anchorDay` (`'localDay'` or `'appDay'`) snaps back
+to the most recent business day per `isBusinessDay`, and single-day selections step by business
+day. Seven days is still seven days, and a month is still a month. A pinned or computed
+`anchorDay` is honored verbatim - a month-end that falls on a Sunday stays the 31st.
 
 Nothing beyond `maxDate` is selectable: later months and days are disabled in the popover, and
 month and year selections spanning `maxDate` are clamped to it, which is how the current year
@@ -257,9 +302,9 @@ falls back to `defaultValue` rather than carrying a previous value over.
 
 | Property | Example | Use |
 |----------|---------|-----|
-| `label` | `MTD`, `Last 6 Months`, `Aug 2026`, `Custom` | The trigger |
+| `label` | `MTD`, `Prev 6 Months`, `Aug 2026`, `Custom` | The trigger |
 | `rangeLabel` | `2026-08-01 ▸ 2026-09-02` | The trigger's dates, per `dateFormat`. A single day reads as one date. |
-| `displayName` | `MTD`, `August 2026`, the dates for a custom range | Panel titles - the label, with months spelled out and custom ranges as their dates |
+| `displayName` | `MTD`, `August 2026`, the dates for a custom range or `As Of` | Panel titles - the label, with months spelled out and unnamed periods as their dates |
 
 ## DateRangePicker
 
@@ -282,9 +327,10 @@ A model configured with one tab renders without the rail, and its popover shrink
 
 A trigger sized by its content never truncates. A stretched trigger (`flex: 1`, or an explicit
 `width`) measures itself and drops the dates when it is too narrow to show them, leaving the
-period label alone. Whenever the dates are not shown, a custom range shows its dates in place of
-the uninformative `Custom` label. The full label and dates remain available in the trigger's
-tooltip.
+period label alone. Whenever the dates are not shown, a custom range - and the anchor day when it
+reads `As Of` - shows its dates in place of the uninformative label. The full label and dates
+remain available in the trigger's tooltip. With the trigger focused, the left and right arrow keys
+step the period.
 
 ### Styling
 
@@ -337,6 +383,20 @@ new DateRangePickerModel({
 });
 ```
 
+### A Business-Day Desk
+
+```typescript
+new DateRangePickerModel({
+    anchorDay: 'appDay',
+    businessDayMode: true,
+    isBusinessDay: d => d.isWeekday && !XH.holidayService.isHoliday(d),
+    presets: ['anchorDay', 'prevDay', 'wtd', 'mtd', 'qtd', 'ytd', 'prevMonth']
+});
+```
+
+On a Saturday this resolves everything as of Friday, and the step buttons walk `anchorDay` from
+Friday to Thursday and back.
+
 ## Common Pitfalls
 
 - **`filterField` is required for filters.** The filter getters throw without it. Use
@@ -348,6 +408,9 @@ new DateRangePickerModel({
   accept that users will see the default after a change.
 - **`all` can be unbounded.** Without `minDate`, its start is `null`, `priorRange` is `null`, and
   `currentRangeFilter` has one entry.
+- **A computed `anchorDay` runs often.** It is re-evaluated every few seconds. Keep it to clock
+  reads and observable reads - derive anything expensive once, store it on an observable, and read
+  that.
 
 ## Related Packages
 

--- a/cmp/daterange/README.md
+++ b/cmp/daterange/README.md
@@ -161,9 +161,10 @@ true whatever the anchor is, where "Last 7 Days" quietly claims the window ends 
 wherever the label would otherwise stand alone.
 
 An app-defined preset is a `DateRangePreset`: a unique `token`, a `label` (string or function of
-the context), an optional longer `name` for its row in the picker, a `resolve` function, an
-optional `resolvePrior`, and an optional `shiftedLabel` for the preset once stepped back (see
-Stepping). The default prior is the preceding range of equal length in days.
+the context), an optional longer `name` for its row in the picker, a `resolve` function, optional
+`resolvePrior` and `resolveNext` for the adjacent ranges, and an optional `shiftedLabel` for the
+preset once stepped (see Stepping). The default adjacent ranges are the preceding and following
+ranges of equal length in days.
 
 ```typescript
 const FISCAL_YTD: DateRangePreset = {
@@ -221,11 +222,12 @@ query body. `getRangeFilter(range, field)` builds filters for any range and fiel
 `stepRange(steps)` moves the applied range by one period per step: `-1` for the previous period,
 `1` for the next. No selection changes kind:
 
-- **Preset and relative** selections adjust their `offset`, stepping through their own prior-range
-  logic - a lookback in months steps by months, MTD steps to the prior MTD, a single day steps by
-  business day in `businessDayMode`. The offset is zero or negative, since the natural range
-  already ends on the anchor date, and is omitted from the value when zero. A stepped selection
-  is still live: `mtd` at offset `-1` becomes the new prior MTD when the month turns.
+- **Preset and relative** selections adjust their `offset`, stepping through their own prior- and
+  next-range logic - a lookback in months steps by months, MTD steps to the prior MTD, a single
+  day steps by business day in `businessDayMode`. Negative offsets are earlier periods. Positive
+  ones are later, and reachable only when `maxDate` allows dates beyond the anchor, since the
+  natural range already ends there. The offset is omitted from the value when zero. A stepped
+  selection is still live: `mtd` at offset `-1` becomes the new prior MTD when the month turns.
 - **Month and year** selections step by calendar unit.
 - **Custom** selections step by their length in days, or by business day when a single day in
   `businessDayMode`.
@@ -235,9 +237,9 @@ step buttons, and the trigger's left and right arrow keys.
 
 Once stepped, the trigger's dates locate the range, so the label describes only its shape: a
 rolling window reads as its length (`7 Days`, `3 Months`), a previous-unit preset as the period it
-now covers (`Jul 2026`), and a to-date preset as its name with the offset (`MTD −1`) - its length
-is set by the calendar, not the selection, so a length alone would mislead. App-defined presets
-control this via `shiftedLabel`; the default appends the offset.
+now covers (`Jul 2026`), and a to-date preset as its name with the signed offset (`MTD −1`,
+`MTD +1`) - its length is set by the calendar, not the selection, so a length alone would
+mislead. App-defined presets control this via `shiftedLabel`; the default appends the offset.
 
 ### Anchor Day and Bounds
 

--- a/cmp/daterange/README.md
+++ b/cmp/daterange/README.md
@@ -240,7 +240,9 @@ Once stepped, the trigger's dates locate the range, so the label describes only 
 rolling window reads as its length (`7 Days`, `3 Months`), a previous-unit preset as the period it
 now covers (`Jul 2026`), and a to-date preset as its name with the signed offset (`MTD −1`,
 `MTD +1`) - its length is set by the calendar, not the selection, so a length alone would
-mislead. App-defined presets control this via `shiftedLabel`; the default appends the offset.
+mislead. Single days read from the anchor in the T-1 idiom: `Today −1`, `Today −2`, or `As Of −1`,
+whether the walk began from `anchorDay` or `prevDay`. App-defined presets control this via
+`shiftedLabel`; the default appends the offset.
 
 ### Anchor Day and Bounds
 

--- a/cmp/daterange/Types.ts
+++ b/cmp/daterange/Types.ts
@@ -100,14 +100,22 @@ export interface DateRangePreset {
     /**
      * Resolve the comparable prior range for a given current range. Default is the immediately
      * preceding range of equal duration in days, or null when the current range is unbounded.
-     * Also drives stepping: a selection at `offset` -n is this applied n times.
+     * Also drives stepping back: a selection at `offset` -n is this applied n times.
      */
     resolvePrior?: (current: LocalDateRange, ctx: DateRangeContext) => LocalDateRange | null;
 
     /**
-     * Label for this preset once stepped back to a non-zero `offset`, when the trigger's dates
-     * locate the range and the label need only describe its shape - e.g. `7 Days` for a rolling
-     * window, or the month itself for a previous-month preset. Default is the label with the
+     * Resolve the comparable range immediately after a given current range - the mirror of
+     * `resolvePrior`, driving stepping forward when `maxDate` allows dates beyond the anchor.
+     * Default is the immediately following range of equal duration in days, or null when the
+     * current range is unbounded.
+     */
+    resolveNext?: (current: LocalDateRange, ctx: DateRangeContext) => LocalDateRange | null;
+
+    /**
+     * Label for this preset once stepped to a non-zero `offset`, when the trigger's dates locate
+     * the range and the label need only describe its shape - e.g. `7 Days` for a rolling window,
+     * or the month itself for a previous-month preset. Default is the label with the signed
      * offset appended, e.g. `MTD −1`.
      */
     shiftedLabel?: (range: LocalDateRange, offset: number, ctx: DateRangeContext) => string;
@@ -119,8 +127,9 @@ export interface PresetDateRangeSelection {
     /** Token of a preset configured on the owning model. */
     token: string;
     /**
-     * Number of periods stepped back from the preset's natural range, zero or negative - each step
-     * applies the preset's prior-range logic once. Omitted when zero. See `stepRange()`.
+     * Number of periods stepped from the preset's natural range - negative for earlier periods,
+     * each applying the preset's prior-range logic once, positive for later ones (reachable only
+     * when `maxDate` allows dates beyond the anchor). Omitted when zero. See `stepRange()`.
      */
     offset?: number;
 }
@@ -138,7 +147,7 @@ export interface RelativeDateRangeSelection {
      * ending on the anchor date. Has no effect for days, where each day is its own boundary.
      */
     snap?: boolean;
-    /** Periods stepped back from the natural window, zero or negative. Omitted when zero. */
+    /** Periods stepped from the natural window - negative earlier, positive later. Omitted when zero. */
     offset?: number;
 }
 

--- a/cmp/daterange/Types.ts
+++ b/cmp/daterange/Types.ts
@@ -20,39 +20,42 @@ export interface ResolvedDateRange {
 }
 
 /** Calendar units supported by relative selections. */
-export type DateRangeCalendarUnit = 'days' | 'weeks' | 'months' | 'quarters' | 'years';
-
-/**
- * Units supported by relative selections. Business days are counted per the context's
- * `isBusinessDay` - weekdays by default - skipping the days that fail it.
- */
-export type DateRangeUnit = DateRangeCalendarUnit | 'businessDays';
+export type DateRangeUnit = 'days' | 'weeks' | 'months' | 'quarters' | 'years';
 
 /** Tabs available within the DateRangePicker popover. */
 export type DateRangePickerTab = 'presets' | 'relative' | 'monthYear' | 'custom';
 
+/**
+ * The day that relative and to-date selections resolve against - see the `anchorDay` config of
+ * {@link DateRangePickerModel}.
+ *
+ * - `'localDay'` - the current day in the browser's time zone, kept current as the day rolls.
+ * - `'appDay'` - the current day in the app's time zone (`LocalDate.currentAppDay()`), likewise.
+ * - A `LocalDate` - a pinned day that never moves, honored verbatim.
+ * - A function returning a `LocalDate` - re-evaluated every few seconds and whenever any
+ *   observables it reads change. Must be pure and cheap. For as-of dates with their own rule, e.g.
+ *   the latest loaded data date, or a day that rolls forward at an evening cutoff.
+ */
+export type DateRangeAnchorDay = 'localDay' | 'appDay' | LocalDate | (() => LocalDate);
+
 /** Tokens for the presets shipped with Hoist - see {@link dateRangePresets}. */
 export type DateRangePresetToken =
-    | 'today'
-    | 'yesterday'
+    | 'anchorDay'
+    | 'prevDay'
     | 'wtd'
     | 'mtd'
     | 'qtd'
     | 'ytd'
-    | 'last7Days'
-    | 'last30Days'
-    | 'last90Days'
-    | 'last3Months'
-    | 'last6Months'
-    | 'last12Months'
-    | 'lastWeek'
-    | 'lastMonth'
-    | 'lastQuarter'
-    | 'lastYear'
-    | 'lastBusinessDay'
-    | 'priorMtd'
-    | 'priorQtd'
-    | 'priorYtd'
+    | 'prev7Days'
+    | 'prev30Days'
+    | 'prev90Days'
+    | 'prev3Months'
+    | 'prev6Months'
+    | 'prev12Months'
+    | 'prevWeek'
+    | 'prevMonth'
+    | 'prevQuarter'
+    | 'prevYear'
     | 'all';
 
 /**
@@ -62,12 +65,16 @@ export type DateRangePresetToken =
 export interface DateRangeContext {
     /** Date that relative and to-date selections resolve against. */
     anchorDate: LocalDate;
+    /** The current day, per the model's `anchorDay` mode - app day for `'appDay'`, else local. */
+    today: LocalDate;
     /** Earliest selectable date, or null if unbounded. */
     minDate: LocalDate | null;
     /** Latest selectable date. Month and year selections spanning it are clamped to it. */
     maxDate: LocalDate;
     /** Whether a date is a business day - weekdays by default, or the model's `isBusinessDay`. */
     isBusinessDay: (date: LocalDate) => boolean;
+    /** True if single-day selections step by business day - see the model config of that name. */
+    businessDayMode: boolean;
     /** Presets available for selection, keyed by token. */
     presets: Record<string, DateRangePreset>;
 }
@@ -93,8 +100,17 @@ export interface DateRangePreset {
     /**
      * Resolve the comparable prior range for a given current range. Default is the immediately
      * preceding range of equal duration in days, or null when the current range is unbounded.
+     * Also drives stepping: a selection at `offset` -n is this applied n times.
      */
     resolvePrior?: (current: LocalDateRange, ctx: DateRangeContext) => LocalDateRange | null;
+
+    /**
+     * Label for this preset once stepped back to a non-zero `offset`, when the trigger's dates
+     * locate the range and the label need only describe its shape - e.g. `7 Days` for a rolling
+     * window, or the month itself for a previous-month preset. Default is the label with the
+     * offset appended, e.g. `MTD −1`.
+     */
+    shiftedLabel?: (range: LocalDateRange, offset: number, ctx: DateRangeContext) => string;
 }
 
 /** A one-click preset, re-resolved against the anchor date as time passes. */
@@ -102,6 +118,11 @@ export interface PresetDateRangeSelection {
     kind: 'preset';
     /** Token of a preset configured on the owning model. */
     token: string;
+    /**
+     * Number of periods stepped back from the preset's natural range, zero or negative - each step
+     * applies the preset's prior-range logic once. Omitted when zero. See `stepRange()`.
+     */
+    offset?: number;
 }
 
 /** A lookback of `count` units ending on the anchor date. */
@@ -114,10 +135,11 @@ export interface RelativeDateRangeSelection {
      * True to snap the window to calendar boundaries of `unit`, counting the current (partial)
      * unit as one - e.g. 3 calendar months ending today covers the prior two full months plus
      * the current month to date. False (default) for a rolling window of exactly `count` units
-     * ending on the anchor date. Has no effect for days or business days, where each day is its own
-     * boundary.
+     * ending on the anchor date. Has no effect for days, where each day is its own boundary.
      */
     snap?: boolean;
+    /** Periods stepped back from the natural window, zero or negative. Omitted when zero. */
+    offset?: number;
 }
 
 /** A calendar month, clamped to the context's `maxDate` when that date falls within it. */

--- a/cmp/daterange/Types.ts
+++ b/cmp/daterange/Types.ts
@@ -29,7 +29,7 @@ export type DateRangeUnit = 'days' | 'weeks' | 'months' | 'quarters' | 'years';
 export type DateRangeFormat = string | ((date: LocalDate) => string);
 
 /** Tabs available within the DateRangePicker popover. */
-export type DateRangePickerTab = 'presets' | 'relative' | 'monthYear' | 'custom';
+export type DateRangePickerTab = 'presets' | 'relative' | 'period' | 'custom';
 
 /**
  * The day that relative and to-date selections resolve against - see the `anchorDay` config of
@@ -168,6 +168,14 @@ export interface MonthDateRangeSelection {
     month: number;
 }
 
+/** A calendar quarter, clamped to the context's `maxDate` when that date falls within it. */
+export interface QuarterDateRangeSelection {
+    kind: 'quarter';
+    year: number;
+    /** Quarter of the year, 1-4. */
+    quarter: number;
+}
+
 /** A calendar year, clamped to the context's `maxDate` when that date falls within it. */
 export interface YearDateRangeSelection {
     kind: 'year';
@@ -190,5 +198,6 @@ export type DateRangeSelection =
     | PresetDateRangeSelection
     | RelativeDateRangeSelection
     | MonthDateRangeSelection
+    | QuarterDateRangeSelection
     | YearDateRangeSelection
     | CustomDateRangeSelection;

--- a/cmp/daterange/Types.ts
+++ b/cmp/daterange/Types.ts
@@ -78,7 +78,7 @@ export interface DateRangeContext {
     today: LocalDate;
     /** Earliest selectable date, or null if unbounded. */
     minDate: LocalDate | null;
-    /** Latest selectable date. Month and year selections spanning it are clamped to it. */
+    /** Latest selectable date. Month, quarter and year selections spanning it are clamped to it. */
     maxDate: LocalDate;
     /** Whether a date is a business day - weekdays by default, or the model's `isBusinessDay`. */
     isBusinessDay: (date: LocalDate) => boolean;
@@ -156,7 +156,7 @@ export interface RelativeDateRangeSelection {
      * ending on the anchor date. Has no effect for days, where each day is its own boundary.
      */
     snap?: boolean;
-    /** Periods stepped from the natural window - negative earlier, positive later. Omitted when zero. */
+    /** Periods stepped from the natural window - negative back, positive forward. Omitted when zero. */
     offset?: number;
 }
 

--- a/cmp/daterange/Types.ts
+++ b/cmp/daterange/Types.ts
@@ -22,6 +22,12 @@ export interface ResolvedDateRange {
 /** Calendar units supported by relative selections. */
 export type DateRangeUnit = 'days' | 'weeks' | 'months' | 'quarters' | 'years';
 
+/**
+ * How the picker renders a date - a moment.js format string, or a function for formats that
+ * depend on the date itself, e.g. one that adds the year only when it is not the current year.
+ */
+export type DateRangeFormat = string | ((date: LocalDate) => string);
+
 /** Tabs available within the DateRangePicker popover. */
 export type DateRangePickerTab = 'presets' | 'relative' | 'monthYear' | 'custom';
 

--- a/cmp/daterange/Types.ts
+++ b/cmp/daterange/Types.ts
@@ -65,7 +65,10 @@ export type DateRangePresetToken =
 export interface DateRangeContext {
     /** Date that relative and to-date selections resolve against. */
     anchorDate: LocalDate;
-    /** The current day, per the model's `anchorDay` mode - app day for `'appDay'`, else local. */
+    /**
+     * The current day in the browser's time zone - what "Today" means to the person looking at
+     * the screen, whatever zone the anchor date is drawn from.
+     */
     today: LocalDate;
     /** Earliest selectable date, or null if unbounded. */
     minDate: LocalDate | null;

--- a/cmp/daterange/impl/DateRangePickerLocalModel.ts
+++ b/cmp/daterange/impl/DateRangePickerLocalModel.ts
@@ -7,7 +7,7 @@
 import {type TabConfig, TabContainerModel} from '@xh/hoist/cmp/tab';
 import {HoistModel, type Intent, lookup, managed} from '@xh/hoist/core';
 import {action, bindable, computed, makeObservable, observable} from '@xh/hoist/mobx';
-import type {LocalDate} from '@xh/hoist/utils/datetime';
+import {LocalDate} from '@xh/hoist/utils/datetime';
 import {clamp, isEqual} from 'lodash';
 import {createRef, type ReactElement} from 'react';
 import {DateRangePickerModel} from '../DateRangePickerModel';
@@ -248,13 +248,27 @@ export class DateRangePickerLocalModel extends HoistModel {
         return activeTabId === 'presets' || activeTabId === 'relative';
     }
 
-    /** Default footer note - tells the user what relative periods resolve against. */
+    /**
+     * Default footer note - tells the user what periods resolve against, and which clock decides
+     * it. A live anchor names its source, so a user whose day differs from the application's can
+     * see why the picker's "today" is not theirs. A pinned or computed anchor is just its date.
+     */
     get anchorNote(): string {
         const {anchorDate, parentModel} = this,
+            {anchorDay, businessDayMode, today} = parentModel,
             date = anchorDate.format(parentModel.dateFormat);
-        return parentModel.isAnchorToday
-            ? `Periods resolve against today, ${date}.`
-            : `Periods resolve against ${date}.`;
+
+        let source = '';
+        if (anchorDay === 'localDay' || anchorDay === 'appDay') {
+            const day = anchorDay === 'appDay' ? LocalDate.currentAppDay() : today;
+            source =
+                anchorDate !== day && businessDayMode
+                    ? 'the most recent business day, '
+                    : anchorDay === 'appDay'
+                      ? 'the current application day, '
+                      : 'your current day, ';
+        }
+        return `Periods resolve against ${source}${date}.`;
     }
 
     private get anchorNoun(): string {

--- a/cmp/daterange/impl/DateRangePickerLocalModel.ts
+++ b/cmp/daterange/impl/DateRangePickerLocalModel.ts
@@ -422,16 +422,12 @@ export class DateRangePickerLocalModel extends HoistModel {
     //------------------
     // Implementation
     //------------------
+    /** Tab configs in the order the app configured them - the model's `tabs` sets the order. */
     private buildTabs(): TabConfig[] {
-        const {tabs} = this.parentModel;
-        return this.tabSpecs
-            .filter(spec => tabs.includes(spec.id))
-            .map(({id, title, icon, content}) => ({
-                id,
-                title,
-                icon,
-                content: () => content({model: this, testId: this.testId})
-            }));
+        return this.parentModel.tabs.map(id => {
+            const {title, icon, content} = this.tabSpecs.find(spec => spec.id === id);
+            return {id, title, icon, content: () => content({model: this, testId: this.testId})};
+        });
     }
 
     private commitDraftIfLive() {

--- a/cmp/daterange/impl/DateRangePickerLocalModel.ts
+++ b/cmp/daterange/impl/DateRangePickerLocalModel.ts
@@ -153,10 +153,11 @@ export class DateRangePickerLocalModel extends HoistModel {
         if (this.relativeSnap) {
             // The window stops at the anchor date, so the last unit is normally incomplete -
             // unless the anchor happens to fall on its final day.
-            const partial = anchorDate.endOf(unit) === anchorDate ? '' : ' (partial)';
+            const partial = anchorDate.endOf(unit) === anchorDate ? '' : ' (partial)',
+                containing = this.parentModel.isAnchorToday ? 'today' : 'the anchor date';
             return n === 1
-                ? `The current${partial} calendar ${singular}.`
-                : `${n} calendar ${units}, including the current${partial} one.`;
+                ? `The${partial} calendar ${singular} containing ${containing}.`
+                : `${n} calendar ${units}, ending with the${partial} one containing ${containing}.`;
         }
         return `Rolling window of exactly ${n} ${units} ending ${anchorNoun}.`;
     }

--- a/cmp/daterange/impl/DateRangePickerLocalModel.ts
+++ b/cmp/daterange/impl/DateRangePickerLocalModel.ts
@@ -242,10 +242,10 @@ export class DateRangePickerLocalModel extends HoistModel {
         return !this.parentModel.commitOnChange;
     }
 
-    /** Whether the default footer note about anchoring applies to the configured tabs. */
+    /** Whether the default footer note about anchoring applies to the active tab. */
     get showAnchorNote(): boolean {
-        const {tabs} = this.parentModel;
-        return tabs.includes('presets') || tabs.includes('relative');
+        const {activeTabId} = this;
+        return activeTabId === 'presets' || activeTabId === 'relative';
     }
 
     /** Default footer note - tells the user what relative periods resolve against. */

--- a/cmp/daterange/impl/DateRangePickerLocalModel.ts
+++ b/cmp/daterange/impl/DateRangePickerLocalModel.ts
@@ -253,8 +253,8 @@ export class DateRangePickerLocalModel extends HoistModel {
         const {anchorDate, parentModel} = this,
             date = anchorDate.format(parentModel.dateFormat);
         return parentModel.isAnchorToday
-            ? `Relative periods anchor to today, ${date}.`
-            : `Relative periods anchor to ${date}.`;
+            ? `Periods resolve against today, ${date}.`
+            : `Periods resolve against ${date}.`;
     }
 
     private get anchorNoun(): string {

--- a/cmp/daterange/impl/DateRangePickerLocalModel.ts
+++ b/cmp/daterange/impl/DateRangePickerLocalModel.ts
@@ -5,9 +5,9 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {type TabConfig, TabContainerModel} from '@xh/hoist/cmp/tab';
-import {HoistModel, type Intent, lookup, managed} from '@xh/hoist/core';
+import {HoistModel, type Intent, lookup, managed, XH} from '@xh/hoist/core';
 import {action, bindable, computed, makeObservable, observable} from '@xh/hoist/mobx';
-import {LocalDate} from '@xh/hoist/utils/datetime';
+import type {LocalDate} from '@xh/hoist/utils/datetime';
 import {clamp, isEqual} from 'lodash';
 import {createRef, type ReactElement} from 'react';
 import {DateRangePickerModel} from '../DateRangePickerModel';
@@ -249,26 +249,24 @@ export class DateRangePickerLocalModel extends HoistModel {
     }
 
     /**
-     * Default footer note - tells the user what periods resolve against, and which clock decides
-     * it. A live anchor names its source, so a user whose day differs from the application's can
-     * see why the picker's "today" is not theirs. A pinned or computed anchor is just its date.
+     * Default footer note - tells the user what periods are relative to, and which clock decides
+     * it, as a prose prefix and the date for the component to set apart. A live anchor names its
+     * source, so a user whose day differs from the application's can see why the picker's "today"
+     * is not theirs. A pinned or computed anchor is just its date.
      */
-    get anchorNote(): string {
+    get anchorNote(): {prefix: string; date: string} {
         const {anchorDate, parentModel} = this,
-            {anchorDay, businessDayMode, today} = parentModel,
-            date = anchorDate.format(parentModel.dateFormat);
+            {anchorDay, businessDayMode} = parentModel,
+            date = parentModel.fmtDay(anchorDate),
+            day = businessDayMode ? 'business day' : 'day';
 
         let source = '';
-        if (anchorDay === 'localDay' || anchorDay === 'appDay') {
-            const day = anchorDay === 'appDay' ? LocalDate.currentAppDay() : today;
-            source =
-                anchorDate !== day && businessDayMode
-                    ? 'the most recent business day, '
-                    : anchorDay === 'appDay'
-                      ? 'the current application day, '
-                      : 'your current day, ';
+        if (anchorDay === 'localDay') {
+            source = ` your current ${day}`;
+        } else if (anchorDay === 'appDay') {
+            source = ` the current ${day} in ${XH.environmentService.get('appTimeZone')}`;
         }
-        return `Periods resolve against ${source}${date}.`;
+        return {prefix: `Relative to${source}: `, date};
     }
 
     private get anchorNoun(): string {

--- a/cmp/daterange/impl/DateRangePickerLocalModel.ts
+++ b/cmp/daterange/impl/DateRangePickerLocalModel.ts
@@ -18,13 +18,7 @@ import {
     MAX_RELATIVE_COUNT,
     MIN_SELECTION_YEAR
 } from '../DateRangeUtils';
-import type {
-    DateRangeCalendarUnit,
-    DateRangePickerTab,
-    DateRangeSelection,
-    DateRangeUnit,
-    LocalDateRange
-} from '../Types';
+import type {DateRangePickerTab, DateRangeSelection, DateRangeUnit, LocalDateRange} from '../Types';
 
 /**
  * A tab within the picker popover - its rail entry and its content component. Declared by the
@@ -138,39 +132,21 @@ export class DateRangePickerLocalModel extends HoistModel {
         return end.diff(start, 'days') + 1;
     }
 
-    /** Unit shown on the Relative tab's unit control - business days display as days. */
-    get relativeDisplayUnit(): DateRangeCalendarUnit {
-        return this.relativeUnit === 'businessDays' ? 'days' : this.relativeUnit;
-    }
-
-    /** How days are counted - the Relative tab's secondary choice when the unit is days. */
-    get relativeDayType(): 'calendar' | 'business' {
-        return this.relativeUnit === 'businessDays' ? 'business' : 'calendar';
-    }
-
-    get isDayUnit(): boolean {
-        return this.relativeDisplayUnit === 'days';
-    }
-
     /**
-     * False for day units, where a day is already a calendar boundary - snapping has nothing to
-     * round out, so days resolve identically either way. The Relative tab offers the calendar vs.
-     * business day choice in its place.
+     * False for days, where a day is already a calendar boundary - snapping has nothing to round
+     * out, so days resolve identically either way.
      */
     get snapApplies(): boolean {
-        return !this.isDayUnit;
+        return this.relativeUnit !== 'days';
     }
 
-    /** Explains the Relative tab's secondary choice - snap mode, or day type for day units. */
+    /** Explains the Relative tab's snap choice, or the day window when snap does not apply. */
     get relativeModeHelpText(): string {
         const {relativeUnit: unit, anchorDate, anchorNoun} = this,
             n = this.clampedCount,
             singular = getDateRangeUnitLabel(unit, 1).toLowerCase(),
             units = getDateRangeUnitLabel(unit, n).toLowerCase();
 
-        if (unit === 'businessDays') {
-            return `The last ${n} ${units} ending ${anchorNoun}. Non-business days are skipped.`;
-        }
         if (unit === 'days') {
             return `Rolling window of exactly ${n} calendar ${units} ending ${anchorNoun}.`;
         }
@@ -187,13 +163,8 @@ export class DateRangePickerLocalModel extends HoistModel {
 
     /** Secondary line for the Relative tab's preview - the window's length. */
     get relativePreviewCountText(): string {
-        const days = this.relativeDayCount,
-            dayLabel = days === 1 ? 'day' : 'days';
-        if (this.relativeUnit === 'businessDays') {
-            const n = this.clampedCount;
-            return `${n} business ${n === 1 ? 'day' : 'days'} (${days} calendar ${dayLabel})`;
-        }
-        return `${days} ${dayLabel}`;
+        const days = this.relativeDayCount;
+        return `${days} ${days === 1 ? 'day' : 'days'}`;
     }
 
     //------------------
@@ -280,13 +251,13 @@ export class DateRangePickerLocalModel extends HoistModel {
     get anchorNote(): string {
         const {anchorDate, parentModel} = this,
             date = anchorDate.format(parentModel.dateFormat);
-        return anchorDate.isToday
+        return parentModel.isAnchorToday
             ? `Relative periods anchor to today, ${date}.`
             : `Relative periods anchor to ${date}.`;
     }
 
     private get anchorNoun(): string {
-        return this.anchorDate.isToday ? 'today' : 'on the anchor date';
+        return this.parentModel.isAnchorToday ? 'today' : 'on the anchor date';
     }
 
     constructor(testId: string, tabSpecs: DateRangePickerTabSpec[]) {
@@ -312,8 +283,7 @@ export class DateRangePickerLocalModel extends HoistModel {
 
         // Never hold a snap that does nothing: it would persist into the committed value and make
         // `relativeModeHelpText` describe an alignment that is not happening. Tracks both sides -
-        // the unit can change under a set snap, and a persisted `{unit: 'days', snap: true}` can
-        // seed one while the unit is already days.
+        // the unit can change under a set snap.
         this.addReaction({
             track: () => [this.snapApplies, this.relativeSnap],
             run: ([applies, snap]) => {
@@ -346,6 +316,7 @@ export class DateRangePickerLocalModel extends HoistModel {
 
         this.tabModel.activateTab(openTabId);
 
+        // A draft starts at offset zero - stepping is done from the trigger, not the tab.
         if (value.kind === 'relative') {
             this.relativeCount = value.count;
             this.relativeUnit = value.unit;
@@ -408,17 +379,6 @@ export class DateRangePickerLocalModel extends HoistModel {
     @action
     stepCount(delta: number) {
         this.relativeCount = clamp(this.clampedCount + delta, 1, MAX_RELATIVE_COUNT);
-    }
-
-    /** Switching units resets the day-type choice - business days apply to days only. */
-    @action
-    setRelativeDisplayUnit(unit: DateRangeCalendarUnit) {
-        this.relativeUnit = unit;
-    }
-
-    @action
-    setRelativeDayType(type: 'calendar' | 'business') {
-        this.relativeUnit = type === 'business' ? 'businessDays' : 'days';
     }
 
     @action

--- a/cmp/daterange/impl/DateRangePickerLocalModel.ts
+++ b/cmp/daterange/impl/DateRangePickerLocalModel.ts
@@ -12,9 +12,9 @@ import {clamp, isEqual} from 'lodash';
 import {createRef, type ReactElement} from 'react';
 import {DateRangePickerModel} from '../DateRangePickerModel';
 import {
-    getDateRangeLabel,
     getDateRangeUnitLabel,
     getMonthStart,
+    getQuarterStart,
     MAX_RELATIVE_COUNT,
     MIN_SELECTION_YEAR
 } from '../DateRangeUtils';
@@ -185,15 +185,15 @@ export class DateRangePickerLocalModel extends HoistModel {
         return start > maxDate || (minDate && start.endOfMonth() < minDate);
     }
 
+    isQuarterDisabled(quarter: number): boolean {
+        const {minDate, maxDate} = this,
+            start = getQuarterStart(this.gridYear, quarter);
+        return start > maxDate || (minDate && start.endOfQuarter() < minDate);
+    }
+
     get yearSelectable(): boolean {
         const {gridYear, minDate, maxDate} = this;
         return gridYear <= yearOf(maxDate) && (!minDate || gridYear >= yearOf(minDate));
-    }
-
-    get yearRowLabel(): string {
-        const {gridYear: year, parentModel} = this,
-            toDate = getDateRangeLabel({kind: 'year', year}, parentModel.context) === 'YTD';
-        return toDate ? `${year} Year to Date` : `Full Year ${year}`;
     }
 
     //------------------
@@ -340,8 +340,7 @@ export class DateRangePickerLocalModel extends HoistModel {
             this.relativeSnap = false;
         }
 
-        this.gridYear =
-            value.kind === 'month' || value.kind === 'year' ? value.year : yearOf(anchorDate);
+        this.gridYear = 'year' in value ? value.year : yearOf(anchorDate);
 
         // Seed the custom draft from the applied resolved range, clamped to selectable bounds.
         const {start: curStart, end: curEnd} = parentModel.currentRange;
@@ -482,8 +481,9 @@ function tabForKind(kind: DateRangeSelection['kind']): DateRangePickerTab {
         case 'preset':
             return 'presets';
         case 'month':
+        case 'quarter':
         case 'year':
-            return 'monthYear';
+            return 'period';
         default:
             return kind;
     }

--- a/cmp/grid/impl/RecordSortUtils.ts
+++ b/cmp/grid/impl/RecordSortUtils.ts
@@ -105,13 +105,21 @@ function getGroupSorters(gridModel: GridModel): RecordSorter[] {
             const column = gridModel.getColumn(colId);
             if (!column) return null;
 
-            const {field} = column;
+            const {field} = column,
+                {getValueFn, ctx} = sorterFor(gridModel, column);
             return {
-                ...sorterFor(gridModel, column),
+                ctx,
+                // groupSortFn expects ag-Grid group keys - always string or null, never raw values.
+                getValueFn: params => toGroupKey(getValueFn(params)),
                 compare: (a, b, nodeA, nodeB) => groupSortFn(a, b, field, {gridModel, nodeA, nodeB})
             };
         })
     );
+}
+
+/** Mirror ag-Grid's ValueService.getKeyForNode - string/null pass through, else String(). */
+function toGroupKey(value: any): string {
+    return value == null || typeof value === 'string' ? value : String(value);
 }
 
 /** Value-resolution half of a sorter - the caller supplies the comparator. */

--- a/desktop/cmp/daterange/DateRangePicker.scss
+++ b/desktop/cmp/daterange/DateRangePicker.scss
@@ -373,20 +373,27 @@ $drp-transition-dur: 120ms;
       text-align: center;
     }
 
+    // A row per quarter - its three months across the left, its button in a narrow trailing column.
     &__month-grid {
       display: grid;
-      grid-template-columns: repeat(4, 1fr);
+      grid-template-columns: repeat(3, 1fr) minmax(44px, auto);
       gap: 6px;
       padding: 4px 6px 0;
     }
 
     // Grid cells stretch; the buttons bring their own chrome, hover, active and disabled states.
-    &__month-btn.xh-button {
+    &__month-btn.xh-button,
+    &__quarter-btn.xh-button {
       width: 100%;
     }
 
+    // The quarter reads as the row's label - quieter than the months it contains, until selected.
+    &__quarter-btn.xh-button:not(.xh-button--active) {
+      color: var(--xh-text-color-muted);
+    }
+
     &__year-row.xh-button {
-      margin: 6px 6px 0;
+      margin: 14px 6px 0;
 
       // Blueprint wraps `items` in a non-flex text span - lay them out, as the trigger does.
       > .bp6-button-text {

--- a/desktop/cmp/daterange/DateRangePicker.scss
+++ b/desktop/cmp/daterange/DateRangePicker.scss
@@ -554,6 +554,13 @@ $drp-transition-dur: 120ms;
       @include drp-secondary-prose;
     }
 
+    // The date the note names - in the date font, receding with the prose around it.
+    &__footer-date {
+      @include drp-date-secondary;
+
+      margin-left: 4px;
+    }
+
     &__single-footer {
       @include drp-footer-shell;
 

--- a/desktop/cmp/daterange/DateRangePicker.scss
+++ b/desktop/cmp/daterange/DateRangePicker.scss
@@ -295,7 +295,7 @@ $drp-transition-dur: 120ms;
       margin-bottom: var(--xh-pad-px);
     }
 
-    &__rel-last {
+    &__rel-prefix {
       color: var(--xh-text-color-muted);
     }
 

--- a/desktop/cmp/daterange/DateRangePicker.ts
+++ b/desktop/cmp/daterange/DateRangePicker.ts
@@ -48,7 +48,7 @@ export interface DateRangePickerProps
 
     /**
      * Text rendered in the popover footer, or null to suppress. Default is a note on the date that
-     * relative periods anchor to, shown when the Presets or Relative tab is offered. Not shown by
+     * relative periods anchor to, shown while the Presets or Relative tab is active. Not shown by
      * a single-tab picker, whose footer carries the resolved dates instead.
      */
     footerNote?: ReactNode;

--- a/desktop/cmp/daterange/DateRangePicker.ts
+++ b/desktop/cmp/daterange/DateRangePicker.ts
@@ -429,7 +429,7 @@ const relativeTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}
 });
 
 //------------------
-// Tab - Months & Years
+// Tab - Period (months, quarters, years)
 //------------------
 const MONTH_LABELS = [
     'Jan',
@@ -446,7 +446,7 @@ const MONTH_LABELS = [
     'Dec'
 ];
 
-const monthYearTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) => {
+const periodTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) => {
     const {parentModel, gridYear} = model,
         {value} = parentModel,
         yearRange = parentModel.resolve({kind: 'year', year: gridYear}).current,
@@ -483,29 +483,52 @@ const monthYearTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId
                 ]
             }),
             div({
+                // One row per quarter: its three months, then the quarter itself - so the quarter
+                // labels the months it contains, and both are a click away.
                 className: 'xh-date-range-picker-popover__month-grid',
-                items: MONTH_LABELS.map((label, idx) => {
-                    const month = idx + 1,
-                        active =
-                            value.kind === 'month' &&
-                            value.month === month &&
-                            value.year === gridYear;
-                    return button({
-                        key: label,
-                        className: 'xh-date-range-picker-popover__month-btn',
-                        text: label,
-                        // Selected reads as a solid accent fill, like the unit selector's
-                        // selected segment. Unselected keeps the outlined treatment used
-                        // elsewhere in the picker - note Hoist buttons are minimal by default,
-                        // so a solid fill needs `minimal: false`, not just `outlined: false`.
-                        outlined: !active,
-                        minimal: !active,
-                        active,
-                        intent: active ? (model.intent ?? 'primary') : undefined,
-                        disabled: model.isMonthDisabled(month),
-                        testId: getTestId(testId, `month-${month}`),
-                        onClick: () => model.commit({kind: 'month', year: gridYear, month})
-                    });
+                items: [1, 2, 3, 4].flatMap(quarter => {
+                    const quarterActive =
+                            value.kind === 'quarter' &&
+                            value.quarter === quarter &&
+                            value.year === gridYear,
+                        months = [quarter * 3 - 2, quarter * 3 - 1, quarter * 3];
+                    return [
+                        ...months.map(month => {
+                            const active =
+                                value.kind === 'month' &&
+                                value.month === month &&
+                                value.year === gridYear;
+                            return button({
+                                key: month,
+                                className: 'xh-date-range-picker-popover__month-btn',
+                                text: MONTH_LABELS[month - 1],
+                                // Selected reads as a solid accent fill, like the unit selector's
+                                // selected segment. Unselected keeps the outlined treatment used
+                                // elsewhere in the picker - note Hoist buttons are minimal by
+                                // default, so a solid fill needs `minimal: false`, not just
+                                // `outlined: false`.
+                                outlined: !active,
+                                minimal: !active,
+                                active,
+                                intent: active ? (model.intent ?? 'primary') : undefined,
+                                disabled: model.isMonthDisabled(month),
+                                testId: getTestId(testId, `month-${month}`),
+                                onClick: () => model.commit({kind: 'month', year: gridYear, month})
+                            });
+                        }),
+                        button({
+                            key: `q${quarter}`,
+                            className: 'xh-date-range-picker-popover__quarter-btn',
+                            text: `Q${quarter}`,
+                            outlined: !quarterActive,
+                            minimal: !quarterActive,
+                            active: quarterActive,
+                            intent: quarterActive ? (model.intent ?? 'primary') : undefined,
+                            disabled: model.isQuarterDisabled(quarter),
+                            testId: getTestId(testId, `quarter-${quarter}`),
+                            onClick: () => model.commit({kind: 'quarter', year: gridYear, quarter})
+                        })
+                    ];
                 })
             }),
             button({
@@ -521,7 +544,7 @@ const monthYearTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId
                     Icon.calendar(),
                     span({
                         className: 'xh-date-range-picker-popover__year-row-label',
-                        item: model.yearRowLabel
+                        item: String(gridYear)
                     }),
                     span({
                         // As on the Presets tab - the single-tab popover is too narrow for dates.
@@ -761,7 +784,7 @@ const anchorNote = hoistCmp.factory<DateRangePickerLocalModel>(({model}) => {
 const TAB_SPECS: DateRangePickerTabSpec[] = [
     {id: 'presets', title: 'Presets', icon: Icon.bolt(), content: presetsTab},
     {id: 'relative', title: 'Relative', icon: Icon.history(), content: relativeTab},
-    {id: 'monthYear', title: 'Months & Years', icon: Icon.calendarDays(), content: monthYearTab},
+    {id: 'period', title: 'Months & Years', icon: Icon.calendarDays(), content: periodTab},
     {id: 'custom', title: 'Custom Range', icon: Icon.calendarRange(), content: customTab}
 ];
 

--- a/desktop/cmp/daterange/DateRangePicker.ts
+++ b/desktop/cmp/daterange/DateRangePicker.ts
@@ -14,7 +14,7 @@ import {
     DateRangePickerLocalModel,
     type DateRangePickerTabSpec
 } from '@xh/hoist/cmp/daterange/impl/DateRangePickerLocalModel';
-import {box, div, filler, hbox, span, vbox} from '@xh/hoist/cmp/layout';
+import {box, div, filler, fragment, hbox, span, vbox} from '@xh/hoist/cmp/layout';
 import {tabContainer} from '@xh/hoist/cmp/tab';
 import {
     hoistCmp,
@@ -35,6 +35,7 @@ import type {LocalDate} from '@xh/hoist/utils/datetime';
 import {elemWithin, getTestId, TEST_ID} from '@xh/hoist/utils/js';
 import {composeRefs, splitLayoutProps, useOnResize} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
+import {isString} from 'lodash';
 import type {KeyboardEvent, ReactNode} from 'react';
 import './DateRangePicker.scss';
 
@@ -48,7 +49,7 @@ export interface DateRangePickerProps
 
     /**
      * Text rendered in the popover footer, or null to suppress. Default is a note on the date that
-     * periods resolve against, shown while the Presets or Relative tab is active. Not shown by
+     * periods are relative to, shown while the Presets or Relative tab is active. Not shown by
      * a single-tab picker, whose footer carries the resolved dates instead.
      */
     footerNote?: ReactNode;
@@ -556,7 +557,10 @@ const customTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) 
                     onCommit: v =>
                         edge === 'start' ? model.commitStartInput(v) : model.commitEndInput(v),
                     valueType: 'localDate',
-                    formatString: parentModel.dateFormat,
+                    // Inputs need a parseable string format - a function format cannot be typed into.
+                    formatString: isString(parentModel.dateFormat)
+                        ? parentModel.dateFormat
+                        : 'YYYY-MM-DD',
                     enablePicker: false,
                     rightElement: null,
                     width: '100%',
@@ -691,7 +695,7 @@ const footer = hoistCmp.factory<DateRangePickerLocalModel>(
             note =
                 footerNote === undefined
                     ? model.showAnchorNote
-                        ? model.anchorNote
+                        ? anchorNote({model})
                         : null
                     : footerNote,
             showNote = !singleTab && note != null && note !== false;
@@ -740,6 +744,15 @@ const footer = hoistCmp.factory<DateRangePickerLocalModel>(
         });
     }
 );
+
+/** The default footer note - muted prose, with the date it names set apart as on the trigger. */
+const anchorNote = hoistCmp.factory<DateRangePickerLocalModel>(({model}) => {
+    const {prefix, date} = model.anchorNote;
+    return fragment(
+        prefix,
+        span({className: 'xh-date-range-picker-popover__footer-date', item: date})
+    );
+});
 
 //------------------
 // Tabs

--- a/desktop/cmp/daterange/DateRangePicker.ts
+++ b/desktop/cmp/daterange/DateRangePicker.ts
@@ -744,7 +744,7 @@ const footer = hoistCmp.factory<DateRangePickerLocalModel>(
 //------------------
 // Tabs
 //------------------
-/** Rail entry + content for each tab, in rail order. Filtered by the model's `tabs` config. */
+/** Switcher entry + content for each tab. The model's `tabs` config selects and orders them. */
 const TAB_SPECS: DateRangePickerTabSpec[] = [
     {id: 'presets', title: 'Presets', icon: Icon.bolt(), content: presetsTab},
     {id: 'relative', title: 'Relative', icon: Icon.history(), content: relativeTab},

--- a/desktop/cmp/daterange/DateRangePicker.ts
+++ b/desktop/cmp/daterange/DateRangePicker.ts
@@ -4,16 +4,11 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
-import {
-    DATE_RANGE_UNITS,
-    DateRangePickerModel,
-    getDateRangePresetName,
-    getDateRangeUnitLabel
-} from '@xh/hoist/cmp/daterange';
+import {DateRangePickerModel} from '@xh/hoist/cmp/daterange';
 import {
     DateRangePickerLocalModel,
     type DateRangePickerTabSpec
-} from '@xh/hoist/cmp/daterange/impl/DateRangePickerLocalModel';
+} from './impl/DateRangePickerLocalModel';
 import {box, div, filler, fragment, hbox, span, vbox} from '@xh/hoist/cmp/layout';
 import {tabContainer} from '@xh/hoist/cmp/tab';
 import {
@@ -26,17 +21,18 @@ import {
     uses
 } from '@xh/hoist/core';
 import {button, type ButtonProps} from '@xh/hoist/desktop/cmp/button';
-import {dateInput, numberInput, segmentedControl} from '@xh/hoist/desktop/cmp/input';
 import '@xh/hoist/desktop/register';
 import {Icon} from '@xh/hoist/icon';
-import {controlGroup, popover} from '@xh/hoist/kit/blueprint';
+import {popover} from '@xh/hoist/kit/blueprint';
 import type {PopoverPosition} from '@blueprintjs/core';
-import type {LocalDate} from '@xh/hoist/utils/datetime';
-import {elemWithin, getTestId, TEST_ID} from '@xh/hoist/utils/js';
+import {elemWithin, getTestId} from '@xh/hoist/utils/js';
 import {composeRefs, splitLayoutProps, useOnResize} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
-import {isString} from 'lodash';
 import type {KeyboardEvent, ReactNode} from 'react';
+import {customTab} from './impl/CustomTab';
+import {periodTab} from './impl/PeriodTab';
+import {presetsTab} from './impl/PresetsTab';
+import {relativeTab} from './impl/RelativeTab';
 import './DateRangePicker.scss';
 
 export interface DateRangePickerProps
@@ -92,13 +88,13 @@ export interface DateRangePickerProps
 
 /**
  * A dropdown control for selecting a period of time - one compact trigger that can express
- * presets (e.g. MTD, Last 30 Days), relative lookbacks, calendar months and years, and custom
- * ranges of dates.
+ * presets (e.g. MTD, Prev 30 Days), relative lookbacks, calendar months, quarters and years, and
+ * custom ranges of dates.
  *
  * The trigger shows the applied period's label with its resolved dates, and opens a popover with a
  * tab for each of those selection shapes. The backing {@link DateRangePickerModel}'s `tabs` config
- * selects which tabs show. Preset and month/year picks commit on click. Relative and custom picks
- * are drafts until Apply, held in a local model that never touches the applied value.
+ * selects which tabs show. Preset and period picks commit on click. Relative and custom picks are
+ * drafts until Apply, held in a local model that never touches the applied value.
  *
  * App code constructs and persists the {@link DateRangePickerModel}, which owns the applied value
  * and the ranges and filters it resolves to - see that class for the full API.
@@ -284,430 +280,6 @@ const popoverContent = hoistCmp.factory<DateRangePickerLocalModel>(
     }
 );
 
-const sectionHeader = (text: string) =>
-    div({className: 'xh-date-range-picker-popover__section-hdr', item: text});
-
-//------------------
-// Tab - Presets
-//------------------
-const presetsTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) => {
-    const {parentModel, singleTab} = model,
-        {value, context} = parentModel;
-
-    return vbox({
-        className: 'xh-date-range-picker-popover__tab',
-        items: [
-            sectionHeader('Presets'),
-            ...parentModel.presets.map(preset => {
-                const {token} = preset,
-                    selected = value.kind === 'preset' && value.token === token,
-                    range = parentModel.resolve({kind: 'preset', token}).current;
-                return div({
-                    key: token,
-                    className: classNames(
-                        'xh-date-range-picker-popover__preset-row',
-                        selected && 'xh-date-range-picker-popover__preset-row--selected'
-                    ),
-                    ...dataAttrs({[TEST_ID]: getTestId(testId, `preset-${token}`)}),
-                    ...clickable(() => model.commit({kind: 'preset', token})),
-                    items: [
-                        Icon.check({
-                            className: classNames(
-                                'xh-date-range-picker-popover__row-check',
-                                !selected && 'xh-date-range-picker-popover__row-check--hidden'
-                            )
-                        }),
-                        span({
-                            className: 'xh-date-range-picker-popover__row-name',
-                            item: getDateRangePresetName(preset, context)
-                        }),
-                        span({
-                            omit: singleTab,
-                            className: 'xh-date-range-picker-popover__row-range',
-                            item: parentModel.fmtRange(range)
-                        })
-                    ]
-                });
-            })
-        ]
-    });
-});
-
-//------------------
-// Tab - Relative
-//------------------
-const relativeTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) => {
-    const {parentModel, relativeRange} = model;
-
-    return vbox({
-        className: 'xh-date-range-picker-popover__tab',
-        items: [
-            sectionHeader('Relative Lookback'),
-            hbox({
-                className: 'xh-date-range-picker-popover__rel-row',
-                items: [
-                    span({className: 'xh-date-range-picker-popover__rel-last', item: 'Last'}),
-                    controlGroup({
-                        items: [
-                            button({
-                                text: '−',
-                                minWidth: 20,
-                                testId: getTestId(testId, 'count-down'),
-                                onClick: () => model.stepCount(-1)
-                            }),
-                            numberInput({
-                                model,
-                                bind: 'relativeCount',
-                                min: 1,
-                                max: 999,
-                                width: 56,
-                                textAlign: 'center',
-                                commitOnChange: true,
-                                testId: getTestId(testId, 'count')
-                            }),
-                            button({
-                                text: '+',
-                                minWidth: 20,
-                                testId: getTestId(testId, 'count-up'),
-                                onClick: () => model.stepCount(1)
-                            })
-                        ]
-                    }),
-                    segmentedControl({
-                        model,
-                        bind: 'relativeUnit',
-                        testId: getTestId(testId, 'unit'),
-                        options: DATE_RANGE_UNITS.map(unit => ({
-                            value: unit,
-                            label: getDateRangeUnitLabel(unit)
-                        }))
-                    })
-                ]
-            }),
-            div({
-                className: 'xh-date-range-picker-popover__snap-box',
-                items: [
-                    // Two ways of counting, named as peers - a checkbox would frame one as a
-                    // modifier on the other, inviting the read that it widens the range. Days have
-                    // nothing to round out, so offer no choice at that grain.
-                    segmentedControl({
-                        omit: !model.snapApplies,
-                        model,
-                        bind: 'relativeSnap',
-                        fill: false,
-                        testId: getTestId(testId, 'snap'),
-                        options: [
-                            {value: false, label: 'Rolling'},
-                            {value: true, label: 'Calendar'}
-                        ]
-                    }),
-                    div({
-                        className: 'xh-date-range-picker-popover__snap-help',
-                        item: model.relativeModeHelpText
-                    })
-                ]
-            }),
-            div({
-                className: 'xh-date-range-picker-popover__preview',
-                items: [
-                    div({
-                        className: 'xh-date-range-picker-popover__preview-label',
-                        item: 'Resolves To'
-                    }),
-                    div({
-                        className: 'xh-date-range-picker-popover__preview-range',
-                        item: parentModel.fmtRange(relativeRange)
-                    }),
-                    div({
-                        className: 'xh-date-range-picker-popover__preview-days',
-                        item: model.relativePreviewCountText
-                    })
-                ]
-            })
-        ]
-    });
-});
-
-//------------------
-// Tab - Period (months, quarters, years)
-//------------------
-const MONTH_LABELS = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec'
-];
-
-const periodTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) => {
-    const {parentModel, gridYear} = model,
-        {value} = parentModel,
-        yearRange = parentModel.resolve({kind: 'year', year: gridYear}).current,
-        yearSelected = value.kind === 'year' && value.year === gridYear;
-
-    return vbox({
-        className: 'xh-date-range-picker-popover__tab',
-        items: [
-            hbox({
-                className: 'xh-date-range-picker-popover__month-hdr',
-                items: [
-                    sectionHeader('Months & Years'),
-                    filler(),
-                    button({
-                        className: 'xh-date-range-picker-popover__nav-btn',
-                        icon: Icon.angleLeft(),
-                        minimal: true,
-                        disabled: !model.canYearBack,
-                        testId: getTestId(testId, 'year-back'),
-                        onClick: () => model.stepYear(-1)
-                    }),
-                    span({
-                        className: 'xh-date-range-picker-popover__year-val',
-                        item: String(gridYear)
-                    }),
-                    button({
-                        className: 'xh-date-range-picker-popover__nav-btn',
-                        icon: Icon.angleRight(),
-                        minimal: true,
-                        disabled: !model.canYearForward,
-                        testId: getTestId(testId, 'year-forward'),
-                        onClick: () => model.stepYear(1)
-                    })
-                ]
-            }),
-            div({
-                // One row per quarter: its three months, then the quarter itself - so the quarter
-                // labels the months it contains, and both are a click away.
-                className: 'xh-date-range-picker-popover__month-grid',
-                items: [1, 2, 3, 4].flatMap(quarter => {
-                    const quarterActive =
-                            value.kind === 'quarter' &&
-                            value.quarter === quarter &&
-                            value.year === gridYear,
-                        months = [quarter * 3 - 2, quarter * 3 - 1, quarter * 3];
-                    return [
-                        ...months.map(month => {
-                            const active =
-                                value.kind === 'month' &&
-                                value.month === month &&
-                                value.year === gridYear;
-                            return button({
-                                key: month,
-                                className: 'xh-date-range-picker-popover__month-btn',
-                                text: MONTH_LABELS[month - 1],
-                                // Selected reads as a solid accent fill, like the unit selector's
-                                // selected segment. Unselected keeps the outlined treatment used
-                                // elsewhere in the picker - note Hoist buttons are minimal by
-                                // default, so a solid fill needs `minimal: false`, not just
-                                // `outlined: false`.
-                                outlined: !active,
-                                minimal: !active,
-                                active,
-                                intent: active ? (model.intent ?? 'primary') : undefined,
-                                disabled: model.isMonthDisabled(month),
-                                testId: getTestId(testId, `month-${month}`),
-                                onClick: () => model.commit({kind: 'month', year: gridYear, month})
-                            });
-                        }),
-                        button({
-                            key: `q${quarter}`,
-                            className: 'xh-date-range-picker-popover__quarter-btn',
-                            text: `Q${quarter}`,
-                            outlined: !quarterActive,
-                            minimal: !quarterActive,
-                            active: quarterActive,
-                            intent: quarterActive ? (model.intent ?? 'primary') : undefined,
-                            disabled: model.isQuarterDisabled(quarter),
-                            testId: getTestId(testId, `quarter-${quarter}`),
-                            onClick: () => model.commit({kind: 'quarter', year: gridYear, quarter})
-                        })
-                    ];
-                })
-            }),
-            button({
-                className: 'xh-date-range-picker-popover__year-row',
-                outlined: !yearSelected,
-                minimal: !yearSelected,
-                active: yearSelected,
-                intent: yearSelected ? (model.intent ?? 'primary') : undefined,
-                disabled: !model.yearSelectable,
-                testId: getTestId(testId, 'year-row'),
-                onClick: () => model.commit({kind: 'year', year: gridYear}),
-                items: [
-                    Icon.calendar(),
-                    span({
-                        className: 'xh-date-range-picker-popover__year-row-label',
-                        item: String(gridYear)
-                    }),
-                    span({
-                        // As on the Presets tab - the single-tab popover is too narrow for dates.
-                        omit: model.singleTab,
-                        className: 'xh-date-range-picker-popover__row-range',
-                        item: parentModel.fmtRange(yearRange)
-                    })
-                ]
-            })
-        ]
-    });
-});
-
-//------------------
-// Tab - Custom
-//------------------
-const customTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) => {
-    const {parentModel, minDate, maxDate, leftMonth, rightMonth} = model;
-
-    const field = (edge: 'start' | 'end') =>
-        vbox({
-            className: classNames(
-                'xh-date-range-picker-popover__field',
-                model.nextEdge === edge && 'xh-date-range-picker-popover__field--armed'
-            ),
-            items: [
-                div({
-                    className: 'xh-date-range-picker-popover__field-label',
-                    item: edge === 'start' ? 'Start' : 'End'
-                }),
-                dateInput({
-                    value: edge === 'start' ? model.customStart : model.customEnd,
-                    onCommit: v =>
-                        edge === 'start' ? model.commitStartInput(v) : model.commitEndInput(v),
-                    valueType: 'localDate',
-                    // Inputs need a parseable string format - a function format cannot be typed into.
-                    formatString: isString(parentModel.dateFormat)
-                        ? parentModel.dateFormat
-                        : 'YYYY-MM-DD',
-                    enablePicker: false,
-                    rightElement: null,
-                    width: '100%',
-                    minDate,
-                    maxDate,
-                    testId: getTestId(testId, `${edge}-input`)
-                })
-            ]
-        });
-
-    return vbox({
-        className: 'xh-date-range-picker-popover__tab',
-        items: [
-            hbox({
-                className: 'xh-date-range-picker-popover__custom-fields',
-                items: [
-                    field('start'),
-                    Icon.arrowRight({className: 'xh-date-range-picker-popover__field-arrow'}),
-                    field('end')
-                ]
-            }),
-            hbox({
-                className: 'xh-date-range-picker-popover__cal-nav',
-                items: [
-                    button({
-                        className: 'xh-date-range-picker-popover__nav-btn',
-                        icon: Icon.angleLeft(),
-                        minimal: true,
-                        disabled: !model.canCalBack,
-                        testId: getTestId(testId, 'cal-back'),
-                        onClick: () => model.stepCalendar(-1)
-                    }),
-                    span({
-                        className: 'xh-date-range-picker-popover__cal-title',
-                        item: leftMonth.format('MMMM YYYY')
-                    }),
-                    span({
-                        className: 'xh-date-range-picker-popover__cal-title',
-                        item: rightMonth.format('MMMM YYYY')
-                    }),
-                    button({
-                        className: 'xh-date-range-picker-popover__nav-btn',
-                        icon: Icon.angleRight(),
-                        minimal: true,
-                        disabled: !model.canCalForward,
-                        testId: getTestId(testId, 'cal-forward'),
-                        onClick: () => model.stepCalendar(1)
-                    })
-                ]
-            }),
-            hbox({
-                className: 'xh-date-range-picker-popover__cals',
-                items: [
-                    calendarMonth({model, monthStart: leftMonth}),
-                    calendarMonth({model, monthStart: rightMonth})
-                ]
-            })
-        ]
-    });
-});
-
-const DOW_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
-
-interface CalendarMonthProps extends HoistProps<DateRangePickerLocalModel> {
-    monthStart: LocalDate;
-}
-
-const calendarMonth = hoistCmp.factory<CalendarMonthProps>(({model, monthStart}) => {
-    const {customStart, customEnd} = model;
-
-    return div({
-        className: 'xh-date-range-picker-popover__cal',
-        items: [
-            div({
-                className: 'xh-date-range-picker-popover__cal-dow',
-                items: DOW_LABELS.map((it, idx) => span({key: idx, item: it}))
-            }),
-            ...buildWeeks(monthStart).map((week, wIdx) =>
-                div({
-                    key: wIdx,
-                    className: 'xh-date-range-picker-popover__cal-week',
-                    items: week.map((day, dIdx) => {
-                        if (!day) {
-                            return div({
-                                key: dIdx,
-                                className: 'xh-date-range-picker-popover__cal-cell'
-                            });
-                        }
-                        const disabled = model.isDayDisabled(day),
-                            edge = day === customStart || day === customEnd,
-                            inRange = day > customStart && day < customEnd;
-                        return div({
-                            key: dIdx,
-                            className: classNames(
-                                'xh-date-range-picker-popover__cal-cell',
-                                edge && 'xh-date-range-picker-popover__cal-cell--edge',
-                                inRange && 'xh-date-range-picker-popover__cal-cell--in-range',
-                                disabled && 'xh-date-range-picker-popover__cal-cell--disabled'
-                            ),
-                            ...dataAttrs({'data-date': day.isoString}),
-                            item: day.format('D'),
-                            ...clickable(disabled ? null : () => model.pickDay(day))
-                        });
-                    })
-                })
-            )
-        ]
-    });
-});
-
-function buildWeeks(monthStart: LocalDate): (LocalDate | null)[][] {
-    const startOffset = monthStart.moment.day(),
-        daysInMonth = monthStart.endOfMonth().diff(monthStart, 'days') + 1,
-        cells: (LocalDate | null)[] = [];
-
-    for (let i = 0; i < startOffset; i++) cells.push(null);
-    for (let d = 0; d < daysInMonth; d++) cells.push(monthStart.add(d, 'days'));
-    while (cells.length % 7 !== 0) cells.push(null);
-
-    const weeks = [];
-    for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
-    return weeks;
-}
-
 //------------------
 // Footer
 //------------------
@@ -757,8 +329,6 @@ const footer = hoistCmp.factory<DateRangePickerLocalModel>(
                     omit: !showApplyControls,
                     text: 'Apply',
                     outlined: true,
-                    // Follows the component's `intent`, so the footer stays coherent with the
-                    // popover's selection accent. Primary otherwise, per the Hoist standard.
                     intent: intent ?? 'primary',
                     testId: getTestId(testId, 'apply'),
                     onClick: () => model.apply()
@@ -787,28 +357,3 @@ const TAB_SPECS: DateRangePickerTabSpec[] = [
     {id: 'period', title: 'Months & Years', icon: Icon.calendarDays(), content: periodTab},
     {id: 'custom', title: 'Custom Range', icon: Icon.calendarRange(), content: customTab}
 ];
-
-//------------------
-// Helpers
-//------------------
-/** Props making a styled div act as a keyboard-accessible button. Pass null to disable. */
-const clickable = (onClick: () => void) =>
-    onClick
-        ? {
-              role: 'button',
-              tabIndex: 0,
-              onClick,
-              onKeyDown: (e: KeyboardEvent) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      onClick();
-                  }
-              }
-          }
-        : {role: 'button', 'aria-disabled': true};
-
-/**
- * Data attributes for a plain element spec, typed loosely - React's HTML attribute types omit them.
- */
-const dataAttrs = (attrs: Record<string, string>) => attrs as object;

--- a/desktop/cmp/daterange/DateRangePicker.ts
+++ b/desktop/cmp/daterange/DateRangePicker.ts
@@ -48,7 +48,7 @@ export interface DateRangePickerProps
 
     /**
      * Text rendered in the popover footer, or null to suppress. Default is a note on the date that
-     * relative periods anchor to, shown while the Presets or Relative tab is active. Not shown by
+     * periods resolve against, shown while the Presets or Relative tab is active. Not shown by
      * a single-tab picker, whose footer carries the resolved dates instead.
      */
     footerNote?: ReactNode;

--- a/desktop/cmp/daterange/DateRangePicker.ts
+++ b/desktop/cmp/daterange/DateRangePicker.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {
-    DATE_RANGE_CALENDAR_UNITS,
+    DATE_RANGE_UNITS,
     DateRangePickerModel,
     getDateRangePresetName,
     getDateRangeUnitLabel
@@ -219,19 +219,23 @@ const stepButton = hoistCmp.factory<DateRangePickerLocalModel>(
 const trigger = hoistCmp.factory<DateRangePickerLocalModel>(
     ({model, testId, intent, showRange, styleButtonAsInput, buttonProps}) => {
         const {parentModel} = model,
-            {label, rangeLabel, value} = parentModel,
-            // Without its dates, a custom range has no meaningful short label - show the dates.
-            text = !showRange && value.kind === 'custom' ? rangeLabel : label,
+            {label, rangeLabel, labelNeedsDates} = parentModel,
+            // Without its dates, `Custom` or `As Of` says nothing - show the dates in their place.
+            text = !showRange && labelNeedsDates ? rangeLabel : label,
             base = 'xh-date-range-picker__trigger';
 
         return button({
-            className: classNames(base, styleButtonAsInput && `${base}--as-input`),
             // Input mode relies on the `--as-input` class for its chrome, so renders minimal.
             ...(styleButtonAsInput ? {minimal: true} : {outlined: true}),
             intent,
             icon: Icon.calendar(),
             title: `${label} | ${rangeLabel}`,
             ...buttonProps,
+            className: classNames(
+                base,
+                styleButtonAsInput && `${base}--as-input`,
+                buttonProps?.className
+            ),
             active: model.isOpen,
             testId: getTestId(testId, 'trigger'),
             items: [
@@ -239,7 +243,15 @@ const trigger = hoistCmp.factory<DateRangePickerLocalModel>(
                 span({omit: !showRange, className: `${base}-divider`, item: '|'}),
                 span({omit: !showRange, className: `${base}-range`, item: rangeLabel})
             ],
-            onClick: () => model.toggleOpen()
+            onClick: () => model.toggleOpen(),
+            // Arrow keys step the period without opening the popover.
+            onKeyDown: (e: KeyboardEvent) => {
+                const steps = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0;
+                if (steps) {
+                    e.preventDefault();
+                    parentModel.stepRange(steps);
+                }
+            }
         });
     }
 );
@@ -362,9 +374,9 @@ const relativeTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}
                     }),
                     segmentedControl({
                         model,
-                        bind: 'relativeDisplayUnit',
+                        bind: 'relativeUnit',
                         testId: getTestId(testId, 'unit'),
-                        options: DATE_RANGE_CALENDAR_UNITS.map(unit => ({
+                        options: DATE_RANGE_UNITS.map(unit => ({
                             value: unit,
                             label: getDateRangeUnitLabel(unit)
                         }))
@@ -375,30 +387,19 @@ const relativeTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}
                 className: 'xh-date-range-picker-popover__snap-box',
                 items: [
                     // Two ways of counting, named as peers - a checkbox would frame one as a
-                    // modifier on the other, inviting the read that it widens the range. For day
-                    // units the same slot chooses calendar vs. business days instead of snapping,
-                    // which has nothing to round out at that grain.
-                    model.isDayUnit
-                        ? segmentedControl({
-                              model,
-                              bind: 'relativeDayType',
-                              fill: false,
-                              testId: getTestId(testId, 'day-type'),
-                              options: [
-                                  {value: 'calendar', label: 'Calendar'},
-                                  {value: 'business', label: 'Business'}
-                              ]
-                          })
-                        : segmentedControl({
-                              model,
-                              bind: 'relativeSnap',
-                              fill: false,
-                              testId: getTestId(testId, 'snap'),
-                              options: [
-                                  {value: false, label: 'Rolling'},
-                                  {value: true, label: 'Calendar'}
-                              ]
-                          }),
+                    // modifier on the other, inviting the read that it widens the range. Days have
+                    // nothing to round out, so offer no choice at that grain.
+                    segmentedControl({
+                        omit: !model.snapApplies,
+                        model,
+                        bind: 'relativeSnap',
+                        fill: false,
+                        testId: getTestId(testId, 'snap'),
+                        options: [
+                            {value: false, label: 'Rolling'},
+                            {value: true, label: 'Calendar'}
+                        ]
+                    }),
                     div({
                         className: 'xh-date-range-picker-popover__snap-help',
                         item: model.relativeModeHelpText

--- a/desktop/cmp/daterange/DateRangePicker.ts
+++ b/desktop/cmp/daterange/DateRangePicker.ts
@@ -45,8 +45,8 @@ export interface DateRangePickerProps
 
     /**
      * Text rendered in the popover footer, or null to suppress. Default is a note on the date that
-     * periods are relative to, shown while the Presets or Relative tab is active. Not shown by
-     * a single-tab picker, whose footer carries the resolved dates instead.
+     * periods are relative to. Not shown by a single-tab picker, whose footer carries the resolved
+     * dates instead.
      */
     footerNote?: ReactNode;
 
@@ -285,26 +285,23 @@ const popoverContent = hoistCmp.factory<DateRangePickerLocalModel>(
 //------------------
 const footer = hoistCmp.factory<DateRangePickerLocalModel>(
     ({model, testId, intent, footerNote}) => {
-        const {parentModel, singleTab, showApplyControls} = model,
+        const {parentModel, singleTab} = model,
             // Explicit null suppresses the note; undefined takes the default.
-            note =
-                footerNote === undefined
-                    ? model.showAnchorNote
-                        ? anchorNote({model})
-                        : null
-                    : footerNote,
-            showNote = !singleTab && note != null && note !== false;
+            note = footerNote === undefined ? anchorNote({model}) : footerNote,
+            showNote = !singleTab && note != null && note !== false,
+            // Apply and Cancel only where there is a draft to apply - presets and periods commit
+            // on click, and drafts commit as they change under `commitOnChange`.
+            showControls = model.showApplyControls && model.applyEnabled;
 
         // A single tab with nothing to apply - or that applies as it changes - needs no buttons.
-        if (singleTab && (!model.applyEnabled || !showApplyControls)) {
+        if (singleTab && !showControls) {
             return div({
                 className: 'xh-date-range-picker-popover__single-footer',
                 item: parentModel.rangeLabel
             });
         }
 
-        // Nothing to show - e.g. multi-tab with `commitOnChange` and the note suppressed.
-        if (!showNote && !showApplyControls) return null;
+        if (!showNote && !showControls) return null;
 
         return hbox({
             className: 'xh-date-range-picker-popover__footer',
@@ -320,13 +317,13 @@ const footer = hoistCmp.factory<DateRangePickerLocalModel>(
                 }),
                 filler(),
                 button({
-                    omit: !showApplyControls,
+                    omit: !showControls,
                     text: 'Cancel',
                     testId: getTestId(testId, 'cancel'),
                     onClick: () => model.close()
                 }),
                 button({
-                    omit: !showApplyControls,
+                    omit: !showControls,
                     text: 'Apply',
                     outlined: true,
                     intent: intent ?? 'primary',

--- a/desktop/cmp/daterange/impl/CustomTab.ts
+++ b/desktop/cmp/daterange/impl/CustomTab.ts
@@ -1,0 +1,165 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import type {DateRangePickerLocalModel} from './DateRangePickerLocalModel';
+import {div, hbox, span, vbox} from '@xh/hoist/cmp/layout';
+import {hoistCmp, type HoistProps} from '@xh/hoist/core';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {dateInput} from '@xh/hoist/desktop/cmp/input';
+import {Icon} from '@xh/hoist/icon';
+import type {LocalDate} from '@xh/hoist/utils/datetime';
+import {getTestId} from '@xh/hoist/utils/js';
+import classNames from 'classnames';
+import {isString} from 'lodash';
+import {clickable, dataAttrs} from './TabUtils';
+
+/** Custom tab - start and end inputs over a two-month calendar, drafted until applied. */
+export const customTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) => {
+    const {parentModel, minDate, maxDate, leftMonth, rightMonth} = model;
+
+    const field = (edge: 'start' | 'end') =>
+        vbox({
+            className: classNames(
+                'xh-date-range-picker-popover__field',
+                model.nextEdge === edge && 'xh-date-range-picker-popover__field--armed'
+            ),
+            items: [
+                div({
+                    className: 'xh-date-range-picker-popover__field-label',
+                    item: edge === 'start' ? 'Start' : 'End'
+                }),
+                dateInput({
+                    value: edge === 'start' ? model.customStart : model.customEnd,
+                    onCommit: v =>
+                        edge === 'start' ? model.commitStartInput(v) : model.commitEndInput(v),
+                    valueType: 'localDate',
+                    // Inputs need a parseable string format - a function format cannot be typed into.
+                    formatString: isString(parentModel.dateFormat)
+                        ? parentModel.dateFormat
+                        : 'YYYY-MM-DD',
+                    enablePicker: false,
+                    rightElement: null,
+                    width: '100%',
+                    minDate,
+                    maxDate,
+                    testId: getTestId(testId, `${edge}-input`)
+                })
+            ]
+        });
+
+    return vbox({
+        className: 'xh-date-range-picker-popover__tab',
+        items: [
+            hbox({
+                className: 'xh-date-range-picker-popover__custom-fields',
+                items: [
+                    field('start'),
+                    Icon.arrowRight({className: 'xh-date-range-picker-popover__field-arrow'}),
+                    field('end')
+                ]
+            }),
+            hbox({
+                className: 'xh-date-range-picker-popover__cal-nav',
+                items: [
+                    button({
+                        className: 'xh-date-range-picker-popover__nav-btn',
+                        icon: Icon.angleLeft(),
+                        minimal: true,
+                        disabled: !model.canCalBack,
+                        testId: getTestId(testId, 'cal-back'),
+                        onClick: () => model.stepCalendar(-1)
+                    }),
+                    span({
+                        className: 'xh-date-range-picker-popover__cal-title',
+                        item: leftMonth.format('MMMM YYYY')
+                    }),
+                    span({
+                        className: 'xh-date-range-picker-popover__cal-title',
+                        item: rightMonth.format('MMMM YYYY')
+                    }),
+                    button({
+                        className: 'xh-date-range-picker-popover__nav-btn',
+                        icon: Icon.angleRight(),
+                        minimal: true,
+                        disabled: !model.canCalForward,
+                        testId: getTestId(testId, 'cal-forward'),
+                        onClick: () => model.stepCalendar(1)
+                    })
+                ]
+            }),
+            hbox({
+                className: 'xh-date-range-picker-popover__cals',
+                items: [
+                    calendarMonth({model, monthStart: leftMonth}),
+                    calendarMonth({model, monthStart: rightMonth})
+                ]
+            })
+        ]
+    });
+});
+
+const DOW_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+
+interface CalendarMonthProps extends HoistProps<DateRangePickerLocalModel> {
+    monthStart: LocalDate;
+}
+
+const calendarMonth = hoistCmp.factory<CalendarMonthProps>(({model, monthStart}) => {
+    const {customStart, customEnd} = model;
+
+    return div({
+        className: 'xh-date-range-picker-popover__cal',
+        items: [
+            div({
+                className: 'xh-date-range-picker-popover__cal-dow',
+                items: DOW_LABELS.map((it, idx) => span({key: idx, item: it}))
+            }),
+            ...buildWeeks(monthStart).map((week, wIdx) =>
+                div({
+                    key: wIdx,
+                    className: 'xh-date-range-picker-popover__cal-week',
+                    items: week.map((day, dIdx) => {
+                        if (!day) {
+                            return div({
+                                key: dIdx,
+                                className: 'xh-date-range-picker-popover__cal-cell'
+                            });
+                        }
+                        const disabled = model.isDayDisabled(day),
+                            edge = day === customStart || day === customEnd,
+                            inRange = day > customStart && day < customEnd;
+                        return div({
+                            key: dIdx,
+                            className: classNames(
+                                'xh-date-range-picker-popover__cal-cell',
+                                edge && 'xh-date-range-picker-popover__cal-cell--edge',
+                                inRange && 'xh-date-range-picker-popover__cal-cell--in-range',
+                                disabled && 'xh-date-range-picker-popover__cal-cell--disabled'
+                            ),
+                            ...dataAttrs({'data-date': day.isoString}),
+                            item: day.format('D'),
+                            ...clickable(disabled ? null : () => model.pickDay(day))
+                        });
+                    })
+                })
+            )
+        ]
+    });
+});
+
+function buildWeeks(monthStart: LocalDate): (LocalDate | null)[][] {
+    const startOffset = monthStart.moment.day(),
+        daysInMonth = monthStart.endOfMonth().diff(monthStart, 'days') + 1,
+        cells: (LocalDate | null)[] = [];
+
+    for (let i = 0; i < startOffset; i++) cells.push(null);
+    for (let d = 0; d < daysInMonth; d++) cells.push(monthStart.add(d, 'days'));
+    while (cells.length % 7 !== 0) cells.push(null);
+
+    const weeks = [];
+    for (let i = 0; i < cells.length; i += 7) weeks.push(cells.slice(i, i + 7));
+    return weeks;
+}

--- a/desktop/cmp/daterange/impl/DateRangePickerLocalModel.ts
+++ b/desktop/cmp/daterange/impl/DateRangePickerLocalModel.ts
@@ -243,12 +243,6 @@ export class DateRangePickerLocalModel extends HoistModel {
         return !this.parentModel.commitOnChange;
     }
 
-    /** Whether the default footer note about anchoring applies to the active tab. */
-    get showAnchorNote(): boolean {
-        const {activeTabId} = this;
-        return activeTabId === 'presets' || activeTabId === 'relative';
-    }
-
     /**
      * Default footer note, as a prose prefix plus the date for the component to set apart. A live
      * anchor names its clock, so a user whose day differs from the app's sees why. A pinned or
@@ -257,7 +251,7 @@ export class DateRangePickerLocalModel extends HoistModel {
     get anchorNote(): {prefix: string; date: string} {
         const {anchorDate, parentModel} = this,
             {anchorDay, businessDayMode} = parentModel,
-            date = parentModel.fmtDay(anchorDate),
+            date = parentModel.fmtSingleDay(anchorDate),
             day = businessDayMode ? 'business day' : 'day';
 
         let source = '';
@@ -372,15 +366,11 @@ export class DateRangePickerLocalModel extends HoistModel {
         this.close();
     }
 
+    /** Commit the active tab's draft - a no-op on tabs whose picks commit on click. */
     apply() {
         const {activeTabId} = this;
-        if (activeTabId === 'relative') {
-            this.commit(this.relativeDraft);
-        } else if (activeTabId === 'custom') {
-            this.commit(this.customDraft);
-        } else {
-            this.close();
-        }
+        if (activeTabId === 'relative') this.commit(this.relativeDraft);
+        else if (activeTabId === 'custom') this.commit(this.customDraft);
     }
 
     //------------------

--- a/desktop/cmp/daterange/impl/DateRangePickerLocalModel.ts
+++ b/desktop/cmp/daterange/impl/DateRangePickerLocalModel.ts
@@ -10,15 +10,18 @@ import {action, bindable, computed, makeObservable, observable} from '@xh/hoist/
 import type {LocalDate} from '@xh/hoist/utils/datetime';
 import {clamp, isEqual} from 'lodash';
 import {createRef, type ReactElement} from 'react';
-import {DateRangePickerModel} from '../DateRangePickerModel';
 import {
+    DateRangePickerModel,
+    type DateRangePickerTab,
+    type DateRangeSelection,
+    type DateRangeUnit,
     getDateRangeUnitLabel,
     getMonthStart,
     getQuarterStart,
+    type LocalDateRange,
     MAX_RELATIVE_COUNT,
     MIN_SELECTION_YEAR
-} from '../DateRangeUtils';
-import type {DateRangePickerTab, DateRangeSelection, DateRangeUnit, LocalDateRange} from '../Types';
+} from '@xh/hoist/cmp/daterange';
 
 /**
  * A tab within the picker popover - its rail entry and its content component. Declared by the
@@ -230,9 +233,7 @@ export class DateRangePickerLocalModel extends HoistModel {
     //------------------
     // Footer
     //------------------
-    /**
-     * True when the active tab holds a draft to apply. Preset and month/year picks commit on click.
-     */
+    /** True when the active tab holds a draft to apply - preset and period picks commit on click. */
     get applyEnabled(): boolean {
         return this.activeTabId === 'relative' || this.activeTabId === 'custom';
     }
@@ -249,10 +250,9 @@ export class DateRangePickerLocalModel extends HoistModel {
     }
 
     /**
-     * Default footer note - tells the user what periods are relative to, and which clock decides
-     * it, as a prose prefix and the date for the component to set apart. A live anchor names its
-     * source, so a user whose day differs from the application's can see why the picker's "today"
-     * is not theirs. A pinned or computed anchor is just its date.
+     * Default footer note, as a prose prefix plus the date for the component to set apart. A live
+     * anchor names its clock, so a user whose day differs from the app's sees why. A pinned or
+     * computed anchor is just its date.
      */
     get anchorNote(): {prefix: string; date: string} {
         const {anchorDate, parentModel} = this,
@@ -294,9 +294,7 @@ export class DateRangePickerLocalModel extends HoistModel {
             run: () => this.tabModel.setTabs(this.buildTabs())
         });
 
-        // Never hold a snap that does nothing: it would persist into the committed value and make
-        // `relativeModeHelpText` describe an alignment that is not happening. Tracks both sides -
-        // the unit can change under a set snap.
+        // Never hold a snap that does nothing - it would persist into the committed value.
         this.addReaction({
             track: () => [this.snapApplies, this.relativeSnap],
             run: ([applies, snap]) => {

--- a/desktop/cmp/daterange/impl/PeriodTab.ts
+++ b/desktop/cmp/daterange/impl/PeriodTab.ts
@@ -1,0 +1,138 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import type {DateRangePickerLocalModel} from './DateRangePickerLocalModel';
+import {div, filler, hbox, span, vbox} from '@xh/hoist/cmp/layout';
+import {hoistCmp, type Intent} from '@xh/hoist/core';
+import {button, type ButtonProps} from '@xh/hoist/desktop/cmp/button';
+import {Icon} from '@xh/hoist/icon';
+import {getTestId} from '@xh/hoist/utils/js';
+import {sectionHeader} from './TabUtils';
+
+/** Period tab - a year of months, each quarter alongside its months, and the year itself. */
+const MONTH_LABELS = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec'
+];
+
+export const periodTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) => {
+    const {parentModel, gridYear} = model,
+        {value} = parentModel,
+        yearRange = parentModel.resolve({kind: 'year', year: gridYear}).current,
+        yearSelected = value.kind === 'year' && value.year === gridYear;
+
+    return vbox({
+        className: 'xh-date-range-picker-popover__tab',
+        items: [
+            hbox({
+                className: 'xh-date-range-picker-popover__month-hdr',
+                items: [
+                    sectionHeader('Months & Years'),
+                    filler(),
+                    button({
+                        className: 'xh-date-range-picker-popover__nav-btn',
+                        icon: Icon.angleLeft(),
+                        minimal: true,
+                        disabled: !model.canYearBack,
+                        testId: getTestId(testId, 'year-back'),
+                        onClick: () => model.stepYear(-1)
+                    }),
+                    span({
+                        className: 'xh-date-range-picker-popover__year-val',
+                        item: String(gridYear)
+                    }),
+                    button({
+                        className: 'xh-date-range-picker-popover__nav-btn',
+                        icon: Icon.angleRight(),
+                        minimal: true,
+                        disabled: !model.canYearForward,
+                        testId: getTestId(testId, 'year-forward'),
+                        onClick: () => model.stepYear(1)
+                    })
+                ]
+            }),
+            div({
+                // One row per quarter: its three months, then the quarter itself - so the quarter
+                // labels the months it contains, and both are a click away.
+                className: 'xh-date-range-picker-popover__month-grid',
+                items: [1, 2, 3, 4].flatMap(quarter => {
+                    const quarterActive =
+                            value.kind === 'quarter' &&
+                            value.quarter === quarter &&
+                            value.year === gridYear,
+                        months = [quarter * 3 - 2, quarter * 3 - 1, quarter * 3];
+                    return [
+                        ...months.map(month => {
+                            const active =
+                                value.kind === 'month' &&
+                                value.month === month &&
+                                value.year === gridYear;
+                            return button({
+                                key: month,
+                                className: 'xh-date-range-picker-popover__month-btn',
+                                text: MONTH_LABELS[month - 1],
+                                ...selectableProps(active, model.intent),
+                                disabled: model.isMonthDisabled(month),
+                                testId: getTestId(testId, `month-${month}`),
+                                onClick: () => model.commit({kind: 'month', year: gridYear, month})
+                            });
+                        }),
+                        button({
+                            key: `q${quarter}`,
+                            className: 'xh-date-range-picker-popover__quarter-btn',
+                            text: `Q${quarter}`,
+                            ...selectableProps(quarterActive, model.intent),
+                            disabled: model.isQuarterDisabled(quarter),
+                            testId: getTestId(testId, `quarter-${quarter}`),
+                            onClick: () => model.commit({kind: 'quarter', year: gridYear, quarter})
+                        })
+                    ];
+                })
+            }),
+            button({
+                className: 'xh-date-range-picker-popover__year-row',
+                ...selectableProps(yearSelected, model.intent),
+                disabled: !model.yearSelectable,
+                testId: getTestId(testId, 'year-row'),
+                onClick: () => model.commit({kind: 'year', year: gridYear}),
+                items: [
+                    Icon.calendar(),
+                    span({
+                        className: 'xh-date-range-picker-popover__year-row-label',
+                        item: String(gridYear)
+                    }),
+                    span({
+                        // As on the Presets tab - the single-tab popover is too narrow for dates.
+                        omit: model.singleTab,
+                        className: 'xh-date-range-picker-popover__row-range',
+                        item: parentModel.fmtRange(yearRange)
+                    })
+                ]
+            })
+        ]
+    });
+});
+
+/**
+ * Button props for a selectable period: a solid accent fill when selected (Hoist buttons are
+ * minimal by default, so that needs `minimal: false` too), outlined otherwise.
+ */
+const selectableProps = (active: boolean, intent: Intent): Partial<ButtonProps> => ({
+    outlined: !active,
+    minimal: !active,
+    active,
+    intent: active ? (intent ?? 'primary') : undefined
+});

--- a/desktop/cmp/daterange/impl/PresetsTab.ts
+++ b/desktop/cmp/daterange/impl/PresetsTab.ts
@@ -1,0 +1,58 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {getDateRangePresetName} from '@xh/hoist/cmp/daterange';
+import type {DateRangePickerLocalModel} from './DateRangePickerLocalModel';
+import {div, span, vbox} from '@xh/hoist/cmp/layout';
+import {hoistCmp} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
+import {getTestId, TEST_ID} from '@xh/hoist/utils/js';
+import classNames from 'classnames';
+import {clickable, dataAttrs, sectionHeader} from './TabUtils';
+
+/** Presets tab - one row per configured preset, committing on click. */
+export const presetsTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) => {
+    const {parentModel, singleTab} = model,
+        {value, context} = parentModel;
+
+    return vbox({
+        className: 'xh-date-range-picker-popover__tab',
+        items: [
+            sectionHeader('Presets'),
+            ...parentModel.presets.map(preset => {
+                const {token} = preset,
+                    selected = value.kind === 'preset' && value.token === token,
+                    range = parentModel.resolve({kind: 'preset', token}).current;
+                return div({
+                    key: token,
+                    className: classNames(
+                        'xh-date-range-picker-popover__preset-row',
+                        selected && 'xh-date-range-picker-popover__preset-row--selected'
+                    ),
+                    ...dataAttrs({[TEST_ID]: getTestId(testId, `preset-${token}`)}),
+                    ...clickable(() => model.commit({kind: 'preset', token})),
+                    items: [
+                        Icon.check({
+                            className: classNames(
+                                'xh-date-range-picker-popover__row-check',
+                                !selected && 'xh-date-range-picker-popover__row-check--hidden'
+                            )
+                        }),
+                        span({
+                            className: 'xh-date-range-picker-popover__row-name',
+                            item: getDateRangePresetName(preset, context)
+                        }),
+                        span({
+                            omit: singleTab,
+                            className: 'xh-date-range-picker-popover__row-range',
+                            item: parentModel.fmtRange(range)
+                        })
+                    ]
+                });
+            })
+        ]
+    });
+});

--- a/desktop/cmp/daterange/impl/RelativeTab.ts
+++ b/desktop/cmp/daterange/impl/RelativeTab.ts
@@ -1,0 +1,107 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {DATE_RANGE_UNITS, getDateRangeUnitLabel} from '@xh/hoist/cmp/daterange';
+import type {DateRangePickerLocalModel} from './DateRangePickerLocalModel';
+import {div, hbox, span, vbox} from '@xh/hoist/cmp/layout';
+import {hoistCmp} from '@xh/hoist/core';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {numberInput, segmentedControl} from '@xh/hoist/desktop/cmp/input';
+import {controlGroup} from '@xh/hoist/kit/blueprint';
+import {getTestId} from '@xh/hoist/utils/js';
+import {sectionHeader} from './TabUtils';
+
+/** Relative tab - a lookback of N units ending on the anchor date, drafted until applied. */
+export const relativeTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, testId}) => {
+    const {parentModel, relativeRange} = model;
+
+    return vbox({
+        className: 'xh-date-range-picker-popover__tab',
+        items: [
+            sectionHeader('Relative Lookback'),
+            hbox({
+                className: 'xh-date-range-picker-popover__rel-row',
+                items: [
+                    span({className: 'xh-date-range-picker-popover__rel-last', item: 'Last'}),
+                    controlGroup({
+                        items: [
+                            button({
+                                text: '−',
+                                minWidth: 20,
+                                testId: getTestId(testId, 'count-down'),
+                                onClick: () => model.stepCount(-1)
+                            }),
+                            numberInput({
+                                model,
+                                bind: 'relativeCount',
+                                min: 1,
+                                max: 999,
+                                width: 56,
+                                textAlign: 'center',
+                                commitOnChange: true,
+                                testId: getTestId(testId, 'count')
+                            }),
+                            button({
+                                text: '+',
+                                minWidth: 20,
+                                testId: getTestId(testId, 'count-up'),
+                                onClick: () => model.stepCount(1)
+                            })
+                        ]
+                    }),
+                    segmentedControl({
+                        model,
+                        bind: 'relativeUnit',
+                        testId: getTestId(testId, 'unit'),
+                        options: DATE_RANGE_UNITS.map(unit => ({
+                            value: unit,
+                            label: getDateRangeUnitLabel(unit)
+                        }))
+                    })
+                ]
+            }),
+            div({
+                className: 'xh-date-range-picker-popover__snap-box',
+                items: [
+                    // Two ways of counting, named as peers rather than as a checkbox modifier.
+                    // Days have nothing to round out, so no choice at that grain.
+                    segmentedControl({
+                        omit: !model.snapApplies,
+                        model,
+                        bind: 'relativeSnap',
+                        fill: false,
+                        testId: getTestId(testId, 'snap'),
+                        options: [
+                            {value: false, label: 'Rolling'},
+                            {value: true, label: 'Calendar'}
+                        ]
+                    }),
+                    div({
+                        className: 'xh-date-range-picker-popover__snap-help',
+                        item: model.relativeModeHelpText
+                    })
+                ]
+            }),
+            div({
+                className: 'xh-date-range-picker-popover__preview',
+                items: [
+                    div({
+                        className: 'xh-date-range-picker-popover__preview-label',
+                        item: 'Resolves To'
+                    }),
+                    div({
+                        className: 'xh-date-range-picker-popover__preview-range',
+                        item: parentModel.fmtRange(relativeRange)
+                    }),
+                    div({
+                        className: 'xh-date-range-picker-popover__preview-days',
+                        item: model.relativePreviewCountText
+                    })
+                ]
+            })
+        ]
+    });
+});

--- a/desktop/cmp/daterange/impl/RelativeTab.ts
+++ b/desktop/cmp/daterange/impl/RelativeTab.ts
@@ -25,7 +25,7 @@ export const relativeTab = hoistCmp.factory<DateRangePickerLocalModel>(({model, 
             hbox({
                 className: 'xh-date-range-picker-popover__rel-row',
                 items: [
-                    span({className: 'xh-date-range-picker-popover__rel-last', item: 'Last'}),
+                    span({className: 'xh-date-range-picker-popover__rel-prefix', item: 'Prev'}),
                     controlGroup({
                         items: [
                             button({

--- a/desktop/cmp/daterange/impl/TabUtils.ts
+++ b/desktop/cmp/daterange/impl/TabUtils.ts
@@ -1,0 +1,31 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {div} from '@xh/hoist/cmp/layout';
+import type {KeyboardEvent} from 'react';
+
+export const sectionHeader = (text: string) =>
+    div({className: 'xh-date-range-picker-popover__section-hdr', item: text});
+
+/** Props making a styled div act as a keyboard-accessible button. Pass null to disable. */
+export const clickable = (onClick: () => void) =>
+    onClick
+        ? {
+              role: 'button',
+              tabIndex: 0,
+              onClick,
+              onKeyDown: (e: KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onClick();
+                  }
+              }
+          }
+        : {role: 'button', 'aria-disabled': true};
+
+/** Data attributes for a plain element spec - React's HTML attribute types omit them. */
+export const dataAttrs = (attrs: Record<string, string>) => attrs as object;

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -27,7 +27,7 @@ import {
     reactWindowedSelect
 } from '@xh/hoist/kit/react-select';
 import {action, bindable, makeObservable, observable, override} from '@xh/hoist/mobx';
-import {debouncePromise, wait} from '@xh/hoist/promise';
+import {debouncePromise, wait, waitFor} from '@xh/hoist/promise';
 import {elemWithin, getTestId, mergeDeep, TEST_ID, throwIf, withDefault} from '@xh/hoist/utils/js';
 import {createObservableRef, getLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
@@ -820,13 +820,14 @@ const cmp = hoistCmp.factory<SelectInputModel>(({model, className, ...props}, re
         rsProps.inputValue = model.inputValue || '';
         rsProps.onInputChange = model.onInputChange;
         rsProps.controlShouldRenderValue = !model.hasFocus;
+    }
+
+    // Scroll selected option into view on open - react-select's own does not fire for portalled menus.
+    if (!model.multiMode && model.renderValue) {
         rsProps.onMenuOpen = () => {
-            wait().then(() => {
-                const selectedEl = document.getElementsByClassName(
-                    'xh-select__option--is-selected'
-                )[0];
-                selectedEl?.scrollIntoView({block: 'end'});
-            });
+            const getSel = () =>
+                document.getElementsByClassName('xh-select__option--is-selected')[0];
+            waitFor(() => !!getSel()).then(() => getSel().scrollIntoView({block: 'end'}));
         };
     }
 


### PR DESCRIPTION
Follow-up to #4648, stacked on `date-range-picker`. Addresses the "Today" problem surfaced in review: the `today` preset resolved to the anchor date, so a picker anchored to an as-of date read "Today | 2026-08-29". The default anchor was also browser-today frozen at construction, so nothing rolled over at midnight.

Motivation and design walkthrough, with an as-implemented section at the top: https://claude.ai/code/artifact/5b7ae746-7b69-4f71-a50d-afaf7c166be9

**Anchor day**
- `anchorDate` config becomes `anchorDay: 'localDay' | 'appDay' | LocalDate | (() => LocalDate)`, default `'localDay'`. `'appDay'` is the right choice for server-dated data; Activity Tracking uses it.
- The model keeps a live anchor current itself on a 10-second managed `Timer` (an identity no-op until the day changes), plus a reaction for observable reads in a computed anchor. No app code needed for midnight rollover.
- `anchorDate` remains the resolved observable. New `today` (always the browser's day) and `isAnchorToday`. `setAnchorDay()` replaces `setAnchorDate()`.

**Presets and labels**
- Renamed to describe a range without claiming it ends today: `anchorDay`, `prevDay`, `prev7Days`, `prev30Days`, `prevMonth`, `prevYear`, etc.
- `anchorDay` reads "Today" only when the anchor is the reader's own day. Otherwise "As Of" with the date, whether the anchor is pinned, business-day snapped, or an `'appDay'` a day apart from the browser. The preset row follows the same rule.
- `priorMtd`/`priorQtd`/`priorYtd` and `lastBusinessDay` dropped as redundant with offsets and `businessDayMode`.

**Lossless stepping**
- Preset and relative selections gain an `offset`. `stepRange()` adjusts it through the selection's own `resolvePrior` / new `resolveNext` logic instead of collapsing to `custom`. Negative offsets step back; positive ones step forward past the anchor when `maxDate` allows. Stepped selections still roll with the day.
- Labels at a non-zero offset describe the range's shape: `7 Days`, `3 Months`, `Jul 2026`, `MTD −1`, `MTD +1`. Single days read from the anchor in the T-1 idiom, for `anchorDay` and `prevDay` alike: `Today −1`, `As Of −2`. New optional `DateRangePreset.shiftedLabel`; `fmtDateRangeOffset` exported for app presets.

**`businessDayMode`**
- A live anchor snaps back to the most recent business day, and single-day selections step by business day. Multi-day ranges are unaffected. Pinned or computed anchors are never snapped.
- The `businessDays` relative unit and its Calendar/Business tab control are removed.

**Period tab**
- New `quarter` selection kind, resolved, clamped, labeled (`Q3 2026`) and stepped like months and years. The tab lays out one row per quarter: its three months, then the quarter button at the right.
- A year pick always reads as its year; `YTD` is reserved for the preset, since the two step differently.
- Tab id `monthYear` renamed `period`. Title unchanged.

**Formats and footer**
- New `singleDayFormat` (default `ddd MMM D`) for one-day ranges and the footer's anchor date, alongside `dateFormat` for the ends of a range. Both accept a moment format string or a function of the date.
- Footer note reads "Relative to your current day: Thu Sep 4", names the app time zone for an `'appDay'` anchor, and shows on every tab. Apply and Cancel render only on the Relative and Custom tabs, which hold a draft; presets and periods commit on click.

**Component**
- Tabs render in the order the model's `tabs` config gives them (the original rendered in the component's fixed order despite documenting otherwise).
- Trigger merges `buttonProps.className` rather than replacing it (fixes lost chrome and a click double-toggle), shows dates for `As Of` when the range readout is hidden, and steps on left/right arrow keys.
- The Relative tab's prefix reads "Prev", matching the trigger.

**Layout**
- The four tabs and their shared helpers live in `desktop/cmp/daterange/impl/`, alongside `DateRangePickerLocalModel`, which moved there from `cmp/daterange/impl` as desktop popover view state. `cmp/daterange` now holds only the model, presets, utils, types and README.

**Admin**
- Activity Tracking drops its own anchor timer in favor of `anchorDay: 'appDay'`.

Typecheck and lint pass. Exercised in the browser against the Toolbox demo, apart from the midnight rollover itself.

Toolbox companion: https://github.com/xh/toolbox/pull/898
