### PR TITLE
Remove dead `cellClassFn` references from `ColumnWidthCalculator`

### DIFF
--- a/cmp/grid/impl/ColumnWidthCalculator.ts
+++ b/cmp/grid/impl/ColumnWidthCalculator.ts
@@ -111,8 +111,7 @@ export class ColumnWidthCalculator {
     }
 
     async calcLevelWidthAsync(gridModel, records, column, options, indentationPx = 0) {
-        const {field, getValueFn, renderer, rendererIsComplex, cellClassFn, cellClassRules} =
-                column,
+        const {field, getValueFn, renderer, rendererIsComplex, cellClassRules} = column,
             {store, sizingMode, rowClassFn, rowClassRules} = gridModel,
             bufferPx = column.autosizeBufferPx ?? options.bufferPx;
 
@@ -163,11 +162,11 @@ export class ColumnWidthCalculator {
         await forEachAsync(sample, ({value, records}) => {
             // Get unique combinations of row and cell classes applied
             const classNames = new Set<string>();
-            if (rowClassFn || cellClassFn || !isEmpty(rowClassRules) || !isEmpty(cellClassRules)) {
+            if (rowClassFn || !isEmpty(rowClassRules) || !isEmpty(cellClassRules)) {
                 records.forEach(record => {
                     const rawValue = getValueFn({record, field, column, gridModel, store}),
                         rowClass = this.getRowClass(gridModel, record),
-                        cellClass = this.getCellClass(gridModel, column, record, rawValue);
+                        cellClass = this.getCellClass(column, record, rawValue);
                     classNames.add(rowClass + '|' + cellClass);
                 });
             } else {
@@ -342,13 +341,9 @@ export class ColumnWidthCalculator {
         return this._cellEl;
     }
 
-    getCellClass(gridModel, column, record, value) {
-        const {cellClassFn, cellClassRules} = column,
+    getCellClass(column, record, value) {
+        const {cellClassRules} = column,
             ret = [];
-
-        if (cellClassFn) {
-            ret.push(cellClassFn({record, column, gridModel}));
-        }
 
         if (cellClassRules) {
             forOwn(cellClassRules, (fn, className) => {


### PR DESCRIPTION
`ColumnWidthCalculator` read `cellClassFn` off its `Column`, but `Column` exposes `cellClass` - the property was renamed without updating this caller, leaving the reference permanently `undefined`. The sibling `getHeaderClass()` handles the equivalent `headerClass` union correctly, which is what makes the omission visible.

- Dropped the destructure at both sites, the always-false branch in `getCellClass()`, and `cellClassFn` from the slow-path test in `calcLevelWidthAsync()`.
- Dropped the now-unused `gridModel` param from `getCellClass()` and updated its single call site.

Pure dead-code removal, no behavior change - the removed branch could never execute. It was also wrong on arity: `ColumnCellClassFn` takes `(value, context)`, while the dead call passed the context object as `value`.

### Known gap left in place

A column's `cellClass` is still not applied when measuring for autosize, so a `cellClass` affecting text metrics or padding yields a wrong width. Deliberately out of scope here - closing it is a behavior change that would shift autosize widths for existing apps and push any column with a `cellClass` onto the expensive class-permutation path. Worth its own issue.

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required. *(Not required - no user-visible change; dead code in an `impl/` class.)*
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. *(None - removed code was unreachable.)*
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required. *(N/A - no behavior change.)*
- [x] Created Toolbox branch / PR, or determined not required. *(N/A.)*