### PR TITLE
Fix hook-count error in `useHotkeys()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 * Fixed `SegmentedControl` clipping an option's label when `equalSegmentWidths` divided the tray
   too narrowly - options now hold their own content width, sharing equally only where there is room.
 * Fixed `useHotkeys()` throwing a React hook-count error when its arguments changed across
-  renders - a collapsible `Panel` given `hotkeys` no longer crashes when first expanded.
+  renders - a collapsible `Panel` given `hotkeys` no longer crashes when first expanded. Hotkeys
+  may now also be changed after the first render.
 
 ## 87.2.0 - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 * Fixed `SegmentedControl` clipping an option's label when `equalSegmentWidths` divided the tray
   too narrowly - options now hold their own content width, sharing equally only where there is room.
+* Fixed `useHotkeys()` throwing a React hook-count error when its arguments changed across
+  renders - a collapsible `Panel` given `hotkeys` no longer crashes when first expanded.
 
 ## 87.2.0 - 2026-09-08
 

--- a/desktop/hooks/UseHotkeys.ts
+++ b/desktop/hooks/UseHotkeys.ts
@@ -4,15 +4,11 @@
  *
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
+import {hoistCmp, HoistProps} from '@xh/hoist/core';
 import {useHotkeys as useHotkeysBp} from '@xh/hoist/kit/blueprint';
-import {isEmpty} from 'lodash';
-import {cloneElement, ReactElement, useMemo, useRef} from 'react';
+import {isEqualWith, isFunction} from 'lodash';
+import {cloneElement, ReactElement, useRef} from 'react';
 import {HotkeyConfig} from '@blueprintjs/core/src/hooks/hotkeys/hotkeyConfig';
-
-/* eslint-disable react-hooks/exhaustive-deps */
-
-/** Stable-identity placeholder - see note on Blueprint re-registration below. */
-const NO_HOTKEYS: HotkeyConfig[] = [];
 
 /**
  * Hook to add Key handling support to a component.
@@ -20,24 +16,46 @@ const NO_HOTKEYS: HotkeyConfig[] = [];
  * The implementation of this hook is based on BlueprintJS.
  * See their docs {@link https://blueprintjs.com/docs/#core/components/hotkeys} for more info.
  *
- * Note that `hotkeys` are captured on the first render of the calling component and held for its
- * lifetime - later changes to the array are not picked up.
+ * Both args may change across renders - keys are (de)registered as they do.
  *
  * @param child - element to be given hotkey support.  Must specify Component
  *      that takes react key events as props (e.g. boxes, panel, div, etc).
- * @param hotkeys - An array of hotkeys, or configs for hotkeys,
- *      as prescribed by blueprint. A Hotkeys element may also be provided.
+ * @param hotkeys - configs for the hotkeys to be installed, as prescribed by blueprint.
  */
-export function useHotkeys(child?: ReactElement<any>, hotkeys?: HotkeyConfig[]) {
-    // Whether this component installs hotkey support must be decided on its first render
-    // and held stable thereafter.
-    const enabled = useRef(!isEmpty(hotkeys)).current;
-    if (!enabled) return child;
-
-    // Blueprint re-registers its handlers whenever the identity of its `keys` arg changes. Pass the
-    // stable empty array while we have no child.
-    const memoHotkeys = useMemo(() => hotkeys, []),
-        {handleKeyDown, handleKeyUp} = useHotkeysBp(child ? memoHotkeys : NO_HOTKEYS);
-
-    return child ? cloneElement(child, {onKeyDown: handleKeyDown, onKeyUp: handleKeyUp}) : child;
+export function useHotkeys(child?: ReactElement<any>, hotkeys?: HotkeyConfig[]): ReactElement {
+    return child && hotkeys ? hotkeysHost({child, hotkeys}) : child;
 }
+
+//------------------------
+// Implementation
+//------------------------
+interface HotkeysHostProps extends HoistProps {
+    child: ReactElement<any>;
+    hotkeys: HotkeyConfig[];
+}
+
+// Hosts BP's hooks, mounted only for callers that pass hotkeys, and only while they have a child
+// to bind them to - BP adds document listeners and warns re. its missing `HotkeysProvider` for
+// every caller of its hook, so it is not run on behalf of the many `Panel`s that specify no keys.
+const hotkeysHost = hoistCmp.factory<HotkeysHostProps>({
+    displayName: 'HotkeysHost',
+    model: false,
+    memo: false,
+    observer: false,
+
+    render({child, hotkeys}) {
+        // Hold configs stable, refreshing handlers in place - BP re-registers on array identity.
+        const ref = useRef<HotkeyConfig[]>(null),
+            prev = ref.current;
+        if (prev && isEqualWith(prev, hotkeys, fnEquals)) {
+            prev.forEach((hk, idx) => Object.assign(hk, hotkeys[idx]));
+        } else {
+            ref.current = hotkeys.map(hk => ({...hk}));
+        }
+
+        const {handleKeyDown, handleKeyUp} = useHotkeysBp(ref.current);
+        return cloneElement(child, {onKeyDown: handleKeyDown, onKeyUp: handleKeyUp});
+    }
+});
+
+const fnEquals = (a, b) => (isFunction(a) && isFunction(b) ? true : undefined);

--- a/desktop/hooks/UseHotkeys.ts
+++ b/desktop/hooks/UseHotkeys.ts
@@ -6,10 +6,13 @@
  */
 import {useHotkeys as useHotkeysBp} from '@xh/hoist/kit/blueprint';
 import {isEmpty} from 'lodash';
-import {cloneElement, ReactElement, useMemo} from 'react';
+import {cloneElement, ReactElement, useMemo, useRef} from 'react';
 import {HotkeyConfig} from '@blueprintjs/core/src/hooks/hotkeys/hotkeyConfig';
 
 /* eslint-disable react-hooks/exhaustive-deps */
+
+/** Stable-identity placeholder - see note on Blueprint re-registration below. */
+const NO_HOTKEYS: HotkeyConfig[] = [];
 
 /**
  * Hook to add Key handling support to a component.
@@ -17,16 +20,24 @@ import {HotkeyConfig} from '@blueprintjs/core/src/hooks/hotkeys/hotkeyConfig';
  * The implementation of this hook is based on BlueprintJS.
  * See their docs {@link https://blueprintjs.com/docs/#core/components/hotkeys} for more info.
  *
+ * Note that `hotkeys` are captured on the first render of the calling component and held for its
+ * lifetime - later changes to the array are not picked up.
+ *
  * @param child - element to be given hotkey support.  Must specify Component
  *      that takes react key events as props (e.g. boxes, panel, div, etc).
  * @param hotkeys - An array of hotkeys, or configs for hotkeys,
  *      as prescribed by blueprint. A Hotkeys element may also be provided.
  */
 export function useHotkeys(child?: ReactElement<any>, hotkeys?: HotkeyConfig[]) {
-    if (!child || isEmpty(hotkeys)) return child;
+    // Whether this component installs hotkey support must be decided on its first render
+    // and held stable thereafter.
+    const enabled = useRef(!isEmpty(hotkeys)).current;
+    if (!enabled) return child;
 
+    // Blueprint re-registers its handlers whenever the identity of its `keys` arg changes. Pass the
+    // stable empty array while we have no child.
     const memoHotkeys = useMemo(() => hotkeys, []),
-        {handleKeyDown, handleKeyUp} = useHotkeysBp(memoHotkeys);
+        {handleKeyDown, handleKeyUp} = useHotkeysBp(child ? memoHotkeys : NO_HOTKEYS);
 
-    return cloneElement(child, {onKeyDown: handleKeyDown, onKeyUp: handleKeyUp});
+    return child ? cloneElement(child, {onKeyDown: handleKeyDown, onKeyUp: handleKeyUp}) : child;
 }


### PR DESCRIPTION
Fixes #4674.

`useHotkeys()` returned before calling any hooks when it had no `child` or no `hotkeys`, but called `useMemo` plus Blueprint's `useHotkeys` when it had both - so any component instance whose args crossed that boundary between renders changed its hook count and threw *"Rendered more hooks than during the previous render."* A collapsible `Panel` given `hotkeys` hits this whenever it starts collapsed, since `Panel` renders `coreContents = null` while collapsed under the default `renderMode: 'lazy'`.

The hooks now live in an internal `HotkeysHost` cmp. `useHotkeys()` itself calls none, so its early return is legitimate and no caller can change its hook count - in either direction.

* The wrapper mounts only for callers that pass `hotkeys`, and only while they have a child to bind them to, so Blueprint's hook is still not run on behalf of the many `Panel`s that specify no keys - it re-registers on `keys` identity, always attaches document `keydown`/`keyup` listeners, and warns about the missing `HotkeysProvider`.
* `hotkeys` may now change across renders, with keys registered and released as they do - the previous implementation captured them on a component's first render via `useMemo(..., [])` and held them for its lifetime. Configs are held stable and their handlers refreshed in place, so the array literal a caller rebuilds each render does not force Blueprint to re-register, while the latest closures are still the ones invoked.
* The guard is `child && hotkeys` rather than a check for a non-empty array, so the wrapper's presence tracks whether the prop was passed rather than what is in it. An app toggling its array between empty and non-empty would otherwise change the element type at that position and remount the panel's contents. No hoist-react caller passes an empty array.
* Dropped a stale doc claim that a `Hotkeys` element may be passed - the arg is typed `HotkeyConfig[]` and goes straight to Blueprint's hook.

**Verification:** `pnpm typecheck` and `eslint` are clean. Exercised in Toolbox: the #4674 repro (a `Panel` with `hotkeys` starting collapsed under `renderMode: 'lazy'`), the converse `unmountOnHide` case (collapsing an already-rendered panel), and a `Panel` whose `hotkeys` array changes across renders - keys register and release as it does, and the current handlers are the ones invoked.

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so - no API change, and behavior is preserved in every case that did not already throw.
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required - `useHotkeys` is desktop-only.
- [x] Created Toolbox branch / PR, or determined not required - no app-side change needed.
