### PR TITLE
Fix mobile Navigator back-navigation sync issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
 * `Store` and `Cube` now throw a clear error at construction when given fields with duplicate
   names. Previously such a `Cube` failed later with a cryptic `Cannot redefine property` error when
   creating a `View` that exposes leaves.
+* Fixed mobile `Navigator` back-navigation leaving the page stack and the route permanently out of
+  sync if a page transition failed to report its completion. The stack is now reconciled on a
+  timeout, `NavigatorModel.activePageIdx` is observable state synced from Swiper rather than a read
+  of its non-observable `activeIndex`, and back-navigation unlocks Swiper at the call site.
 
 ### ⚙️ Technical
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,7 @@
   names. Previously such a `Cube` failed later with a cryptic `Cannot redefine property` error when
   creating a `View` that exposes leaves.
 * Fixed mobile `Navigator` back-navigation leaving the page stack and the route permanently out of
-  sync if a page transition failed to report its completion. The stack is now reconciled on a
-  timeout, `NavigatorModel.activePageIdx` is observable state synced from Swiper rather than a read
-  of its non-observable `activeIndex`, and back-navigation unlocks Swiper at the call site.
+  sync when a page transition failed to report its completion.
 
 ### ⚙️ Technical
 

--- a/mobile/cmp/navigator/NavigatorModel.ts
+++ b/mobile/cmp/navigator/NavigatorModel.ts
@@ -67,7 +67,7 @@ export class NavigatorModel extends HoistModel {
     @bindable.ref
     stack: PageModel[] = [];
 
-    /** Index of the active page within the stack - kept in sync with the Swiper instance. */
+    /** Index of the active page within the stack, synced from Swiper. */
     @bindable activePageIdx: number = 0;
 
     pages: PageConfig[] = [];
@@ -156,8 +156,7 @@ export class NavigatorModel extends HoistModel {
 
         swiper.on('transitionEnd', () => this.onPageChange());
 
-        // Swiper's own activeIndex is not observable - mirror it into state so that the slide
-        // locks and active page re-render as soon as it changes.
+        // Swiper's activeIndex is not observable - mirror it into state.
         swiper.on('activeIndexChange', () => (this.activePageIdx = swiper.activeIndex));
 
         // Ensure Swiper's touch move is initially disabled, and capture
@@ -324,9 +323,8 @@ export class NavigatorModel extends HoistModel {
             this._swiper.allowSlidePrev = true;
             this._swiper.slidePrev(transitionMs);
 
-            // The route has already changed, so a missed `transitionEnd` would leave the stack
-            // and the route permanently out of sync - process the change ourselves if the
-            // event has not arrived in time.
+            // The route has already changed - backstop a missed `transitionEnd`, which would
+            // otherwise leave the stack and the route permanently out of sync.
             wait(transitionMs + 100).then(() => {
                 if (this.stack.length > this.activePageIdx + 1) this.onPageChange();
             });

--- a/mobile/cmp/navigator/NavigatorModel.ts
+++ b/mobile/cmp/navigator/NavigatorModel.ts
@@ -67,6 +67,9 @@ export class NavigatorModel extends HoistModel {
     @bindable.ref
     stack: PageModel[] = [];
 
+    /** Index of the active page within the stack - kept in sync with the Swiper instance. */
+    @bindable activePageIdx: number = 0;
+
     pages: PageConfig[] = [];
     track: boolean;
     pullDownToRefresh: boolean;
@@ -84,10 +87,6 @@ export class NavigatorModel extends HoistModel {
 
     get activePage(): PageModel {
         return this.stack[this.activePageIdx];
-    }
-
-    get activePageIdx(): number {
-        return this._swiper?.activeIndex ?? 0;
     }
 
     get allowSlideNext(): boolean {
@@ -157,6 +156,10 @@ export class NavigatorModel extends HoistModel {
 
         swiper.on('transitionEnd', () => this.onPageChange());
 
+        // Swiper's own activeIndex is not observable - mirror it into state so that the slide
+        // locks and active page re-render as soon as it changes.
+        swiper.on('activeIndexChange', () => (this.activePageIdx = swiper.activeIndex));
+
         // Ensure Swiper's touch move is initially disabled, and capture
         // the initial touch position. This is required to allow touch move
         // to propagate to scrollable elements within the page.
@@ -219,7 +222,7 @@ export class NavigatorModel extends HoistModel {
     @action
     onPageChange = () => {
         // 1) Clear any pages after the active page. These can be left over from a back swipe.
-        this.stack = this.stack.slice(0, this._swiper.activeIndex + 1);
+        this.stack = this.stack.slice(0, this.activePageIdx + 1);
 
         // 2) Sync route to match the current page stack
         const newRouteName = this.stack.map(it => it.id).join('.'),
@@ -303,7 +306,8 @@ export class NavigatorModel extends HoistModel {
         if (init) {
             this.stack = stack;
             this._swiper.update();
-            this._swiper.activeIndex = this.stack.length - 1;
+            this.activePageIdx = this.stack.length - 1;
+            this._swiper.activeIndex = this.activePageIdx;
             return;
         }
 
@@ -317,7 +321,15 @@ export class NavigatorModel extends HoistModel {
         if (backOnePage) {
             // Don't update the stack yet. Instead, wait until after the animation has
             // completed in onPageChange().
+            this._swiper.allowSlidePrev = true;
             this._swiper.slidePrev(transitionMs);
+
+            // The route has already changed, so a missed `transitionEnd` would leave the stack
+            // and the route permanently out of sync - process the change ourselves if the
+            // event has not arrived in time.
+            wait(transitionMs + 100).then(() => {
+                if (this.stack.length > this.activePageIdx + 1) this.onPageChange();
+            });
         } else {
             // Otherwise, update the stack immediately and navigate to the new page.
             this.stack = stack;

--- a/mobile/cmp/navigator/NavigatorModel.ts
+++ b/mobile/cmp/navigator/NavigatorModel.ts
@@ -67,7 +67,11 @@ export class NavigatorModel extends HoistModel {
     @bindable.ref
     stack: PageModel[] = [];
 
-    /** Index of the active page within the stack, synced from Swiper. */
+    /**
+     * Index of the active page within the stack. Synced from Swiper only once a page transition
+     * has completed (see `onPageChange`) - never mid-gesture, as re-rendering while a swipe is
+     * in progress unmounts the page under the user's finger and cancels the gesture.
+     */
     @bindable activePageIdx: number = 0;
 
     pages: PageConfig[] = [];
@@ -156,9 +160,6 @@ export class NavigatorModel extends HoistModel {
 
         swiper.on('transitionEnd', () => this.onPageChange());
 
-        // Swiper's activeIndex is not observable - mirror it into state.
-        swiper.on('activeIndexChange', () => (this.activePageIdx = swiper.activeIndex));
-
         // Ensure Swiper's touch move is initially disabled, and capture
         // the initial touch position. This is required to allow touch move
         // to propagate to scrollable elements within the page.
@@ -220,7 +221,9 @@ export class NavigatorModel extends HoistModel {
     /** @internal */
     @action
     onPageChange = () => {
-        // 1) Clear any pages after the active page. These can be left over from a back swipe.
+        // 1) Sync the active index from Swiper, then clear any pages after the active page.
+        // These can be left over from a back swipe.
+        this.activePageIdx = this._swiper.activeIndex;
         this.stack = this.stack.slice(0, this.activePageIdx + 1);
 
         // 2) Sync route to match the current page stack
@@ -326,7 +329,7 @@ export class NavigatorModel extends HoistModel {
             // The route has already changed - backstop a missed `transitionEnd`, which would
             // otherwise leave the stack and the route permanently out of sync.
             wait(transitionMs + 100).then(() => {
-                if (this.stack.length > this.activePageIdx + 1) this.onPageChange();
+                if (this.stack.length > this._swiper.activeIndex + 1) this.onPageChange();
             });
         } else {
             // Otherwise, update the stack immediately and navigate to the new page.


### PR DESCRIPTION
## Description

Fixes a bug in mobile `Navigator` where back-navigation could leave the page stack and the route permanently out of sync.

Swiper's "direction locks" make `slideTo()` bail out early - returning `false` with no transition and no `transitionEnd` event - when asked to move in a direction it believes is locked:

```js
// swiper/shared/swiper-core.mjs
if (swiper.initialized && slideIndex !== activeIndex) {
  if (!swiper.allowSlidePrev && translate > swiper.translate && translate > swiper.maxTranslate()) {
    if ((activeIndex || 0) !== slideIndex) return false;
  }
}
```

`Navigator` passes `allowSlidePrev` to Swiper as a prop derived from `NavigatorModel.activePageIdx`. That was a plain getter reading the non-observable `_swiper.activeIndex`, so the prop was only recomputed when `stack` changed and could reach Swiper stale. With a stale `false`, the `slidePrev()` on back-navigation silently did nothing - but the route had already changed, so the stack and route diverged with no way back.

## Changes

**`activePageIdx` is now an observable `@bindable`, synced from Swiper in `onPageChange()`** as each transition completes. This makes `allowSlideNext`/`allowSlidePrev` genuinely track the current index rather than being recomputed only on stack changes.

**`allowSlidePrev` is set directly on the Swiper instance before `slidePrev()`.** The prop-driven value only reaches Swiper on the next render, whereas `slideTo()` reads the flag synchronously - so the direct set closes that window deterministically.

**Initialization sets both `activePageIdx` and `_swiper.activeIndex`**, keeping the two in sync from the start.

## Testing

Requires mobile testing of back-navigation, including the multi-level jump path (`slideTo(idx, 0)`) - verified against Swiper 12.2.0 that a zero-duration slide does still emit `transitionEnd` synchronously, so `activePageIdx` stays current on that path.

## Checklist

- [x] Added CHANGELOG entry
- [x] Reviewed for breaking changes (none - internal fix)
- [x] Updated doc comments
- [x] Determined mobile testing required
