### PR TITLE
Split grid tooltip styling from tooltip state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@
 
 ### ✨ Styles
 
+* Added `.xh-grid-tooltip-frame`, a standalone utility class carrying Hoist's standard tooltip
+  chrome - background, border, radius, padding and max-width. Hoist applies it to the tooltip
+  content it renders itself, and apps can add it to a custom (element) tooltip's own root to match.
+  Line-break handling moves alongside it to a `.xh-grid-tooltip--prewrap` modifier.
+    * ⚠️The `.xh-grid-tooltip--default` and `--custom` classes have been removed. They carried
+      the styling that now lives in the utility classes above, and nothing consumed them once it
+      moved out. Apps with CSS targeting either should retarget `.xh-grid-tooltip`, still applied
+      to every grid tooltip, or the new utility classes.
+* Fixed validation tooltips on an editable column rendering without rounded corners or a max-width
+  when that column also defined a custom (element) `tooltip`. Validation messages now always use
+  the standard frame, since they supersede the column's own tooltip entirely.
+    * ⚠️`.xh-grid-tooltip--validation` now sits on the tooltip itself rather than the message
+      list inside it, making it a true modifier of `.xh-grid-tooltip`, and `--validation--single`
+      is renamed `--validation-single` to match. The list carries no class of its own.
 * Grid cell flag styles are now keyed by `Intent` (`.xh-cell--flag-{intent}`), with size driven by
   the new `--xh-grid-cell-flag-size` custom property. The classes previously emitted for cell
   validation state - `.xh-cell--invalid`, `.xh-cell--warning`, and `.xh-cell--info` - are

--- a/cmp/grid/Grid.scss
+++ b/cmp/grid/Grid.scss
@@ -367,45 +367,38 @@
     display: none;
   }
 
