### PR TITLE
Navigator: make back-navigation resilient to a missed transitionEnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
 * `Store` and `Cube` now throw a clear error at construction when given fields with duplicate
   names. Previously such a `Cube` failed later with a cryptic `Cannot redefine property` error when
   creating a `View` that exposes leaves.
+* Fixed mobile `Navigator` back-navigation leaving the page stack and the route permanently out of
+  sync if a page transition failed to report its completion. The stack is now reconciled on a
+  timeout, `NavigatorModel.activePageIdx` is observable state synced from Swiper rather than a read
+  of its non-observable `activeIndex`, and back-navigation unlocks Swiper at the call site.
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,7 @@
   names. Previously such a `Cube` failed later with a cryptic `Cannot redefine property` error when
   creating a `View` that exposes leaves.
 * Fixed mobile `Navigator` back-navigation leaving the page stack and the route permanently out of
-  sync if a page transition failed to report its completion. The stack is now reconciled on a
-  timeout, `NavigatorModel.activePageIdx` is observable state synced from Swiper rather than a read
-  of its non-observable `activeIndex`, and back-navigation unlocks Swiper at the call site.
+  sync when a page transition failed to report its completion.
 
 ### ⚙️ Technical
 

--- a/mobile/cmp/navigator/NavigatorModel.ts
+++ b/mobile/cmp/navigator/NavigatorModel.ts
@@ -67,7 +67,7 @@ export class NavigatorModel extends HoistModel {
     @bindable.ref
     stack: PageModel[] = [];
 
-    /** Index of the active page within the stack - kept in sync with the Swiper instance. */
+    /** Index of the active page within the stack, synced from Swiper. */
     @bindable activePageIdx: number = 0;
 
     pages: PageConfig[] = [];
@@ -156,8 +156,7 @@ export class NavigatorModel extends HoistModel {
 
         swiper.on('transitionEnd', () => this.onPageChange());
 
-        // Swiper's own activeIndex is not observable - mirror it into state so that the slide
-        // locks and active page re-render as soon as it changes.
+        // Swiper's activeIndex is not observable - mirror it into state.
         swiper.on('activeIndexChange', () => (this.activePageIdx = swiper.activeIndex));
 
         // Ensure Swiper's touch move is initially disabled, and capture
@@ -324,9 +323,8 @@ export class NavigatorModel extends HoistModel {
             this._swiper.allowSlidePrev = true;
             this._swiper.slidePrev(transitionMs);
 
-            // The route has already changed, so a missed `transitionEnd` would leave the stack
-            // and the route permanently out of sync - process the change ourselves if the
-            // event has not arrived in time.
+            // The route has already changed - backstop a missed `transitionEnd`, which would
+            // otherwise leave the stack and the route permanently out of sync.
             wait(transitionMs + 100).then(() => {
                 if (this.stack.length > this.activePageIdx + 1) this.onPageChange();
             });

--- a/mobile/cmp/navigator/NavigatorModel.ts
+++ b/mobile/cmp/navigator/NavigatorModel.ts
@@ -67,6 +67,9 @@ export class NavigatorModel extends HoistModel {
     @bindable.ref
     stack: PageModel[] = [];
 
+    /** Index of the active page within the stack - kept in sync with the Swiper instance. */
+    @bindable activePageIdx: number = 0;
+
     pages: PageConfig[] = [];
     track: boolean;
     pullDownToRefresh: boolean;
@@ -84,10 +87,6 @@ export class NavigatorModel extends HoistModel {
 
     get activePage(): PageModel {
         return this.stack[this.activePageIdx];
-    }
-
-    get activePageIdx(): number {
-        return this._swiper?.activeIndex ?? 0;
     }
 
     get allowSlideNext(): boolean {
@@ -157,6 +156,10 @@ export class NavigatorModel extends HoistModel {
 
         swiper.on('transitionEnd', () => this.onPageChange());
 
+        // Swiper's own activeIndex is not observable - mirror it into state so that the slide
+        // locks and active page re-render as soon as it changes.
+        swiper.on('activeIndexChange', () => (this.activePageIdx = swiper.activeIndex));
+
         // Ensure Swiper's touch move is initially disabled, and capture
         // the initial touch position. This is required to allow touch move
         // to propagate to scrollable elements within the page.
@@ -219,7 +222,7 @@ export class NavigatorModel extends HoistModel {
     @action
     onPageChange = () => {
         // 1) Clear any pages after the active page. These can be left over from a back swipe.
-        this.stack = this.stack.slice(0, this._swiper.activeIndex + 1);
+        this.stack = this.stack.slice(0, this.activePageIdx + 1);
 
         // 2) Sync route to match the current page stack
         const newRouteName = this.stack.map(it => it.id).join('.'),
@@ -303,7 +306,8 @@ export class NavigatorModel extends HoistModel {
         if (init) {
             this.stack = stack;
             this._swiper.update();
-            this._swiper.activeIndex = this.stack.length - 1;
+            this.activePageIdx = this.stack.length - 1;
+            this._swiper.activeIndex = this.activePageIdx;
             return;
         }
 
@@ -317,7 +321,15 @@ export class NavigatorModel extends HoistModel {
         if (backOnePage) {
             // Don't update the stack yet. Instead, wait until after the animation has
             // completed in onPageChange().
+            this._swiper.allowSlidePrev = true;
             this._swiper.slidePrev(transitionMs);
+
+            // The route has already changed, so a missed `transitionEnd` would leave the stack
+            // and the route permanently out of sync - process the change ourselves if the
+            // event has not arrived in time.
+            wait(transitionMs + 100).then(() => {
+                if (this.stack.length > this.activePageIdx + 1) this.onPageChange();
+            });
         } else {
             // Otherwise, update the stack immediately and navigate to the new page.
             this.stack = stack;


### PR DESCRIPTION
Addresses the two latent items called out at the end of #4559. The Swiper 14 regression itself was handled by the revert in `97fa16d27`, and is now filed upstream as nolimits4web/swiper#8229 (still present in 14.2.0). This PR fixes the two things in `NavigatorModel` that turned that upstream timing bug into a silent, unrecoverable dead end - both of which survive the revert.

### `activePageIdx` is now observable state

It read `this._swiper.activeIndex`, a plain non-observable property, and `activePage`, `activePageId`, `allowSlideNext` and `allowSlidePrev` all derive from it. `allowSlidePrev` had no observable input at all - it was refreshed purely as a side effect of `onPageChange` reassigning `stack` (via `slice()`, so always a new identity) on every transition end. Correctness also depended on React deferring the init-branch render past an imperative `activeIndex` write.

It is now a `@bindable` synced from Swiper's `activeIndexChange` event, which fires from `updateActiveIndex` independently of the transition machinery.

### `backOnePage` has a backstop

It is the only branch that defers its state change to the animation - the router has already moved to the parent route while `stack` still holds the child. If `transitionEnd` never lands, the two disagree permanently: `onRouteChange` fires only on route *changes*, so a second back-tap invokes nothing at all and the app needs a reload. The Swiper regression was one way to lose the event; an interrupted transition or iOS suspending the app mid-slide are others.

The branch now reconciles the stack on a `transitionMs + 100` timeout if the event has not been processed. `onPageChange` is already effectively idempotent, so the guard only avoids churn on the happy path.

It also sets `allowSlidePrev` on the instance immediately before `slidePrev`, where render timing cannot defeat it - the call-site lock from the #4559 plan, which was never applied.

### To eyeball on device

The active page now flips at the *start* of a transition rather than at its end, since `activeIndexChange` fires when `slideTo`/`slidePrev` begins. A `renderMode: 'lazy'` page therefore renders as the slide begins instead of popping in when it lands. That looks like the better behavior, but it does mean a heavy page renders during the animation rather than after it - worth a look on-device before merge. Happy to split live index from settled active page if you would rather keep the old timing.

One case the backstop deliberately does not cover: if `slidePrev` is rejected outright, the slide never moves and trimming the stack would produce a visual jump. The call-site lock is what prevents that case.
