### PR TITLE
Add `Column.cellFlag` for Excel-style corner flags on grid cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@
 
 ## 88.0.0-SNAPSHOT - unreleased
 
+### 🎁 New Features
+
+* Added `Column.cellFlag`, rendering a small triangular flag in a grid cell's top-right corner in
+  the color of a Hoist `Intent` - a compact marker for values warranting attention. Called per
+  record, returning the `Intent` to draw, or null for no flag.
+
+### ✨ Styles
+
+* Grid cell flag styles are now keyed by `Intent` (`.xh-cell--flag-{intent}`), with size driven by
+  the new `--xh-grid-cell-flag-size` custom property. The classes previously emitted for cell
+  validation state - `.xh-cell--invalid`, `.xh-cell--warning`, and `.xh-cell--info` - are
+  deprecated but still styled, so apps applying them directly continue to render a flag. Retarget
+  any CSS overriding these at the new class names.
+
 
 ## 87.3.0 - 2026-09-10
 

--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -104,40 +104,63 @@
     padding-right: 0;
   }
 
-  // Render badge on cells with validation issues
-  .ag-cell.xh-cell--invalid,
-  .ag-cell.xh-cell--warning,
+  // Cell corner flags - small triangular markers in a cell's top-right corner, colored by Intent.
+  // Driven by `Column.cellFlag`, and by the framework to surface cell validation state.
+  .ag-cell.xh-cell--flag-primary {
+    --xh-grid-cell-flag-color: var(--xh-intent-primary);
+  }
+
+  .ag-cell.xh-cell--flag-success {
+    --xh-grid-cell-flag-color: var(--xh-intent-success);
+  }
+
+  .ag-cell.xh-cell--flag-warning {
+    --xh-grid-cell-flag-color: var(--xh-intent-warning);
+  }
+
+  .ag-cell.xh-cell--flag-danger {
+    --xh-grid-cell-flag-color: var(--xh-intent-danger);
+  }
+
+  // DEPRECATED - legacy validation flag classes, superseded by the intent-keyed classes above.
+  // Hoist no longer emits these; they are retained only so that an app applying them directly
+  // (e.g. via its own `cellClassRules`) continues to render a flag. Remove in a future major.
   .ag-cell.xh-cell--info {
+    --xh-grid-cell-flag-color: var(--xh-intent-primary);
+  }
+
+  .ag-cell.xh-cell--warning {
+    --xh-grid-cell-flag-color: var(--xh-intent-warning);
+  }
+
+  .ag-cell.xh-cell--invalid {
+    --xh-grid-cell-flag-color: var(--xh-intent-danger);
+  }
+
+  .ag-cell[class*='xh-cell--flag-'],
+  .ag-cell.xh-cell--info,
+  .ag-cell.xh-cell--warning,
+  .ag-cell.xh-cell--invalid {
+    // Drawn as a triangle via two colored borders meeting at the cell's top-right corner.
     &::before {
       content: '';
       position: absolute;
       top: 0;
       right: 0;
       border-color: transparent;
+      border-top-color: var(--xh-grid-cell-flag-color, transparent);
+      border-right-color: var(--xh-grid-cell-flag-color, transparent);
       border-style: solid;
+      // Sized per grid sizing mode - see the size-mode blocks below.
+      border-width: var(--xh-grid-cell-flag-size, 5px);
     }
 
-    // Render badge on top of nested editor, and move to account for padding while editing
+    // Render flag on top of a nested editor, nudged to clear the editor's padding.
     &.ag-cell-inline-editing::before {
       z-index: 1;
       margin-top: 1px;
       margin-right: 3px;
     }
-  }
-
-  .ag-cell.xh-cell--invalid::before {
-    border-right-color: var(--xh-intent-danger);
-    border-top-color: var(--xh-intent-danger);
-  }
-
-  .ag-cell.xh-cell--warning::before {
-    border-right-color: var(--xh-intent-warning);
-    border-top-color: var(--xh-intent-warning);
-  }
-
-  .ag-cell.xh-cell--info::before {
-    border-right-color: var(--xh-intent-primary);
-    border-top-color: var(--xh-intent-primary);
   }
 
   // Render left / right group borders
@@ -149,37 +172,23 @@
     @include AgGrid.group-border(right);
   }
 