-  // Default minimal styling. Not applied when using a custom tooltip.
-  // Uses pre-wrap to honor intentional \n line breaks in tooltip content
-  // while still wrapping long lines at the max-width boundary.
-  &--default {
-    padding: var(--xh-grid-tooltip-padding);
-    background: var(--xh-grid-tooltip-bg);
-    border: var(--xh-grid-tooltip-border);
-    border-radius: var(--xh-grid-tooltip-border-radius);
-    max-width: var(--xh-grid-tooltip-max-width);
+  // Honors intentional \n line breaks in tooltip content, while still wrapping long lines at the
+  // max-width boundary. Applied by Hoist to the tooltip content it renders itself.
+  &--prewrap {
     white-space: pre-wrap;
   }
 
-  // Validation tooltip styling. Adjust depending on if within a default or custom tooltip.
-  &--validation {
+  // Validation messages, which Hoist renders in place of a column's own tooltip, as a list within
+  // the tooltip. Framed by the wrapper in every case, so this only needs list padding - the 2em
+  // reserves room for the markers, which a lone message does without.
+  &--validation ul {
     margin: 0;
-
-    &--single {
-      list-style-type: none;
-    }
-  }
-
-  &--default > div > .xh-grid-tooltip--validation {
     padding: 0 var(--xh-pad-half-px) 0 2em;
-
-    &--single {
-      padding: 0 var(--xh-pad-half-px);
-    }
   }
 
-  &--custom > div > .xh-grid-tooltip--validation {
-    padding: var(--xh-grid-tooltip-padding) var(--xh-grid-tooltip-padding)
-      var(--xh-grid-tooltip-padding) 2em;
-    background: var(--xh-grid-tooltip-bg);
-    border: var(--xh-grid-tooltip-border);
-
-    &--single {
-      padding: var(--xh-grid-tooltip-padding);
-    }
+  &--validation-single ul {
+    list-style-type: none;
+    padding: 0 var(--xh-pad-half-px);
   }
+}
+
+// Standard grid-tooltip chrome, applied by Hoist to any tooltip content it renders itself, and
+// available to apps for a custom (element) tooltip - which is otherwise left unframed so that it
+// can supply its own chrome.
+// Note this is a standalone utility class, not a BEM element or modifier of `.xh-grid-tooltip`:
+// unlike `--prewrap` above, it is applied to elements an app may own, and so must be valid with no
+// `.xh-grid-tooltip` ancestor.
+.xh-grid-tooltip-frame {
+  padding: var(--xh-grid-tooltip-padding);
+  background: var(--xh-grid-tooltip-bg);
+  border: var(--xh-grid-tooltip-border);
+  border-radius: var(--xh-grid-tooltip-border-radius);
+  max-width: var(--xh-grid-tooltip-max-width);
 }
 
 //-----------

--- a/cmp/grid/README.md
+++ b/cmp/grid/README.md
@@ -264,6 +264,31 @@ columns: [
 ]
 ```
 
+### Tooltips
+
+Hoist styles the tooltip content it renders itself - a plain value or string, and the validation
+messages shown on an editable cell - with `xh-grid-tooltip-frame` (background, border, radius,
+padding, max-width) and `xh-grid-tooltip--prewrap` (honors `\n` line breaks while still wrapping at
+max-width).
+
+A `tooltip` that returns an **element** is left unstyled, so that a custom tooltip can supply its
+own chrome. To take Hoist's frame instead, add `xh-grid-tooltip-frame` to your own root:
+
+```typescript
+{
+    field: 'volume',
+    tooltip: volume =>
+        vbox({
+            className: 'xh-grid-tooltip-frame',
+            items: [fmtNumberTooltip(volume), div('Unusually high volume')]
+        })
+}
+```
+
+`xh-grid-tooltip-frame` is a standalone utility class, usable on any element - a custom tooltip is
+not nested in anything that provides the frame for it. (`--prewrap` is an ordinary modifier that
+Hoist applies to its own tooltips; set `white-space` directly if a custom tooltip needs it.)
+
 ### Cell Corner Flags
 
 `cellFlag` marks a cell with a small triangle in its top-right corner, in the color of a standard

--- a/cmp/grid/columns/Column.ts
+++ b/cmp/grid/columns/Column.ts
@@ -941,9 +941,9 @@ export class Column {
                             }
                         }
                     }
-                    wrapperRef.current
-                        ?.closest('.ag-react-container')
-                        .classList.add(...xhToolTipClassNames);
+                    const container = wrapperRef.current?.closest('.ag-react-container');
+                    container?.classList.add(...xhToolTipClassNames);
+                    return () => container?.classList.remove(...xhToolTipClassNames);
                 }, [isCustom, validationCount, location]);
 
                 // Required by agGrid, even though empty.

--- a/cmp/grid/columns/Column.ts
+++ b/cmp/grid/columns/Column.ts
@@ -18,7 +18,6 @@ import {
     ValidationSeverity
 } from '@xh/hoist/data';
 import {logDebug, logWarn, throwIf, warnIf, withDefault} from '@xh/hoist/utils/js';
-import classNames from 'classnames';
 import {
     castArray,
     clone,
@@ -901,20 +900,51 @@ export class Column {
                     }
                 }
 
-                const isElement = isValidElement(ret);
+                // Validation state replaces a column's own tooltip entirely - resolve it here, so
+                // that the classes below describe what is actually rendered rather than the
+                // tooltip it supersedes.
+                let validationMessages: string[] = null;
+                if (hasRecord && editor) {
+                    const bySeverity = groupBy(
+                        record.validationResults[field],
+                        'severity'
+                    ) as Record<ValidationSeverity, ValidationResult[]>;
+                    const msgs = (bySeverity.error ?? bySeverity.warning ?? bySeverity.info)?.map(
+                        v => v.message
+                    );
+                    if (!isEmpty(msgs)) validationMessages = msgs;
+                }
+
+                // Hoist frames the content it renders itself - a plain value/string tooltip, or the
+                // validation list above. A custom element tooltip is left unframed, so that it can
+                // supply its own chrome (opting in with `xh-grid-tooltip-frame` if it wants ours).
+                const isElement = isValidElement(ret),
+                    isCustom = !validationMessages && isElement,
+                    validationCount = validationMessages?.length ?? 0;
 
                 useLayoutEffect(() => {
-                    const xhToolTipClassNames: string[] =
-                        location === 'header'
-                            ? ['ag-tooltip']
-                            : [
-                                  'xh-grid-tooltip',
-                                  isElement ? 'xh-grid-tooltip--custom' : 'xh-grid-tooltip--default'
-                              ];
+                    let xhToolTipClassNames: string[];
+                    if (location === 'header') {
+                        xhToolTipClassNames = ['ag-tooltip'];
+                    } else if (isCustom) {
+                        xhToolTipClassNames = ['xh-grid-tooltip'];
+                    } else {
+                        xhToolTipClassNames = [
+                            'xh-grid-tooltip',
+                            'xh-grid-tooltip--prewrap',
+                            'xh-grid-tooltip-frame'
+                        ];
+                        if (validationCount) {
+                            xhToolTipClassNames.push('xh-grid-tooltip--validation');
+                            if (validationCount === 1) {
+                                xhToolTipClassNames.push('xh-grid-tooltip--validation-single');
+                            }
+                        }
+                    }
                     wrapperRef.current
                         ?.closest('.ag-react-container')
                         .classList.add(...xhToolTipClassNames);
-                }, [isElement, location]);
+                }, [isCustom, validationCount, location]);
 
                 // Required by agGrid, even though empty.
                 // If not present agGrid logs this warning:
@@ -924,33 +954,16 @@ export class Column {
                 if (location === 'header') return div({ref: wrapperRef, item: this.headerTooltip});
                 if (!hasRecord) return null;
 
-                // Override with validation errors, if present -- only show highest-severity level
-                if (editor) {
-                    const validationsBySeverity = groupBy(
-                            record.validationResults[field],
-                            'severity'
-                        ) as Record<ValidationSeverity, ValidationResult[]>,
-                        validationMessages = (
-                            validationsBySeverity.error ??
-                            validationsBySeverity.warning ??
-                            validationsBySeverity.info
-                        )?.map(v => v.message);
-                    if (!isEmpty(validationMessages)) {
-                        return div({
-                            ref: wrapperRef,
-                            item: ul({
-                                className: classNames(
-                                    'xh-grid-tooltip--validation',
-                                    validationMessages.length === 1
-                                        ? 'xh-grid-tooltip--validation--single'
-                                        : null
-                                ),
-                                items: validationMessages.map((it, idx) => li({key: idx, item: it}))
-                            })
-                        });
-                    }
-                    if (!tooltip) return null;
+                // Validation messages supersede the column's own tooltip - resolved above.
+                if (validationMessages) {
+                    return div({
+                        ref: wrapperRef,
+                        item: ul({
+                            items: validationMessages.map((it, idx) => li({key: idx, item: it}))
+                        })
+                    });
                 }
+                if (editor && !tooltip) return null;
 
                 if (isNil(ret) || ret === '') return null;
 


### PR DESCRIPTION
**Stacked on #4684** - please merge that first. Base is `grid-cell-flag`, so this diff shows only the tooltip work.

`.xh-grid-tooltip--default` carried two unrelated things at once: the *state* "this tooltip's content was a string" and the *appearance* "draw a frame and pre-wrap". That conflation is the root of several problems this PR fixes.

### Appearance now composes

Applied by Hoist to the tooltip content it renders itself:

- **`xh-grid-tooltip-frame`** - background, border, radius, padding, max-width. A standalone **utility** class, not an element or modifier, because apps apply it to their own custom tooltip root where no `.xh-grid-tooltip` ancestor exists (header tooltips get `ag-tooltip` only). This is the one app-facing class.
- **`xh-grid-tooltip--prewrap`** - honors `\n` breaks while wrapping at max-width. An ordinary **modifier**: Hoist only ever applies it to the wrapper, which always carries the block.

Previously an app wanting a custom tooltip to match had to copy the five `--xh-grid-tooltip-*` tokens, or co-opt `--default` and assert something untrue about its content.

### Bug fix: validation tooltips

`isElement` was computed from a column's own tooltip - but validation messages *replace* that tooltip entirely, so the wrapper was labelled from content that was never rendered. A column with both an `editor` and a custom element `tooltip` therefore got an unframed wrapper, leaving the validation list to rebuild the frame via a parallel `--custom > div >` rule that supplied background and border but **neither border-radius nor max-width**. Two columns with identical validation errors rendered differently based on unrelated config.

Validation state is now resolved *before* the classes are assigned, so validation always uses the standard frame and the two `> div >` rules collapse into one.

### Class changes

- `--default` / `--custom` **removed**. Once styling moved out nothing read them - no rule in hoist-react, no usage across our sample apps - and a class that looks meaningful but is never consumed invites exactly the co-opting this PR ends. `.xh-grid-tooltip` remains on every grid tooltip as the stable hook.
- `--validation` **moved to the tooltip** from the message list inside it, making it a true modifier; `--validation--single` → `--validation-single`. The list now carries no class.

Net result is six flat rules with no structural `> div >` selectors, and every class correctly categorised as block, modifier or utility.

### Testing

Verified in Toolbox against a local hoist-react: string tooltips framed with pre-wrap; custom element tooltips unstyled (`bg: transparent`, `border: 0px`); validation tooltips framed with `radius: 4px` / `max-width: 400px` in both the string-tooltip and custom-tooltip cases - the latter being the bug above. Final `--validation` placement verified by @amcclain.

A matching Toolbox branch demos `cellFlag` plus a framed custom tooltip; it will go up once both this and #4684 are merged and a SNAPSHOT is published.

Hoist P/R Checklist
-------------------

- [x] Caught up with `develop` branch as of last change.
- [x] Added CHANGELOG entry, or determined not required.
- [x] Reviewed for breaking changes, added `breaking-change` label + CHANGELOG if so. *(Class removals/renames called out with ⚠️ sub-bullets; no app in our sample referenced any of them.)*
- [x] Updated doc comments / prop-types, or determined not required. *(New "Tooltips" section in the grid README.)*
- [x] Reviewed and tested on Mobile, or determined not required. *(`cmp/grid` and `Grid.scss` are shared.)*
- [x] Created Toolbox branch / PR, or determined not required. *(Branch ready; see above.)*