### PR TITLE
Center checkbox + radio indicators in compact Toolbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   may now also be changed after the first render.
 * Fixed mobile `Navigator` back-navigation leaving the page stack and the route permanently out of
   sync when a stale `allowSlidePrev` caused Swiper to silently skip the transition.
+* Fixed `RadioInput` and `Checkbox` options being clipped by top of the `Toolbar` - they
+  are now centered within the compact item height.
 * Fixed `dateEditor` crashing when opening its picker on a column backed by a `localDate` field -
   the editor now defaults its `valueType` from the Store field type.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@
   may now also be changed after the first render.
 * Fixed mobile `Navigator` back-navigation leaving the page stack and the route permanently out of
   sync when a stale `allowSlidePrev` caused Swiper to silently skip the transition.
-* Fixed `RadioInput` and `Checkbox` options being clipped by top of the `Toolbar` - they
+* Fixed `RadioInput` and `Checkbox` options overhanging the top of the `Toolbar` - they
   are now centered within the compact item height, sharing one rule with `SwitchInput`.
+* Fixed an unlabeled `Slider` (`labelRenderer: false`) sitting high in a compact `Toolbar`.
 * Fixed `SegmentedControl` overflowing a compact `Toolbar` - it now takes its compact sizing from
   the toolbar, without needing its own `compact: true`.
 * Fixed `dateEditor` crashing when opening its picker on a column backed by a `localDate` field -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,9 @@
 * Fixed mobile `Navigator` back-navigation leaving the page stack and the route permanently out of
   sync when a stale `allowSlidePrev` caused Swiper to silently skip the transition.
 * Fixed `RadioInput` and `Checkbox` options being clipped by top of the `Toolbar` - they
-  are now centered within the compact item height.
+  are now centered within the compact item height, sharing one rule with `SwitchInput`.
+* Fixed `SegmentedControl` overflowing a compact `Toolbar` - it now takes its compact sizing from
+  the toolbar, without needing its own `compact: true`.
 * Fixed `dateEditor` crashing when opening its picker on a column backed by a `localDate` field -
   the editor now defaults its `valueType` from the Store field type.
 

--- a/desktop/cmp/input/SegmentedControl.scss
+++ b/desktop/cmp/input/SegmentedControl.scss
@@ -120,9 +120,8 @@
     }
   }
 
-  // Compact mode - reduced sizing for toolbars and space-constrained contexts. Applied via the
-  // `compact` prop, or implicitly when hosted by a compact Toolbar, whose item height the
-  // default sizing above (keyed to a standard Toolbar) would otherwise overflow.
+  // Compact mode - via the `compact` prop, or implicitly within a compact Toolbar, whose
+  // item height the standard sizing above would overflow.
   &--compact .bp6-segmented-control,
   .xh-toolbar--compact & .bp6-segmented-control {
     padding: 0;

--- a/desktop/cmp/input/SegmentedControl.scss
+++ b/desktop/cmp/input/SegmentedControl.scss
@@ -120,8 +120,11 @@
     }
   }
 
-  // Compact mode - reduced sizing for toolbars and space-constrained contexts.
-  &--compact .bp6-segmented-control {
+  // Compact mode - reduced sizing for toolbars and space-constrained contexts. Applied via the
+  // `compact` prop, or implicitly when hosted by a compact Toolbar, whose item height the
+  // default sizing above (keyed to a standard Toolbar) would otherwise overflow.
+  &--compact .bp6-segmented-control,
+  .xh-toolbar--compact & .bp6-segmented-control {
     padding: 0;
     gap: 0;
 
@@ -138,7 +141,8 @@
   }
 
   // Compact + outlined - shrink buttons to account for the border.
-  &--compact#{&}--outlined .bp6-segmented-control > .bp6-button {
+  &--compact#{&}--outlined .bp6-segmented-control > .bp6-button,
+  .xh-toolbar--compact &#{&}--outlined .bp6-segmented-control > .bp6-button {
     --compact-btn-h: calc(var(--xh-tbar-compact-item-height-px) - 2px);
     min-height: var(--compact-btn-h);
     max-height: var(--compact-btn-h);

--- a/desktop/cmp/toolbar/Toolbar.scss
+++ b/desktop/cmp/toolbar/Toolbar.scss
@@ -155,8 +155,7 @@
         }
       }
 
-      // BP aligns control indicators to the text baseline, leaving them clipped when compact -
-      // lay them out with flex instead to center within the reduced item height.
+      // BP baseline-aligns control indicators, clipping them when compact - flex to center.
       &.xh-switch-input,
       &.xh-check-box,
       &.xh-radio-input .xh-radio-input-option {

--- a/desktop/cmp/toolbar/Toolbar.scss
+++ b/desktop/cmp/toolbar/Toolbar.scss
@@ -170,6 +170,29 @@
         padding-right: 0;
       }
 