+  // Corner flag size by grid sizing mode. Apps may override per mode, e.g.
+  // `.xh-ag-grid--standard {--xh-grid-cell-flag-size: 8px;}`.
   .xh-ag-grid {
     &--tiny {
-      .ag-cell.xh-cell--invalid::before,
-      .ag-cell.xh-cell--warning::before,
-      .ag-cell.xh-cell--info::before {
-        border-width: 3px;
-      }
+      --xh-grid-cell-flag-size: 3px;
     }
 
     &--compact {
-      .ag-cell.xh-cell--invalid::before,
-      .ag-cell.xh-cell--warning::before,
-      .ag-cell.xh-cell--info::before {
-        border-width: 4px;
-      }
+      --xh-grid-cell-flag-size: 4px;
     }
 
     &--standard {
-      .ag-cell.xh-cell--invalid::before,
-      .ag-cell.xh-cell--warning::before,
-      .ag-cell.xh-cell--info::before {
-        border-width: 5px;
-      }
+      --xh-grid-cell-flag-size: 5px;
     }
 
     &--large {
-      .ag-cell.xh-cell--invalid::before,
-      .ag-cell.xh-cell--warning::before,
-      .ag-cell.xh-cell--info::before {
-        border-width: 6px;
-      }
+      --xh-grid-cell-flag-size: 6px;
     }
   }
 }

