### PR TITLE
Label HoistBase instances as `ClassName [xhName]` or `ClassName [id]`

### DIFF
--- a/cmp/form/FormModel.ts
+++ b/cmp/form/FormModel.ts
@@ -176,7 +176,7 @@ export class FormModel extends HoistModel {
         forOwn(this.fields, f => {
             f.formModel = this;
             f.xhImpl = xhImpl;
-            f.xhName ??= this.childXhName(f.name) ?? f.name;
+            f.xhName ??= this.childXhName(f.name);
         });
     }
 

--- a/cmp/tab/TabModel.ts
+++ b/cmp/tab/TabModel.ts
@@ -137,7 +137,7 @@ export class TabModel extends HoistModel {
         );
 
         this.id = id.toString();
-        this.xhName = xhName ?? containerModel.childXhName(this.id) ?? this.id;
+        this.xhName = xhName ?? containerModel.childXhName(this.id);
         this.title = title;
         this.icon = icon;
         this.tooltip = tooltip;

--- a/desktop/cmp/dash/DashViewModel.ts
+++ b/desktop/cmp/dash/DashViewModel.ts
@@ -112,7 +112,7 @@ export abstract class DashViewModel<T extends DashViewSpec = DashViewSpec> exten
         this.title = title ?? viewSpec.title;
         this.viewState = viewState;
         this.containerModel = containerModel;
-        this.xhName = xhName ?? containerModel?.childXhName(id) ?? id;
+        this.xhName = xhName ?? containerModel?.childXhName(id);
 
         this.refreshContextModel = new ManagedRefreshContextModel(this);
         this.refreshContextModel.xhName = this.childXhName('refreshContextModel');

--- a/desktop/cmp/dock/DockViewModel.ts
+++ b/desktop/cmp/dock/DockViewModel.ts
@@ -140,7 +140,7 @@ export class DockViewModel extends HoistModel {
 
         this.id = id;
         this.containerModel = containerModel;
-        this.xhName = xhName ?? containerModel?.childXhName(id) ?? id;
+        this.xhName = xhName ?? containerModel?.childXhName(id);
         this.title = title;
         this.icon = icon;
         this.content = content;

--- a/mobile/cmp/navigator/PageModel.ts
+++ b/mobile/cmp/navigator/PageModel.ts
@@ -131,7 +131,7 @@ export class PageModel extends HoistModel {
 
         this.id = id;
         this.navigatorModel = navigatorModel;
-        this.xhName = xhName ?? navigatorModel?.childXhName(id) ?? id;
+        this.xhName = xhName ?? navigatorModel?.childXhName(id);
         this.content = content;
         this.props = withDefault(props, {});
         this.disableDirectLink = withDefault(disableDirectLink, false);

--- a/utils/js/LangUtils.ts
+++ b/utils/js/LangUtils.ts
@@ -290,12 +290,28 @@ export type NameSource = string | HoistBase | {displayName: string} | {construct
 
 /**
  * Resolve a {@link NameSource} to a string, or null if unresolvable.
- * Prefers an instance-level `xhName` when set - see {@link parseTypeName} to skip it.
+ *
+ * A HoistBase instance is labelled per {@link formatInstanceLabel}. Other sources resolve via
+ * `xhName` or {@link parseTypeName}.
  */
 export function parseNameSource(source: NameSource): string {
     if (!source) return null;
     if (isString(source)) return source;
-    return source['xhName'] || parseTypeName(source);
+    const typeName = parseTypeName(source);
+    if (!source['isHoistBase']) return source['xhName'] || typeName;
+    return formatInstanceLabel(typeName, source['xhName'], source['xhId']);
+}
+
+/**
+ * Label for a HoistBase instance - `ClassName [xhName]`, or `ClassName [id]` (short `xhId`) when
+ * unnamed. An `xhName` matching the class name (e.g. `fetchService`) marks a singleton and is
+ * omitted.
+ */
+export function formatInstanceLabel(className: string, xhName: string, xhId: string): string {
+    if (!xhName) return `${className} [${xhId.replace(/^xh-id-/, '')}]`;
+    return xhName.toLowerCase() === className.toLowerCase()
+        ? className
+        : `${className} [${xhName}]`;
 }
 
 /**


### PR DESCRIPTION
Cherry-picked from #4647 - the framework-side half of that PR's instance labelling work, split out so it can land independently of the Inspector overhaul.

- `parseNameSource` now routes HoistBase instances through a new exported `formatInstanceLabel(className, xhName, xhId)`, which renders `ClassName [xhName]`, falls back to `ClassName [id]` (short `xhId`) when unnamed, and collapses to the bare class name when the `xhName` matches the class (services, `appModel`). Non-HoistBase sources keep the prior `xhName || parseTypeName` path.
- Dropped the bare id/name `xhName` fallback on `TabModel`, `FormModel` fields, `DashViewModel`, `DockViewModel` and `PageModel` - children of an unnamed parent now stay unnamed rather than picking up a raw id.

`LogUtils` is the only caller of `parseNameSource`, so the visible effect is log prefixes across the framework. `formatInstanceLabel` is exported but unused in-library until the Inspector work in #4647 lands.

No CHANGELOG entry needed - the existing `HoistBase.xhName` entry on `develop` already documents this behavior ("instances log as `ClassName [xhName]`, or `ClassName [id]` when unnamed"); this is the change that makes it true.