### PR TITLE
Add IntentInput, a compact swatch-row input for selecting a Hoist Intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Added `SegmentedControl.equalSegmentWidths` to the desktop control, matching the existing mobile
   prop. Defaults to `true`, so a filled control now divides its width into equal segments rather
   than sizing each option to its own label.
+* Added `IntentInput` (desktop), a compact input for selecting a Hoist `Intent`.
 * Added read-only detail panels to the Admin Console's Config, User Preferences, and JSON Blobs
   tabs, docked to the right of each grid and tracking its selection. The Config panel shows every
   view of a config's value - resolved, instance override, database, and typedClass defaults -

--- a/admin/tabs/general/alertBanner/AlertBannerPanel.ts
+++ b/admin/tabs/general/alertBanner/AlertBannerPanel.ts
@@ -28,6 +28,7 @@ import {formField} from '@xh/hoist/desktop/cmp/form';
 import {
     buttonGroupInput,
     dateInput,
+    intentInput,
     select,
     switchInput,
     textArea
@@ -112,19 +113,7 @@ const formPanel = hoistCmp.factory<AlertBannerModel>(({model}) => {
                         }),
                         formField({
                             field: 'intent',
-                            item: buttonGroupInput({
-                                items: model.intentOptions.map(intent =>
-                                    button({
-                                        intent,
-                                        minimal: false,
-                                        // Opacity solution to account for Icon.placeholder() causing label to move when primary deselected
-                                        icon: Icon.check({
-                                            opacity: formModel.values.intent === intent ? 1 : 0
-                                        }),
-                                        value: intent
-                                    })
-                                )
-                            })
+                            item: intentInput({intents: model.intentOptions})
                         }),
                         formField({
                             field: 'iconName',

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -113,6 +113,7 @@ Desktop form inputs with Blueprint styling:
 | `Slider` | Range slider |
 | `ButtonGroupInput` | Segmented button selection |
 | `SegmentedControl` | Toggle group for mutually exclusive options with strong visual differentiation of the active selection |
+| `IntentInput` | Compact swatch row for selecting a Hoist `Intent`, with optional intent names |
 | `CodeInput` | Code editor with syntax highlighting |
 | `JsonInput` | JSON editor with validation |
 

--- a/desktop/cmp/input/IntentInput.scss
+++ b/desktop/cmp/input/IntentInput.scss
@@ -1,0 +1,202 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+
+.xh-intent-input {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--xh-intent-input-gap-px);
+
+  // Selection ring geometry. Drawn as an outline on the swatch fill, so it takes no part in
+  // layout - the container reserves room for it with matching padding, derived from these two
+  // values so the two cannot drift apart.
+  --ring-offset: 2px;
+  --ring-width: 1px;
+
+  padding: calc(var(--ring-offset) + var(--ring-width));
+  // Pin the box against the line rather than letting its own baseline drive the line box. An
+  // inline-flex box takes its baseline from its first flex item, so the baseline would otherwise
+  // shift as the first swatch gains or loses the check - moving neighboring content (e.g. a
+  // FormField label) by a couple of pixels on every selection change.
+  vertical-align: middle;
+
+  &__swatch {
+    // Inset hairline color, shared by every fill state below. Overridden by the --none variant,
+    // whose transparent fill needs a visible outline rather than a darkening edge.
+    --swatch-hairline-color: rgba(0, 0, 0, 0.15);
+
+    // Reset the UA button styling - the swatch fill below is the entire control.
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--xh-pad-half-px);
+    cursor: pointer;
+    color: var(--xh-text-color);
+    font-family: inherit;
+    font-size: var(--xh-font-size-px);
+    line-height: 1;
+
+    // Focus ring - drawn in the primary intent so it reads as focus rather than as selection.
+    // Higher specificity than the selected/hover rules below, so focus wins where they coincide.
+    &:focus-visible {
+      outline: none;
+
+      .xh-intent-input__swatch__fill {
+        outline: var(--ring-width) solid var(--xh-intent-primary);
+        outline-offset: var(--ring-offset);
+      }
+    }
+
+    // The color chip itself. Sized identically whether or not it holds the check, so selecting
+    // an option never shifts the row.
+    &__fill {
+      flex: none;
+      width: var(--xh-intent-input-swatch-size-px);
+      height: var(--xh-intent-input-swatch-size-px);
+      border-radius: var(--xh-intent-input-border-radius-px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      // Inner hairline keeps a swatch legible where its color sits close to the surface behind it.
+      box-shadow: inset 0 0 0 1px var(--swatch-hairline-color);
+      transition:
+        box-shadow 100ms,
+        outline-color 100ms;
+    }
+
+    // Check is rendered for every swatch and merely hidden when unselected. This keeps each
+    // swatch's box AND its baseline identical in both states: a flex container takes its baseline
+    // from its first flex item, so a fill that gained/lost the check would move the whole control's
+    // baseline, shifting baseline-aligned siblings - most visibly an inline FormField label, which
+    // aligns its row with `align-items: baseline`.
+    &__check {
+      color: var(--xh-white);
+      font-size: calc(var(--xh-intent-input-swatch-size-px) * 0.6);
+
+      &--hidden {
+        visibility: hidden;
+      }
+    }
+
+    &__name {
+      white-space: nowrap;
+    }
+
+    // Selected / hover - a ring offset from the swatch, echoing its own color. Drawn as an
+    // outline rather than a second box-shadow: the offset gap then shows the actual surface
+    // behind the control, instead of a band painted in --xh-bg that would be the wrong color on
+    // any other surface (a panel, a toolbar, a grid cell).
+    &--selected .xh-intent-input__swatch__fill,
+    &:hover:not(:disabled) .xh-intent-input__swatch__fill {
+      outline: var(--ring-width) solid currentColor;
+      outline-offset: var(--ring-offset);
+    }
+
+    &:disabled {
+      cursor: default;
+      color: var(--xh-input-disabled-text-color);
+
+      .xh-intent-input__swatch__fill {
+        opacity: 0.5;
+      }
+    }
+
+    // The null option, shown when `enableClear` is set - an empty outlined box standing in for
+    // "no intent". Keeps the shared geometry, so it selects and checks exactly like the others.
+    &--none {
+      // With no fill behind it, this outline IS the swatch, so it needs real contrast against the
+      // surface - the standard border color is too faint to read as a selectable target. Mixed
+      // from the text color so it adapts per theme; --xh-text-color-muted resolves to the same
+      // mid-gray in both, which lands too light against a white background.
+      --swatch-hairline-color: color-mix(in srgb, var(--xh-text-color) 60%, var(--xh-bg));
+
+      color: var(--xh-text-color-muted);
+
+      .xh-intent-input__swatch__fill {
+        background-color: transparent;
+      }
+
+      // No colored fill to sit on, so the check takes the normal text color instead of white.
+      .xh-intent-input__swatch__check {
+        color: var(--xh-text-color);
+      }
+    }
+
+    // Per-intent coloring. `color` carries the intent so the selected ring and the label can
+    // both pick it up via currentColor - the check reasserts white against the fill.
+    @each $intent in (primary, success, warning, danger) {
+      &--#{$intent} {
+        color: var(--xh-intent-#{$intent});
+
+        .xh-intent-input__swatch__fill {
+          background-color: var(--xh-intent-#{$intent});
+        }
+      }
+    }
+  }
+
+  // Names shown - label text returns to the standard text color, leaving the swatch to carry
+  // the intent's color. Selected names are emphasized instead.
+  &--with-names .xh-intent-input__swatch {
+    margin-right: var(--xh-pad-half-px);
+
+    &__name {
+      color: var(--xh-text-color);
+    }
+
+    &--selected .xh-intent-input__swatch__name {
+      font-weight: 600;
+    }
+
+    &:disabled .xh-intent-input__swatch__name {
+      color: var(--xh-input-disabled-text-color);
+    }
+  }
+
+  // Compact mode - reduced sizing for toolbars and space-constrained contexts. The ring offset
+  // tightens too, keeping the control inside the compact toolbar's item height.
+  &--compact {
+    --ring-offset: 1px;
+
+    gap: calc(var(--xh-intent-input-gap-px) / 2);
+
+    .xh-intent-input__swatch {
+      font-size: var(--xh-tbar-compact-font-size-px);
+
+      &__fill {
+        width: var(--xh-intent-input-compact-swatch-size-px);
+        height: var(--xh-intent-input-compact-swatch-size-px);
+      }
+
+      &__check {
+        font-size: calc(var(--xh-intent-input-compact-swatch-size-px) * 0.6);
+      }
+    }
+  }
+
+  // Validation borders - drawn on the container, as the swatches themselves are borderless.
+  &.xh-input--invalid,
+  &.xh-input--warning,
+  &.xh-input--info {
+    border-radius: var(--xh-intent-input-border-radius-px);
+  }
+
+  &.xh-input--invalid {
+    border: var(--xh-form-field-invalid-border);
+  }
+
+  &.xh-input--warning {
+    border: var(--xh-form-field-warning-border);
+  }
+
+  &.xh-input--info {
+    border: var(--xh-form-field-info-border);
+  }
+}

--- a/desktop/cmp/input/IntentInput.ts
+++ b/desktop/cmp/input/IntentInput.ts
@@ -1,0 +1,211 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2026 Extremely Heavy Industries Inc.
+ */
+import {HoistInputModel, HoistInputProps, useHoistInputModel} from '@xh/hoist/cmp/input';
+import {div} from '@xh/hoist/cmp/layout';
+import {elementFactory, hoistCmp, HoistProps, Intent} from '@xh/hoist/core';
+import '@xh/hoist/desktop/register';
+import {Icon} from '@xh/hoist/icon';
+import {computed, makeObservable} from '@xh/hoist/mobx';
+import {getTestId, TEST_ID} from '@xh/hoist/utils/js';
+import {getLayoutProps, getNonLayoutProps} from '@xh/hoist/utils/react';
+import classNames from 'classnames';
+import {capitalize, filter, isEmpty} from 'lodash';
+import {KeyboardEvent} from 'react';
+import './IntentInput.scss';
+
+export const INTENTS: Intent[] = ['primary', 'success', 'warning', 'danger'];
+
+export interface IntentInputProps extends HoistProps, HoistInputProps {
+    /** True to render in a compact mode with reduced sizing for space-constrained contexts. */
+    compact?: boolean;
+
+    /**
+     * True to offer a null value, rendered as an additional outlined swatch ahead of the intents
+     * and holding the check while the value is null. Defaults to false, leaving the control a
+     * required single-select.
+     */
+    enableClear?: boolean;
+
+    /**
+     * Intents to offer, in render order. Defaults to all four Hoist intents - specify a subset
+     * to restrict or reorder the available choices.
+     */
+    intents?: Intent[];
+
+    /**
+     * True to render each intent's name alongside its swatch. Defaults to false, for the most
+     * compact presentation - note swatches always carry their intent name as a tooltip and as
+     * their accessible label, so an unlabelled control remains identifiable.
+     */
+    showNames?: boolean;
+}
+
+/**
+ * An input for selecting a Hoist Intent, rendered as a compact row of color swatches drawn in
+ * the intent colors themselves. The selected swatch is marked with a check and a surrounding
+ * ring; names can optionally be rendered alongside each swatch.
+ *
+ * Set `enableClear` to offer a null value, rendered as an additional outlined swatch ahead of
+ * the intents.
+ *
+ * Designed to fit within a toolbar or a dense form without additional chrome. Swatches are
+ * rendered as an ARIA radiogroup, supporting selection via click, enter/space, and arrow keys.
+ */
+export const [IntentInput, intentInput] = hoistCmp.withFactory<IntentInputProps>({
+    displayName: 'IntentInput',
+    className: 'xh-intent-input',
+    render(props, ref) {
+        return useHoistInputModel(cmp, props, ref, IntentInputModel);
+    }
+});
+(IntentInput as any).hasLayoutSupport = true;
+
+//-----------------------
+// Implementation
+//-----------------------
+const buttonEl = elementFactory('button');
+
+class IntentInputModel extends HoistInputModel {
+    override xhImpl = true;
+
+    @computed
+    get intents(): Intent[] {
+        const {intents} = this.componentProps;
+        return isEmpty(intents) ? INTENTS : intents;
+    }
+
+    /**
+     * Selectable values in render order - the offered intents, preceded by a null entry when
+     * `enableClear` is set. Null is a value here like any other, so it selects, renders a check,
+     * and takes part in keyboard nav without any special-casing.
+     */
+    @computed
+    get options(): Intent[] {
+        const {intents} = this;
+        return this.componentProps.enableClear ? [null, ...intents] : intents;
+    }
+
+    get enabledButtons(): HTMLButtonElement[] {
+        const btns = this.domEl?.querySelectorAll('button') ?? [];
+        return filter(btns, (b: HTMLButtonElement) => !b.disabled) as HTMLButtonElement[];
+    }
+
+    constructor() {
+        super();
+        makeObservable(this);
+    }
+
+    onSwatchClick = (intent: Intent) => {
+        this.noteValueChange(intent);
+    };
+
+    /**
+     * Arrow keys move the selection to the adjacent option, as expected of a radiogroup. Wraps
+     * around at either end, and starts from the first option when the current value is not among
+     * those offered.
+     */
+    onKeyDown = (e: KeyboardEvent) => {
+        const delta = e.key === 'ArrowRight' ? 1 : e.key === 'ArrowLeft' ? -1 : null;
+        if (delta == null) return;
+
+        const {options, renderValue} = this,
+            currIdx = options.indexOf(renderValue);
+
+        e.preventDefault();
+
+        const nextIdx = currIdx === -1 ? 0 : (currIdx + delta + options.length) % options.length;
+        this.noteValueChange(options[nextIdx]);
+        this.enabledButtons[nextIdx]?.focus();
+    };
+
+    override blur() {
+        this.enabledButtons.forEach(it => it.blur());
+    }
+
+    override focus() {
+        this.enabledButtons[0]?.focus();
+    }
+}
+
+const cmp = hoistCmp.factory<IntentInputModel>(({model, className, ...props}, ref) => {
+    const {
+        // HoistInput props - exclude from passthrough to the container
+        bind,
+        disabled,
+        onChange,
+        onCommit,
+        tabIndex,
+        value,
+        commitOnChange,
+        // Consumed by model
+        enableClear,
+        intents,
+        // Consumed by this component
+        compact,
+        showNames,
+        testId,
+        // Remainder passed to the container div
+        ...rest
+    } = getNonLayoutProps(props);
+
+    const {renderValue} = model;
+
+    return div({
+        ...rest,
+        className: classNames(
+            className,
+            compact && 'xh-intent-input--compact',
+            showNames && 'xh-intent-input--with-names'
+        ),
+        ref,
+        role: 'radiogroup',
+        onFocus: model.onFocus,
+        onBlur: model.onBlur,
+        onKeyDown: disabled ? null : model.onKeyDown,
+        ...getLayoutProps(props),
+        [TEST_ID]: testId,
+        items: model.options.map(intent => {
+            const isSelected = renderValue === intent,
+                isNull = intent == null,
+                name = isNull ? 'None' : capitalize(intent);
+
+            return buttonEl({
+                key: intent ?? 'none',
+                type: 'button',
+                className: classNames(
+                    'xh-intent-input__swatch',
+                    `xh-intent-input__swatch--${intent ?? 'none'}`,
+                    isSelected && 'xh-intent-input__swatch--selected'
+                ),
+                role: 'radio',
+                'aria-checked': isSelected,
+                'aria-label': name,
+                title: name,
+                disabled,
+                tabIndex,
+                onClick: () => model.onSwatchClick(intent),
+                [TEST_ID]: getTestId(testId, intent ?? 'none'),
+                items: [
+                    div({
+                        className: 'xh-intent-input__swatch__fill',
+                        // Check is always rendered, and hidden via `visibility` when unselected.
+                        // Omitting it instead would change the swatch's baseline, which shifts
+                        // baseline-aligned siblings (e.g. an inline FormField label) on every
+                        // selection change - see the note in IntentInput.scss.
+                        item: Icon.check({
+                            className: classNames(
+                                'xh-intent-input__swatch__check',
+                                !isSelected && 'xh-intent-input__swatch__check--hidden'
+                            )
+                        })
+                    }),
+                    div({omit: !showNames, className: 'xh-intent-input__swatch__name', item: name})
+                ]
+            });
+        })
+    });
+});

--- a/desktop/cmp/input/index.ts
+++ b/desktop/cmp/input/index.ts
@@ -3,6 +3,7 @@ export * from './Checkbox';
 export * from './CheckboxButton';
 export * from './CodeInput';
 export * from './DateInput';
+export * from './IntentInput';
 export * from './JsonInput';
 export * from './NumberInput';
 export * from './Picker';

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -698,6 +698,13 @@ body {
     --xh-segmented-control-selected-bg: var(--segmented-control-selected-bg, #{mc('blue-grey', '700')});
   }
 
+  //------------------------
+  // Intent Input
+  //------------------------
+  --xh-intent-input-swatch-size-px: var(--intent-input-swatch-size-px, 20px);
+  --xh-intent-input-compact-swatch-size-px: var(--intent-input-compact-swatch-size-px, 16px);
+  --xh-intent-input-gap-px: var(--intent-input-gap-px, var(--xh-pad-half-px));
+  --xh-intent-input-border-radius-px: var(--intent-input-border-radius-px, var(--xh-border-radius-px));
 
   //------------------------
   // Mask + LoadingIndicator


### PR DESCRIPTION
Adds `IntentInput` (desktop) - a small input that emits a Hoist `Intent`, rendered as a row of color swatches drawn in the intent colors themselves. Sized to fit a toolbar or a dense form without additional chrome.

### Props

* `showNames` - render each intent's name alongside its swatch (default `false`)
* `enableClear` - offer a null value as an additional outlined swatch, ahead of the intents (default `false`)
* `intents` - restrict or reorder the offered intents (default: all four)
* `compact` - reduced sizing for space-constrained contexts

Swatches form an ARIA radiogroup, selectable via click, enter/space, and arrow keys. Every swatch carries its intent name as both `title` and `aria-label`, so the unlabelled form stays identifiable.

### Also here

* Replaces the Admin Console alert banner's hand-rolled equivalent, which faked this control with a `buttonGroupInput` of colored buttons plus an opacity-toggled check icon.
* Four `--xh-intent-input-*` CSS vars for swatch size, compact size, gap, and radius.

### Screenshots

<img width="826" height="596" alt="CleanShot 2026-09-03 at 16 55 03@2x" src="https://github.com/user-attachments/assets/292d2f5a-47df-4f76-9cd2-faba1414250f" />

<img width="926" height="836" alt="CleanShot 2026-09-03 at 16 55 26@2x" src="https://github.com/user-attachments/assets/8fae7eac-19c0-4d95-85c9-c40e0dfbeb81" />

### Two notes for reviewers

Both of these look like odd choices in the diff, so they carry comments in the source:

* **The check is always rendered**, hidden with `visibility` when unselected. Omitting it changes the swatch's baseline - and since a flex container takes its baseline from its first flex item, that moved the whole control's baseline, visibly shifting an inline `FormField` label on every selection change. The `opacity: 0` trick in the old alert banner code was working around this same issue.
* **The selection ring is an `outline` with `outline-offset`**, not stacked box-shadows. The offset gap then shows the actual surface behind the control, rather than a band painted in `--xh-bg` that would be the wrong color on a panel, toolbar, or grid cell. Container padding is derived from the ring geometry so the two cannot drift apart.

### Companion PR

Toolbox demo: xh/toolbox#899
