### PR TITLE
Add `domAttrs` for applying data-* and aria-* attributes to rendered DOM elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,16 @@
   tabs. The Config panel shows every view of a config's value - resolved, instance override,
   database, and typedClass defaults - and renders notes as Markdown. Editing is now confined to the
   grid's editor: double-click no longer opens a view-only dialog for read-only admins.
+* Added `domAttrs`, a prop for applying arbitrary `data-*` and `aria-*` attributes to the primary
+  DOM element a component renders - the same element that receives `data-testid` from `testId`.
+  Supported by `Box` and the layout components built on it (and therefore `Panel`, `Toolbar`, and
+  similar containers), `Button`, `ButtonGroup`, `Card`, `Badge`, `FormField`, and the desktop and
+  mobile inputs.
 
 ### 🐞 Bug Fixes
 
+* Fixed `testId` being silently dropped by desktop `Slider`, desktop `FileChooser`, and mobile
+  `Label` - all accepted the prop but never emitted a `data-testid` attribute.
 * Fixed icon misalignment in desktop `DateInput` when a `leftIcon` is specified.
 * Fixed `SegmentedControl.fill: false` leaving an empty run of tray to the right of its options -
   the control now sizes to its options.

--- a/cmp/badge/Badge.ts
+++ b/cmp/badge/Badge.ts
@@ -37,8 +37,10 @@ export const [Badge, badge] = hoistCmp.withFactory<BadgeProps>({
 
     render(props, ref) {
         const classes = [],
-            [layoutProps, {className, intent, compact, icon, children, testId, ...restProps}] =
-                splitLayoutProps(props);
+            [
+                layoutProps,
+                {className, intent, compact, icon, children, testId, domAttrs, ...restProps}
+            ] = splitLayoutProps(props);
 
         if (intent) {
             classes.push(`xh-bg-intent-${intent}`);
@@ -51,7 +53,7 @@ export const [Badge, badge] = hoistCmp.withFactory<BadgeProps>({
         const divProps = mergeDeep(
             {className: classNames(className, classes)},
             {style: layoutProps},
-            {[TEST_ID]: testId},
+            {[TEST_ID]: testId, ...domAttrs},
             restProps
         );
 

--- a/cmp/card/Card.ts
+++ b/cmp/card/Card.ts
@@ -8,6 +8,7 @@
 import {box, fieldset} from '@xh/hoist/cmp/layout';
 import {
     BoxProps,
+    DomAttrsProps,
     hoistCmp,
     HoistProps,
     Intent,
@@ -26,7 +27,7 @@ import {CardModel} from './CardModel';
 import './Card.scss';
 
 export interface CardProps<M extends CardModel = CardModel>
-    extends HoistProps<M>, TestSupportProps, LayoutProps {
+    extends HoistProps<M>, TestSupportProps, DomAttrsProps, LayoutProps {
     /** An icon placed left of the title. */
     icon?: ReactElement;
     /** Intent to apply to the inline header and border. */
@@ -75,9 +76,9 @@ export const [Card, card] = hoistCmp.withFactory<CardProps>({
         const wasDisplayed = useRef(false),
             {collapsed, renderMode} = model;
 
-        let [layoutProps, {testId, ...restProps}] = splitLayoutProps(rest);
+        let [layoutProps, {testId, domAttrs, ...restProps}] = splitLayoutProps(rest);
 
-        restProps = mergeDeep({style: layoutProps}, {[TEST_ID]: testId}, restProps);
+        restProps = mergeDeep({style: layoutProps}, {[TEST_ID]: testId, ...domAttrs}, restProps);
 
         const classes: string[] = [];
 

--- a/cmp/input/HoistInputProps.ts
+++ b/cmp/input/HoistInputProps.ts
@@ -5,9 +5,9 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 
-import {TestSupportProps} from '@xh/hoist/core';
+import {DomAttrsProps, TestSupportProps} from '@xh/hoist/core';
 
-export interface HoistInputProps extends TestSupportProps {
+export interface HoistInputProps extends TestSupportProps, DomAttrsProps {
     /**
      * Field or model property name from which this component should read and write its value
      * in controlled mode. Can be set by parent FormField.

--- a/cmp/input/README.md
+++ b/cmp/input/README.md
@@ -139,6 +139,30 @@ The common props interface extended by all input components.
 | `onCommit` | `(value, oldValue) => void` | Called when value is committed |
 | `tabIndex` | `number` | Tab order for focus (-1 to skip) |
 | `id` | `string` | DOM ID for the input element |
+| `testId` | `string` | Emits `data-testid` on the input's primary DOM element |
+| `domAttrs` | `data-*` / `aria-*` / `role` keys | Extra HTML attributes for that same element |
+
+### Extra DOM Attributes with `domAttrs`
+
+Input components pass an explicit, named set of props to the element they render, so any other
+attribute is dropped. Use `domAttrs` to apply `data-*` or `aria-*` attributes that Hoist does not
+model with a dedicated prop.
+
+```typescript
+textInput({
+    bind: 'email',
+    domAttrs: {'data-analytics-id': 'signup-email', 'aria-describedby': 'email-help'}
+});
+```
+
+Keys are constrained by type to `data-*` and `aria-*` attributes, plus `role`, so the prop cannot
+reach attributes the component manages itself.
+
+> **Mobile caveat:** `TextInput` and `NumberInput` on mobile render Onsen's `<ons-input>` custom
+> element, and `SearchInput` renders `<ons-search-input>`. Both mirror only a fixed allowlist of
+> attributes onto the real `<input>` they create. Attributes supplied via `domAttrs` are applied to the `<ons-input>` wrapper,
+> not to the inner `<input>`. This matches where `testId` lands today. Mobile `TextArea` is
+> unaffected - it renders a native `<textarea>`.
 
 ## Integration with Forms
 

--- a/cmp/layout/Box.ts
+++ b/cmp/layout/Box.ts
@@ -35,12 +35,13 @@ export const [Box, box] = hoistCmp.withFactory<BoxComponentProps>({
         // Note `model` destructured off of non-layout props to avoid setting
         // model as a bogus DOM attribute. This low-level component may easily be passed one from
         // a parent that has not properly managed its own props.
-        let [layoutProps, {children, model, testId, ...restProps}] = splitLayoutProps(props);
+        let [layoutProps, {children, model, testId, domAttrs, ...restProps}] =
+            splitLayoutProps(props);
 
         restProps = mergeDeep(
             {style: {display: 'flex', overflow: 'hidden', position: 'relative'}},
             {style: layoutProps},
-            {[TEST_ID]: testId},
+            {[TEST_ID]: testId, ...domAttrs},
             restProps
         );
 

--- a/core/HoistProps.ts
+++ b/core/HoistProps.ts
@@ -76,6 +76,7 @@ export interface BoxProps
     extends
         LayoutProps,
         TestSupportProps,
+        DomAttrsProps,
         Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'contextMenu'> {}
 
 /**
@@ -97,6 +98,32 @@ export interface TestSupportProps {
      * and apply additional child testIds to support testing of nested elements.
      */
     testId?: string;
+}
+
+/**
+ * Props to support applying arbitrary HTML attributes to the primary DOM element rendered by a
+ * component.
+ *
+ * Intended as an escape hatch for `data-*` and `aria-*` attributes that Hoist does not model with
+ * a dedicated prop - e.g. attributes read by analytics libraries, browser extensions, or
+ * third-party test tooling. Hoist components pick the props they pass to the elements they render,
+ * so attributes specified any other way are typically dropped and never reach the DOM.
+ */
+export interface DomAttrsProps {
+    /**
+     * Additional HTML attributes to apply to the primary DOM element rendered by this component -
+     * the same element that receives `data-testid` when {@link TestSupportProps.testId} is set.
+     *
+     * Keys are constrained to `data-*` and `aria-*` attributes, plus `role`, so this cannot be
+     * used to override attributes the component manages itself (`className`, `style`, `value`).
+     * Note the constraint applies to object literals only - a pre-built `Record<string, string>`
+     * will still assign, for the rare case that calls for an attribute outside this set. Take care
+     * there: precedence against component-managed attributes is not guaranteed and varies by
+     * component.
+     */
+    domAttrs?: Record<`data-${string}` | `aria-${string}`, string | number | boolean> & {
+        role?: string;
+    };
 }
 
 export interface LayoutProps {

--- a/core/README.md
+++ b/core/README.md
@@ -553,6 +553,37 @@ Button.defaults.minimal = false;
 This pattern is analogous to `static defaults` on Model and Service classes (e.g.
 `GridModel.defaults`), adapted for functional components created via `hoistCmp`.
 
+### Extra DOM Attributes with `domAttrs`
+
+Hoist components choose which props they pass along to the elements they render. An attribute that
+a component does not model with a dedicated prop is therefore dropped and never reaches the DOM.
+
+`DomAttrsProps` provides the escape hatch. Components that support it accept a `domAttrs` object
+and apply its entries to their primary DOM element - the same element that receives `data-testid`
+when `testId` is set.
+
+```typescript
+textInput({
+    bind: 'email',
+    testId: 'signup-email',
+    domAttrs: {'data-analytics-id': 'signup-email', 'aria-describedby': 'email-help'}
+});
+```
+
+Keys are constrained by type to `data-*` and `aria-*` attributes, plus `role`, so the prop cannot
+be used to reach for attributes the component manages itself (`className`, `style`, `value`). The
+constraint applies to object literals only; a pre-built `Record<string, string>` still assigns, for
+the rare attribute outside that set. Take care there - precedence against component-managed
+attributes is not guaranteed and varies by component.
+
+As with `style`, an inline `domAttrs` literal is a new object on each render, so hoist a constant
+out of the render function when passing one to a component that relies on `memo`.
+
+Support is provided by `Box` and the layout components built on it (and therefore by `Panel`,
+`Toolbar`, and similar containers), by `Button` and `ButtonGroup`, by `Card` and `Badge`, and by
+the input components in `/cmp/input/`. See [`/cmp/input/README.md`](../cmp/input/README.md) for
+notes specific to inputs.
+
 ## Element Factories
 
 **File**: `elem.ts`

--- a/desktop/cmp/button/Button.ts
+++ b/desktop/cmp/button/Button.ts
@@ -6,6 +6,7 @@
  */
 import {ButtonProps as BpButtonProps} from '@blueprintjs/core';
 import {
+    DomAttrsProps,
     hoistCmp,
     HoistModel,
     HoistProps,
@@ -23,7 +24,13 @@ import {ReactElement, ReactNode} from 'react';
 import './Button.scss';
 
 export interface ButtonProps<M extends HoistModel = null>
-    extends HoistProps<M>, StyleProps, LayoutProps, TestSupportProps, Omit<BpButtonProps, 'ref'> {
+    extends
+        HoistProps<M>,
+        StyleProps,
+        LayoutProps,
+        TestSupportProps,
+        DomAttrsProps,
+        Omit<BpButtonProps, 'ref'> {
     active?: boolean;
     autoFocus?: boolean;
     disabled?: boolean;
@@ -83,6 +90,7 @@ export const [Button, button] = hoistCmp.withFactory<ButtonProps, ButtonDefaults
             tooltip,
             active,
             testId,
+            domAttrs,
             ...rest
         } = nonLayoutProps;
 
@@ -111,6 +119,7 @@ export const [Button, button] = hoistCmp.withFactory<ButtonProps, ButtonDefaults
             className: classNames(className, classes),
             ref,
             [TEST_ID]: testId,
+            ...domAttrs,
             disabled,
             icon,
             intent,

--- a/desktop/cmp/button/ButtonGroup.ts
+++ b/desktop/cmp/button/ButtonGroup.ts
@@ -6,6 +6,7 @@
  */
 import {ButtonGroupProps as BpButtonGroupProps} from '@blueprintjs/core';
 import {
+    DomAttrsProps,
     hoistCmp,
     HoistModel,
     HoistProps,
@@ -25,6 +26,7 @@ export interface ButtonGroupProps<M extends HoistModel = null>
         LayoutProps,
         StyleProps,
         TestSupportProps,
+        DomAttrsProps,
         SetOptional<Omit<BpButtonGroupProps, 'ref'>, 'children'> {
     /** True to have all buttons fill available width equally. */
     fill?: boolean;
@@ -45,13 +47,14 @@ export const [ButtonGroup, buttonGroup] = hoistCmp.withFactory<ButtonGroupProps>
     className: 'xh-button-group',
 
     render(props, ref) {
-        const [layoutProps, {fill, minimal, vertical, style, testId, ...rest}] =
+        const [layoutProps, {fill, minimal, vertical, style, testId, domAttrs, ...rest}] =
             splitLayoutProps(props);
         return bpButtonGroup({
             fill,
             minimal,
             vertical,
             [TEST_ID]: testId,
+            ...domAttrs,
             style: {
                 ...style,
                 ...layoutProps

--- a/desktop/cmp/filechooser/FileChooser.ts
+++ b/desktop/cmp/filechooser/FileChooser.ts
@@ -112,6 +112,8 @@ export const [FileChooser, fileChooser] = hoistCmp.withFactory<FileChooserProps>
                         container = isTop ? vframe : hframe;
                     return container({
                         className,
+                        testId: props.testId,
+                        domAttrs: props.domAttrs,
                         items: [
                             // `box` (flex: none) so the rail keeps a fixed size beside the grid;
                             // `frame` would grow and crowd it out.
@@ -149,6 +151,8 @@ export const [FileChooser, fileChooser] = hoistCmp.withFactory<FileChooserProps>
                         !hasFiles ? 'xh-file-chooser__target--empty' : null,
                         clickable ? 'xh-file-chooser__target--clickable' : null
                     ),
+                    testId: props.testId,
+                    domAttrs: props.domAttrs,
                     items: [dropzoneItem, targetMask, input({...getInputProps()})],
                     ...getRootProps(),
                     ...getLayoutProps(props)

--- a/desktop/cmp/form/FormField.ts
+++ b/desktop/cmp/form/FormField.ts
@@ -273,6 +273,7 @@ export const [FormField, formField] = hoistCmp.withFactory<FormFieldProps>({
             className: classNames(className, classes),
             ...getLayoutProps(props),
             testId,
+            domAttrs: props.domAttrs,
             items: [
                 labelEl({
                     omit: !label,

--- a/desktop/cmp/input/Checkbox.ts
+++ b/desktop/cmp/input/Checkbox.ts
@@ -75,6 +75,7 @@ const cmp = hoistCmp.factory<CheckboxInputModel>(({model, className, ...props}, 
         tabIndex: props.tabIndex,
         id: props.id,
         [TEST_ID]: props.testId,
+        ...props.domAttrs,
         className,
         style: props.style,
 

--- a/desktop/cmp/input/CodeInput.ts
+++ b/desktop/cmp/input/CodeInput.ts
@@ -671,6 +671,7 @@ const cmp = hoistCmp.factory<CodeInputModel>(({model, className, ...props}, ref)
             model: model.modalSupportModel,
             item: inputCmp({
                 testId: props.testId,
+                domAttrs: props.domAttrs,
                 width: '100%',
                 height: '100%',
                 className,

--- a/desktop/cmp/input/DateInput.ts
+++ b/desktop/cmp/input/DateInput.ts
@@ -468,6 +468,7 @@ const cmp = hoistCmp.factory<DateInputProps & {model: DateInputModel}>(
                         inputRef: model.inputRef,
                         ref: model.textInputRef,
                         testId: getTestId(props),
+                        domAttrs: props.domAttrs,
                         ...getLayoutProps(props)
                     }),
                     className: 'xh-date-input__click-target',

--- a/desktop/cmp/input/IntentInput.ts
+++ b/desktop/cmp/input/IntentInput.ts
@@ -148,6 +148,7 @@ const cmp = hoistCmp.factory<IntentInputModel>(({model, className, ...props}, re
         compact,
         showNames,
         testId,
+        domAttrs,
         // Remainder passed to the container div
         ...rest
     } = getNonLayoutProps(props);
@@ -168,6 +169,7 @@ const cmp = hoistCmp.factory<IntentInputModel>(({model, className, ...props}, re
         onKeyDown: disabled ? null : model.onKeyDown,
         ...getLayoutProps(props),
         [TEST_ID]: testId,
+        ...domAttrs,
         items: model.options.map(intent => {
             const isSelected = renderValue === intent,
                 isNull = intent == null,

--- a/desktop/cmp/input/NumberInput.ts
+++ b/desktop/cmp/input/NumberInput.ts
@@ -278,6 +278,7 @@ const cmp = hoistCmp.factory<NumberInputModel>(({model, className, ...props}, re
             textAlign: withDefault(props.textAlign, 'right')
         },
         [TEST_ID]: props.testId,
+        ...props.domAttrs,
         onBlur: model.onBlur,
         onFocus: model.onFocus,
         onKeyDown: model.onKeyDown,

--- a/desktop/cmp/input/Picker.ts
+++ b/desktop/cmp/input/Picker.ts
@@ -478,6 +478,7 @@ const triggerButton = hoistCmp.factory<PickerModel>(({model, props, nothingSelec
         width: withDefault(width, 160),
         style: props.style,
         [TEST_ID]: getTestId(props, 'trigger'),
+        ...props.domAttrs,
         onClick: () => {
             if (model.popoverIsOpen) {
                 model.closePopover();

--- a/desktop/cmp/input/RadioInput.ts
+++ b/desktop/cmp/input/RadioInput.ts
@@ -113,6 +113,7 @@ const cmp = hoistCmp.factory<RadioInputModel>(({model, className, ...props}, ref
         inline: props.inline,
         selectedValue: model.renderValue,
         onChange: model.onChange,
-        [TEST_ID]: props.testId
+        [TEST_ID]: props.testId,
+        ...props.domAttrs
     });
 });

--- a/desktop/cmp/input/SegmentedControl.ts
+++ b/desktop/cmp/input/SegmentedControl.ts
@@ -185,6 +185,7 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
         showTrayBackground = true,
         showOptionDividers = 'auto',
         testId,
+        domAttrs,
         // Remainder passed to BP SegmentedControl
         ...bpProps
     } = getNonLayoutProps(props);
@@ -224,6 +225,7 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
         onBlur: model.onBlur,
         ...getLayoutProps(props),
         [TEST_ID]: props.testId,
+        ...domAttrs,
         item: bpSegmentedControl({
             ...bpProps,
             fill,

--- a/desktop/cmp/input/Select.ts
+++ b/desktop/cmp/input/Select.ts
@@ -875,6 +875,7 @@ const cmp = hoistCmp.factory<SelectInputModel>(({model, className, ...props}, re
             }
         },
         testId: props.testId,
+        domAttrs: props.domAttrs,
         ...layoutProps,
         width: withDefault(width, 200),
         height: height,

--- a/desktop/cmp/input/Slider.ts
+++ b/desktop/cmp/input/Slider.ts
@@ -114,6 +114,8 @@ const cmp = hoistCmp.factory<SliderInputModel>(({model, className, ...props}, re
         ...layoutProps,
         width: withDefault(width, 200),
         className,
+        testId: props.testId,
+        domAttrs: props.domAttrs,
 
         onBlur: model.onBlur,
         onFocus: model.onFocus,

--- a/desktop/cmp/input/SwitchInput.ts
+++ b/desktop/cmp/input/SwitchInput.ts
@@ -63,6 +63,7 @@ const cmp = hoistCmp.factory<SwitchInputModel>(({model, className, ...props}, re
         className,
 
         [TEST_ID]: props.testId,
+        ...props.domAttrs,
         onBlur: model.onBlur,
         onFocus: model.onFocus,
         onChange: e => model.noteValueChange(e.target.checked),

--- a/desktop/cmp/input/TextArea.ts
+++ b/desktop/cmp/input/TextArea.ts
@@ -91,6 +91,7 @@ const cmp = hoistCmp.factory<TextAreaInputModel>(({model, className, ...props}, 
         spellCheck: withDefault(props.spellCheck, false),
         tabIndex: props.tabIndex,
         [TEST_ID]: props.testId,
+        ...props.domAttrs,
         id: props.id,
         className,
         style: {

--- a/desktop/cmp/input/TextInput.ts
+++ b/desktop/cmp/input/TextInput.ts
@@ -155,6 +155,7 @@ const cmp = hoistCmp.factory<TextInputProps & {model: TextInputModel}>(
                     textAlign: withDefault(props.textAlign, 'left')
                 },
                 [TEST_ID]: props.testId,
+                ...props.domAttrs,
                 onChange: model.onChange,
                 onKeyDown: model.onKeyDown
             }),

--- a/desktop/cmp/panel/Panel.ts
+++ b/desktop/cmp/panel/Panel.ts
@@ -129,7 +129,7 @@ export const [Panel, panel] = hoistCmp.withFactory<PanelProps, PanelDefaults>({
         compactHeader: false
     },
 
-    render({model, className, testId, ...props}, ref) {
+    render({model, className, testId, domAttrs, ...props}, ref) {
         const contextModel = useContextModel('*');
 
         let wasDisplayed = useRef(false),
@@ -264,16 +264,19 @@ export const [Panel, panel] = hoistCmp.withFactory<PanelProps, PanelDefaults>({
                 item: frame({
                     item,
                     className: model.isModal ? className : undefined,
-                    testId: model.isModal ? testId : undefined
+                    testId: model.isModal ? testId : undefined,
+                    domAttrs: model.isModal ? domAttrs : undefined
                 })
             });
         }
 
-        testId = model.isModal ? undefined : testId; // Only apply testId once
+        // Only apply testId / domAttrs once - to the modal frame above, or here.
+        testId = model.isModal ? undefined : testId;
+        domAttrs = model.isModal ? undefined : domAttrs;
 
         return useResizeContainer
-            ? resizeContainer({ref, item, className, testId})
-            : box({ref, item, className, testId, ...layoutProps});
+            ? resizeContainer({ref, item, className, testId, domAttrs})
+            : box({ref, item, className, testId, domAttrs, ...layoutProps});
     }
 });
 

--- a/desktop/cmp/panel/impl/ResizeContainer.ts
+++ b/desktop/cmp/panel/impl/ResizeContainer.ts
@@ -18,7 +18,7 @@ export const resizeContainer = hoistCmp.factory({
     model: false,
     className: 'xh-resizable',
 
-    render({className, children, testId}, ref) {
+    render({className, children, testId, domAttrs}, ref) {
         const panelModel = useContextModel(PanelModel),
             {size, resizable, collapsed, vertical, contentFirst, showSplitter} = panelModel,
             dim = vertical ? 'height' : 'width',
@@ -53,6 +53,7 @@ export const resizeContainer = hoistCmp.factory({
             [maxDim]: '100%',
             [minDim]: dragBarWidth,
             testId,
+            domAttrs,
             items
         });
     }

--- a/desktop/cmp/tab/impl/TabContainer.ts
+++ b/desktop/cmp/tab/impl/TabContainer.ts
@@ -24,6 +24,7 @@ export function tabContainerImpl({
     childContainerProps,
     className,
     testId,
+    domAttrs,
     ...props
 }: TabContainerProps) {
     const switcherProps = getSwitcherProps(props),
@@ -40,6 +41,7 @@ export function tabContainerImpl({
         ...layoutProps,
         className,
         testId,
+        domAttrs,
         item: getChildren(model, switcherProps, testId, childContainerProps)
     });
 }

--- a/mobile/cmp/button/Button.ts
+++ b/mobile/cmp/button/Button.ts
@@ -6,6 +6,7 @@
  */
 import {hspacer} from '@xh/hoist/cmp/layout';
 import {
+    DomAttrsProps,
     LayoutProps,
     StyleProps,
     hoistCmp,
@@ -23,7 +24,7 @@ import {ReactNode, ReactElement, MouseEvent} from 'react';
 import './Button.scss';
 
 export interface ButtonProps<M extends HoistModel = HoistModel>
-    extends HoistProps<M>, TestSupportProps, LayoutProps, StyleProps {
+    extends HoistProps<M>, TestSupportProps, DomAttrsProps, LayoutProps, StyleProps {
     active?: boolean;
     disabled?: boolean;
     icon?: ReactElement;
@@ -51,8 +52,19 @@ export const [Button, button] = hoistCmp.withFactory<ButtonProps>({
             classes = [],
             items = [];
 
-        const {active, className, disabled, icon, intent, onClick, style, testId, text, ...rest} =
-            nonLayoutProps;
+        const {
+            active,
+            className,
+            disabled,
+            domAttrs,
+            icon,
+            intent,
+            onClick,
+            style,
+            testId,
+            text,
+            ...rest
+        } = nonLayoutProps;
 
         let {outlined, minimal} = nonLayoutProps;
         if (disabled) {
@@ -91,6 +103,7 @@ export const [Button, button] = hoistCmp.withFactory<ButtonProps>({
                 ...layoutProps
             },
             [TEST_ID]: testId,
+            ...domAttrs,
             ...rest
         });
     }

--- a/mobile/cmp/form/FormField.ts
+++ b/mobile/cmp/form/FormField.ts
@@ -160,6 +160,7 @@ export const [FormField, formField] = hoistCmp.withFactory<FormFieldProps>({
         return box({
             ref,
             testId,
+            domAttrs: props.domAttrs,
             className: classNames(className, classes),
             ...layoutProps,
             items: [

--- a/mobile/cmp/input/Checkbox.ts
+++ b/mobile/cmp/input/Checkbox.ts
@@ -46,6 +46,7 @@ const cmp = hoistCmp.factory<CheckboxInputModel>(({model, className, ...props}, 
 
         style: props.style,
         [TEST_ID]: props.testId,
+        ...props.domAttrs,
 
         onBlur: model.onBlur,
         onFocus: model.onFocus,

--- a/mobile/cmp/input/DateInput.ts
+++ b/mobile/cmp/input/DateInput.ts
@@ -163,6 +163,7 @@ const cmp = hoistCmp.factory<DateInputModel>(({model, className, ...props}, ref)
                 style: {textAlign},
                 tabIndex: props.tabIndex,
                 [TEST_ID]: props.testId,
+                ...props.domAttrs,
                 item: model.formattedRenderValue,
                 onClick: () => model.openPicker()
             }),

--- a/mobile/cmp/input/Label.ts
+++ b/mobile/cmp/input/Label.ts
@@ -8,6 +8,7 @@ import {HoistInputModel, HoistInputProps, useHoistInputModel} from '@xh/hoist/cm
 import {div} from '@xh/hoist/cmp/layout';
 import {hoistCmp, HoistProps, StyleProps} from '@xh/hoist/core';
 import '@xh/hoist/mobile/register';
+import {TEST_ID} from '@xh/hoist/utils/js';
 import './Label.scss';
 
 export interface LabelProps extends HoistProps, HoistInputProps, StyleProps {}
@@ -30,11 +31,15 @@ class LabelInputModel extends HoistInputModel {
 //-----------------------
 // Implementation
 //-----------------------
-const cmp = hoistCmp.factory(({model, className, style, width, children}, ref) => {
-    return div({
-        className,
-        style: {...style, whiteSpace: 'nowrap', width},
-        items: children,
-        ref
-    });
-});
+const cmp = hoistCmp.factory(
+    ({model, className, style, width, children, testId, domAttrs}, ref) => {
+        return div({
+            className,
+            [TEST_ID]: testId,
+            ...domAttrs,
+            style: {...style, whiteSpace: 'nowrap', width},
+            items: children,
+            ref
+        });
+    }
+);

--- a/mobile/cmp/input/NumberInput.ts
+++ b/mobile/cmp/input/NumberInput.ts
@@ -257,6 +257,7 @@ const cmp = hoistCmp.factory<NumberInputModel>(
             },
             spellCheck: false,
             [TEST_ID]: props.testId,
+            ...props.domAttrs,
 
             onInput: model.onValueChange,
             onKeyDown: model.onKeyDown,

--- a/mobile/cmp/input/SearchInput.ts
+++ b/mobile/cmp/input/SearchInput.ts
@@ -94,6 +94,7 @@ const cmp = hoistCmp.factory<SearchInputModel>(({model, className, ...props}, re
             textAlign: withDefault(props.textAlign, 'left')
         },
         [TEST_ID]: props.testId,
+        ...props.domAttrs,
 
         onInput: model.onChange,
         onKeyDown: model.onKeyDown,

--- a/mobile/cmp/input/SegmentedControl.ts
+++ b/mobile/cmp/input/SegmentedControl.ts
@@ -17,7 +17,6 @@ import {hoistCmp, HoistProps, Intent} from '@xh/hoist/core';
 import {button} from '@xh/hoist/mobile/cmp/button';
 import '@xh/hoist/mobile/register';
 import {computed, makeObservable} from '@xh/hoist/mobx';
-import {TEST_ID} from '@xh/hoist/utils/js';
 import {getLayoutProps, getNonLayoutProps} from '@xh/hoist/utils/react';
 import classNames from 'classnames';
 import {filter, isObject} from 'lodash';
@@ -180,6 +179,7 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
         showTrayBackground = true,
         showOptionDividers = 'auto',
         testId,
+        domAttrs,
         ...rest
     } = getNonLayoutProps(props);
 
@@ -229,7 +229,8 @@ const cmp = hoistCmp.factory<SegmentedControlModel>(({model, className, ...props
         onFocus: model.onFocus,
         onBlur: model.onBlur,
         ...getLayoutProps(props),
-        [TEST_ID]: testId,
+        testId,
+        domAttrs,
         items: buttons,
         ...rest
     });

--- a/mobile/cmp/input/Select.ts
+++ b/mobile/cmp/input/Select.ts
@@ -696,6 +696,7 @@ const cmp = hoistCmp.factory<SelectInputModel>(({model, className, ...props}, re
                     item: factory(rsProps),
                     className,
                     testId: props.testId,
+                    domAttrs: props.domAttrs,
                     ref
                 })
             }),
@@ -708,6 +709,7 @@ const cmp = hoistCmp.factory<SelectInputModel>(({model, className, ...props}, re
             ...layoutProps,
             width: withDefault(width, null),
             testId: props.testId,
+            domAttrs: props.domAttrs,
             ref
         });
     }

--- a/mobile/cmp/input/SwitchInput.ts
+++ b/mobile/cmp/input/SwitchInput.ts
@@ -47,6 +47,7 @@ const cmp = hoistCmp.factory<SwitchInputModel>(({model, className, ...props}, re
         className,
         style: props.style,
         [TEST_ID]: props.testId,
+        ...props.domAttrs,
 
         onBlur: model.onBlur,
         onFocus: model.onFocus,

--- a/mobile/cmp/input/TextArea.ts
+++ b/mobile/cmp/input/TextArea.ts
@@ -85,6 +85,7 @@ const cmp = hoistCmp.factory<TextAreaInputModel>(({model, className, ...props}, 
             spellCheck: withDefault(props.spellCheck, false),
             tabIndex: props.tabIndex,
             [TEST_ID]: props.testId,
+            ...props.domAttrs,
 
             onChange: model.onChange,
             onKeyDown: model.onKeyDown,

--- a/mobile/cmp/input/TextInput.ts
+++ b/mobile/cmp/input/TextInput.ts
@@ -145,6 +145,7 @@ const cmp = hoistCmp.factory<TextInputModel>(({model, className, ...props}, ref)
                 className: 'xh-text-input__input',
                 style: {textAlign: withDefault(props.textAlign, 'left')},
                 [TEST_ID]: props.testId,
+                ...props.domAttrs,
 
                 onInput: model.onChange,
                 onKeyDown: model.onKeyDown,

--- a/mobile/cmp/tab/impl/TabContainer.ts
+++ b/mobile/cmp/tab/impl/TabContainer.ts
@@ -20,7 +20,13 @@ import {TabContainerProps, TabModel, TabSwitcherProps} from '@xh/hoist/cmp/tab';
  *
  * @internal
  */
-export function tabContainerImpl({model, className, testId, ...props}: TabContainerProps) {
+export function tabContainerImpl({
+    model,
+    className,
+    testId,
+    domAttrs,
+    ...props
+}: TabContainerProps) {
     const switcherProps = getSwitcherProps(props),
         {activeTab} = model,
         tabs = model.tabs.filter(it => !it.excludeFromSwitcher),
@@ -34,6 +40,7 @@ export function tabContainerImpl({model, className, testId, ...props}: TabContai
     if (isEmpty(tabs)) {
         return page({
             [TEST_ID]: testId,
+            ...domAttrs,
             className: 'xh-tab-page',
             item: placeholder(model.emptyText)
         });
@@ -41,6 +48,7 @@ export function tabContainerImpl({model, className, testId, ...props}: TabContai
 
     return onsenTabbar({
         [TEST_ID]: testId,
+        ...domAttrs,
         className: classNames(className, `xh-tab-container--${switcherProps?.orientation}`),
         position: switcherProps?.orientation,
         activeIndex: activeTab ? tabs.indexOf(activeTab) : 0,


### PR DESCRIPTION
Adds `domAttrs`, a prop for applying `data-*` and `aria-*` attributes to the primary DOM element a component renders.

Hoist components pass an explicit, named set of props to the elements they render, so any other attribute is dropped. This was most acute across `cmp/input/`, but the gap was framework-wide at the type level: arbitrary `data-*` did not typecheck anywhere, including on `div()` and `panel()`, because `ElementSpec` has no index signature and special-cases only `data-testid`. Apps had to cast to `any`.

### Design

`domAttrs` is consumed at the same element a component already tags with `data-testid`. Hoist has already made that call component by component, so reusing it avoids inventing a second notion of "primary element" and keeps the two attributes co-located.

Keys are constrained to `data-*`, `aria-*`, and `role`:

```typescript
domAttrs?: Record<`data-${string}` | `aria-${string}`, string | number | boolean> & {role?: string};
```

Narrow-then-widen is deliberate: widening a key type later is non-breaking, narrowing is not. Excess-property checking applies to object literals only, so a pre-built `Record<string, string>` still assigns for the rare attribute outside that set.

### Changes

* Added `DomAttrsProps` to `core/HoistProps.ts`, mixed into `BoxProps`, `HoistInputProps`, desktop + mobile `ButtonProps`, `ButtonGroupProps`, and `CardProps`.
* Consumed in `Box` - which transitively covers `Panel`, `Toolbar`, `Frame`/`Viewport`/`Placeholder`/`TileFrame`, `ErrorMessage`, and the mobile containers - plus `Card`, `Badge`, desktop `Panel`, both `Button`s, `ButtonGroup`, `FormField`, `TabContainer`, and the input components.
* Fixed `testId` being silently dropped by desktop `Slider`, desktop `FileChooser`, and mobile `Label`.
* Moved `Picker`'s `domAttrs` to its trigger button - Blueprint's `PopoverTarget` does not forward arbitrary props, so attributes set on the popover never reach the DOM.

`CheckboxButton` and `JsonInput` gain support with no change of their own, forwarding props wholesale to `button()` and `codeInput()`.

### Verified

Typecheck, ESLint, and Prettier clean. Rendered DOM confirmed in Toolbox running against this branch inline: `Panel` -> `div.xh-panel`; `TextInput`/`NumberInput` -> the real `<input>`; `TextArea` -> `<textarea>`; `SegmentedControl` -> outer Hoist div with no stray attribute and no React warning; `Picker` -> trigger button alongside its `data-testid`; `FormField` -> its own `xh-form-field` div carrying both `data-testid` and the attribute, with the child input receiving the derived `-input` id.

### Known limitations

* Mobile `TextInput`, `NumberInput`, and `SearchInput` render Onsen custom elements that mirror only a fixed allowlist of attributes onto the inner `<input>`, so `domAttrs` lands on the wrapper - matching where `testId` lands today. Confirmed in the browser and documented in `cmp/input/README.md`.
* `Picker` applies no bare `testId` (only a `-trigger` suffixed id on its button), matching the pattern in `DateRangePicker`. Left as-is rather than changed under this PR.
* Precedence against component-managed attributes is not guaranteed for a widened `Record`, since `...domAttrs` is spread after `className`/`style` at several sites. The type prevents this for object literals; documented rather than reordered.