--- a/cmp/grid/README.md
+++ b/cmp/grid/README.md
@@ -264,6 +264,31 @@ columns: [
 ]
 ```
 
+### Cell Corner Flags
+
+`cellFlag` marks a cell with a small triangle in its top-right corner, in the color of a standard
+Hoist `Intent` - a compact alternative to spending a column or restyling the cell. Called per
+record, returning an `Intent` or `null`.
+
+```typescript
+columns: [
+    {
+        field: 'volume',
+        cellFlag: volume => (volume >= 9_000_000_000 ? 'warning' : null)
+    },
+    {
+        field: 'price',
+        cellFlag: (value, {record}) => (record.data.isStale ? 'warning' : null)
+    }
+]
+```
+
+One flag renders per cell, and on an editable column a failing validation always wins. Keep the
+function cheap - it runs once per candidate `Intent` on each rendered cell and is deliberately
+uncached, so a flag still reflects state that changes without the record, such as an async
+validation result. Size follows the grid's `sizingMode` via the `--xh-grid-cell-flag-size` custom
+property. Flags are CSS pseudo-elements, so they add no width and do not appear in grid exports.
+
 ## Column Properties Reference
 
 Every column within a `GridModel` must resolve to a **unique ID**. The `colId` defaults to `field`
@@ -283,7 +308,7 @@ Key categories of `ColumnSpec` properties:
 | Editing | `editable`, `editor`, `editorIsPopup`                                                                        |
 | Export | `exportName`, `exportValue`, `excludeFromExport`, `excelFormat`, `excelWidth`                                |
 | Chooser | `chooserName`, `chooserGroup`, `chooserDescription`\*, `excludeFromChooser`, `hideable`                      |
-| Rendering | `renderer`, `rendererIsComplex`, `tooltip`, `cellClass`, `cellClassRules`                                    |
+| Rendering | `renderer`, `rendererIsComplex`, `tooltip`, `cellClass`, `cellClassRules`, `cellFlag`                         |
 | Tree | `isTreeColumn`, `headerHasExpandCollapse`                                                                    |
 | Autosize | `autosizable`, `autosizeIncludeHeader`, `autosizeIncludeHeaderIcons`, `autosizeMinWidth`, `autosizeMaxWidth` |
 

--- a/cmp/grid/Types.ts
+++ b/cmp/grid/Types.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 
-import type {HoistModel, HSide, PersistOptions, Some} from '@xh/hoist/core';
+import type {HoistModel, HSide, Intent, PersistOptions, Some} from '@xh/hoist/core';
 import type {PanelConfig} from '@xh/hoist/desktop/cmp/panel';
 import type {
     FilterBindTarget,
@@ -382,6 +382,14 @@ export type ColumnCellClassFn<T = any> = (
  *      it should be removed.
  */
 export type ColumnCellClassRuleFn = (agParams: CellClassParams) => boolean;
+
+/**
+ * Function to determine the corner flag, if any, to render on a grid cell's top-right corner.
+ * @param value - cell data value (column + row).
+ * @param context - additional data about the column, row and GridModel.
+ * @returns the Intent to draw the flag in, or null for no flag.
+ */
+export type ColumnCellFlagFn<T = any> = (value: T, context: CellContext) => Intent | null;
 
 /**
  * Function to produce a grid column tooltip.

--- a/cmp/grid/columns/Column.ts
+++ b/cmp/grid/columns/Column.ts
@@ -5,7 +5,7 @@
  * Copyright © 2026 Extremely Heavy Industries Inc.
  */
 import {div, li, span, ul} from '@xh/hoist/cmp/layout';
-import {HAlign, HSide, PlainObject, Some, XH, Thunkable} from '@xh/hoist/core';
+import {HAlign, HSide, Intent, PlainObject, Some, XH, Thunkable} from '@xh/hoist/core';
 import {
     CubeFieldSpec,
     FieldSpec,
@@ -52,6 +52,7 @@ import {getAgHeaderClassFn, managedRenderer} from '../impl/Utils';
 import {
     ColumnCellClassFn,
     ColumnCellClassRuleFn,
+    ColumnCellFlagFn,
     ColumnComparator,
     ColumnEditableFn,
     ColumnEditorFn,
@@ -69,6 +70,7 @@ import {
 } from '../Types';
 import {ExcelFormat} from '../enums/ExcelFormat';
 import type {
+    CellClassParams,
     ColDef,
     ITooltipParams,
     ValueGetterParams,
@@ -158,6 +160,23 @@ export interface ColumnSpec {
      * See Ag-Grid docs on "cell styles" for details.
      */
     cellClassRules?: Record<string, ColumnCellClassRuleFn>;
+
+    /**
+     * Render a small triangular flag in a cell's top-right corner - a compact marker for values
+     * warranting attention, without consuming a column or altering cell contents.
+     *
+     * Called per record. Return the Intent to draw the flag in, or null for no flag. Flags
+     * always render in the cell's top-right corner.
+     *
+     * Keep this cheap - it is called once per candidate Intent on every rendered cell,
+     * whenever the cell refreshes. It is intentionally not cached, so that a flag reflects
+     * current state even when that state (e.g. an async validation result) changes without the
+     * record or its value changing.
+     *
+     * At most one flag is rendered per cell. On an editable column, a cell failing validation
+     * always shows its validation flag, taking precedence over any flag returned here.
+     */
+    cellFlag?: ColumnCellFlagFn;
 
     /** True to suppress default display of the column.*/
     hidden?: boolean;
@@ -492,6 +511,7 @@ export class Column {
     headerClass: ColumnHeaderClassFn | Some<string>;
     cellClass: ColumnCellClassFn | Some<string>;
     cellClassRules: Record<string, ColumnCellClassRuleFn>;
+    cellFlag: ColumnCellFlagFn;
     align: HAlign;
     hidden: boolean;
     flex: boolean | number;
@@ -566,6 +586,7 @@ export class Column {
             headerClass,
             cellClass,
             cellClassRules,
+            cellFlag,
             hidden,
             align,
             width,
@@ -647,6 +668,7 @@ export class Column {
 
         this.cellClass = cellClass;
         this.cellClassRules = cellClassRules || {};
+        this.cellFlag = cellFlag;
 
         this.align = align;
         this.omit = omit;
@@ -1059,17 +1081,49 @@ export class Column {
             });
             ret.cellEditorPopup = this.editorIsPopup;
             ret.cellClassRules = {
-                'xh-cell--invalid': agParams =>
-                    maxSeverity(agParams.data?.validationResults[field]) === 'error',
-                'xh-cell--warning': agParams =>
-                    maxSeverity(agParams.data?.validationResults[field]) === 'warning',
-                'xh-cell--info': agParams =>
-                    maxSeverity(agParams.data?.validationResults[field]) === 'info',
                 'xh-cell--editable': agParams => {
                     return this.isEditableForRecord(agParams.data);
                 },
                 ...ret.cellClassRules
             };
+        }
+
+        // Cell flags, from `cellFlag` and/or the validation state of an editable cell. Always
+        // emitted via cellClassRules, never cellClass, so that a flag is *removed* when record
+        // data changes or when validation supersedes it - see the note on ColumnSpec.cellClass.
+        //
+        // Deliberately composed into the ag colDef here and never onto `this.cellClassRules`,
+        // which is what ColumnWidthCalculator reads. Flags are absolutely-positioned pseudo-
+        // elements and cannot affect measured width, so keeping them out of that config spares
+        // every flagged column the calculator's expensive class-permutation path.
+        const {cellFlag} = this;
+        if (cellFlag || editor) {
+            // Resolved fresh on every evaluation, holding no state between calls. Deliberately
+            // NOT memoized on the record: `validationResults` is populated asynchronously and can
+            // change while a record and its value stay identical, so a record-keyed cache serves
+            // a stale flag once an async rule settles. Holding no record reference also keeps this
+            // closure - which lives as long as the ag colDef - from pinning a StoreRecord.
+            const intentForCell = (agParams: CellClassParams): Intent => {
+                const record = agParams.data as StoreRecord,
+                    {value} = agParams;
+
+                // Validation state wins - it reports an error, not an annotation.
+                if (editor) {
+                    const severity = maxSeverity(record?.validationResults[field]);
+                    if (severity) return SEVERITY_FLAG_INTENTS[severity];
+                }
+
+                return cellFlag ? cellFlag(value, {record, column: this, gridModel}) : null;
+            };
+
+            const flagRules: Record<string, ColumnCellClassRuleFn> = {};
+            CELL_FLAG_INTENTS.forEach(intent => {
+                flagRules[`xh-cell--flag-${intent}`] = agParams =>
+                    intentForCell(agParams) === intent;
+            });
+
+            // Flag rules first, so app-supplied cellClassRules continue to win.
+            ret.cellClassRules = {...flagRules, ...ret.cellClassRules};
         }
 
         // Finally, apply explicit app requests.  The customer is always right....
@@ -1195,3 +1249,15 @@ export class Column {
             : (record?.data[sortValue] ?? v);
     }
 }
+
+//------------------------
+// Cell flag implementation
+//------------------------
+const CELL_FLAG_INTENTS: Intent[] = ['primary', 'success', 'warning', 'danger'];
+
+// Validation severity to the Intent used for its flag - preserves long-standing flag colors.
+const SEVERITY_FLAG_INTENTS: Record<ValidationSeverity, Intent> = {
+    error: 'danger',
+    warning: 'warning',
+    info: 'primary'
+};

--- a/cmp/grid/columns/Column.ts
+++ b/cmp/grid/columns/Column.ts
@@ -162,19 +162,10 @@ export interface ColumnSpec {
     cellClassRules?: Record<string, ColumnCellClassRuleFn>;
 
     /**
-     * Render a small triangular flag in a cell's top-right corner - a compact marker for values
-     * warranting attention, without consuming a column or altering cell contents.
-     *
-     * Called per record. Return the Intent to draw the flag in, or null for no flag. Flags
-     * always render in the cell's top-right corner.
-     *
-     * Keep this cheap - it is called once per candidate Intent on every rendered cell,
-     * whenever the cell refreshes. It is intentionally not cached, so that a flag reflects
-     * current state even when that state (e.g. an async validation result) changes without the
-     * record or its value changing.
-     *
-     * At most one flag is rendered per cell. On an editable column, a cell failing validation
-     * always shows its validation flag, taking precedence over any flag returned here.
+     * Render a small triangular flag in the top-right corner of each cell, in the color of the
+     * returned Intent - a compact marker for values warranting attention. Return null for no flag.
+     * Called per record on every cell refresh and deliberately not cached, so keep it cheap.
+     * On an editable column, a cell failing validation shows its validation flag instead.
      */
     cellFlag?: ColumnCellFlagFn;
 
@@ -1088,21 +1079,13 @@ export class Column {
             };
         }
 
-        // Cell flags, from `cellFlag` and/or the validation state of an editable cell. Always
-        // emitted via cellClassRules, never cellClass, so that a flag is *removed* when record
-        // data changes or when validation supersedes it - see the note on ColumnSpec.cellClass.
-        //
-        // Deliberately composed into the ag colDef here and never onto `this.cellClassRules`,
-        // which is what ColumnWidthCalculator reads. Flags are absolutely-positioned pseudo-
-        // elements and cannot affect measured width, so keeping them out of that config spares
-        // every flagged column the calculator's expensive class-permutation path.
+        // Flags must go via cellClassRules (removable) rather than cellClass (sticky), and must be
+        // composed into the ag colDef here rather than `this.cellClassRules` - the latter feeds
+        // ColumnWidthCalculator, and these pseudo-elements cannot affect measured width.
         const {cellFlag} = this;
         if (cellFlag || editor) {
-            // Resolved fresh on every evaluation, holding no state between calls. Deliberately
-            // NOT memoized on the record: `validationResults` is populated asynchronously and can
-            // change while a record and its value stay identical, so a record-keyed cache serves
-            // a stale flag once an async rule settles. Holding no record reference also keeps this
-            // closure - which lives as long as the ag colDef - from pinning a StoreRecord.
+            // Not memoized by record - `validationResults` can settle while the record and its
+            // value stay identical, and a captured record would be pinned for the colDef's life.
             const intentForCell = (agParams: CellClassParams): Intent => {
                 const record = agParams.data as StoreRecord,
                     {value} = agParams;
@@ -1255,7 +1238,6 @@ export class Column {
 //------------------------
 const CELL_FLAG_INTENTS: Intent[] = ['primary', 'success', 'warning', 'danger'];
 
-// Validation severity to the Intent used for its flag - preserves long-standing flag colors.
 const SEVERITY_FLAG_INTENTS: Record<ValidationSeverity, Intent> = {
     error: 'danger',
     warning: 'warning',


### PR DESCRIPTION
Closes #4673.

`cellFlag` renders a small triangle in a grid cell's top-right corner, in the color of a standard Hoist `Intent`. Called per record, returning an `Intent` or null.

Hoist already drew this glyph, but only for itself - the styles were reachable only via the classes installed for cell validation state on editable columns. This promotes that private mechanism to a public column config and re-expresses the validation flags on top of it, leaving one implementation rather than two.

```typescript
{field: 'volume', cellFlag: volume => (volume >= 9_000_000_000 ? 'warning' : null)}
```

### Notes for reviewers

Three decisions are load-bearing and easy to "tidy" into bugs later, so each carries a comment in the code:

- **`cellClassRules`, never `cellClass`** - a `cellClass` is never removed once applied, so a flag built on it would stick permanently.
- **Deliberately uncached** - `validationResults` is populated asynchronously and can change while a record and its value stay identical. A record-keyed memo (which this originally had) serves a stale flag once an async rule settles; it was reproducible in the Toolbox inline-editing demo with async validation on. Holding no record reference also keeps the closure, which lives as long as the ag colDef, from pinning a `StoreRecord`. The function runs once per candidate `Intent` per rendered cell, so it must stay cheap - documented on the config.
- **Composed into the ag colDef, not `Column.cellClassRules`** - the latter is what `ColumnWidthCalculator` reads. Flags are absolutely-positioned pseudo-elements that cannot affect measured width, so this keeps flagged columns off the calculator's class-permutation path. Do not merge them into `Column.cellClassRules`.

Scope was deliberately trimmed during review: no static (non-function) config form, and no configurable corner - both were speculative, and the corner doubled the per-cell call count for no requested use case. Either can be added later without a breaking change.

### Deprecation

`.xh-cell--invalid`, `.xh-cell--warning` and `.xh-cell--info` remain styled, so an app applying them directly still renders a flag. Hoist itself no longer emits them.

### Toolbox

Matching branch `grid-cell-flag` swaps the `SampleGrid` Volume column's hand-rolled `cellClassRules` + SCSS for a `cellFlag`. It cannot be committed until a SNAPSHOT carrying this change is published, since its pre-commit `tsc` resolves `@xh/hoist` from npm.

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. *(Deprecated classes stay styled, so apps applying them keep working.)*
- [x] Updated doc comments / prop-types, or determined not required.
- [x] Reviewed and tested on Mobile, or determined not required. *(`cmp/grid` and `Grid.scss` are shared, so this lands on both platforms.)*
- [x] Created Toolbox branch / PR, or determined not required. *(Branch ready; see above.)*