+      // BP aligns checkbox/radio indicators to the text baseline, leaving them clipped
+      // when compact - lay them out with flex instead to center within it.
+      &.xh-check-box,
+      &.xh-radio-input .xh-radio-input-option {
+        display: flex;
+        align-items: center;
+        padding-inline-start: 0;
+
+        .bp6-control-indicator {
+          margin: 0 var(--xh-pad-half-px) 0 0;
+        }
+
+        &.bp6-align-right {
+          flex-direction: row-reverse;
+          padding-right: 0;
+
+          .bp6-control-indicator {
+            float: none;
+            margin: 0 0 0 var(--xh-pad-half-px);
+          }
+        }
+      }
+
       &.xh-select {
         display: flex;
         align-items: center;

--- a/desktop/cmp/toolbar/Toolbar.scss
+++ b/desktop/cmp/toolbar/Toolbar.scss
@@ -155,23 +155,9 @@
         }
       }
 
-      &.xh-switch-input {
-        display: flex;
-        align-items: center;
-
-        .bp6-control-indicator {
-          margin-top: 1px;
-          margin-right: var(--xh-pad-half-px);
-        }
-      }
-
-      &.xh-switch-input.bp6-align-right {
-        flex-direction: row-reverse;
-        padding-right: 0;
-      }
-
-      // BP aligns checkbox/radio indicators to the text baseline, leaving them clipped
-      // when compact - lay them out with flex instead to center within it.
+      // BP aligns control indicators to the text baseline, leaving them clipped when compact -
+      // lay them out with flex instead to center within the reduced item height.
+      &.xh-switch-input,
       &.xh-check-box,
       &.xh-radio-input .xh-radio-input-option {
         display: flex;

--- a/desktop/cmp/toolbar/Toolbar.scss
+++ b/desktop/cmp/toolbar/Toolbar.scss
@@ -155,7 +155,7 @@
         }
       }
 
-      // BP baseline-aligns control indicators, clipping them when compact - flex to center.
+      // BP baseline-aligns control indicators, overhanging the bar when compact - flex to center.
       &.xh-switch-input,
       &.xh-check-box,
       &.xh-radio-input .xh-radio-input-option {
@@ -176,6 +176,12 @@
             margin: 0 0 0 var(--xh-pad-half-px);
           }
         }
+      }
+
+      // BP's unlabeled slider (labelRenderer: false) is 16px - center it. Labeled ones are 40px
+      // and overhang the bar.
+      &.xh-slider .bp6-slider-unlabeled {
+        margin-top: calc((var(--xh-tbar-compact-item-height-px) - 16px) / 2);
       }
 
       &.xh-select {


### PR DESCRIPTION
Fixes #4671

### Cause

Blueprint aligns `.bp6-control-indicator` to the text *baseline* (16px inline-block with `margin-top: -3px`). In a compact `Toolbar`, `.xh-input` is pinned to `--xh-tbar-compact-item-height-px` (20px) and the type is smaller, so the indicator hangs above its container and overhangs the 24px toolbar - measured indicator top `137.7` vs toolbar top `137.4`, with 7.7px of unused space below it.

`Checkbox` has the same defect as `RadioInput` (it just reads as a less obvious overhang). `SwitchInput` already carried a `display: flex; align-items: center` rule in the compact block, which is why it looked right.

### Fix

In the compact block of `Toolbar.scss`, alongside the existing switch/select rules: lay checkbox and radio options out with flex and center them, replacing BP's baseline hang and its `padding-inline-start` / negative-margin indent with plain margins. The `bp6-align-right` variant (`labelSide: 'left'`) gets the row-reverse treatment the switch already uses, plus `float: none`, inert in flex.

Indicators stay at 16px rather than shrinking to 12-14px as the issue suggests - 16px is what the compact switch already renders, so all three controls now share one size and one alignment. Happy to add a size reduction if we'd rather have the indicators track the smaller type.

### Verification

The rule is scoped under `--compact`, so standard toolbars are untouched. Measured with a static harness built from the compiled SCSS (`vars` + `Toolbar` + `RadioInput`) and Blueprint's own DOM order:

| | before | after |
| --- | --- | --- |
| compact radio indicator | top 137.7 in a 137.4-161.4 toolbar (2.2px *above* its container) | top 141.9, bottom 157.9 - centered in the 139.9-159.9 input |
| compact checkbox indicator | top 212.4 vs container 214.6 | top 216.6, bottom 232.6 - centered |

Also checked `labelSide: 'left'`. A follow-up commit folds `SwitchInput` into the same rule (a `margin-top: 1px` fudge left it 1px low), sizes `SegmentedControl` to the compact item height when hosted by a compact toolbar, and centers an unlabeled `Slider` (`labelRenderer: false`, 16px in BP) - see the audit comment below. Labeled sliders are 40px and still overhang; that needs a call on whether a compact toolbar should suppress their labels. Worth an eyeball on Toolbox's RadioInput and Checkbox & Switch pages before merge.
